### PR TITLE
Removed calls to programs and courses APIs in frontend

### DIFF
--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -3,12 +3,6 @@ import _ from 'lodash';
 import * as api from '../util/api';
 import * as util from '../util/util';
 
-// course list actions
-export const REQUEST_COURSE_LIST = 'REQUEST_COURSE_LIST';
-export const RECEIVE_COURSE_LIST_SUCCESS = 'RECEIVE_COURSE_LIST_SUCCESS';
-export const RECEIVE_COURSE_LIST_FAILURE = 'RECEIVE_COURSE_LIST_FAILURE';
-export const CLEAR_COURSE_LIST = 'CLEAR_COURSE_LIST';
-
 // user profile actions
 export const REQUEST_GET_USER_PROFILE = 'REQUEST_GET_USER_PROFILE';
 export const RECEIVE_GET_USER_PROFILE_SUCCESS = 'RECEIVE_GET_USER_PROFILE_SUCCESS';
@@ -26,29 +20,6 @@ export const UPDATE_PROFILE_VALIDATION = 'UPDATE_PROFILE_VALIDATION';
 export const FETCH_FAILURE = 'FETCH_FAILURE';
 export const FETCH_SUCCESS = 'FETCH_SUCCESS';
 export const FETCH_PROCESSING = 'FETCH_PROCESSING';
