### PR TITLE
Added Servers status app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ web:
     MICROMASTERS_USE_WEBPACK_DEV_SERVER: 'True'
     MICROMASTERS_SECURE_SSL_REDIRECT: 'False'
     MICROMASTERS_DB_DISABLE_SSL: 'True'
-    STATUS_TOKEN: 'test-token'
   env_file: .env
   ports:
     - "8079:8079"

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -81,6 +81,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'server_status',
     'social.apps.django_app.default',
     # Our INSTALLED_APPS
     'ui',
@@ -284,6 +285,6 @@ LOGGING = {
     },
 }
 
-# status
+# server-status
 STATUS_TOKEN = get_var("STATUS_TOKEN", "")
 HEALTH_CHECK = ['POSTGRES']

--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
     url('', include('social.apps.django_app.urls', namespace='social')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^api/v0/', include(router.urls)),
+    url(r'^status/', include('server_status.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Django==1.9.0
 PyYAML==3.11
 dj-database-url==0.3.0
 dj-static==0.0.6
+django-server-status==0.3
 djangorestframework==3.3.2
 newrelic==2.54.0.41
 psycopg2==2.6


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #16 

This is dependent on the release of `django-server-status==0.3`

#### What's this PR do?
Adds the `django-server-status` app to Micromasters

#### Where should the reviewer start?
`micromasters/settings.py` and then `micromasters/urls.py`

#### How should this be manually tested?
add an entry for the status token in your .env file, rebuild the web container and then test that `/status/?token=<your token>` works

#### What GIF best describes this PR or how it makes you feel?
![](http://gif-finder.com/wp-content/uploads/2015/05/Mr.Bean-Thumbs-Up.gif)