### PR TITLE
Removed unused authentication state, use profile state instead for name

### DIFF
--- a/static/js/components/Dashboard.js
+++ b/static/js/components/Dashboard.js
@@ -19,7 +19,7 @@ class Dashboard extends React.Component {
             <UserImage imageUrl={imageUrl}/>
         </div>
         <div className="card-name">
-          { SETTINGS.name }
+          { profile.preferred_name || SETTINGS.name }
           <div className="card-student-id">
             ID: { profile.pretty_printed_student_id }
           </div>

--- a/static/js/containers/LoginButton.js
+++ b/static/js/containers/LoginButton.js
@@ -1,3 +1,4 @@
+/* global SETTINGS: false */
 import React from 'react';
 import { connect } from 'react-redux';
 import DropdownButton from 'react-bootstrap/lib/DropdownButton';
@@ -6,11 +7,11 @@ import MenuItem from 'react-bootstrap/lib/MenuItem';
 
 class LoginButton extends React.Component {
   render() {
-    const { authentication } = this.props;
+    const { profile } = this.props;
 
     return (
       <DropdownButton
-        title={authentication.name}
+        title={profile.preferred_name || SETTINGS.name}
         bsStyle="danger"
         id="logout-button">
         <LinkContainer to={{ pathname: '/profile' }} active={false}>
@@ -34,12 +35,12 @@ class LoginButton extends React.Component {
 
 LoginButton.propTypes = {
   dispatch: React.PropTypes.func.isRequired,
-  authentication: React.PropTypes.object.isRequired
+  profile: React.PropTypes.object.isRequired
 };
 
 const mapStateToProps = (state) => {
   return {
-    authentication: state.authentication
+    profile: state.userProfile.profile
   };
 };
 

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -130,16 +130,6 @@ export const userProfile = (state = INITIAL_USER_PROFILE_STATE, action) => {
   }
 };
 
-const INITIAL_AUTHENTICATION_STATE = {
-  isAuthenticated: SETTINGS.isAuthenticated,
-  name: SETTINGS.name,
-};
-
-export const authentication = (state = INITIAL_AUTHENTICATION_STATE, action) => {
-  return state;
-};
-
-
 const INITIAL_DASHBOARD_STATE = {
   programs: []
 };
@@ -169,7 +159,6 @@ export const dashboard = (state = INITIAL_DASHBOARD_STATE, action) => {
 
 export default combineReducers({
   courseList,
-  authentication,
   userProfile,
   dashboard,
 });

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -303,23 +303,6 @@ describe('reducers', () => {
     });
   });
 
-  describe('authentication reducers', () => {
-    let dispatchThen;
-    beforeEach(() => {
-      dispatchThen = store.createDispatchThen(state => state.authentication);
-    });
-
-    it('should have default authentication state', done => {
-      dispatchThen({type: 'unknown'}, ['unknown']).then(state => {
-        assert.deepEqual(state, {
-          name: SETTINGS.name,
-          isAuthenticated: SETTINGS.isAuthenticated
-        });
-        done();
-      });
-    });
-  });
-
   describe('dashboard reducers', () => {
     let dashboardStub;
 


### PR DESCRIPTION
#### What are the relevant tickets?

#### What's this PR do?
Removes the unused `authentication` reducer, and uses the name from the profile instead. Now the name updates in the header immediately after the profile is saved

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

