### PR TITLE
Added Privacy tab to profile

### DIFF
--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -51,11 +51,6 @@ def update_profile_from_edx(backend, user, response, is_new, *args, **kwargs):  
         }
     )
 
-    account_privacy = user_profile_edx.get('account_privacy')
-    if account_privacy == 'all_users':
-        user_profile.account_privacy = Profile.PUBLIC
-    else:
-        user_profile.account_privacy = Profile.PRIVATE
     name = user_profile_edx.get('name', "")
     user_profile.edx_name = name
     user_profile.first_name, user_profile.last_name = split_name(name)

--- a/backends/pipeline_api_test.py
+++ b/backends/pipeline_api_test.py
@@ -164,7 +164,7 @@ class EdxPipelineApiTest(TestCase):
         first_name, last_name = split_name(mocked_content['name'])
 
         all_fields = [
-            ('account_privacy', Profile.PUBLIC),
+            ('account_privacy', Profile.PRIVATE),
             ('edx_name', mocked_content['name']),
             ('first_name', first_name),
             ('last_name', last_name),
@@ -206,26 +206,6 @@ class EdxPipelineApiTest(TestCase):
             self.user_profile.refresh_from_db()
             assert self.user_profile.preferred_language is None
             assert self.user_profile.edx_language_proficiencies == proficiencies
-
-    @mock.patch('backends.edxorg.EdxOrgOAuth2.get_json')
-    def test_account_privacy(self, mocked_get_json):
-        """
-        Test that account_privacy is modified correctly
-        """
-        account_privacy_values = [
-            ('private', Profile.PRIVATE),
-            (None, Profile.PRIVATE),
-            ('all_users', Profile.PUBLIC),
-        ]
-        for edx_privacy, mm_privacy in account_privacy_values:
-            mocked_content = dict(self.mocked_edx_profile)
-            mocked_content['account_privacy'] = edx_privacy
-            mocked_get_json.return_value = mocked_content
-            pipeline_api.update_profile_from_edx(
-                edxorg.EdxOrgOAuth2, self.user, {'access_token': 'foo_token'}, True)
-
-            self.user_profile.refresh_from_db()
-            assert self.user_profile.account_privacy == mm_privacy
 
 
 class LinkedInPipelineTests(TestCase):

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -9,7 +9,7 @@ import { saveAndContinue } from '../util/profile_edit';
 class EmploymentTab extends ProfileTab {
   constructor(props) {
     super(props);
-    this.saveAndContinue = saveAndContinue.bind(this, '/dashboard', EmploymentTab.validation);
+    this.saveAndContinue = saveAndContinue.bind(this, '/profile/privacy', EmploymentTab.validation);
     this.blankWorkHistoryEntry = {
       position: "",
       industry: "",

--- a/static/js/components/PrivacyTab.js
+++ b/static/js/components/PrivacyTab.js
@@ -22,7 +22,7 @@ class PrivacyTab extends ProfileTab {
       ['account_privacy']
     ],
     validationMessages: {
-      'account_privacy': 'Privacy'
+      'account_privacy': 'Privacy level'
     }
   };
 

--- a/static/js/components/PrivacyTab.js
+++ b/static/js/components/PrivacyTab.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import Button from 'react-mdl/lib/Button';
+
+import ProfileTab from "../util/ProfileTab";
+import { saveAndContinue } from "../util/profile_edit";
+
+class PrivacyTab extends ProfileTab {
+  constructor(props) {
+    super(props);
+    this.saveAndContinue = saveAndContinue.bind(this, '/dashboard');
+  }
+
+  static propTypes = {
+    profile:        React.PropTypes.object,
+    errors:         React.PropTypes.object,
+    saveProfile:    React.PropTypes.func,
+    updateProfile:  React.PropTypes.func
+  };
+
+  static defaultProps = {
+    requiredFields: [
+      ['account_privacy']
+    ],
+    validationMessages: {
+      'account_privacy': 'Privacy'
+    }
+  };
+
+  render() {
+    return <div>
+      <h4>Micromasters learners can see my:</h4>
+      {this.boundSelectField(['account_privacy'], 'Privacy', this.privacyOptions)}<br />
+      <br />
+      <Button raised onClick={this.saveAndContinue}>
+        Save and continue
+      </Button>
+    </div>;
+  }
+}
+
+export default PrivacyTab;

--- a/static/js/dashboard_routes.js
+++ b/static/js/dashboard_routes.js
@@ -7,6 +7,7 @@ import DashboardPage from './containers/DashboardPage';
 import ProfilePage from './containers/ProfilePage';
 import PersonalTab from './components/PersonalTab';
 import EmploymentTab from './components/EmploymentTab';
+import PrivacyTab from './components/PrivacyTab';
 import TermsOfServicePage from './containers/TermsOfServicePage';
 
 /**
@@ -27,6 +28,7 @@ export function makeDashboardRoutes(browserHistory, store, onRouteUpdate) {
             <IndexRedirect to="personal" />
             <Route path="personal" component={PersonalTab} />
             <Route path="professional" component={EmploymentTab} />
+            <Route path="privacy" component={PrivacyTab} />
           </Route>
           <Route path="/terms_of_service" component={TermsOfServicePage} />
         </Route>

--- a/static/js/util/ProfileTab.js
+++ b/static/js/util/ProfileTab.js
@@ -42,6 +42,11 @@ class ProfileTab extends React.Component {
       value: language.alpha2,
       label: language.English
     }));
+    this.privacyOptions = [
+      { value: 'public', label: 'Public to the world'},
+      { value: 'public_to_mm', label: 'Public to other micromasters students'},
+      { value: 'private', label: 'Private'}
+    ]
   }
 
   static contextTypes = {

--- a/static/js/util/ProfileTab.js
+++ b/static/js/util/ProfileTab.js
@@ -46,7 +46,7 @@ class ProfileTab extends React.Component {
       { value: 'public', label: 'Public to the world'},
       { value: 'public_to_mm', label: 'Public to other micromasters students'},
       { value: 'private', label: 'Private'}
-    ]
+    ];
   }
 
   static contextTypes = {

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -50,7 +50,7 @@ export function boundSelectField(keySet, label, options) {
   } = this.props;
   let onChange = value => {
     let clone = _.cloneDeep(profile);
-    _.set(clone, keySet, value? value.value : null);
+    _.set(clone, keySet, value? value.value : '');
     updateProfile(clone);
   };
   return <div>


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #215 
#### What's this PR do?
Add Privacy tab to profile. Set account privacy default value to be 'private'.
#### Where should the reviewer start?
PrivacyTab.js
#### How should this be manually tested?
Go to Privacy tab. For a newly created account the value should be set to 'private'. For already existing accounts the value was set from the edx profile on creation of the mm account, and is public by default.


