### PR TITLE
Added redirect, "/dashboard" -> "/" if user not logged in

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -144,6 +144,7 @@ SOCIAL_AUTH_PIPELINE = (
     'social.pipeline.user.user_details',
 )
 LOGIN_REDIRECT_URL = '/'
+LOGIN_URL = '/'
 
 ROOT_URLCONF = 'micromasters.urls'
 

--- a/ui/views.py
+++ b/ui/views.py
@@ -7,6 +7,7 @@ import logging
 from django.conf import settings
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
 
 from courses.models import Program
 
@@ -52,6 +53,7 @@ def index(request):
     })
 
 
+@login_required()
 def dashboard(request):
     """
     The app dashboard view


### PR DESCRIPTION
#### What are the relevant tickets?
this closes #98

#### What's this PR do?

this adds a simple redirect check when hitting `/dashboard`. if
`request.user` is not authenticated, we redirect to `/`.

#### Where should the reviewer start?

in `/ui/views.py`

#### How should this be manually tested?

1. log in to micromasters
2. check that you can visit `/dashboard`
3. click the (brand new!) logout button
4. visit `/dashboard`
5. confirm

#### Any background context you want to provide?

first python commit!

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

![abe-simpson-gif](https://cloud.githubusercontent.com/assets/6207644/14329000/6133ca92-fc07-11e5-9d22-5ec8db073313.gif)