### PR TITLE
Certificates taken in account in dashboard

### DIFF
--- a/dashboard/fixtures/certificates.json
+++ b/dashboard/fixtures/certificates.json
@@ -1,0 +1,18 @@
+[
+	{
+	    "username": "staff",
+	    "course_id": "course-v1:edX+DemoX+Demo_Course",
+	    "certificate_type": "verified",
+	    "status": "downloadable",
+	    "download_url": "http://www.example.com/demo.pdf",
+	    "grade": "0.98"
+	},
+	{
+	    "username": "staff",
+	    "course_id": "course-v1:MITx+8.MechCX+2014_T1",
+	    "certificate_type": "honor",
+	    "status": "downloadable",
+	    "download_url": "http://www.example.com/mechcx.pdf",
+	    "grade": "0.88"
+	}
+]

--- a/dashboard/fixtures/user_enrollments.json
+++ b/dashboard/fixtures/user_enrollments.json
@@ -9,9 +9,9 @@
                     "description": null,
                     "expiration_datetime": null,
                     "min_price": 0,
-                    "name": "Audit",
+                    "name": "Verified",
                     "sku": null,
-                    "slug": "audit",
+                    "slug": "verified",
                     "suggested_prices": ""
                 }
             ],

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -42,13 +42,16 @@ class UserDashboard(APIView):
         edx_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL)
         # get an enrollments client for the student
         enrollments = edx_client.enrollments.get_student_enrollments()
+        # get a certificates client for the student
+        certificates = edx_client.certificates.get_student_certificates(
+            request.user.username, enrollments.get_enrolled_course_ids())
 
         response_data = {'courses': []}
         for program in Program.objects.all():
             for course in program.course_set.all():
                 response_data['courses'].append(
                     get_info_for_course(
-                        request.user, course, enrollments, user_certificates=None)
+                        request.user, course, enrollments, user_certificates=certificates)
                 )
 
         response_data['courses'].sort(key=lambda x: x['position_in_program'])


### PR DESCRIPTION
#### What are the relevant tickets?

#### What's this PR do?
Takes in account certificates in the dashboard

#### Where should the reviewer start?
dashboard/api.py

#### How should this be manually tested?
In Micromasters, the course needs to be "past", meaning the end date should be past.
In EDX, you need to create a verified enrollment and certificate for the micromaster course for a user.
To manually create a certificate for a user `bob` for a course `course-v1:odl+GIO101+CR-FALL15`:
```
from certificates.models import CertificateStatuses
from certificates.tests.factories import GeneratedCertificateFactory
from django.contrib.auth.models import User
from opaque_keys.edx.keys import CourseKey
bob = User.objects.get(username='bob')
course_key = CourseKey.from_string('course-v1:odl+GIO101+CR-FALL15')
GeneratedCertificateFactory.create(user= bob, course_id=course_key, status=CertificateStatuses.downloadable, mode='verified', download_url='www.google.com', grade="0.88",)
```
Make sure the user `bob` is enrolled in the course, then change the enrollment mode to `verified` in the following way:
```
from course_modes.models import CourseMode
from enrollment.api import update_enrollment
CourseMode.objects.create(course_id=course_key, mode_slug='verified', mode_display_name='Gio verified', min_price=50, )
update_enrollment('bob', 'course-v1:odl+GIO101+CR-FALL15', mode='verified')

```
#### Any background context you want to provide?
You need to rebuild `web` because the `edx-api-client` library has changed.
You also need the latest edx master to use the certificate rest apis


