### PR TITLE
Implemented refresh token

### DIFF
--- a/backends/edxorg.py
+++ b/backends/edxorg.py
@@ -1,6 +1,7 @@
 """
 EdX.org backend for Python Social Auth
 """
+from datetime import datetime
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -15,11 +16,25 @@ class EdxOrgOAuth2(BaseOAuth2):
     ID_KEY = 'edx_id'
     REQUEST_TOKEN_URL = None
     EDXORG_BASE_URL = settings.EDXORG_BASE_URL
+
+    # Settings for Django OAUTH toolkit
+    # AUTHORIZATION_URL = urljoin(EDXORG_BASE_URL, '/_o/authorize/')
+    # ACCESS_TOKEN_URL = urljoin(EDXORG_BASE_URL, '/_o/token/')
+    # DEFAULT_SCOPE = ['read', 'write']
+
+    # Settings for old edx OAUTH library
     AUTHORIZATION_URL = urljoin(EDXORG_BASE_URL, '/oauth2/authorize/')
     ACCESS_TOKEN_URL = urljoin(EDXORG_BASE_URL, '/oauth2/access_token/')
+    DEFAULT_SCOPE = ['email', ]
+
     ACCESS_TOKEN_METHOD = 'POST'
     REDIRECT_STATE = False
-    DEFAULT_SCOPE = ['email']
+    EXTRA_DATA = [
+        ('refresh_token', 'refresh_token', True),
+        ('expires_in', 'expires_in'),
+        ('token_type', 'token_type', True),
+        ('scope', 'scope'),
+    ]
 
     def user_data(self, access_token, *args, **kwargs):
         """
@@ -82,3 +97,17 @@ class EdxOrgOAuth2(BaseOAuth2):
             string: the unique identifier for the user in the remote service.
         """
         return details.get(self.ID_KEY)
+
+    def refresh_token(self, token, *args, **kwargs):
+        """
+        Overridden method to add extra info during refresh token.
+
+        Args:
+            token (str): valid refresh token
+
+        Returns:
+            dict of information about the user
+        """
+        response = super(EdxOrgOAuth2, self).refresh_token(token, *args, **kwargs)
+        response['updated_at'] = datetime.utcnow().timestamp()
+        return response

