### PR TITLE
Added google analytics to base ui template

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -161,6 +161,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'ui.context_processors.google_analytics',
             ],
         },
     },

--- a/ui/context_processors.py
+++ b/ui/context_processors.py
@@ -1,0 +1,10 @@
+"""
+context processors for ui
+"""
+from django.conf import settings
+
+
+def google_analytics(request):
+    """inject GA_TRACKING_ID into templates"""
+    # pylint: disable=unused-argument
+    return {'GA_TRACKING_ID': settings.GA_TRACKING_ID}

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -11,6 +11,17 @@
     <title>{% block title %}{% endblock %}</title>
     {% block extrahead %}
     {% endblock %}
+    <!-- Google Analytics -->
+    <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', '{{ GA_TRACKING_ID }}', 'auto');
+    ga('send', 'pageview');
+    </script>
+<!-- End Google Analytics -->
   </head>
   <body>
     {% block content %}


### PR DESCRIPTION
#### What are the relevant tickets?

closes #135

#### What's this PR do?

this adds google analytics to the base template for the ui app.

first, this adds a template tag for the ui app that lets us pull values
out of `settings.py` (we store the google analytics id there).

then we can just pop the google analytics JS snippet into the `<head>`
of our base template, and pull in the analytics id using the template
tag. Nice!

#### Where should the reviewer start?

`/ui/templatetags/ui_extras.py` <- this is the thing I'm least sure
about.

#### How should this be manually tested?

we can generate a throwaway google analytics account, set the
environment variable `GA_TRACKING_ID` to the tracking id for that
account (in the micromasters `.env`), and then confirm that visiting any
page results in a page view being registered.

#### Any background context you want to provide?

I was a little unsure as to how to get the environment variable defining
our tracking ID into the template. this SE thread was handy:

https://stackoverflow.com/questions/433162/can-i-access-constants-in-settings-py-from-templates-in-django
