### PR TITLE
Added dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.tox
+htmlcov
+.coverage
+node_modules
+static/bundles
+staticfiles/
+


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #101 

#### What's this PR do?
Adds a .dockerignore file which lets us skip copying certain directories and files from the host to the docker container on build. The main offender here is `node_modules` which should not be dealt with at all during `docker-compose build`

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