-
-// actions for course
-const requestCourseList = () => ({ type: REQUEST_COURSE_LIST });
-export const receiveCourseListSuccess = (courseList, programList) => ({
-  type: RECEIVE_COURSE_LIST_SUCCESS,
-  payload: {
-    courseList,
-    programList,
-  }
-});
-const receiveCourseListFailure = () => ({ type: RECEIVE_COURSE_LIST_FAILURE });
-export const clearCourseList = () => ({ type: CLEAR_COURSE_LIST });
-
-export function fetchCourseList() {
-  return dispatch => {
-    dispatch(requestCourseList());
-    let courseListPromise = api.getCourseList();
-    let programListPromise = api.getProgramList();
-    return Promise.all([courseListPromise, programListPromise]).
-      then(values => dispatch(receiveCourseListSuccess(...values))).
-      catch(() => dispatch(receiveCourseListFailure()));
-  };
-}
 
 // actions for user profile
 const requestGetUserProfile = () => ({ type: REQUEST_GET_USER_PROFILE });

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -1,33 +1,3 @@
-export const COURSE_LIST_RESPONSE = [
-  {
-    "id": 2,
-    "title": "Course xkGecQLCBCuI",
-    "enrollment_start": null,
-    "start_date": null,
-    "enrollment_url": null,
-    "prerequisites": null,
-    "program": 1
-  },
-  {
-    "id": 1,
-    "title": "Course zXHatukOIMTZ",
-    "enrollment_start": null,
-    "start_date": null,
-    "enrollment_url": null,
-    "prerequisites": null,
-    "program": 1
-  },
-  {
-    "id": 7,
-    "title": "Course plTYyFhMcEBj",
-    "enrollment_start": null,
-    "start_date": null,
-    "enrollment_url": null,
-    "prerequisites": null,
-    "program": 3
-  }
-];
-
 export const USER_PROFILE_RESPONSE = {
   "filled_out": false,
   "agreed_to_terms_of_service": true,
@@ -52,16 +22,6 @@ export const USER_PROFILE_RESPONSE = {
   "gender": "f",
   "pretty_printed_student_id": "MMM000011"
 };
-
-export const PROGRAM_LIST_RESPONSE = [
-  {
-    "id": 1,
-    "title": "Program one"
-  }, {
-    "id": 3,
-    "title": "Program three"
-  }
-];
 
 export const STATUS_PASSED = 'passed';
 export const STATUS_NOT_PASSED = 'not-passed';

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -5,8 +5,6 @@ import { connect } from 'react-redux';
 import Header from '../components/Header';
 import {
   FETCH_SUCCESS,
-  fetchCourseList,
-  clearCourseList,
   fetchUserProfile,
   clearProfile,
   fetchDashboard,
@@ -17,14 +15,12 @@ const TERMS_OF_SERVICE_REGEX = /\/terms_of_service\/?/;
 
 class App extends React.Component {
   componentDidMount() {
-    this.fetchCourseList();
     this.fetchUserProfile(SETTINGS.username);
     this.fetchDashboard();
     this.requireTermsOfService();
   }
 
   componentDidUpdate() {
-    this.fetchCourseList();
     this.fetchUserProfile(SETTINGS.username);
     this.fetchDashboard();
     this.requireTermsOfService();
@@ -32,17 +28,10 @@ class App extends React.Component {
 
   componentWillUnmount() {
     const { dispatch } = this.props;
-    dispatch(clearCourseList());
     dispatch(clearProfile());
     dispatch(clearDashboard());
   }
 
-  fetchCourseList() {
-    const { courseList, dispatch } = this.props;
-    if (courseList.fetchStatus === undefined) {
-      dispatch(fetchCourseList());
-    }
-  }
   fetchUserProfile(username) {
     const { userProfile, dispatch } = this.props;
     if (userProfile.getStatus === undefined) {
@@ -89,14 +78,12 @@ class App extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
-    courseList: state.courseList,
     userProfile: state.userProfile,
     dashboard: state.dashboard,
   };
 };
 
 App.propTypes = {
-  courseList: React.PropTypes.object.isRequired,
   children:   React.PropTypes.object.isRequired,
   userProfile:    React.PropTypes.object.isRequired,
   dashboard:  React.PropTypes.object.isRequired,

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -4,7 +4,6 @@ import '../global_init';
 import ReactDOM from 'react-dom';
 
 import {
-  CLEAR_COURSE_LIST,
   CLEAR_DASHBOARD,
   CLEAR_PROFILE,
 } from '../actions';
@@ -22,9 +21,9 @@ describe('App', () => {
     helper.cleanup();
   });
 
-  it('clears profile, dashboard and course list after unmounting', done => {
+  it('clears profile and dashboard after unmounting', done => {
     renderComponent("/dashboard").then(([component, div]) => {  // eslint-disable-line no-unused-vars
-      listenForActions([CLEAR_COURSE_LIST, CLEAR_DASHBOARD, CLEAR_PROFILE], () => {
+      listenForActions([CLEAR_DASHBOARD, CLEAR_PROFILE], () => {
         ReactDOM.unmountComponentAtNode(div);
       }).then(() => {
         done();

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -1,11 +1,6 @@
 /* global SETTINGS: false */
 import { combineReducers } from 'redux';
 import {
-  REQUEST_COURSE_LIST,
-  RECEIVE_COURSE_LIST_SUCCESS,
-  RECEIVE_COURSE_LIST_FAILURE,
-  CLEAR_COURSE_LIST,
-
   REQUEST_GET_USER_PROFILE,
   RECEIVE_GET_USER_PROFILE_SUCCESS,
   RECEIVE_GET_USER_PROFILE_FAILURE,
@@ -27,34 +22,6 @@ import {
   FETCH_PROCESSING,
   FETCH_SUCCESS,
 } from '../actions';
-
-const INITIAL_COURSE_LIST_STATE = {
-  courseList: [],
-  programList: []
-};
-
-export const courseList = (state = INITIAL_COURSE_LIST_STATE, action) => {
-  switch (action.type) {
-  case REQUEST_COURSE_LIST:
-    return Object.assign({}, state, {
-      fetchStatus: FETCH_PROCESSING
-    });
-  case RECEIVE_COURSE_LIST_SUCCESS:
-    return Object.assign({}, state, {
-      fetchStatus: FETCH_SUCCESS,
-      courseList: action.payload.courseList,
-      programList: action.payload.programList
-    });
-  case RECEIVE_COURSE_LIST_FAILURE:
-    return Object.assign({}, state, {
-      fetchStatus: FETCH_FAILURE
-    });
-  case CLEAR_COURSE_LIST:
-    return INITIAL_COURSE_LIST_STATE;
-  default:
-    return state;
-  }
-};
 
 export const INITIAL_USER_PROFILE_STATE = {
   profile: {}
@@ -158,7 +125,6 @@ export const dashboard = (state = INITIAL_DASHBOARD_STATE, action) => {
 
 
 export default combineReducers({
-  courseList,
   userProfile,
   dashboard,
 });

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -1,13 +1,5 @@
 /* global SETTINGS: false */
 import {
-
-  fetchCourseList,
-  clearCourseList,
-  REQUEST_COURSE_LIST,
-  RECEIVE_COURSE_LIST_SUCCESS,
-  RECEIVE_COURSE_LIST_FAILURE,
-  CLEAR_COURSE_LIST,
-
   fetchUserProfile,
   receiveGetUserProfileSuccess,
   clearProfile,
@@ -41,8 +33,6 @@ import {
 } from '../actions/index';
 import * as api from '../util/api';
 import {
-  COURSE_LIST_RESPONSE,
-  PROGRAM_LIST_RESPONSE,
   DASHBOARD_RESPONSE,
   USER_PROFILE_RESPONSE,
 } from '../constants';
@@ -64,67 +54,6 @@ describe('reducers', () => {
     dispatchThen = null;
   });
 
-  describe('course reducers', () => {
-    let courseListStub, programListStub;
-
-    beforeEach(() => {
-      dispatchThen = store.createDispatchThen(state => state.courseList);
-      courseListStub = sandbox.stub(api, 'getCourseList');
-      programListStub = sandbox.stub(api, 'getProgramList');
-    });
-
-    it('should have an empty default state', done => {
-      dispatchThen({type: 'unknown'}, ['unknown']).then(state => {
-        assert.deepEqual(state, {
-          courseList: [],
-          programList: []
-        });
-        done();
-      });
-    });
-
-    it('should fetch a list of courses successfully then clear the course list', done => {
-      courseListStub.returns(Promise.resolve(COURSE_LIST_RESPONSE));
-      programListStub.returns(Promise.resolve(PROGRAM_LIST_RESPONSE));
-
-      dispatchThen(fetchCourseList(), [REQUEST_COURSE_LIST, RECEIVE_COURSE_LIST_SUCCESS]).then(courseState => {
-        assert.deepEqual(courseState.courseList, COURSE_LIST_RESPONSE);
-        assert.deepEqual(courseState.programList, PROGRAM_LIST_RESPONSE);
-        assert.equal(courseState.fetchStatus, FETCH_SUCCESS);
-
-        dispatchThen(clearCourseList(), [CLEAR_COURSE_LIST]).then(courseState => {
-          assert.deepEqual(courseState, {
-            courseList: [],
-            programList: []
-          });
-
-          done();
-        });
-      });
-    });
-
-    it("should fail to fetch a list of courses if we can't access the course API", done => {
-      courseListStub.returns(Promise.reject());
-      programListStub.returns(Promise.resolve(PROGRAM_LIST_RESPONSE));
-
-      dispatchThen(fetchCourseList(), [REQUEST_COURSE_LIST, RECEIVE_COURSE_LIST_FAILURE]).then(courseState => {
-        assert.equal(courseState.fetchStatus, FETCH_FAILURE);
-
-        done();
-      });
-    });
-
-    it("should fail to fetch a list of courses if we can't access the program API", done => {
-      courseListStub.returns(Promise.reject(COURSE_LIST_RESPONSE));
-      programListStub.returns(Promise.reject());
-
-      dispatchThen(fetchCourseList(), [REQUEST_COURSE_LIST, RECEIVE_COURSE_LIST_FAILURE]).then(courseState => {
-        assert.equal(courseState.fetchStatus, FETCH_FAILURE);
-
-        done();
-      });
-    });
-  });
   describe('profile reducers', () => {
     let getUserProfileStub, patchUserProfileStub;
     beforeEach(() => {

--- a/static/js/util/api.js
+++ b/static/js/util/api.js
@@ -76,14 +76,6 @@ function fetchJSONWithCSRF(input, init) {
   });
 }
 
-export function getCourseList() {
-  return fetchJSONWithCSRF('/api/v0/courses/');
-}
-
-export function getProgramList() {
-  return fetchJSONWithCSRF('/api/v0/programs/');
-}
-
 export function getUserProfile(username) {
   return fetchJSONWithCSRF(`/api/v0/profiles/${username}/`);
 }

--- a/static/js/util/api_test.js
+++ b/static/js/util/api_test.js
@@ -1,15 +1,11 @@
 import assert from 'assert';
 import fetchMock from 'fetch-mock/src/server';
 import {
-  getCourseList,
-  getProgramList,
   getUserProfile,
   patchUserProfile,
   getDashboard,
 } from './api';
 import {
-  COURSE_LIST_RESPONSE,
-  PROGRAM_LIST_RESPONSE,
   USER_PROFILE_RESPONSE,
   DASHBOARD_RESPONSE,
 } from '../constants';
@@ -17,29 +13,10 @@ import {
 describe('common api functions', function() {
   this.timeout(5000);  // eslint-disable-line no-invalid-this
 
-  it('gets a list of courses', done => {
-    fetchMock.mock('/api/v0/courses/', COURSE_LIST_RESPONSE);
-    getCourseList().then(receivedCourseList => {
-      assert.deepEqual(receivedCourseList, COURSE_LIST_RESPONSE);
-      done();
-    });
-  });
-
-  it('fails to get a list of courses', done => {
-    fetchMock.mock('/api/v0/courses/', () => {
-      return {
-        status: 400
-      };
-    });
-
-    getCourseList().catch(() => {
-      done();
-    });
-  });
-
   it('gets user profile', done => {
     fetchMock.mock('/api/v0/profiles/jane/', USER_PROFILE_RESPONSE);
     getUserProfile('jane').then(receivedUserProfile => {
+      assert.ok(fetchMock.called('/api/v0/profiles/jane/'));
       assert.deepEqual(receivedUserProfile, USER_PROFILE_RESPONSE);
       done();
     });
@@ -53,6 +30,7 @@ describe('common api functions', function() {
     });
 
     getUserProfile('jane').catch(() => {
+      assert.ok(fetchMock.called('/api/v0/profiles/jane/'));
       done();
     });
   });
@@ -63,6 +41,7 @@ describe('common api functions', function() {
       return { status: 200 };
     });
     patchUserProfile('jane', USER_PROFILE_RESPONSE).then(() => {
+      assert.ok(fetchMock.called('/api/v0/profiles/jane/'));
       done();
     });
   });
@@ -73,26 +52,7 @@ describe('common api functions', function() {
       return { status: 400 };
     });
     patchUserProfile('jane', USER_PROFILE_RESPONSE).catch(() => {
-      done();
-    });
-  });
-
-  it('gets a list of programs', done => {
-    fetchMock.mock('/api/v0/programs/', PROGRAM_LIST_RESPONSE);
-    getProgramList().then(receivedProgramList => {
-      assert.deepEqual(receivedProgramList, PROGRAM_LIST_RESPONSE);
-      done();
-    });
-  });
-
-  it('fails to get a list of programs', done => {
-    fetchMock.mock('/api/v0/programs/', () => {
-      return {
-        status: 400
-      };
-    });
-
-    getProgramList().catch(() => {
+      assert.ok(fetchMock.called('/api/v0/profiles/jane/'));
       done();
     });
   });
@@ -100,6 +60,7 @@ describe('common api functions', function() {
   it('gets the dashboard', done => {
     fetchMock.mock('/api/v0/dashboard/', DASHBOARD_RESPONSE);
     getDashboard().then(dashboard => {
+      assert.ok(fetchMock.called('/api/v0/dashboard/'));
       assert.deepEqual(dashboard, DASHBOARD_RESPONSE);
       done();
     });
@@ -110,7 +71,8 @@ describe('common api functions', function() {
       status: 400
     }));
 
-    getProgramList().catch(() => {
+    getDashboard().catch(() => {
+      assert.ok(fetchMock.called('/api/v0/dashboard/'));
       done();
     });
   });

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -5,16 +5,12 @@ import { createMemoryHistory } from 'react-router';
 
 import * as api from '../util/api';
 import {
-  COURSE_LIST_RESPONSE,
   DASHBOARD_RESPONSE,
-  PROGRAM_LIST_RESPONSE,
   USER_PROFILE_RESPONSE,
 } from '../constants';
 import {
-  REQUEST_COURSE_LIST,
   REQUEST_DASHBOARD,
   REQUEST_GET_USER_PROFILE,
-  RECEIVE_COURSE_LIST_SUCCESS,
   RECEIVE_DASHBOARD_SUCCESS,
   RECEIVE_GET_USER_PROFILE_SUCCESS,
 } from '../actions';
@@ -34,10 +30,6 @@ class IntegrationTestHelper {
     this.listenForActions = this.store.createListenForActions();
     this.dispatchThen = this.store.createDispatchThen();
 
-    this.programStub = this.sandbox.stub(api, 'getProgramList');
-    this.programStub.returns(Promise.resolve(PROGRAM_LIST_RESPONSE));
-    this.courseStub = this.sandbox.stub(api, 'getCourseList');
-    this.courseStub.returns(Promise.resolve(COURSE_LIST_RESPONSE));
     this.dashboardStub = this.sandbox.stub(api, 'getDashboard');
     this.dashboardStub.returns(Promise.resolve(DASHBOARD_RESPONSE));
     this.profileGetStub = this.sandbox.stub(api, 'getUserProfile');
@@ -56,10 +48,8 @@ class IntegrationTestHelper {
   renderComponent(url = "/", extraTypesToAssert = []) {
     return new Promise(resolve => {
       let expectedTypes = [
-        REQUEST_COURSE_LIST,
         REQUEST_DASHBOARD,
         REQUEST_GET_USER_PROFILE,
-        RECEIVE_COURSE_LIST_SUCCESS,
         RECEIVE_DASHBOARD_SUCCESS,
         RECEIVE_GET_USER_PROFILE_SUCCESS,
       ];


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #237 

#### What's this PR do?
Removes unused calls to `/api/v0/programs/` and `/api/v0/courses/` from the frontend

#### Where should the reviewer start?

#### How should this be manually tested?
Everything should work the same as before, but there should not be these requests in the Network tab

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
