### PR TITLE
Added a minimal pytest for quick feedback

### DIFF
--- a/pytest_minimal.ini
+++ b/pytest_minimal.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --ds=micromasters.settings
+norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.egg


### PR DESCRIPTION
this just adds a new `py.test` config that runs only the tests (no pep8, no coverage, etc). makes it a little faster to get feedback when developing.

if you want to use it you do `docker-compose run py.test -c pytest_minimal.ini`.