### PR TITLE
Added REST API for profiles

### DIFF
--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -4,10 +4,12 @@ from django.contrib import admin
 from rest_framework import routers
 
 from courses.views import ProgramViewSet, CourseViewSet
+from profiles.views import ProfileViewSet
 
 router = routers.DefaultRouter()
 router.register(r'programs', ProgramViewSet)
 router.register(r'courses', CourseViewSet)
+router.register(r'profiles', ProfileViewSet)
 
 urlpatterns = [
     url(r'', include('ui.urls')),

--- a/profiles/factories.py
+++ b/profiles/factories.py
@@ -1,8 +1,22 @@
 """Factories for making test data"""
+from datetime import datetime, timezone
+
 from django.contrib.auth.models import User
-import factory
+from factory import (
+    Sequence,
+    SubFactory,
+)
 from factory.django import DjangoModelFactory
+from factory.fuzzy import (
+    FuzzyAttribute,
+    FuzzyChoice,
+    FuzzyDateTime,
+    FuzzyInteger,
+    FuzzyText,
+)
 import faker
+
+from profiles.models import Profile
 
 
 FAKE = faker.Factory.create()
@@ -10,7 +24,42 @@ FAKE = faker.Factory.create()
 
 class UserFactory(DjangoModelFactory):
     """Factory for Users"""
-    username = factory.Sequence(lambda n: "user_%d" % n)
+    username = Sequence(lambda n: "user_%d" % n)
 
     class Meta:  # pylint: disable=missing-docstring,no-init,too-few-public-methods,old-style-class
         model = User
+
+
+class ProfileFactory(DjangoModelFactory):
+    """Factory for Profiles"""
+    user = SubFactory(UserFactory)
+    account_privacy = FuzzyChoice(
+        [choice[0] for choice in Profile.ACCOUNT_PRIVACY_CHOICES]
+    )
+    email_optin = FuzzyAttribute(FAKE.boolean)
+    employer = FuzzyText(suffix=" corp")
+    job_title = FuzzyText(suffix=" consultant")
+    state_or_territory = FuzzyText(suffix=" state")
+    name = FuzzyText(prefix="User ")
+    bio = FuzzyText()
+    country = FuzzyText(suffix="land")
+    has_profile_image = FuzzyAttribute(FAKE.boolean)
+    profile_url_full = FuzzyText(prefix="http://")
+    profile_url_large = FuzzyText(prefix="http://")
+    profile_url_medium = FuzzyText(prefix="http://")
+    profile_url_small = FuzzyText(prefix="http://")
+    requires_parental_consent = FuzzyAttribute(FAKE.boolean)
+    year_of_birth = FuzzyInteger(1850, 2015)
+    level_of_education = FuzzyChoice(
+        [choice[0] for choice in Profile.LEVEL_OF_EDUCATION_CHOICES]
+    )
+    goals = FuzzyText()
+    gender = FuzzyChoice(
+        [choice[0] for choice in Profile.GENDER_CHOICES]
+    )
+    mailing_address = FuzzyText()
+    date_joined_micromasters = FuzzyDateTime(datetime(1850, 1, 1, tzinfo=timezone.utc))
+    language_proficiencies = FuzzyAttribute(lambda: [FAKE.text() for _ in range(3)])
+
+    class Meta:  # pylint: disable=missing-docstring
+        model = Profile

--- a/profiles/permissions.py
+++ b/profiles/permissions.py
@@ -1,0 +1,22 @@
+"""
+Permission classes for profiles
+"""
+from rest_framework.permissions import (
+    BasePermission,
+    SAFE_METHODS,
+)
+
+
+class CanEditIfOwner(BasePermission):
+    """
+    Only owner of a profile has permission to edit the profile.
+    """
+
+    def has_object_permission(self, request, view, profile):
+        """
+        Only allow editing for owner of the profile.
+        """
+        if request.method in SAFE_METHODS:
+            return True
+
+        return profile.user == request.user

--- a/profiles/permissions_test.py
+++ b/profiles/permissions_test.py
@@ -1,0 +1,52 @@
+"""
+Tests for profile permissions
+"""
+
+from mock import Mock
+from django.db.models.signals import post_save
+from django.test import TestCase
+from factory.django import mute_signals
+
+from profiles.factories import ProfileFactory, UserFactory
+from profiles.permissions import CanEditIfOwner
+
+
+# pylint: disable=no-self-use
+class CanEditIfOwnerTests(TestCase):
+    """
+    Tests for CanEditIfOwner permissions
+    """
+
+    def test_allow_nonedit(self):
+        """
+        Users are allowed to use safe methods without owning the profile.
+        """
+        perm = CanEditIfOwner()
+        for method in ('GET', 'HEAD', 'OPTIONS'):
+            request = Mock(method=method)
+            with mute_signals(post_save):
+                profile = ProfileFactory.create()
+            assert perm.has_object_permission(request, None, profile)
+
+    def test_edit_if_owner(self):
+        """
+        Users are allowed to edit their own profile
+        """
+        perm = CanEditIfOwner()
+        for method in ('POST', 'PATCH', 'PUT'):
+            with mute_signals(post_save):
+                profile = ProfileFactory.create()
+            request = Mock(method=method, user=profile.user)
+            assert perm.has_object_permission(request, None, profile)
+
+    def test_cant_edit_if_not_owner(self):
+        """
+        Users are not allowed to edit if it's not their profile.
+        """
+        perm = CanEditIfOwner()
+        other_user = UserFactory.create()
+        for method in ('POST', 'PATCH', 'PUT'):
+            with mute_signals(post_save):
+                profile = ProfileFactory.create()
+            request = Mock(method=method, user=other_user)
+            assert not perm.has_object_permission(request, None, profile)

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -1,0 +1,78 @@
+"""
+Serializers for user profiles
+"""
+from rest_framework.fields import JSONField
+from rest_framework.serializers import ModelSerializer
+
+from profiles.models import Profile
+
+
+class ProfileSerializer(ModelSerializer):
+    """Serializer for Profile objects"""
+    language_proficiencies = JSONField()
+
+    class Meta:  # pylint: disable=missing-docstring
+        model = Profile
+        fields = (
+            'account_privacy',
+            'email_optin',
+            'employer',
+            'job_title',
+            'state_or_territory',
+            'name',
+            'bio',
+            'country',
+            'has_profile_image',
+            'profile_url_full',
+            'profile_url_large',
+            'profile_url_medium',
+            'profile_url_small',
+            'requires_parental_consent',
+            'year_of_birth',
+            'level_of_education',
+            'goals',
+            'language_proficiencies',
+            'gender',
+            'mailing_address',
+            'date_joined_micromasters',
+        )
+
+
+class ProfileLimitedSerializer(ModelSerializer):
+    """
+    Serializer for Profile objects, limited to fields that other users are
+    allowed to see if a profile is marked public.
+    """
+    class Meta:  # pylint: disable=missing-docstring
+        model = Profile
+        fields = (
+            'name',
+            'bio',
+            'account_privacy',
+            'employer',
+            'job_title',
+            'state_or_territory',
+            'country',
+            'has_profile_image',
+            'profile_url_full',
+            'profile_url_large',
+            'profile_url_medium',
+            'profile_url_small',
+        )
+
+
+class ProfilePrivateSerializer(ModelSerializer):
+    """
+    Serializer for Profile objects, limited to fields that other users are
+    allowed to see if a profile is marked private.
+    """
+    class Meta:  # pylint: disable=missing-docstring
+        model = Profile
+        fields = (
+            'account_privacy',
+            'has_profile_image',
+            'profile_url_full',
+            'profile_url_large',
+            'profile_url_medium',
+            'profile_url_small',
+        )

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -1,0 +1,83 @@
+"""
+Tests for profile serializers
+"""
+
+from unittest import TestCase
+
+from rest_framework.fields import DateTimeField
+
+from profiles.factories import ProfileFactory
+from profiles.serializers import (
+    ProfileLimitedSerializer,
+    ProfilePrivateSerializer,
+    ProfileSerializer,
+)
+
+
+class ProfileTests(TestCase):
+    """
+    Tests for profile serializers
+    """
+
+    def test_full(self):  # pylint: disable=no-self-use
+        """
+        Test full serializer
+        """
+        profile = ProfileFactory.build()
+        assert ProfileSerializer().to_representation(profile) == {
+            'name': profile.name,
+            'date_joined_micromasters': DateTimeField().to_representation(profile.date_joined_micromasters),
+            'email_optin': profile.email_optin,
+            'gender': profile.gender,
+            'goals': profile.goals,
+            'language_proficiencies': profile.language_proficiencies,
+            'level_of_education': profile.level_of_education,
+            'mailing_address': profile.mailing_address,
+            'requires_parental_consent': profile.requires_parental_consent,
+            'year_of_birth': profile.year_of_birth,
+            'account_privacy': profile.account_privacy,
+            'has_profile_image': profile.has_profile_image,
+            'profile_url_full': profile.profile_url_full,
+            'profile_url_large': profile.profile_url_large,
+            'profile_url_medium': profile.profile_url_medium,
+            'profile_url_small': profile.profile_url_small,
+            'bio': profile.bio,
+            'country': profile.country,
+            'state_or_territory': profile.state_or_territory,
+            'employer': profile.employer,
+            'job_title': profile.job_title,
+        }
+
+    def test_limited(self):  # pylint: disable=no-self-use
+        """
+        Test limited serializer
+        """
+        profile = ProfileFactory.build()
+        assert ProfileLimitedSerializer().to_representation(profile) == {
+            'name': profile.name,
+            'account_privacy': profile.account_privacy,
+            'has_profile_image': profile.has_profile_image,
+            'profile_url_full': profile.profile_url_full,
+            'profile_url_large': profile.profile_url_large,
+            'profile_url_medium': profile.profile_url_medium,
+            'profile_url_small': profile.profile_url_small,
+            'bio': profile.bio,
+            'country': profile.country,
+            'state_or_territory': profile.state_or_territory,
+            'employer': profile.employer,
+            'job_title': profile.job_title,
+        }
+
+    def test_private(self):  # pylint: disable=no-self-use
+        """
+        Test private serializer
+        """
+        profile = ProfileFactory.build()
+        assert ProfilePrivateSerializer().to_representation(profile) == {
+            'account_privacy': profile.account_privacy,
+            'has_profile_image': profile.has_profile_image,
+            'profile_url_full': profile.profile_url_full,
+            'profile_url_large': profile.profile_url_large,
+            'profile_url_medium': profile.profile_url_medium,
+            'profile_url_small': profile.profile_url_small,
+        }

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -1,0 +1,38 @@
+"""Views for courses"""
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.mixins import (
+    RetrieveModelMixin,
+    UpdateModelMixin,
+)
+from rest_framework.viewsets import GenericViewSet
+
+from profiles.models import Profile
+from profiles.serializers import (
+    ProfileSerializer,
+    ProfileLimitedSerializer,
+    ProfilePrivateSerializer,
+)
+from profiles.permissions import CanEditIfOwner
+
+
+class ProfileViewSet(RetrieveModelMixin, UpdateModelMixin, GenericViewSet):
+    """API for the Program collection"""
+    serializer_class_owner = ProfileSerializer
+    serializer_class_limited = ProfileLimitedSerializer
+    serializer_class_private = ProfilePrivateSerializer
+    permission_classes = (IsAuthenticated, CanEditIfOwner)
+    lookup_field = 'user__username'
+    lookup_url_kwarg = 'user'
+    queryset = Profile.objects.all()
+
+    def get_serializer_class(self):
+        """
+        Different parts of a user profile are visible in different conditions
+        """
+        profile = self.get_object()
+        if self.request.user == profile.user:
+            return self.serializer_class_owner
+        elif profile.account_privacy == Profile.PRIVATE:
+            return self.serializer_class_private
+        else:
+            return self.serializer_class_limited

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -1,0 +1,147 @@
+"""
+Tests for profile view
+"""
+import json
+from mock import patch
+
+from django.core.urlresolvers import resolve, reverse
+from django.db.models.signals import post_save
+from django.test import TestCase
+from factory.django import mute_signals
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.status import (
+    HTTP_405_METHOD_NOT_ALLOWED,
+)
+
+from profiles.factories import ProfileFactory, UserFactory
+from profiles.models import Profile
+from profiles.permissions import CanEditIfOwner
+from profiles.serializers import (
+    ProfileLimitedSerializer,
+    ProfilePrivateSerializer,
+    ProfileSerializer,
+)
+from profiles.views import ProfileViewSet
+
+
+class ProfileTests(TestCase):
+    """
+    Tests for GET on profile view
+    """
+
+    def setUp(self):
+        """
+        Create a user and profile
+        """
+        super(ProfileTests, self).setUp()
+
+        with mute_signals(post_save):
+            self.user1 = UserFactory.create()
+        self.url1 = reverse('profile-detail', kwargs={'user': self.user1.username})
+
+        with mute_signals(post_save):
+            self.user2 = UserFactory.create()
+        self.url2 = reverse('profile-detail', kwargs={'user': self.user2.username})
+
+    def test_viewset(self):
+        """
+        Assert that the URL links up with the viewset
+        """
+        view = resolve(self.url1)
+        assert view.func.cls is ProfileViewSet
+
+    def test_permissions(self):  # pylint: disable=no-self-use
+        """
+        Assert that we set permissions correctly
+        """
+        # No unauthenticated users allowed
+        assert IsAuthenticated in ProfileViewSet.permission_classes
+        # Users can only edit their own profile
+        assert CanEditIfOwner in ProfileViewSet.permission_classes
+
+    def test_check_object_permissions(self):
+        """
+        Make sure check_object_permissions is called at some point so the permissions work correctly
+        """
+        with mute_signals(post_save):
+            ProfileFactory.create(user=self.user1)
+        self.client.force_login(self.user1)
+
+        with patch.object(ProfileViewSet, 'check_object_permissions', autospec=True) as check_object_permissions:
+            self.client.get(self.url1)
+        assert check_object_permissions.called
+
+    def test_get_own_profile(self):
+        """
+        Get a user's own profile. This should work no matter what setting is in
+        account_privacy.
+        """
+        with mute_signals(post_save):
+            profile = ProfileFactory.create(user=self.user1)
+        self.client.force_login(self.user1)
+        resp = self.client.get(self.url1)
+        assert resp.json() == ProfileSerializer().to_representation(profile)
+
+    def test_get_public_profile(self):
+        """
+        Get another user's public profile.
+        """
+        with mute_signals(post_save):
+            profile = ProfileFactory.create(user=self.user2, account_privacy=Profile.PUBLIC)
+        self.client.force_login(self.user1)
+
+        resp = self.client.get(self.url2)
+        assert resp.json() == ProfileLimitedSerializer().to_representation(profile)
+
+    def test_get_public_to_mm_profile(self):
+        """
+        Get another user's public_to_mm profile.
+        """
+        with mute_signals(post_save):
+            profile = ProfileFactory.create(user=self.user2, account_privacy=Profile.PUBLIC_TO_MM)
+        self.client.force_login(self.user1)
+
+        resp = self.client.get(self.url2)
+        assert resp.json() == ProfileLimitedSerializer().to_representation(profile)
+
+    def test_get_private_profile(self):
+        """
+        Get another user's private profile
+        """
+        with mute_signals(post_save):
+            profile = ProfileFactory.create(user=self.user2, account_privacy=Profile.PRIVATE)
+        self.client.force_login(self.user1)
+
+        resp = self.client.get(self.url2)
+        assert resp.json() == ProfilePrivateSerializer().to_representation(profile)
+
+    def test_patch_own_profile(self):
+        """
+        A user PATCHes their own profile
+        """
+        with mute_signals(post_save):
+            ProfileFactory.create(user=self.user1)
+        self.client.force_login(self.user1)
+
+        new_profile = ProfileFactory.build()
+        patch_data = ProfileSerializer().to_representation(new_profile)
+
+        resp = self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
+        assert resp.status_code == 200
+
+        old_profile = Profile.objects.get(user__username=self.user1.username)
+        for key, value in patch_data.items():
+            if key == "date_joined_micromasters":
+                # this field is readonly
+                continue
+            else:
+                assert getattr(old_profile, key) == value
+
+    def test_forbidden_methods(self):
+        """
+        POST is not implemented.
+        """
+        with mute_signals(post_save):
+            ProfileFactory.create(user=self.user1)
+        self.client.force_login(self.user1)
+        assert self.client.post(self.url1).status_code == HTTP_405_METHOD_NOT_ALLOWED

--- a/pylintrc
+++ b/pylintrc
@@ -17,4 +17,4 @@ ignored-modules=
 	six.moves,
 
 [MESSAGES CONTROL]
-disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors
+disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors, line-too-long


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #18

#### What's this PR do?
 - Adds a REST API for viewing and editing user profiles: `/api/v0/profiles/<username>/`
 - Updates ProfileFactory to have randomized values for all fields

#### Where should the reviewer start?
profiles/serializers.py

#### How should this be manually tested?
- In the Django shell, run

        from profiles.factories import ProfileFactory
        from django.contrib.auth.models import User
        user = User.objects.create_user(username="user", password="pass")
        profile = ProfileFactory.create(user=user, account_privacy="public")

This will create a user named `user` with `account_privacy` set to `public`. Keep the shell open so we can edit profile later.

- Create a superuser and login as that superuser via Django Admin.
- View `/api/v0/profiles/user/`. You should see 12 key value pairs, including `bio` and `country` for example, but not `mailing_address`.
- In the Django shell run

        profile.account_privacy = "public_to_mm"
        profile.save()

- View `/api/v0/profiles/user/` again. You should see exactly the same data as before
- In the Django shell run

        profile.account_privacy = "private"
        profile.save()

- View `/api/v0/profiles/user/` again. You should see only fields related to profile image, and `account_privacy`.

#### Any background context you want to provide?
This doesn't add any additional roles or permissions. See #89

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
![](http://45.media.tumblr.com/8dd61e1ff4a342fcb054a6fe3bfe05d8/tumblr_o1hgbfcWwW1smqfiko1_500.gif)