### PR TITLE
Use sitepackages=True so tox reuses the same packages in the docker environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skip_missing_interpreters = True
 skipsdist = True
 
 [testenv]
+sitepackages = True
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #108 

#### What's this PR do?
Updates tox.ini to use site packages. Since we only have one environment which is exactly the same as the docker container, this should not cause any problems, and it speeds up builds a little bit.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

