### PR TITLE
Build employment tab

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015", "react"],
+  "presets": ["es2015", "react", "stage-1"],
   "ignore": [
     "node_modules/**"
   ]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "babel-eslint": "5.0.0",
     "babel-plugin-transform-react-jsx": "6.6.4",
+    "babel-preset-stage-1": "6.5.0",
     "babel-register": "6.7.2",
     "eslint": "2.2.0",
     "eslint-config-defaults": "9.0.0",
@@ -35,6 +36,7 @@
     "moment": "2.12.0",
     "node-neat": "1.7.2",
     "node-sass": "3.4.2",
+    "object.entries": "1.0.3",
     "react": "0.14.7",
     "react-bootstrap": "0.28.3",
     "react-datepicker": "0.25.0",

--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -92,9 +92,9 @@ export const updateProfileValidation = errors => ({
   payload: { errors }
 });
 
-export const validateProfile = profile => {
+export const validateProfile = (profile, requiredFields, messages) => {
   return dispatch => {
-    let errors = util.validateProfile(profile);
+    let errors = util.validateProfile(profile, requiredFields, messages);
     dispatch(updateProfileValidation(errors));
     if (_.isEmpty(errors)) {
       return Promise.resolve();

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -1,21 +1,135 @@
 import React from 'react';
+import Button from 'react-mdl/lib/Button';
+import Grid from 'react-mdl/lib/Grid';
+import { Cell } from 'react-mdl/lib/Grid';
 
-class EmploymentTab extends React.Component {
+import ProfileTab from "../util/ProfileTab";
+import { saveAndContinue } from '../util/profile_edit';
+
+class EmploymentTab extends ProfileTab {
+  constructor(props) {
+    super(props);
+    this.saveAndContinue = saveAndContinue.bind(this, '/dashboard', EmploymentTab.validation);
+    this.blankWorkHistoryEntry = {
+      id: null,
+      position: "",
+      industry: "",
+      company_name: "",
+      start_date: "",
+      end_date: "",
+      city: "",
+      country: "",
+      state_or_territory: '',
+    }
+  }
+
+  static propTypes = {
+    profile:        React.PropTypes.object,
+    saveProfile:    React.PropTypes.func,
+    updateProfile:  React.PropTypes.func,
+  };
+
+  static defaultProps = {
+    requiredFields: [
+      ['currently_employed']
+    ],
+    validationMessages: {
+      'currently_employed': 'Current employment status',
+      'position': 'Position',
+      'industry': 'Industry',
+      'company_name': 'Company Name',
+      'start_date': 'Start Date',
+      'end_date': 'End Date',
+      'city': 'City',
+      'country': 'Country',
+      'state_or_territory': 'State or Territory',
+    },
+  };
+
+  static validation (profile, requiredFields) {
+    const keys = [
+      'position',
+      'industry',
+      'company_name',
+      'start_date',
+      'end_date',
+      'city',
+      'country',
+      'state_or_territory',
+    ];
+
+    let nestedFields = (index) => {
+      let keySet = (key) => ['work_history', index, key];
+      return keys.map(key => keySet(key));
+    }
+
+    return requiredFields.concat(
+      ...profile.work_history.map( (v,i) => nestedFields(i))
+    );
+  }
+
+  employmentEntriesForm (index) {
+    let keySet = (key) => ['work_history', index, key];
+    return (
+      <Grid key={index} className="profile-tab-grid">
+        <Cell col={12}>
+          {this.boundTextField(keySet('company_name'), 'Company Name')}
+        </Cell>
+        <Cell col={12}>
+          {this.boundTextField(keySet('position'), 'Position')}
+        </Cell>
+        <Cell col={12}>
+          {this.boundTextField(keySet('industry'), 'Industry')}
+        </Cell>
+        <Cell col={12}>
+          {this.boundTextField(keySet('city'), 'City')}
+        </Cell>
+        <Cell col={12}>
+          {this.boundTextField(keySet('state_or_territory'), 'State or Territory')}
+        </Cell>
+        <Cell col={12}>
+          {this.boundSelectField(keySet('country'), 'Country', this.countryOptions)}
+        </Cell>
+        <Cell col={12}>
+          {this.boundDateField(keySet('start_date'), 'Start Date')}
+        </Cell>
+        <Cell col={12}>
+          {this.boundDateField(keySet('end_date'), 'End Date')}
+        </Cell>
+      </Grid>
+    );
+  }
+
   render () {
     return (
       <div>
-        Employment
-        <br/>
-        id: {this.props.profile.pretty_printed_student_id}
+        <Grid className="profile-tab-grid">
+          <Cell col={6}>
+            Are you currently employed?
+          </Cell>
+          <Cell col={6}>
+            {this.boundSelectField(['currently_employed'], 'Yes/No (required)', this.boolOptions)}
+          </Cell>
+        </Grid>
+        {this.editProfileObjectArray(
+          'work_history',
+          this.blankWorkHistoryEntry,
+          this.employmentEntriesForm.bind(this)
+        )}
+        <Grid className="profile-tab-grid">
+          <Cell className="profile-terms" col={6}>
+            By clicking Save, you agree to the MIT Micromasters Terms of Service and you agree to
+            receiving email from MIT.
+          </Cell>
+          <Cell col={6}>
+            <Button raised onClick={this.saveAndContinue}>
+              Save and continue
+            </Button>
+          </Cell>
+        </Grid>
       </div>
     );
   }
-}
-
-EmploymentTab.propTypes = {
-  profile:    React.PropTypes.object,
-  saveProfile:    React.PropTypes.func,
-  updateProfile:  React.PropTypes.func,
 }
 
 export default EmploymentTab;

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -3,66 +3,72 @@ import Button from 'react-mdl/lib/Button';
 
 import ProfileTab from "../util/ProfileTab";
 import { saveAndContinue } from "../util/profile_edit";
-import LANGUAGE_CODES from '../language_codes';
 
 class PersonalTab extends ProfileTab {
   constructor(props) {
     super(props);
-    this.genderOptions = [
-      { value: 'm', label: 'Male' },
-      { value: 'f', label: 'Female' },
-      { value: 'o', label: 'Other/Prefer not to say' }
-    ];
-    this.languageOptions = LANGUAGE_CODES.map(language => ({
-      value: language.alpha2,
-      label: language.English
-    }));
-    this.saveAndContinue = saveAndContinue.bind(this, '/dashboard');
+    this.saveAndContinue = saveAndContinue.bind(this, '/profile/professional');
+  }
+
+  static propTypes = {
+    profile:        React.PropTypes.object,
+    errors:         React.PropTypes.object,
+    saveProfile:    React.PropTypes.func,
+    updateProfile:  React.PropTypes.func,
+  };
+
+  static defaultProps = {
+    requiredFields: [
+      ['first_name'],
+      ['last_name'],
+      ['preferred_name'],
+      ['gender'],
+      ['preferred_language'],
+      ['city'],
+      ['country'],
+      ['birth_city'],
+      ['birth_country'],
+      ['date_of_birth'],
+    ],
+    validationMessages: {
+      'first_name': "Given name",
+      'last_name': "Family name",
+      'preferred_name': "Preferred name",
+      'gender': "Gender",
+      'preferred_language': "Preferred language",
+      'city': "City",
+      'country': "Country",
+      'birth_city': 'City',
+      'birth_country': "Country",
+      'date_of_birth': "Date of birth"
+    }
   }
 
   render() {
-    const { errors } = this.props;
     return <div>
-      {this.boundTextField("first_name", "Given name", errors.first_name)}<br />
-      {this.boundTextField("last_name", "Family name", errors.last_name)}<br />
-      {this.boundTextField("preferred_name", "Preferred name", errors.preferred_name)}<br />
-      {this.boundSelectField('gender', 'Gender', this.genderOptions, errors.gender)}<br />
+      {this.boundTextField(["first_name"], "Given name")}<br />
+      {this.boundTextField(["last_name"], "Family name")}<br />
+      {this.boundTextField(["preferred_name"], "Preferred name")}<br />
+      {this.boundSelectField(['gender'], 'Gender', this.genderOptions)}<br />
       {this.boundSelectField(
-        'preferred_language',
+        ['preferred_language'],
         'Preferred language',
-        this.languageOptions,
-        errors.preferred_language
+        this.languageOptions
       )}<br />
       <h4>Where do you live?</h4>
-      {this.boundTextField('city', 'City', errors.city)}<br />
-      {this.boundTextField(
-        'state_or_territory',
-        'State or Territory',
-        errors.state_or_territory
-      )}<br />
-      {this.boundSelectField('country', 'Country', this.countryOptions, errors.country)}<br />
+      {this.boundTextField(['city'], 'City')}<br />
+      {this.boundTextField(['state_or_territory'],'State or Territory')}<br />
+      {this.boundSelectField(['country'], 'Country', this.countryOptions)}<br />
       <h4>Where were you born?</h4>
-      {this.boundTextField('birth_city', 'City', errors.birth_city)}<br />
-      {this.boundTextField(
-        'birth_state_or_territory',
-        'State or Territory',
-        errors.birth_state_or_territory
-      )}<br />
-      {this.boundSelectField('birth_country', 'Country', this.countryOptions, errors.birth_country)}<br />
-      {this.boundDateField('date_of_birth', 'Date of birth', errors.date_of_birth)}<br />
-
+      {this.boundTextField(['birth_city'], 'City')}<br />
+      {this.boundTextField(['birth_state_or_territory'], 'State or Territory')}<br />
+      {this.boundSelectField(['birth_country'], 'Country', this.countryOptions)}<br />
+      {this.boundDateField(['date_of_birth'], 'Date of birth')}<br />
       <Button raised onClick={this.saveAndContinue}>
         Save and continue
       </Button>
     </div>;
   }
 }
-
-PersonalTab.propTypes = {
-  profile:        React.PropTypes.object,
-  errors:         React.PropTypes.object,
-  saveProfile:    React.PropTypes.func,
-  updateProfile:  React.PropTypes.func,
-};
 
 export default PersonalTab;

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -13,6 +13,17 @@ import {
 } from '../actions';
 
 class ProfilePage extends React.Component {
+  static propTypes = {
+    profile:    React.PropTypes.object.isRequired,
+    children:   React.PropTypes.node,
+    dispatch:   React.PropTypes.func.isRequired,
+    history:    React.PropTypes.object.isRequired,
+  };
+
+  static contextTypes = {
+    router: React.PropTypes.object.isRequired
+  };
+
   updateProfile(isEdit, profile) {
     const { dispatch } = this.props;
     if (!isEdit) {
@@ -21,13 +32,13 @@ class ProfilePage extends React.Component {
     dispatch(updateProfile(profile));
   }
 
-  saveProfile(isEdit, profile) {
+  saveProfile(isEdit, profile, requiredFields, messages) {
     const { dispatch } = this.props;
     if (!isEdit) {
       // Validation errors will only show up if we start the edit
       dispatch(startProfileEdit());
     }
-    return dispatch(validateProfile(profile)).then(() => {
+    return dispatch(validateProfile(profile, requiredFields, messages)).then(() => {
       dispatch(saveProfile(SETTINGS.username, profile)).then(() => {
         dispatch(clearProfileEdit());
       });
@@ -35,11 +46,10 @@ class ProfilePage extends React.Component {
   }
 
   makeTabs () {
-    const { history } = this.props;
     return this.props.route.childRoutes.map( (route) => (
       <Tab
         key={route.path}
-        onClick={() => history.push(`/profile/${route.path}`)} >
+        onClick={() => this.context.router.push(`/profile/${route.path}`)} >
         {route.path}
       </Tab>
     ));
@@ -91,13 +101,6 @@ class ProfilePage extends React.Component {
     </div>;
   }
 }
-
-ProfilePage.propTypes = {
-  profile:    React.PropTypes.object.isRequired,
-  children:   React.PropTypes.node,
-  dispatch:   React.PropTypes.func.isRequired,
-  history:    React.PropTypes.object.isRequired,
-};
 
 const mapStateToProps = state => ({
   profile: state.userProfile

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -16,6 +16,11 @@ import 'style!css!react-select/dist/react-select.css';
 // requirement for react-datepicker
 import 'style!css!react-datepicker/dist/react-datepicker.css';
 
+import entries from 'object.entries';
+if (!Object.entries) {
+  entries.shim();
+}
+
 const store = configureStore();
 
 let debug = SETTINGS.reactGaDebug === "true";

--- a/static/js/dashboard_routes.js
+++ b/static/js/dashboard_routes.js
@@ -7,6 +7,7 @@ import App from './containers/App';
 import DashboardPage from './containers/DashboardPage';
 import ProfilePage from './containers/ProfilePage';
 import PersonalTab from './components/PersonalTab';
+import EmploymentTab from './components/EmploymentTab';
 import TermsOfServicePage from './containers/TermsOfServicePage';
 
 /**
@@ -34,6 +35,7 @@ export function makeDashboardRoutes(browserHistory, store, onRouteUpdate, addDeb
           <Route path="profile" component={ProfilePage}>
             <IndexRedirect to="personal" />
             <Route path="personal" component={PersonalTab} />
+            <Route path="professional" component={EmploymentTab} />
           </Route>
           <Route path="/terms_of_service" component={TermsOfServicePage} />
         </Route>

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -50,6 +50,7 @@ import configureTestStore from 'redux-asserts';
 import rootReducer, { INITIAL_USER_PROFILE_STATE } from '../reducers';
 import assert from 'assert';
 import sinon from 'sinon';
+import PersonalTab from '../components/PersonalTab';
 
 describe('reducers', () => {
   let sandbox, store, dispatchThen;
@@ -251,11 +252,19 @@ describe('reducers', () => {
       store.dispatch(receiveGetUserProfileSuccess(USER_PROFILE_RESPONSE));
       store.dispatch(startProfileEdit());
 
-      dispatchThen(validateProfile(USER_PROFILE_RESPONSE), [UPDATE_PROFILE_VALIDATION]).then(profileState => {
+      dispatchThen(validateProfile(
+        USER_PROFILE_RESPONSE,
+        PersonalTab.defaultProps.requiredFields,
+        PersonalTab.defaultProps.validationMessages
+      ), [UPDATE_PROFILE_VALIDATION]).then(profileState => {
         assert.deepEqual(profileState.edit.errors, {});
 
         // also assert that it returns a resolved promise
-        store.dispatch(validateProfile(USER_PROFILE_RESPONSE)).then(() => {
+        store.dispatch(validateProfile(
+          USER_PROFILE_RESPONSE,
+          PersonalTab.defaultProps.requiredFields,
+          PersonalTab.defaultProps.validationMessages
+        )).then(() => {
           done();
         });
       });
@@ -265,21 +274,73 @@ describe('reducers', () => {
       let profileWithError = Object.assign({}, USER_PROFILE_RESPONSE, {
         first_name: ''
       });
+      let keysToCheck = [["first_name"]];
+      let messages = {"first_name": "Given name"};
 
       // populate a profile
       store.dispatch(receiveGetUserProfileSuccess(USER_PROFILE_RESPONSE));
       store.dispatch(startProfileEdit());
-      dispatchThen(validateProfile(profileWithError), [UPDATE_PROFILE_VALIDATION]).then(profileState => {
+      dispatchThen(validateProfile(
+        profileWithError,
+        keysToCheck,
+        messages
+      ), [UPDATE_PROFILE_VALIDATION]).then(profileState => {
         assert.deepEqual(profileState.edit.errors, {
           first_name: 'Given name is required'
         });
 
         // also assert that it returns a rejected promise
-        store.dispatch(validateProfile(profileWithError)).catch(() => {
+        store.dispatch(validateProfile(
+          profileWithError,
+          keysToCheck,
+          messages
+        )).catch(() => {
           done();
         });
       });
     });
+
+    it('should validate a profile with nested objects and errors', done => {
+      let profileWithError = Object.assign({}, USER_PROFILE_RESPONSE, {
+        work_history: [{
+          company_name: "foocorp",
+          position: undefined
+        }]
+      });
+      let keysToCheck = [
+        ["work_history", 0, "company_name"],
+        ["work_history", 0, "position"],
+      ];
+      let messages = {
+        "company_name": "Company name",
+        "position": "Position",
+      };
+
+      // populate a profile
+      store.dispatch(receiveGetUserProfileSuccess(USER_PROFILE_RESPONSE));
+      store.dispatch(startProfileEdit());
+      dispatchThen(validateProfile(
+        profileWithError,
+        keysToCheck,
+        messages
+      ), [UPDATE_PROFILE_VALIDATION]).then(profileState => {
+        assert.deepEqual(profileState.edit.errors, {
+          work_history: [
+            {position: 'Position is required'}
+          ]
+        });
+
+        // also assert that it returns a rejected promise
+        store.dispatch(validateProfile(
+          profileWithError,
+          keysToCheck,
+          messages
+        )).catch(() => {
+          done();
+        });
+      });
+    });
+
 
     it("can't edit a profile if we never get it successfully", done => {
       dispatchThen(startProfileEdit(), [START_PROFILE_EDIT]).then(profileState => {

--- a/static/js/util/ProfileTab.js
+++ b/static/js/util/ProfileTab.js
@@ -4,20 +4,44 @@ import {
   boundDateField,
   boundTextField,
   boundSelectField,
+  editProfileObjectArray,
 } from './profile_edit';
 import COUNTRIES from '../countries';
+import LANGUAGE_CODES from '../language_codes';
 
 class ProfileTab extends React.Component {
   constructor(props) {
     super(props);
+
+    // bind our field methods to this
     this.boundTextField = boundTextField.bind(this);
     this.boundSelectField = boundSelectField.bind(this);
     this.boundDateField = boundDateField.bind(this);
+    this.editProfileObjectArray = editProfileObjectArray.bind(this);
+
+    // options we set (for select components)
     this.countryOptions = COUNTRIES.map(country => ({
       value: country.Code,
       label: country.Name
     }));
+    this.boolOptions = [
+      { value: 'yes', label: 'Yes' },
+      { value: 'no', label: 'No' }
+    ];
+    this.genderOptions = [
+      { value: 'm', label: 'Male' },
+      { value: 'f', label: 'Female' },
+      { value: 'o', label: 'Other/Prefer not to say' }
+    ];
+    this.languageOptions = LANGUAGE_CODES.map(language => ({
+      value: language.alpha2,
+      label: language.English
+    }));
   }
+
+  static contextTypes = {
+    router: React.PropTypes.object.isRequired
+  };
 }
 
 export default ProfileTab;

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -2,8 +2,10 @@ import React from 'react';
 import TextField from 'react-mdl/lib/Textfield';
 import Select from 'react-select';
 import DatePicker from 'react-datepicker';
-import { browserHistory } from 'react-router';
+import Button from 'react-mdl/lib/Button';
+import Grid, { Cell } from 'react-mdl/lib/Grid';
 import moment from 'moment';
+import _ from 'lodash';
 
 // utility functions for pushing changes to profile forms back to the
 // redux store.
@@ -12,19 +14,26 @@ import moment from 'moment';
 
 // bind to this.boundTextField in the constructor of a form component
 // to update text fields when editing the profile
-export function boundTextField(key, label, error) {
-  const { updateProfile, profile } = this.props;
+// we pass in a keyset looking like this:
+//
+// ["top-level-key", index, "nested_object_key"] or just ["top_level_key"]
+export function boundTextField(keySet, label) {
+  const {
+    profile,
+    errors,
+    updateProfile
+  } = this.props;
   let onChange = e => {
-    let clone = Object.assign({}, profile);
-    clone[key] = e.target.value;
+    let clone = _.cloneDeep(profile);
+    _.set(clone, keySet, e.target.value);
     updateProfile(clone);
   };
   return (
     <TextField
       floatingLabel
       label={label}
-      value={profile[key]}
-      error={error}
+      value={_.get(profile, keySet)}
+      error={_.get(errors, keySet)}
       onChange={onChange} />
   );
 }
@@ -32,35 +41,44 @@ export function boundTextField(key, label, error) {
 // bind this to this.boundSelectField in the constructor of a form component
 // to update select fields
 // pass in the name (used as placeholder), key for profile, and the options.
-export function boundSelectField(key, label, options, error) {
-  const { updateProfile, profile } = this.props;
+export function boundSelectField(keySet, label, options) {
+  const {
+    profile,
+    errors,
+    updateProfile,
+  } = this.props;
   let onChange = value => {
-    let clone = Object.assign({}, profile);
-    clone[key] = value ? value.value : null;
+    let clone = _.cloneDeep(profile);
+    _.set(clone, keySet, value? value.value : null)
     updateProfile(clone);
   };
   return <div>
     <Select
       options={options}
-      value={profile[key]}
+      value={_.get(profile, keySet)}
       placeholder={label}
       onChange={onChange} />
-    <span className="validation-error-text">{error}</span>
+    <span className="validation-error-text">{_.get(errors, keySet)}</span>
   </div>;
 }
 
 // bind this to this.boundSelectField in the constructor of a form component
 // to update select fields
 // pass in the name (used as placeholder), key for profile, and the options.
-export function boundDateField(key, label, error) {
-  const { updateProfile, profile } = this.props;
+export function boundDateField(keySet, label) {
+  const {
+    profile,
+    errors,
+    updateProfile,
+  } = this.props;
+
   let onChange = date => {
-    let clone = Object.assign({}, profile);
+    let clone = _.cloneDeep(profile);
     // format as ISO-8601
-    clone[key] = date.format("YYYY-MM-DD");
-    updateProfile(clone);
+    _.set(clone, keySet, date.format("YYYY-MM-DD"));
+    updateProfile(clone)
   };
-  let newDate = profile[key] ? moment(profile[key], "YYYY-MM-DD") : null;
+  let newDate = _.get(profile, keySet) ? moment(_.get(profile, keySet), "YYYY-MM-DD") : null;
   return <div>
     <DatePicker
       selected={newDate}
@@ -68,16 +86,73 @@ export function boundDateField(key, label, error) {
       showYearDropdown
       onChange={onChange}
     />
-    <span className="validation-error-text">{error}</span>
+    <span className="validation-error-text">{_.get(errors, keySet)}</span>
   </div>;
 }
 
 
 // bind to this.saveAndContinue.bind(this, '/next/url')
-export function saveAndContinue(next) {
-  const { saveProfile, profile } = this.props;
+// pass an option callback if you need nested validation
+// (see EmploymentTab for an example)
+export function saveAndContinue(next, nestedValidationCallback) {
+  const {
+    saveProfile,
+    profile,
+    requiredFields,
+    validationMessages
+  } = this.props;
 
-  saveProfile(profile).then(() => {
-    browserHistory.push(next)
+  let fields;
+  if ( _.isFunction(nestedValidationCallback) ) {
+    fields = nestedValidationCallback(profile, requiredFields);
+  } else {
+    fields = requiredFields;
+  }
+
+  saveProfile( profile, fields, validationMessages).then(() => {
+    this.context.router.push(next)
   });
+}
+
+// allows editing an array of objects stored in the profile
+// params:
+//    arrayName: key the array is stored under on the profile
+//    blankEntry: an object with the requisite fields, with undefined, "", or null values
+//    formCallBank: a function that takes an index (into the object array) and draws
+//      ui (using boundTextField and so on) to edit an object in the array
+export function editProfileObjectArray (arrayName, blankEntry, formCallback) {
+  const { updateProfile, profile } = this.props;
+  if ( profile.hasOwnProperty(arrayName) && !_.isEmpty(profile[arrayName]) ) {
+    let editForms = profile[arrayName].map((v, i) => formCallback(i));
+    let addAnotherBlankEntry = () => {
+      let clone = Object.assign({}, profile);
+      clone[arrayName] = clone[arrayName].concat(blankEntry);
+      updateProfile(clone);
+    }
+    editForms.push(
+      <Grid className="profile-tab-grid" key={arrayName}>
+        <Cell col={12} align='middle'>
+          <Button onClick={addAnotherBlankEntry}>
+            Add another entry
+          </Button>
+        </Cell>
+      </Grid>
+    );
+    return editForms;
+  } else {
+    let startEditing = () => {
+      let clone = Object.assign({}, profile);
+      clone[arrayName] = [blankEntry];
+      updateProfile(clone);
+    }
+    return (
+      <Grid className="profile-tab-grid">
+        <Cell col={12} align='middle'>
+          <Button onClick={startEditing}>
+            Start Editing
+          </Button>
+        </Cell>
+      </Grid>
+    );
+  }
 }

--- a/static/js/util/profile_edit_test.js
+++ b/static/js/util/profile_edit_test.js
@@ -1,0 +1,116 @@
+import assert from 'assert';
+import moment from 'moment';
+
+import {
+  boundTextField,
+  boundDateField,
+  boundSelectField
+} from './profile_edit';
+
+describe('Profile Editing utility functions', () => {
+  let that;
+  const change = (clone) => that.props.profile = clone;
+  beforeEach(() => {
+    that = {
+      props: {
+        profile: {
+          "first_name": "",
+          "date_of_birth": "",
+          "gender": undefined,
+        },
+        errors: {
+          "first_name": "First name is required",
+          "date_of_birth": "Date of birth is required",
+          "gender": "Gender is required",
+        },
+        updateProfile: change
+      }
+    };
+  });
+
+  describe('Bound Text field', () => {
+    let textField;
+    beforeEach(() => {
+      textField = boundTextField.call(
+        that,
+        ["first_name"],
+        "First Name"
+      );
+    });
+
+    it('should correctly set props on itself', () => {
+      assert.deepEqual('First Name', textField.props.label);
+      assert.deepEqual('First name is required', textField.props.error);
+      assert.deepEqual('', textField.props.value);
+      assert.deepEqual(true, textField.props.floatingLabel);
+    });
+
+    it('should call the updateProfile callback when onChange fires', () => {
+      textField.props.onChange({target: {value: "foo"}});
+      assert.deepEqual("foo", that.props.profile.first_name);
+    });
+  });
+
+  describe('Bound Date field', () => {
+    let dateField, dateElement, errorText;
+    beforeEach(() => {
+      dateField = boundDateField.call(
+        that,
+        ["date_of_birth"],
+        "Date of birth"
+      );
+      dateElement = dateField.props.children[0];
+      errorText = dateField.props.children[1];
+    });
+
+    it('should correctly set props on itself', () => {
+      assert.equal('Date of birth', dateElement.props.placeholderText);
+      assert.equal(errorText.type, 'span');
+      assert.deepEqual({
+        className: 'validation-error-text',
+        children: "Date of birth is required",
+      }, errorText.props);
+    });
+
+    it('should call the updateProfile callback when onChange fires', () => {
+      let cur = moment();
+      dateElement.props.onChange(cur);
+      assert.deepEqual(cur.format('YYYY-MM-DD'), that.props.profile.date_of_birth)
+    });
+  });
+
+  describe('Bound select field', () => {
+    let selectField, selectElement, errorText;
+    let genderOptions = [
+      { value: 'm', label: 'Male' },
+      { value: 'f', label: 'Female' },
+      { value: 'o', label: 'Other/Prefer not to say' }
+    ];
+
+    beforeEach(() => {
+      selectField = boundSelectField.call(
+        that,
+        ['gender'],
+        "Gender",
+        genderOptions
+      );
+      selectElement = selectField.props.children[0];
+      errorText = selectField.props.children[1];
+    });
+
+    it('should set props correctly', () => {
+      assert.deepEqual(selectElement.props.options, genderOptions);
+      assert.equal(selectElement.props.placeholder, 'Gender');
+      assert.equal(selectElement.props.value, undefined);
+      assert.deepEqual({
+        className: 'validation-error-text',
+        children: "Gender is required",
+      }, errorText.props);
+    });
+
+    it('should call the updateProfile callback when onChange fires', () => {
+      selectElement.props.onChange(genderOptions[1]);
+      assert.equal(that.props.profile.gender, 'f');
+    });
+  });
+});

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -4,6 +4,7 @@ import ga from 'react-ga';
 import moment from 'moment';
 import Button from 'react-bootstrap/lib/Button';
 import striptags from 'striptags';
+import _ from 'lodash';
 
 import {
   STATUS_PASSED,
@@ -178,30 +179,17 @@ export function makeCourseProgressDisplay(course, isFirst, isLast) {
  * @param {Object} profile The user profile
  * @returns {Object} Validation errors or an empty object if no errors
  */
-export function validateProfile(profile) {
+export function validateProfile(profile, requiredFields, messages) {
   let errors = {};
-
-  let required = {
-    'first_name': "Given name",
-    'last_name': "Family name",
-    'preferred_name': "Preferred name",
-    'gender': "Gender",
-    'preferred_language': "Preferred language",
-    'city': "City",
-    'country': "Country",
-    'birth_city': 'City',
-    'birth_country': "Country",
-    'date_of_birth': "Date of birth"
-  };
-
-  for (let key of Object.keys(required)) {
-    if (!profile[key]) {
-      errors[key] = `${required[key]} is required`;
+  for (let keySet of requiredFields) {
+    let val = _.get(profile, keySet);
+    if (_.isUndefined(val) || _.isNull(val) || val === "" ) {
+      _.set(errors, keySet,  `${messages[keySet.slice(-1)[0]]} is required`);
     }
   }
-
   return errors;
 }
+
 /* eslint-enable camelcase */
 
 /**

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -242,35 +242,73 @@ describe('utility functions', () => {
   });
 
   describe("validateProfile", () => {
+    let requiredFields = [
+      ['first_name'],
+      ['last_name'],
+      ['preferred_name'],
+      ['gender'],
+      ['preferred_language'],
+      ['city'],
+      ['country'],
+      ['birth_city'],
+      ['birth_country'],
+      ['date_of_birth'],
+    ];
+
+    let messages = {
+      'first_name': 'First Name',
+      'last_name': 'Last Name',
+      'preferred_name': 'Preferred Name',
+      'gender': 'Gender',
+      'preferred_language': 'Preferred language',
+      'city': 'City',
+      'country': 'Country',
+      'birth_city': 'Birth City',
+      'birth_country': 'Birth Country',
+      'date_of_birth': 'Birth Date',
+    };
+
     it('validates the test profile successfully', () => {
-      let errors = validateProfile(USER_PROFILE_RESPONSE);
+      let errors = validateProfile(USER_PROFILE_RESPONSE, requiredFields, messages);
       assert.deepEqual(errors, {});
     });
 
     it('validates required fields', () => {
-      let requiredFields = [
-        'first_name',
-        'last_name',
-        'preferred_name',
-        'gender',
-        'preferred_language',
-        'city',
-        'country',
-        'birth_city',
-        'birth_country',
-        'date_of_birth',
-      ];
-
       let profile = {};
       for (let key of requiredFields) {
-        profile[key] = '';
+        profile[key[0]] = '';
       }
 
-      let errors = validateProfile(profile);
+      let errors = validateProfile(profile, requiredFields, messages);
       for (let key of requiredFields) {
         let error = errors[key];
         assert.ok(error.indexOf("is required") !== -1);
       }
+    });
+
+    it('validates nested fields', () => {
+      let profile = {
+        nested_array: [{foo: "bar", baz: null}]
+      };
+      const keysToCheck = [
+        ["nested_array", 0, "foo"],
+        ["nested_array", 0, "baz"],
+      ];
+      const nestMessages = {"baz": "Baz"};
+      let errors = validateProfile(profile, keysToCheck, nestMessages);
+      assert.deepEqual({nested_array: [ { baz: "Baz is required" } ] }, errors);
+    });
+
+    it('correctly validates fields with 0', () => {
+      let profile = {
+        nested_array: [{foo: 0}]
+      };
+      const keysToCheck = [
+        ["nested_array", 0, "foo"]
+      ];
+      const nestMessages = {"foo": "Foo"};
+      let errors = validateProfile(profile, keysToCheck, nestMessages);
+      assert.deepEqual({}, errors);
     });
   });
 });

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -1,4 +1,11 @@
 #dashboard {
+  .validation-wrapper {
+    padding-bottom: 10px;
+  }
+  .validation-error-text {
+    color: #DA0000;
+    font-size: smaller;
+  }
   .main-content {
     @include outer-container;
 
@@ -111,5 +118,9 @@
       @include omega(3n);
       text-align: center;
     }
+  }
+
+  .profile-tab-grid {
+    max-width: 900px;
   }
 }

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -35,14 +35,6 @@ body {
     height: auto;
 }
 
-.validation-wrapper {
-  padding-bottom: 10px;
-}
-.validation-error-text {
-  color: red;
-  font-size: smaller;
-}
-
 .responsive-object {
     position: relative;
 }

--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -21,7 +21,7 @@ module.exports = {
         exclude: /node_modules/,
         loader: 'babel-loader',
         query: {
-          presets: ['es2015', 'react']
+          presets: ['es2015', 'stage-1', 'react']
         }
       },  // to transform JSX into JS
       {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #150 

#### What's this PR do?

this adds an 'employment' tab to the profile editing page.

#### Where should the reviewer start?

There are a lot of changes. I would start by reviewing the changes to the `bound${inputType}Field` methods in `util/profile_edit` and the changes to the validation logic (in `util/util`).

#### How should this be manually tested?

Pull down the branch, and make sure you can edit all the fields on the employment and personal tabs, and that they are all correctly validated.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

![dogtongue](https://cloud.githubusercontent.com/assets/6207644/14924685/b4db3696-0e11-11e6-99ac-000054ee9987.gif)


