### PR TITLE
Moved JS tests to npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "babel-eslint": "5.0.0",
     "babel-plugin-transform-react-jsx": "6.6.4",
+    "babel-register": "6.7.2",
     "eslint": "2.2.0",
     "eslint-config-defaults": "9.0.0",
     "eslint-plugin-babel": "3.1.0",
@@ -49,6 +50,9 @@
     "webpack-dev-server": "1.14.1"
   },
   "scripts": {
-    "postinstall": "./webpack_if_prod.sh"
+    "postinstall": "./webpack_if_prod.sh",
+    "lint": "node ./node_modules/eslint/bin/eslint.js ./static/js",
+    "test": "mocha --compilers js:babel-register --require static/js/global_init.js 'static/**/*/*_test.js'",
+    "coverage": "node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- --compilers js:babel-register --require static/js/global_init.js 'static/**/*/*_test.js'"
   }
 }

--- a/static/js/mocha.opts
+++ b/static/js/mocha.opts
@@ -1,1 +1,0 @@
---compilers js:babel-core/register

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ passenv = *
 [testenv:js]
 commands =
     npm install --no-bin-links --prefix {toxinidir}
-    node {toxinidir}/node_modules/eslint/bin/eslint.js {toxinidir}/static/js
-    node {toxinidir}/node_modules/istanbul/lib/cli.js cover {toxinidir}/node_modules/mocha/bin/_mocha -- {posargs} --opts static/js/mocha.opts static/js/global_init.js "static/**/*_test.js"
+    npm run-script lint
+    npm run-script coverage
 setenv =
     NODE_ENV=development
 


### PR DESCRIPTION
#### relevant tickets

this closes #140

#### what's this PR do?

This moves our JS testing commands into npm scripts (defined in
`package.json`).

#### where should the reviewer start?

I'd take a look at `tox.ini` and `package.json` first.

#### How should this be manually tested?

pull down the branch and make sure the tests are running.

#### Any background context?

This is a nice change because:

1. it's a bit cleaner to package all the JS stuff together, then when we
want to run the JS tests in `tox` we just do `npm run-script coverage`.

2. when we're running inside of a `package.json` script we have access
to the executables installed in our `node_modules` directory, so we
don't need to provide the absolute path to, say, `mocha`. this is nice
because we get nicer looking commands, without having to install a bunch
of JS modules globally.

3. now we have an `npm test` command that just runs the JS tests,
without a coverage report, which is much faster! On my system:

```
time drun npm run-script coverage > /dev/null
>> docker-compose run web npm run-script coverage > /dev/null  0.39s user 0.03s system 2% cpu 14.944 total

time drun npm test > /dev/null
>> docker-compose run web npm test > /dev/null  0.37s user 0.03s system 8% cpu 4.670 total
```

the `coverage` script runs istanbul, the `test` command just runs the
test suite.