### PR TITLE
Deleted the `employment` route placeholder

### DIFF
--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -18,7 +18,7 @@ class PersonalTab extends React.Component {
       value: language.alpha2,
       label: language.English
     }));
-    this.saveAndContinue = saveAndContinue.bind(this, '/profile/professional');
+    this.saveAndContinue = saveAndContinue.bind(this, '/dashboard');
   }
 
   render() {

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -6,7 +6,6 @@ import App from './containers/App';
 import DashboardPage from './containers/DashboardPage';
 import ProfilePage from './containers/ProfilePage';
 import PersonalTab from './components/PersonalTab';
-import EmploymentTab from './components/EmploymentTab';
 import { Provider } from 'react-redux';
 import configureStore from './store/configureStore';
 import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react';
@@ -41,7 +40,6 @@ ReactDOM.render(
           <Route path="profile" component={ProfilePage}>
             <IndexRedirect to="personal" />
             <Route path="personal" component={PersonalTab} />
-            <Route path="professional" component={EmploymentTab} />
           </Route>
         </Route>
       </Router>


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

This removes the employment route placeholder from our router. We
probably aren't going to have the employment tab ready in time for the
demo, and we'd rather not show off the placeholder.

    modified:   static/js/dashboard.js

This just removes the route for the `EmploymentTab` component.

    modified:   static/js/components/PersonalTab.js

This sets the `PersonalTab` component to redirect to `/dashboard` on
save, instead of to `/profile/professional`.

#### Where should the reviewer start?

#### How should this be manually tested?

Make sure nothing is wacky with react-router.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

