### PR TITLE
Old not passed courses in dashboard API

### DIFF
--- a/dashboard/fixtures/user_enrollments.json
+++ b/dashboard/fixtures/user_enrollments.json
@@ -51,5 +51,31 @@
         "is_active": true,
         "mode": "audit",
         "user": "staff"
+    },
+    {
+        "course_details": {
+            "course_end": "2015-05-10T23:59:00Z",
+            "course_id": "course-v1:odl+FOO101+CR-FALL15",
+            "course_modes": [
+                {
+                    "currency": "usd",
+                    "description": null,
+                    "expiration_datetime": null,
+                    "min_price": 0,
+                    "name": "Audit",
+                    "sku": null,
+                    "slug": "audit",
+                    "suggested_prices": ""
+                }
+            ],
+            "course_start": "2015-01-08T14:00:00Z",
+            "enrollment_end": "2015-05-10T23:59:00Z",
+            "enrollment_start": null,
+            "invite_only": false
+        },
+        "created": "2016-01-27T18:10:35Z",
+        "is_active": true,
+        "mode": "verified",
+        "user": "staff"
     }
 ]


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #219 

#### What's this PR do?
the old not-passed runs now are added to the list of runs for a course together with the next one to take or with the current one

#### Where should the reviewer start?
dashboard/api.py

#### How should this be manually tested?
the rest api interface should show multiple runs. the additional ones can be only `passed` or `not-passed`

#### Any background context you want to provide?
the UI will most likely not work properly until #223 is done

#### What GIF best describes this PR or how it makes you feel?
![](https://66.media.tumblr.com/tumblr_m0q1bwqvIs1rqnbfjo1_250.gif)