### PR TITLE
React-router for profile tabs, basic employment tab

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,11 @@
     "react/jsx-indent-props": [2, 2], // no tabs, indent is two spaces
     "react/jsx-key": [2], // validate that key prop exists
     "react/jsx-no-undef": [2], // disallow undeclared variables in JSX
+    "react/prop-types": [ 1, {
+      "ignore": [
+        "route",
+        "location"
+      ]}],
     "no-unused-vars": [ 1, {
       "vars": "local",
       "argsIgnorePattern": "action"

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+class EmploymentTab extends React.Component {
+  render () {
+    return (
+      <div>
+        Employment
+        <br/>
+        id: {this.props.profile.pretty_printed_student_id}
+      </div>
+    );
+  }
+}
+
+EmploymentTab.propTypes = {
+  profile:    React.PropTypes.object,
+  saveProfile:    React.PropTypes.func,
+  updateProfile:  React.PropTypes.func,
+}
+
+export default EmploymentTab;

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -1,82 +1,34 @@
 import React from 'react';
-import TextField from 'react-mdl/lib/Textfield';
 import Button from 'react-mdl/lib/Button';
-import Select from 'react-select';
+import { boundTextField, boundSelectField, saveAndContinue } from '../util/profile_edit';
 
 import { LANGUAGE_CODES } from '../language_codes';
 
 class PersonalTab extends React.Component {
-  boundTextField(name, label) {
-    const { updateProfile, profile } = this.props;
-    let onChange = e => {
-      let clone = Object.assign({}, profile);
-      clone[name] = e.target.value;
-      updateProfile(clone);
-    };
-    return <TextField
-      floatingLabel
-      label={label}
-      value={profile[name]}
-      onChange={onChange}
-    />;
-  }
-
-  updateGender(gender) {
-    const { updateProfile, profile } = this.props;
-    let clone = Object.assign({}, profile, {
-      gender: gender ? gender.value : null
-    });
-    updateProfile(clone);
-  }
-
-  updateLanguage(language) {
-    const { updateProfile, profile } = this.props;
-    let clone = Object.assign({}, profile, {
-      'preferred_language': language ? language.value : null
-    });
-    updateProfile(clone);
-  }
-
-  saveAndContinue() {
-    const { saveProfile, profile } = this.props;
-
-    saveProfile(profile).then(() => {
-      // TODO: update to next tab
-    });
-  }
-
-  render() {
-    const { profile } = this.props;
-
-    let languages = LANGUAGE_CODES.map(language => ({
+  constructor(props) {
+    super(props);
+    this.boundTextField = boundTextField.bind(this);
+    this.boundSelectField = boundSelectField.bind(this);
+    this.genderOptions = [
+      { value: 'm', label: 'Male' },
+      { value: 'f', label: 'Female' },
+      { value: 'o', label: 'Other/Prefer not to say' }
+    ];
+    this.languageOptions = LANGUAGE_CODES.map(language => ({
       value: language.alpha2,
       label: language.English
     }));
+    this.saveAndContinue = saveAndContinue.bind(this, '/profile/professional');
+  }
 
-    let boundTextField = this.boundTextField.bind(this);
+  render() {
     return <div>
-      {boundTextField("first_name", "Given name")}<br />
-      {boundTextField("last_name", "Family name")}<br />
-      {boundTextField("preferred_name", "Preferred name (optional)")}<br />
-      <Select
-        options={[
-          { value: 'm', label: 'Male' },
-          { value: 'f', label: 'Female' },
-          { value: 'o', label: 'Other/Prefer not to say' }
-        ]}
-        value={profile.gender}
-        onChange={this.updateGender.bind(this)}
-        placeholder="Gender"
-      /><br />
-
-      <Select
-        options={languages}
-        value={profile.preferred_language}
-        onChange={this.updateLanguage.bind(this)}
-        placeholder="Preferred language"
-      /><br />
-
-      <Button raised onClick={this.saveAndContinue.bind(this)}>
+      {this.boundTextField("first_name", "Given name")}<br />
+      {this.boundTextField("last_name", "Family name")}<br />
+      {this.boundTextField("preferred_name", "Preferred name (optional)")}<br />
+      {this.boundSelectField('Gender', this.genderOptions, 'gender')}<br />
+      {this.boundSelectField('Preferred language', this.languageOptions, 'preferred_language')}<br />
+      <Button raised onClick={this.saveAndContinue}>
         Save and continue
       </Button>
     </div>;
@@ -84,9 +36,9 @@ class PersonalTab extends React.Component {
 }
 
 PersonalTab.propTypes = {
-  profile: React.PropTypes.object.isRequired,
-  saveProfile: React.PropTypes.func.isRequired,
-  updateProfile: React.PropTypes.func.isRequired,
+  profile:        React.PropTypes.object,
+  saveProfile:    React.PropTypes.func,
+  updateProfile:  React.PropTypes.func,
 };
 
 export default PersonalTab;

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Tabs from 'react-mdl/lib/Tabs/Tabs';
 import Tab from 'react-mdl/lib/Tabs/Tab';
+import { browserHistory } from 'react-router';
 
 import {
   startProfileEdit,
@@ -10,7 +11,6 @@ import {
   clearProfileEdit,
   saveProfile,
 } from '../actions';
-import PersonalTab from '../components/PersonalTab';
 
 class ProfilePage extends React.Component {
   updateProfile(profile) {
@@ -28,6 +28,22 @@ class ProfilePage extends React.Component {
     });
   }
 
+  makeTabs () {
+    return this.props.route.childRoutes.map( (route) => (
+      <Tab
+        key={route.path}
+        onClick={() => browserHistory.push(`/profile/${route.path}`)} >
+        {route.path}
+      </Tab>
+    ));
+  }
+
+  activeTab () {
+    return this.props.route.childRoutes.findIndex( (route) => (
+      route.path === this.props.location.pathname.split("/")[2]
+    ));
+  }
+
   render() {
     let { profile } = this.props;
 
@@ -37,6 +53,14 @@ class ProfilePage extends React.Component {
       profile = profile.profile;
     }
 
+    let childrenWithProps = React.Children.map(this.props.children, (child) => (
+      React.cloneElement(child, {
+        profile: profile,
+        updateProfile: this.updateProfile.bind(this),
+        saveProfile: this.saveProfile.bind(this)
+      })
+    ));
+
     return <div className="card">
       <div className="card-copy">
         <h1>Enroll in MIT Micromasters</h1>
@@ -44,17 +68,11 @@ class ProfilePage extends React.Component {
           Please tell us more about yourself so you can participate in the
           micromasters community and qualify for your micromasters certificate.
         </p>
-        <Tabs activeTab={0}>
-          <Tab>Personal</Tab>
-          <Tab className="no-hover">Education</Tab>
-          <Tab className="no-hover">Professional</Tab>
+        <Tabs activeTab={this.activeTab()}>
+          {this.makeTabs()}
         </Tabs>
         <section>
-          <PersonalTab
-            profile={profile}
-            updateProfile={this.updateProfile.bind(this)}
-            saveProfile={this.saveProfile.bind(this)}
-          />
+          {this.props.children && childrenWithProps}
         </section>
       </div>
     </div>;
@@ -63,6 +81,7 @@ class ProfilePage extends React.Component {
 
 ProfilePage.propTypes = {
   profile:    React.PropTypes.object.isRequired,
+  children:   React.PropTypes.node,
   dispatch:   React.PropTypes.func.isRequired
 };
 

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -5,10 +5,12 @@ import ReactDOM from 'react-dom';
 import App from './containers/App';
 import DashboardPage from './containers/DashboardPage';
 import ProfilePage from './containers/ProfilePage';
+import PersonalTab from './components/PersonalTab';
+import EmploymentTab from './components/EmploymentTab';
 import { Provider } from 'react-redux';
 import configureStore from './store/configureStore';
 import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react';
-import { Router, Route, browserHistory } from 'react-router';
+import { Router, IndexRedirect, Route, browserHistory } from 'react-router';
 import ga from 'react-ga';
 
 // requirements for react-mdl which uses a modified version of material-design-lite
@@ -36,7 +38,11 @@ ReactDOM.render(
       <Router history={browserHistory}>
         <Route path="/" component={App} onUpdate={ga.pageview(window.location.pathname)}>
           <Route path="dashboard" component={DashboardPage} />
-          <Route path="profile" component={ProfilePage} />
+          <Route path="profile" component={ProfilePage}>
+            <IndexRedirect to="personal" />
+            <Route path="personal" component={PersonalTab} />
+            <Route path="professional" component={EmploymentTab} />
+          </Route>
         </Route>
       </Router>
     </Provider>

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import TextField from 'react-mdl/lib/Textfield';
+import Select from 'react-select';
+import { browserHistory } from 'react-router';
+
+// utility functions for pushing changes to profile forms back to the
+// redux store.
+// this expects that the `updateProfile` and `profile` props are passed
+// in to whatever component it is used in.
+
+// bind to this.boundTextField in the constructor of a form component
+// to update text fields when editing the profile
+function boundTextField(name, label) {
+  const { updateProfile, profile } = this.props;
+  let onChange = e => {
+    let clone = Object.assign({}, profile);
+    clone[name] = e.target.value;
+    updateProfile(clone);
+  };
+  return (
+    <TextField
+      floatingLabel
+      label={label}
+      value={profile[name]}
+      onChange={onChange} />
+  );
+}
+
+// bind this to this.boundSelectField in the constructor of a form component
+// to update select fields
+// pass in the name (used as placeholder), key for profile, and the options.
+function boundSelectField(name, options, key) {
+  const { updateProfile, profile } = this.props;
+  let onChange = value => {
+    let clone = Object.assign({}, profile);
+    clone[key] = value ? value.value : null;
+    updateProfile(clone);
+  };
+  return (
+    <Select
+      options={options}
+      value={profile[key]}
+      placeholder={name}
+      onChange={onChange} />
+  );
+}
+
+// bind to this.saveAndContinue.bind(this, '/next/url')
+function  saveAndContinue(next) {
+  const { saveProfile, profile } = this.props;
+
+  saveProfile(profile).then(() => {
+    browserHistory.push(next)
+  });
+}
+
+
+export { boundTextField, boundSelectField, saveAndContinue };


### PR DESCRIPTION
#### What are the relevant tickets?

#150 

#### What's this PR do?

This

1. adds a tab where the user can fill out their employment history

2. sets up using react-router to transition between the tabs in the profile screen

3. pulls form <-> store communication logic out into a shared file

4. automatically redirects from `/profile/personal` to `/profile/professional` when you click 'save'

#### Where should the reviewer start?

The changes in `static/js/components/PersonalTab.js`, `static/js/containers/ProfilePage.js`, and `static/js/dashboard.js` are probably the biggest ones.

#### How should this be manually tested?

check out the branch and make sure that everything is working (you can change fields and they update, etc).

#### Any background context you want to provide?

I ran into a couple of issues with react-router and passing props down to `this.props.children`. relevant issue here: https://github.com/reactjs/react-router/issues/1857

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
