### PR TITLE
Updated eslint configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,10 @@
 {
   "parser": "babel-eslint",
-  "extends": "defaults/configurations/google",
+  "extends": [
+      "defaults/configurations/google",
+      "eslint:recommended",
+      "plugin:react/recommended"
+  ],
   "rules": {
     "quotes": [0], // no opinion on ' vs "
     "object-curly-spacing": [0],
@@ -10,7 +14,12 @@
     "newline-after-var": [0],
     "react/jsx-indent-props": [2, 2], // no tabs, indent is two spaces
     "react/jsx-key": [2], // validate that key prop exists
-    "react/jsx-no-undef": [2] // disallow undeclared variables in JSX
+    "react/jsx-no-undef": [2], // disallow undeclared variables in JSX
+    "no-unused-vars": [ 1, {
+      "vars": "local",
+      "argsIgnorePattern": "action"
+    }],
+    "comma-dangle": [0]
   },
   "env": {
     "es6": true,

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import TextField from 'react-mdl/lib/Textfield';
-import Card from 'react-mdl/lib/Card';
 import Select from 'react-select';
 
 import { updateProfile } from '../actions';
@@ -20,7 +19,7 @@ class PersonalTab extends React.Component {
       value={profileCopy[name]}
       onChange={onChange}
     />;
-  };
+  }
 
   updateGender(gender) {
     const { dispatch, profile: { profileCopy } } = this.props;

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -25,7 +25,7 @@ class App extends React.Component {
   }
 
   componentWillUnmount() {
-    const { dispatch, profile } = this.props;
+    const { dispatch } = this.props;
     dispatch(clearCourseList());
     dispatch(clearProfile());
     dispatch(clearDashboard());
@@ -73,9 +73,10 @@ const mapStateToProps = (state) => {
 
 App.propTypes = {
   courseList: React.PropTypes.object.isRequired,
-  profile: React.PropTypes.object.isRequired,
-  dashboard: React.PropTypes.object.isRequired,
-  dispatch: React.PropTypes.func.isRequired
+  children:   React.PropTypes.object.isRequired,
+  profile:    React.PropTypes.object.isRequired,
+  dashboard:  React.PropTypes.object.isRequired,
+  dispatch:   React.PropTypes.func.isRequired
 };
 
 export default connect(mapStateToProps)(App);

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -30,7 +30,8 @@ class ProfilePage extends React.Component {
 }
 
 ProfilePage.propTypes = {
-  profile: React.PropTypes.object.isRequired
+  profile:    React.PropTypes.object.isRequired,
+  dispatch:   React.PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -2,7 +2,6 @@
 import {
 
   fetchCourseList,
-  receiveCourseListSuccess,
   clearCourseList,
   REQUEST_COURSE_LIST,
   RECEIVE_COURSE_LIST_SUCCESS,
@@ -10,7 +9,6 @@ import {
   CLEAR_COURSE_LIST,
 
   fetchUserProfile,
-  receiveUserProfileSuccess,
   clearProfile,
   REQUEST_USER_PROFILE,
   RECEIVE_USER_PROFILE_SUCCESS,

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -44,7 +44,7 @@ export function makeCourseStatusDisplay(course, now = moment()) {
       {asPercent(course.grade)}
     </span>;
 
-  case STATUS_VERIFIED_NOT_COMPLETED:
+  case STATUS_VERIFIED_NOT_COMPLETED: {
     if (!course.course_start_date) {
       // Invalid case, API should always send a valid course start date
       return "";
@@ -63,8 +63,8 @@ export function makeCourseStatusDisplay(course, now = moment()) {
     return <span className="course-list-grade">
       {asPercent(grade)}
     </span>;
-
-  case STATUS_ENROLLED_NOT_VERIFIED:
+  }
+  case STATUS_ENROLLED_NOT_VERIFIED: {
     if (!course.verification_date) {
       // Invalid case, API should always send a valid verification date
       return "";
@@ -77,8 +77,8 @@ export function makeCourseStatusDisplay(course, now = moment()) {
       // User cannot verify anymore
       return "";
     }
-
-  case STATUS_OFFERED_NOT_ENROLLED:
+  }
+  case STATUS_OFFERED_NOT_ENROLLED: {
     if (!course.enrollment_start_date) {
       return course.fuzzy_enrollment_start_date;
     }
@@ -89,7 +89,7 @@ export function makeCourseStatusDisplay(course, now = moment()) {
     } else {
       return <Button bsStyle="success">ENROLL</Button>;
     }
-
+  }
   default:
     // also covers NOT_OFFERED case
     return "";


### PR DESCRIPTION
#### What are the relevant tickets?

none.

#### What's this PR do?

updates the eslint config to properly lint ES6 / JSX code, sets a few options, and deals with the errors the linter points out.

#### Where should the reviewer start?

`.eslintrc`, and then review the changes made to pass linting.

#### How should this be manually tested?

Make sure none of the style changes broke anything!

#### Any background context you want to provide?

Originally I just wanted to enable the `no-unused-vars` option, but quickly discovered that we didn't have `eslint-plugin-react` configured quite right, so when enabling `no-unused-vars` eslint would complain that the following code wasn't using `React`, for instance:

```
import React from 'react';

class Foo extends React.Component {
  ...
}
```

using the right configuration base (setting `extends: [ "plugin:react/recommended" ]`) gave us that easily.

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

![](http://www.yummymummyclub.ca/sites/default/files/styles/large/public/field/image/lint.jpg?itok=lcMuETya)
