### PR TITLE
Made log out button on dashboard log user out

### DIFF
--- a/static/js/containers/LoginButton.js
+++ b/static/js/containers/LoginButton.js
@@ -7,9 +7,17 @@ class LoginButton extends React.Component {
   render() {
     const { authentication } = this.props;
 
-    return <DropdownButton title={authentication.name}>
-      <MenuItem eventKey="logout">Logout</MenuItem>
-    </DropdownButton>;
+    return (
+      <DropdownButton
+        title={authentication.name}
+        id="logout-button">
+        <MenuItem
+          href="/logout"
+          eventKey="logout">
+          Logout
+        </MenuItem>
+      </DropdownButton>
+    );
   }
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?

closes #99

#### What's this PR do?

change the log out button on the dashboard to, you know, log out. we just need to set the `href` prop on the `MenuItem` react bootstrap component.

#### Where should the reviewer start?

`static/js/containers/LoginButton.js`

#### How should this be manually tested?

make sure it logs out!

#### Any background context you want to provide?

#### Screenshots (if appropriate)