--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -2,6 +2,7 @@
 APIs for extending the python social auth pipeline
 """
 import logging
+from datetime import datetime
 from urllib.parse import urljoin
 
 from profiles.models import Profile
@@ -115,3 +116,18 @@ def update_from_linkedin(backend, user, response, *args, **kwargs):   # pylint: 
 
     user_profile.linkedin = response
     user_profile.save()
+
+
+def set_last_update(details, *args, **kwargs):  # pylint: disable=unused-argument
+    """
+    Pipeline function to add extra information about when the social auth
+    profile has been updated.
+
+    Args:
+        details (dict): dictionary of informations about the user
+
+    Returns:
+        dict: updated details dictionary
+    """
+    details['updated_at'] = datetime.utcnow().timestamp()
+    return details

--- a/backends/utils.py
+++ b/backends/utils.py
@@ -1,0 +1,50 @@
+"""
+Utility functions for the backends
+"""
+from datetime import datetime, timedelta
+
+from requests.exceptions import HTTPError
+from social.apps.django_app.utils import load_strategy
+
+
+class InvalidCredentialStored(Exception):
+    """Custom exception to throw in some specific situations"""
+    def __init__(self, message, http_status_code):
+        super(InvalidCredentialStored, self).__init__(message)
+        self.http_status_code = http_status_code
+
+
+def _send_refresh_request(user_social):
+    """
+    Private function that refresh an user access token
+    """
+    strategy = load_strategy()
+    try:
+        user_social.refresh_token(strategy)
+    except HTTPError as exc:
+        if exc.response.status_code in (400, 401,):
+            raise InvalidCredentialStored(
+                message='Received a {} status code from the OAUTH server'.format(
+                    exc.response.status_code),
+                http_status_code=exc.response.status_code
+            )
+        raise
+
+
+def refresh_user_token(user_social):
+    """
+    Utility function to refresh the access token if is (almost) expired
+
+    Args:
+        user_social (UserSocialAuth): a user social auth instance
+    """
+    try:
+        last_update = datetime.fromtimestamp(user_social.extra_data.get('updated_at'))
+        expires_in = timedelta(seconds=user_social.extra_data.get('expires_in'))
+    except TypeError:
+        _send_refresh_request(user_social)
+        return
+    # small error margin of 5 minutes to be safe
+    error_margin = timedelta(minutes=5)
+    if datetime.utcnow() - last_update >= expires_in - error_margin:
+        _send_refresh_request(user_social)

--- a/backends/utils_test.py
+++ b/backends/utils_test.py
@@ -1,0 +1,120 @@
+"""
+Tests for the utils
+"""
+from datetime import datetime, timedelta
+from mock import (
+    MagicMock,
+    patch,
+)
+
+import pytz
+from django.test import TestCase
+from requests.exceptions import HTTPError
+
+from backends import utils
+from profiles.factories import UserFactory
+
+# pylint: disable=protected-access
+
+
+class RefreshTest(TestCase):
+    """Class to test refresh token"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super(RefreshTest, cls).setUpTestData()
+        # create an user
+        cls.user = UserFactory.create()
+        # create a social auth for the user
+        cls.user.social_auth.create(
+            provider='edxorg',
+            uid=cls.user.username,
+            extra_data='{"access_token": "fooooootoken", "refresh_token": "baaaarrefresh"}'
+        )
+
+    def setUp(self):
+        super(RefreshTest, self).setUp()
+        self.now = datetime.now(pytz.utc)
+
+    def update_social_extra_data(self, data):
+        """Helper function to update the python social auth extra data"""
+        social_user = self.user.social_auth.get(provider='edxorg')
+        social_user.extra_data.update(data)
+        social_user.save()
+        return social_user
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_refresh(self, mock_refresh):
+        """The refresh needs to be called"""
+        extra_data = {
+            "updated_at": (self.now - timedelta(weeks=1)).timestamp(),
+            "expires_in": 100  # seconds
+        }
+        social_user = self.update_social_extra_data(extra_data)
+        utils.refresh_user_token(social_user)
+        assert mock_refresh.called
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_refresh_no_extradata(self, mock_refresh):
+        """The refresh needs to be called because there is not valid timestamps"""
+        social_user = self.user.social_auth.get(provider='edxorg')
+        social_user.extra_data = {"access_token": "fooooootoken", "refresh_token": "baaaarrefresh"}
+        social_user.save()
+        utils.refresh_user_token(social_user)
+        assert mock_refresh.called
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_no_refresh(self, mock_refresh):
+        """The refresh does not need to be called"""
+        extra_data = {
+            "updated_at": (self.now - timedelta(minutes=1)).timestamp(),
+            "expires_in": 31535999  # 1 year - 1 second
+        }
+        social_user = self.update_social_extra_data(extra_data)
+        utils.refresh_user_token(social_user)
+        assert not mock_refresh.called
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_refresh_400_error_server(self, mock_refresh):
+        """Test to check what happens when the OAUTH server returns 400 code"""
+        def raise_http_error(*args, **kwargs):  # pylint: disable=unused-argument
+            """Mock function to raise an exception"""
+            error = HTTPError()
+            error.response = MagicMock()
+            error.response.status_code = 400
+            raise error
+
+        mock_refresh.side_effect = raise_http_error
+        social_user = self.user.social_auth.get(provider='edxorg')
+        with self.assertRaises(utils.InvalidCredentialStored):
+            utils._send_refresh_request(social_user)
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_refresh_401_error_server(self, mock_refresh):
+        """Test to check what happens when the OAUTH server returns 401 code"""
+        def raise_http_error(*args, **kwargs):  # pylint: disable=unused-argument
+            """Mock function to raise an exception"""
+            error = HTTPError()
+            error.response = MagicMock()
+            error.response.status_code = 401
+            raise error
+
+        mock_refresh.side_effect = raise_http_error
+        social_user = self.user.social_auth.get(provider='edxorg')
+        with self.assertRaises(utils.InvalidCredentialStored):
+            utils._send_refresh_request(social_user)
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_refresh_500_error_server(self, mock_refresh):
+        """Test to check what happens when the OAUTH server returns 500 code"""
+        def raise_http_error(*args, **kwargs):  # pylint: disable=unused-argument
+            """Mock function to raise an exception"""
+            error = HTTPError()
+            error.response = MagicMock()
+            error.response.status_code = 500
+            raise error
+
+        mock_refresh.side_effect = raise_http_error
+        social_user = self.user.social_auth.get(provider='edxorg')
+        with self.assertRaises(HTTPError):
+            utils._send_refresh_request(social_user)

