### PR TITLE
Added course progress indicator for dashboard

### DIFF
--- a/static/js/components/CourseList.js
+++ b/static/js/components/CourseList.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import _ from 'lodash';
 
-import { makeCourseStatusDisplay } from '../util/util';
+import {
+  makeCourseStatusDisplay,
+  makeCourseProgressDisplay,
+} from '../util/util';
 
 class CourseList extends React.Component {
   render() {
@@ -9,27 +12,37 @@ class CourseList extends React.Component {
 
     let sortedCourses = _.sortBy(dashboard.courses, 'position_in_program');
 
-    let table = sortedCourses.map(course => {
+    let table = sortedCourses.map((course, i) => {
       // id number is not guaranteed to exist here so we need to use the whole
       // object to test uniqueness
       // TODO: fix this when we refactor
+
+      let isTop = i === 0;
+      let isBottom = i === sortedCourses.length - 1;
+
       return <ul
         key={JSON.stringify(course)}
-        className={"course-list-status-" + course.status}
+        className={"course-list-body course-list-status-" + course.status}
       >
-        <li>
+        <li className="course-title">
           {course.title}
         </li>
-        <li>
+        <li className="course-status">
           {makeCourseStatusDisplay(course)}
+        </li>
+        <li className="course-progress">
+          {makeCourseProgressDisplay(course, isTop, isBottom)}
         </li>
       </ul>;
     });
 
     return <div className="course-list">
       <ul className="course-list-header">
-        <li />
-        <li />
+        <li className="course-title" />
+        <li className="course-status " />
+        <li className="course-progress">
+          Progress
+        </li>
       </ul>
       {table}
     </div>;

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import ga from 'react-ga';
 import moment from 'moment';
 import Button from 'react-bootstrap/lib/Button';
+import striptags from 'striptags';
 
 import {
   STATUS_PASSED,
@@ -96,6 +98,69 @@ export function makeCourseStatusDisplay(course, now = moment()) {
   }
 }
 
+/**
+ * Determine progress React element for the UI given a course
+ * @param {object} course A course coming from the dashboard
+ * @param {bool} isFirst If false, draw a line up to the previous course
+ * @param {bool} isLast If false, draw a line down to the next course
+ * @returns {ReactElement} Some React element or string to display for course status
+ */
+export function makeCourseProgressDisplay(course, isFirst, isLast) {
+  let height = 70, outerRadius = 10, innerRadius = 8, width = 30, color="#7fbaec";
+  let centerX = width/2, centerY = height/2;
+
+  let topLine;
+  if (!isFirst) {
+    topLine = <line
+      x1={centerX}
+      x2={centerX}
+      y1={0}
+      y2={centerY - outerRadius}
+      stroke={color}
+      strokeWidth={1}
+    />;
+  }
+  let bottomLine;
+  if (!isLast) {
+    bottomLine = <line
+      x1={centerX}
+      x2={centerX}
+      y1={centerY + outerRadius}
+      y2={height}
+      stroke={color}
+      strokeWidth={1}
+    />;
+  }
+
+  let alt = "Course not started";
+  let innerElement;
+  if (course.status === STATUS_PASSED) {
+    // full circle to indicate course passed
+    alt = "Course passed";
+    innerElement = <circle cx={centerX} cy={centerY} r={innerRadius} fill={color} />;
+  } else if (course.status === STATUS_VERIFIED_NOT_COMPLETED) {
+    alt = "Course started";
+    // semi circle on the left side
+    // see path docs: https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#Arcs
+    let path = [
+      "M", centerX, centerY - innerRadius,
+      "A", innerRadius, innerRadius, 0, 0, 0, centerX, centerY + innerRadius
+    ].join(" ");
+    innerElement = <path
+      d={path}
+      fill={color}
+    />;
+  }
+
+  return <svg style={{width: width, height: height}}>
+    <desc>{alt}</desc>
+    <circle cx={centerX} cy={centerY} r={outerRadius} stroke={color} fillOpacity={0} />
+    {innerElement}
+    {topLine}
+    {bottomLine}
+  </svg>;
+}
+
 /* eslint-disable camelcase */
 /**
  * Validates the profile
@@ -128,3 +193,17 @@ export function validateProfile(profile) {
   return errors;
 }
 /* eslint-enable camelcase */
+
+/**
+ * Returns the string with any HTML rendered and then its tags stripped
+ * @return {String} rendered text stripped of HTML
+ */
+export function makeStrippedHtml(textOrElement) {
+  if (React.isValidElement(textOrElement)) {
+    let container = document.createElement("div");
+    ReactDOM.render(textOrElement, container);
+    return striptags(container.innerHTML);
+  } else {
+    return striptags(textOrElement);
+  }
+}

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -1,8 +1,6 @@
 import assert from 'assert';
 import moment from 'moment';
 import React from 'react';
-import ReactDOM from 'react-dom';
-import striptags from 'striptags';
 
 import {
   STATUS_NOT_OFFERED,
@@ -15,29 +13,30 @@ import {
 } from '../constants';
 import {
   makeCourseStatusDisplay,
+  makeCourseProgressDisplay,
   validateProfile,
+  makeStrippedHtml,
 } from '../util/util';
 
 /* eslint-disable camelcase */
 describe('utility functions', () => {
+  describe('makeStrippedHtml', () => {
+    it('strips HTML from a string', () => {
+      assert.equal(makeStrippedHtml("<a href='x'>y</a>"), "y");
+    });
+    it('strips HTML from a react element', () => {
+      assert.equal(makeStrippedHtml(<div><strong>text</strong></div>), "text");
+    });
+  });
+
   describe("makeCourseStatusDisplay", () => {
     let yesterday = '2016-03-30';
     let today = '2016-03-31';
     let tomorrow = '2016-04-01';
 
-    /**
-     * Returns the string with any HTML rendered and then its tags stripped
-     * @return {String} rendered text stripped of HTML
-     */
     let renderCourseStatusDisplay = (...args) => {
       let textOrElement = makeCourseStatusDisplay(...args);
-      if (React.isValidElement(textOrElement)) {
-        let container = document.createElement("div");
-        ReactDOM.render(textOrElement, container);
-        return striptags(container.innerHTML);
-      } else {
-        return textOrElement;
-      }
+      return makeStrippedHtml(textOrElement);
     };
 
     it('is a passed a course', () => {
@@ -168,6 +167,47 @@ describe('utility functions', () => {
         status: "missing"
       }), "");
     });
+  });
+
+  describe("makeCourseStatusDisplay", () => {
+    let renderCourseProgressDisplay = (...args) => {
+      let textOrElement = makeCourseProgressDisplay(...args);
+      return makeStrippedHtml(textOrElement);
+    };
+
+    it('is a course which is passed', () => {
+      assert.equal(
+        renderCourseProgressDisplay({
+          status: STATUS_PASSED
+        }),
+        "Course passed"
+      );
+    });
+
+    it('is a course which is in progress', () => {
+      assert.equal(
+        renderCourseProgressDisplay({
+          status: STATUS_VERIFIED_NOT_COMPLETED
+        }),
+        "Course started"
+      );
+    });
+
+    it('is a course which is not passed or in progress', () => {
+      for (let status of [
+        STATUS_NOT_PASSED,
+        STATUS_ENROLLED_NOT_VERIFIED,
+        STATUS_OFFERED_NOT_ENROLLED,
+        STATUS_NOT_OFFERED,
+      ]) {
+        assert.equal(
+          renderCourseProgressDisplay({
+            status: status
+          }),
+          "Course not started"
+        );
+      }
+    })
   });
 
   describe("validateProfile", () => {

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -65,26 +65,49 @@
       @include span-columns(8 of 8);
       border-bottom: 1px solid lightgray;
       margin: 0px;
+      display: flex;
+      align-items: center;
+      height: 70px; // same as progress indicator, see makeCourseProgressDisplay
     }
     ul:last-child {
       border-bottom: 0px;
+    }
+
+    li {
+      display: block;
     }
 
     .course-list-header {
       background-color: #eff5f7;
       font-weight: bold;
       font-size: larger;
+
+      .course-progress {
+        font-weight: normal;
+        font-size: small;
+      }
     }
 
-    li {
+    .course-list-body {
+      .course-status {
+        text-align: right;
+      }
+    }
+
+    .course-title {
       @include span-columns(4 of 8);
-      @include omega(2n);
-      display: block;
-      padding: 15px;
+      @include omega(3n);
     }
 
-    li:last-child {
-      text-align: right;
+    .course-status {
+      @include span-columns(3 of 8);
+      @include omega(3n);
+    }
+
+    .course-progress {
+      @include span-columns(1 of 8);
+      @include omega(3n);
+      text-align: center;
     }
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #105

#### What's this PR do?
Adds a column to the dashboard display and draws a circle based on the course status. 

#### Where should the reviewer start?

#### How should this be manually tested?
Add some courses with different statuses (or change `api.getDashboard()` to use the `DASHBOARD_RESPONSE` constant). Then view them in the UI. A course which is passed has a full circle, a course which is verified but not passed has a half circle, and all other courses have a empty circle. Each circle should connect exactly with the circles above and below it.

#### Any background context you want to provide?

#### Screenshots (if appropriate)
![screenshot from 2016-04-22 14-45-04](https://cloud.githubusercontent.com/assets/863262/14751642/d761f156-0898-11e6-9e0b-09f7c34a113b.png)


#### What GIF best describes this PR or how it makes you feel?

