### PR TITLE
Added script to run development server on OS X without docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ codekit-config.json
 
 # Django static
 staticfiles/
+
+.venv

--- a/osx_start.sh
+++ b/osx_start.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euf -o pipefail
+set -a
+
+export NODE_ENV=development
+export DEBUG=True
+export PORT=8079
+export COVERAGE_DIR=htmlcov
+export DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
+export MICROMASTERS_USE_WEBPACK_DEV_SERVER=True
+export MICROMASTERS_SECURE_SSL_REDIRECT=False
+export MICROMASTERS_DB_DISABLE_SSL=True
+
+# Workaround for a python package complaining about uwsgi not having a compiler
+# http://stackoverflow.com/questions/11669594/error-while-installing-uwsgi-on-mac
+export CC=gcc
+
+source .env
+
+# Before this script is run make sure that:
+# - Python3 is installed from the official Python 3 installer
+# - Postgres 9.x is installed
+# - A user 'postgres' exists with password 'postgres'
+
+if ! which psql
+then
+    echo "postgres must be installed first."
+    exit 1
+fi
+
+if ! which python3
+then
+    echo "Python 3 must be installed first."
+    exit 1
+fi
+
+if ! which npm
+then
+    echo "Node JS must be installed first."
+    exit 1
+fi
+
+if [[ ! -d ".venv" ]]
+then
+    virtualenv .venv -p $(which python3)
+fi
+
+# Update requirements (should be fast if already present)
+.venv/bin/pip install -r requirements.txt
+.venv/bin/pip install -r test_requirements.txt
+
+npm install
+
+# required to link with libsass
+npm rebuild node-sass
+
+# Postgres is assumed to be running already
+.venv/bin/python3 ./manage.py migrate
+.venv/bin/python3 manage.py runserver 0.0.0.0:8079 &
+export DJANGO_PID=$!
+
+node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.config.dev.js -d --content-base ./static --host 0.0.0.0 --port 8078 --progress --inline --hot &
+export WEBPACK_PID=$!
+
+trap "echo Killing Django $DJANGO_PID, Webpack $WEBPACK_PID; pkill -TERM -P $DJANGO_PID; pkill -TERM -P $WEBPACK_PID; echo Exiting..." INT TERM
+
+echo "--- Servers are started"
+wait $DJANGO_PID
+wait $WEBPACK_PID
+
+echo "--- Servers are stopped"


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #142

#### What's this PR do?
Provides a script to let OS X users (and Linux users) run the webserver and webpack dev servers from the host environment instead of within Docker.

#### Where should the reviewer start?

#### How should this be manually tested?
This requires a whole lot of manual installation steps compared to Docker setup, but it should make the development process easier:
 - Postgres must be installed and its binaries added to the `$PATH`
 - The postgres user must have the password 'postgres'
 - Python 3 should be installed
 - Node JS 4.x or later should be installed
 - All dependencies of the various Python libraries need to be installed first. (There are many here.)

After the manual installation is done, the user should just need to run `./osx_start.sh`. The python and npm dependencies will be installed, then the servers will start. The script will trap SIGTERM and SIGINT to kill these servers when Ctrl+C is pressed.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

