### PR TITLE
Pointing the edx-api-client requirement to release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ tox==2.3.1
 uwsgi==2.0.12
 Pillow==3.1.1
 wagtail==1.4.3
--e git+git://github.com/mitodl/edx-api-client.git#egg=edx-api-client
+edx-api-client==0.2.0


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #231
#### What's this PR do?
changes the `edx-api` client from dev to named release
