### PR TITLE
Fixed a JS console warning, react-router and react-bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-mdl": "1.5.3",
     "react-redux": "4.4.0",
     "react-router": "2.0.0",
+    "react-router-bootstrap": "0.22.1",
     "react-select": "1.0.0-beta12",
     "redux-devtools": "2.1.5",
     "redux-logger": "2.6.1",

--- a/static/js/containers/LoginButton.js
+++ b/static/js/containers/LoginButton.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import DropdownButton from 'react-bootstrap/lib/DropdownButton';
+import LinkContainer from 'react-router-bootstrap/lib/LinkContainer';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
-import Link from 'react-router/lib/Link';
 
 class LoginButton extends React.Component {
   render() {
@@ -12,11 +12,11 @@ class LoginButton extends React.Component {
       <DropdownButton
         title={authentication.name}
         id="logout-button">
-        <MenuItem>
-          <Link to="/profile">
+        <LinkContainer to={{ pathname: '/profile' }} active={false}>
+          <MenuItem>
             Profile
-          </Link>
-        </MenuItem>
+          </MenuItem>
+        </LinkContainer>
         <MenuItem
           href="/settings">
           Settings


### PR DESCRIPTION
#### What are the relevant tickets?

none, this fixes a bug I noticed.

#### What's this PR do?

this adds a library called react-router-bootstrap that is designed to
make react-router and react-bootstrap play nicely together.

basically, we were getting a JS warning that looks like this:

```
warning.js:45 Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>. See LoginButton > MenuItem > SafeAnchor > a > ... > Link > a
```

this is occurring because we had the following code:

```javascript
<MenuItem>
  <Link to="/profile">
    Profile
  </Link>
</MenuItem>
```

`MenuItem` comes from `react-bootstrap`, and `Link` is a `react-router`
link. basically, the problem is that `MenuItem` implicitly includes an
`<a ..></a>` element, and places `this.props.children` inside that
element.

hence, we get a console warning about improperly nesting `<a>` tags.

of course, the outer one has `href=undefined`, so only the inner
`<Link>` tag does anything, and the ui works as expected, but still, the
warning.

the `react-router-bootstrap` library saves us here. we get a component
called `<LinkContainer>` which can wrap any `react-bootstrap` component
and make it behave like a `react-router` `<Link>`. we just set a `to`
prop on the `<LinkContainer>` with the path we want and any url params,
and off we go!

#### Where should the reviewer start?

I think just take a look in here:

	modified:   static/js/containers/LoginButton.js

#### How should this be manually tested?

pull down the branch, restart docker, visit `/dashboard` and confirm the
js console error is gone.

#### Any background context you want to provide?

docs for the lib here:
https://github.com/react-bootstrap/react-router-bootstrap