### PR TITLE
Fixed JS console error with react-router history

### DIFF
--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -58,13 +58,13 @@ class App extends React.Component {
   }
 
   requireTermsOfService() {
-    const { userProfile, location: { pathname }, history } = this.props;
+    const { userProfile, location: { pathname } } = this.props;
     if (
       userProfile.getStatus === FETCH_SUCCESS &&
       !userProfile.profile.agreed_to_terms_of_service &&
       !(TERMS_OF_SERVICE_REGEX.test(pathname))
     ) {
-      history.push('/terms_of_service');
+      this.context.router.push('/terms_of_service');
     }
   }
 
@@ -102,6 +102,10 @@ App.propTypes = {
   dashboard:  React.PropTypes.object.isRequired,
   dispatch:   React.PropTypes.func.isRequired,
   history: React.PropTypes.object.isRequired,
+};
+
+App.contextTypes = {
+  router:   React.PropTypes.object.isRequired
 };
 
 export default connect(mapStateToProps)(App);

--- a/static/js/containers/TermsOfServicePage.js
+++ b/static/js/containers/TermsOfServicePage.js
@@ -7,7 +7,7 @@ import { saveProfile, FETCH_SUCCESS } from '../actions';
 
 class TermsOfServicePage extends React.Component {
   handleAgree() {
-    const { dispatch, userProfile, history } = this.props;
+    const { dispatch, userProfile } = this.props;
     if (userProfile.getStatus !== FETCH_SUCCESS) {
       // wait until we get user profile before user can agree to terms
       return;
@@ -16,7 +16,7 @@ class TermsOfServicePage extends React.Component {
       agreed_to_terms_of_service: true
     });
     dispatch(saveProfile(SETTINGS.username, profile)).then(() => {
-      history.push("/profile");
+      this.context.router.push("/profile");
     });
   }
 
@@ -51,6 +51,10 @@ TermsOfServicePage.propTypes = {
   dispatch: React.PropTypes.func.isRequired,
   userProfile: React.PropTypes.object.isRequired,
   history: React.PropTypes.object.isRequired
+};
+
+TermsOfServicePage.contextTypes = {
+  router:   React.PropTypes.object.isRequired
 };
 
 export default connect(mapStateToProps)(TermsOfServicePage);


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

React router throws up a console warning if you grab `history` out of
`this.props` instead of importing the history provider (e.g.
`browserHistory` or `hashHistory`) and calling `.push` on that.

This just makes that change, so the warning doesn't show up!

#### Where should the reviewer start?

`static/js/containers/App.js` and `static/js/containers/TermsOfServicePage.js`

#### How should this be manually tested?

- update your profile so that `agreed_to_terms_of_service == False`
- visit `/dashboard`
- click 'agree'
- confirm no JS console warning

#### Any background context you want to provide?

#### Screenshots (if appropriate)

original warning (can repro by following the 'manual testing' steps on master):

![react-router-error](https://cloud.githubusercontent.com/assets/6207644/14926962/105edcc4-0e1d-11e6-9c0c-35af8f5d8ad4.png)
