### PR TITLE
Fixed LICENSE organization

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,7 +11,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of micromasters nor the names of its
+* Neither the name of MIT Office of Digital Learning nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 


### PR DESCRIPTION
From the 3 clause BSD license template [here](https://en.wikipedia.org/wiki/BSD_licenses) it seems like this should be our organization, not the Micromasters name specifically.