--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -4,10 +4,14 @@ Tests for the dashboard views
 import json
 import os
 from datetime import datetime, timedelta
+from mock import (
+    MagicMock,
+    patch,
+)
 
 import pytz
 from django.core.urlresolvers import reverse
-from mock import patch
+from requests.exceptions import HTTPError
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -96,7 +100,8 @@ class DashboardTest(APITestCase):
         res = self.client.get(self.url)
         assert res.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_no_run_available(self):
+    @patch('backends.utils.refresh_user_token', autospec=True)
+    def test_no_run_available(self, mocked_refresh):
         """Test for GET"""
         with patch(
             'edx_api.enrollments.CourseEnrollments.get_student_enrollments',
@@ -104,6 +109,7 @@ class DashboardTest(APITestCase):
             return_value=self.enrollments
         ):
             res = self.client.get(self.url)
+        assert mocked_refresh.called
         assert res.status_code == status.HTTP_200_OK
         data = res.data
         assert len(data) == 2
@@ -113,7 +119,8 @@ class DashboardTest(APITestCase):
             for course in program['courses']:
                 assert course['status'] == CourseStatus.NOT_OFFERED
 
-    def test_with_runs(self):
+    @patch('backends.utils.refresh_user_token', autospec=True)
+    def test_with_runs(self, mocked_refresh):
         """Test for GET"""
         # create some runs
         self.create_run(
@@ -138,6 +145,7 @@ class DashboardTest(APITestCase):
             return_value=self.enrollments
         ):
             res = self.client.get(self.url)
+        assert mocked_refresh.called
         assert res.status_code == status.HTTP_200_OK
         data = res.data
         assert len(data) == 2
@@ -153,3 +161,90 @@ class DashboardTest(APITestCase):
                         assert course_data['runs'][0]['status'] == CourseStatus.CURRENT_GRADE
                     if course_data['runs'][0]['course_id'] == "course-v1:MITx+8.MechCX+2014_T1":
                         assert course_data['runs'][0]['status'] == CourseStatus.UPGRADE
