### PR TITLE
Updated profile PATCH code to use return value as new profile

### DIFF
--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -54,7 +54,7 @@ export const saveProfile = (username, profile) => {
   return dispatch => {
     dispatch(requestPatchUserProfile());
     return api.patchUserProfile(username, profile).
-      then(() => dispatch(receivePatchUserProfileSuccess(profile))).
+      then(newProfile => dispatch(receivePatchUserProfileSuccess(newProfile))).
       catch(() => dispatch(receivePatchUserProfileFailure()));
   };
 };

--- a/static/js/containers/TermsOfServicePage_test.js
+++ b/static/js/containers/TermsOfServicePage_test.js
@@ -41,14 +41,13 @@ describe("TermsOfService", () => {
       agreed_to_terms_of_service: false
     });
     helper.profileGetStub.returns(Promise.resolve(response));
+
+    let updatedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+      agreed_to_terms_of_service: true
+    });
     let profilePatchStub = helper.sandbox.stub(api, 'patchUserProfile');
     profilePatchStub.throws("Invalid arguments");
-    profilePatchStub.withArgs(
-      SETTINGS.username,
-      Object.assign({}, USER_PROFILE_RESPONSE, {
-        agreed_to_terms_of_service: true
-      })
-    ).returns(Promise.resolve());
+    profilePatchStub.withArgs(SETTINGS.username, updatedProfile).returns(Promise.resolve(updatedProfile));
 
     renderComponent("/terms_of_service").then(([component]) => {
       listenForActions([REQUEST_PATCH_USER_PROFILE, RECEIVE_PATCH_USER_PROFILE_SUCCESS], () => {

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -102,14 +102,17 @@ describe('reducers', () => {
     });
 
     it("should patch the profile successfully", done => {
-      patchUserProfileStub.returns(Promise.resolve());
+      let updatedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+        change: true
+      });
+      patchUserProfileStub.returns(Promise.resolve(updatedProfile));
 
       dispatchThen(
         saveProfile('jane', USER_PROFILE_RESPONSE),
         [REQUEST_PATCH_USER_PROFILE, RECEIVE_PATCH_USER_PROFILE_SUCCESS]
       ).then(profileState => {
         assert.equal(profileState.patchStatus, FETCH_SUCCESS);
-        assert.deepEqual(profileState.profile, USER_PROFILE_RESPONSE);
+        assert.deepEqual(profileState.profile, updatedProfile);
 
         assert.ok(patchUserProfileStub.calledWith('jane', USER_PROFILE_RESPONSE));
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #272

#### What's this PR do?
Instead of assigning the profile in edit to be the profile on successful PATCH, use the return value from the PATCH. This is necessary so we can keep track of the id number

#### Where should the reviewer start?


#### How should this be manually tested?
Add a new work history item to your profile and save it. Then, without refreshing, look at your redux state and verify that the work history item in your profile has an id number.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

