### PR TITLE
Fetch information for user profile from edX

### DIFF
--- a/backends/edxorg.py
+++ b/backends/edxorg.py
@@ -35,7 +35,12 @@ class EdxOrgOAuth2(BaseOAuth2):
             dict: a dictionary containing user information
                 coming from the remote service.
         """
-        return super(EdxOrgOAuth2, self).user_data(access_token, *args, **kwargs)
+        return self.get_json(
+            urljoin(EDXORG_BASE_URL, "/api/mobile/v0.5/my_user_info"),
+            headers={
+                "Authorization": "Bearer {}".format(access_token),
+            }
+        )
 
     def get_user_details(self, response):
         """
@@ -54,13 +59,15 @@ class EdxOrgOAuth2(BaseOAuth2):
                 the following keys:
                 <remote_id>, `username`, `email`, `fullname`, `first_name`, `last_name`
         """
+        full, first, last = self.get_user_names(response['name'])
+
         return {
-            'edx_id': 'unique_edx_id_1',
-            'username': 'my_username',
-            'email': 'firstname_lastname@example.com',
-            'fullname': 'firstname lastname',
-            'first_name': 'firstname',
-            'last_name': 'lastname'
+            'edx_id': response['username'],
+            'username': response['username'],
+            'email': response['email'],
+            'fullname': full,
+            'first_name': first,
+            'last_name': last,
         }
 
     def get_user_id(self, details, response):

--- a/backends/edxorg_test.py
+++ b/backends/edxorg_test.py
@@ -1,0 +1,51 @@
+"""
+Oauth Backend Tests
+"""
+# pylint: disable=no-self-use
+from unittest import TestCase
+from .edxorg import EdxOrgOAuth2
+
+
+class EdxOrgOAuth2Tests(TestCase):
+    """Tests for EdxOrgOAuth2"""
+    def test_response_parsing(self):
+        """
+        Should have properly formed payload if working.
+        """
+        eoo = EdxOrgOAuth2()
+        result = eoo.get_user_details({
+            'id': 5,
+            'username': 'darth',
+            'email': 'darth@deathst.ar',
+            'name': 'Darth Vader'
+        })
+
+        assert {
+            'edx_id': 'darth',
+            'username': 'darth',
+            'fullname': 'Darth Vader',
+            'email': 'darth@deathst.ar',
+            'first_name': 'Darth',
+            'last_name': 'Vader'
+        } == result
+
+    def test_single_name(self):
+        """
+        If the user only has one name, last_name should be blank.
+        """
+        eoo = EdxOrgOAuth2()
+        result = eoo.get_user_details({
+            'id': 5,
+            'username': 'staff',
+            'email': 'staff@example.com',
+            'name': 'staff'
+        })
+
+        assert {
+            'edx_id': 'staff',
+            'username': 'staff',
+            'fullname': 'staff',
+            'email': 'staff@example.com',
+            'first_name': 'staff',
+            'last_name': ''
+        } == result


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #50 

#### What's this PR do?
Fetches information from edx for user's profile
#### Where should the reviewer start?
edxorg.py
#### How should this be manually tested?
Same as https://github.com/mitodl/micromasters/pull/47 , but the user should be created with the correct username. If you're already logged in (as superuser), that account will be associated to you.

#### Any background context you want to provide?
Status codes are [handled](https://github.com/omab/python-social-auth/blob/master/social/backends/base.py#L228) by python-social-auth.

#### Screenshots (if appropriate)
![admin-fail](https://cloud.githubusercontent.com/assets/3853/13684769/33f86952-e6db-11e5-8138-8005153be4d3.png)


#### What GIF best describes this PR or how it makes you feel?
![](http://s.mlkshk-cdn.com/r/17TNA.jpg)