+
+
+class DashboardTokensTest(APITestCase):
+    """
+    Tests for access tokens in dashboard Rest API
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super(DashboardTokensTest, cls).setUpTestData()
+        # create an user
+        cls.user = UserFactory.create()
+        # create a social auth for the user
+        cls.user.social_auth.create(
+            provider='edxorg',
+            uid=cls.user.username,
+            extra_data='{"access_token": "fooooootoken", "refresh_token": "baaaarrefresh"}'
+        )
+
+        cls.enrollments = Enrollments([])
+
+        # url for the dashboard
+        cls.url = reverse('dashboard_api')
+
+    def setUp(self):
+        super(DashboardTokensTest, self).setUp()
+        self.client.force_login(self.user)
+        self.now = datetime.now(pytz.utc)
+
+    def update_social_extra_data(self, data):
+        """Helper function to update the python social auth extra data"""
+        social_user = self.user.social_auth.get(provider='edxorg')
+        social_user.extra_data.update(data)
+        social_user.save()
+
+    def request_with_mocked_enrollments(self):
+        """Helper function to make requests with mocked enrollment endpoint"""
+        with patch(
+            'edx_api.enrollments.CourseEnrollments.get_student_enrollments',
+            autospec=True,
+            return_value=self.enrollments
+        ):
+            return self.client.get(self.url)
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_refresh_token(self, mock_refresh):
+        """Test to verify that the access token is refreshed if it has expired"""
+        extra_data = {
+            "updated_at": (self.now - timedelta(weeks=1)).timestamp(),
+            "expires_in": 100  # seconds
+        }
+        self.update_social_extra_data(extra_data)
+        res = self.request_with_mocked_enrollments()
+        assert mock_refresh.called
+        assert res.status_code == status.HTTP_200_OK
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_refresh_token_still_valid(self, mock_refresh):
+        """Test to verify that the access token is not refreshed if it has not expired"""
+        extra_data = {
+            "updated_at": (self.now - timedelta(minutes=1)).timestamp(),
+            "expires_in": 31535999  # 1 year - 1 second
+        }
+        self.update_social_extra_data(extra_data)
+        res = self.request_with_mocked_enrollments()
+        assert not mock_refresh.called
+        assert res.status_code == status.HTTP_200_OK
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_refresh_token_error_server(self, mock_refresh):
+        """Test to check what happens when the OAUTH server returns an invalid status code"""
+        def raise_http_error(*args, **kwargs):  # pylint: disable=unused-argument
+            """Mock function to raise an exception"""
+            error = HTTPError()
+            error.response = MagicMock()
+            error.response.status_code = 400
+            raise error
+
+        mock_refresh.side_effect = raise_http_error
+        extra_data = {
+            "updated_at": (self.now - timedelta(weeks=1)).timestamp(),
+            "expires_in": 100  # seconds
+        }
+        self.update_social_extra_data(extra_data)
+        res = self.request_with_mocked_enrollments()
+        assert mock_refresh.called
+        assert res.status_code == status.HTTP_400_BAD_REQUEST

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -159,11 +159,19 @@ SOCIAL_AUTH_PIPELINE = (
     'social.pipeline.user.get_username',
     'social.pipeline.user.create_user',
     'social.pipeline.social_auth.associate_user',
+    # the following custom pipeline func goes before load_extra_data
+    'backends.pipeline_api.set_last_update',
     'social.pipeline.social_auth.load_extra_data',
     'social.pipeline.user.user_details',
     'backends.pipeline_api.update_profile_from_edx',
     'backends.pipeline_api.update_from_linkedin',
 )
+SOCIAL_AUTH_EDXORG_AUTH_EXTRA_ARGUMENTS = {
+    'access_type': 'offline',
+    'approval_prompt': 'auto'
+}
+SOCIAL_AUTH_EDXORG_EXTRA_DATA = ['updated_at']
+
 LOGIN_REDIRECT_URL = '/dashboard'
 LOGIN_URL = '/'
 


### PR DESCRIPTION
#### What are the relevant tickets?
closes #278 
fixes mitocw/edx-platform#217

#### What's this PR do?
switches the backend to use the new edX oauth toolkit library and implements the OAUTH2 refresh token.

#### Where should the reviewer start?
first `backend/pipeline_api.py`
then `backend/edxorg.py`
then `dashboard/views.py`

#### How should this be manually tested?
you need to create in your edx instance a new application in the section `django oauth toolkit`, then update `client_id` and `client_secret` in your `.env` file.

#### Any background context you want to provide?
Until the current edx PR#12435 gets merged, the  endpoint for Django OAUTH Toolkit cannot be used (the certificates rest api will not work).
In the meantime it woks with the old library (that turned out to support refresh tokens as well)

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
