### PR TITLE
Removed node-sass rebuild step

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,7 @@ watch:
   image: micromasters_web
   command: >
     /bin/bash -c '
-    npm cache clean &&
     npm install --no-bin-links &&
-    npm rebuild node-sass &&
     echo Finished npm install &&
     node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.config.dev.js -d --content-base ./static --host 0.0.0.0 --port 8078 --progress --inline --hot'
   ports:


### PR DESCRIPTION
#### What are the relevant tickets?

#### What's this PR do?
This removes the `node rebuild node-sass` step which was introduced here: https://github.com/mitodl/teachersportal/pull/43. I don't think anyone uses the OS X libsass library so I believe this isn't useful.

#### Where should the reviewer start?

#### How should this be manually tested?
Make sure `docker-compose up` still works fine

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

