### PR TITLE
Added material-ui AutoComplete 

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "react-redux": "4.4.5",
     "react-router": "2.4.0",
     "react-router-bootstrap": "0.23.0",
-    "react-select": "1.0.0-beta13",
     "react-tap-event-plugin": "1.0.0",
     "redux": "3.5.2",
     "redux-logger": "2.6.1",

--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -14,8 +14,10 @@ import {
   closeEducationForm,
   clearProfileEdit
 } from '../actions';
-import { Grid, Cell, Switch, FABButton, Icon } from 'react-mdl';
-
+import Grid, { Cell } from 'react-mdl/lib/Grid';
+import Switch from 'react-mdl/lib/Switch';
+import FABButton from 'react-mdl/lib/FABButton';
+import Icon from 'react-mdl/lib/Icon';
 import Dialog from 'material-ui/Dialog';
 
 class EducationTab extends ProfileTab {
@@ -31,7 +33,7 @@ class EducationTab extends ProfileTab {
     this.handleCloseDialog = this.handleCloseDialog.bind(this);
 
   }
-  static propTypes ={
+  static propTypes = {
     educationLevels: React.PropTypes.object,
     educationDialog: React.PropTypes.object,
     profile: React.PropTypes.object,
@@ -185,6 +187,7 @@ class EducationTab extends ProfileTab {
       <Button key="save" type='button' onClick={()=>{this.saveEducationForm(EducationTab.validation);}}>Save</Button>,
       <Button key="cancel" type='button' onClick={this.handleCloseDialog}>Cancel</Button>
     ];
+
     return <Grid className="profile-tab-grid">
       <Dialog
         open={educationDialog.openDialog}
@@ -197,11 +200,8 @@ class EducationTab extends ProfileTab {
           <Cell col={6}>
             {this.boundTextField(keySet('field_of_study'), 'Field of Study')}
           </Cell>
-          <Cell col={3}>
-            {this.boundMonthField(keySet('graduation_date'), 'Month')}
-          </Cell>
-          <Cell col={3}>
-            {this.boundYearField(keySet('graduation_date'), 'YYYY')}
+          <Cell col={6}>
+            {this.boundDateField(keySet('graduation_date'), 'Graduation Date')}
           </Cell>
         </Grid>
         <Grid>
@@ -222,7 +222,6 @@ class EducationTab extends ProfileTab {
             {this.boundSelectField(keySet('school_country'), 'Country', this.countryOptions)}
           </Cell>
         </Grid>
-
       </Dialog>
 
       {levelsGrid}

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Button from 'react-mdl/lib/Button';
+import Grid, { Cell } from 'react-mdl/lib/Grid';
 
 import ProfileTab from "../util/ProfileTab";
 import { saveAndContinue } from "../util/profile_edit";
@@ -45,30 +46,34 @@ class PersonalTab extends ProfileTab {
   }
 
   render() {
-    return <div>
-      {this.boundTextField(["first_name"], "Given name")}<br />
-      {this.boundTextField(["last_name"], "Family name")}<br />
-      {this.boundTextField(["preferred_name"], "Preferred name")}<br />
-      {this.boundSelectField(['gender'], 'Gender', this.genderOptions)}<br />
-      {this.boundSelectField(
+    return <Grid className="profile-tab-grid">
+      <Cell col={4}>{this.boundTextField(["first_name"], "Given name")}</Cell><Cell col={8} />
+      <Cell col={4}>{this.boundTextField(["last_name"], "Family name")}</Cell><Cell col={8} />
+      <Cell col={4}>{this.boundTextField(["preferred_name"], "Preferred name")}</Cell><Cell col={8} />
+      <Cell col={4}>{this.boundSelectField(['gender'], 'Gender', this.genderOptions)}</Cell><Cell col={8} />
+      <Cell col={4}>{this.boundSelectField(
         ['preferred_language'],
         'Preferred language',
         this.languageOptions
-      )}<br />
-      <h4>Where do you live?</h4>
-      {this.boundTextField(['city'], 'City')}<br />
-      {this.boundStateSelectField(['state_or_territory'], ['country'], 'State or Territory')}<br />
-      {this.boundSelectField(['country'], 'Country', this.countryOptions)}<br />
-      <h4>Where were you born?</h4>
-      {this.boundTextField(['birth_city'], 'City')}<br />
-      {this.boundStateSelectField(['birth_state_or_territory'], ['birth_country'], 'State or Territory')}<br />
-      {this.boundSelectField(['birth_country'], 'Country', this.countryOptions)}<br />
-      {this.boundDateField(['date_of_birth'], 'Date of birth')}<br />
+      )}</Cell><Cell col={8} />
+      <Cell col={4}><h4>Where do you live?</h4></Cell><Cell col={8} />
+      <Cell col={4}>{this.boundTextField(['city'], 'City')}</Cell><Cell col={8} />
+      <Cell col={4}>
+        {this.boundStateSelectField(['state_or_territory'], ['country'], 'State or Territory')}
+      </Cell><Cell col={8} />
+      <Cell col={4}>{this.boundSelectField(['country'], 'Country', this.countryOptions)}</Cell><Cell col={8} />
+      <Cell col={4}><h4>Where were you born?</h4></Cell><Cell col={8} />
+      <Cell col={4}>{this.boundTextField(['birth_city'], 'City')}</Cell><Cell col={8} />
+      <Cell col={4}>
+        {this.boundStateSelectField(['birth_state_or_territory'], ['birth_country'], 'State or Territory')}
+      </Cell><Cell col={8} />
+      <Cell col={4}>{this.boundSelectField(['birth_country'], 'Country', this.countryOptions)}</Cell><Cell col={8} />
+      <Cell col={4}>{this.boundDateField(['date_of_birth'], 'Date of birth')}</Cell><Cell col={8} />
 
       <Button raised onClick={this.saveAndContinue}>
         Save and continue
       </Button>
-    </div>;
+    </Grid>;
   }
 }
 

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -11,9 +11,6 @@ import { makeDashboardRoutes } from './dashboard_routes';
 import 'style!css!react-mdl/extra/material.css';
 import 'react-mdl/extra/material.js';
 
-// requirements for react-select
-import 'style!css!react-select/dist/react-select.css';
-
 // requirement for react-datepicker
 import 'style!css!react-datepicker/dist/react-datepicker.css';
 

--- a/static/js/dashboard_routes.js
+++ b/static/js/dashboard_routes.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Route, Router, IndexRedirect } from 'react-router';
 import { Provider } from 'react-redux';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
 import App from './containers/App';
 import DashboardPage from './containers/DashboardPage';
@@ -10,8 +12,6 @@ import EmploymentTab from './components/EmploymentTab';
 import PrivacyTab from './components/PrivacyTab';
 import EducationTab from './components/EducationTab';
 import TermsOfServicePage from './containers/TermsOfServicePage';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
 /**
  * Create the dashboard routes (the root React elements to be rendered into our container)
@@ -27,15 +27,15 @@ export function makeDashboardRoutes(browserHistory, store, onRouteUpdate) {
       <Provider store={store}>
         <Router history={browserHistory} onUpdate={onRouteUpdate}>
           <Route path="/" component={App}>
-            <Route path="dashboard" component={DashboardPage}/>
+            <Route path="dashboard" component={DashboardPage} />
             <Route path="profile" component={ProfilePage}>
-              <IndexRedirect to="personal"/>
-              <Route path="personal" component={PersonalTab}/>
+              <IndexRedirect to="personal" />
+              <Route path="personal" component={PersonalTab} />
               <Route path="education" component={EducationTab}/>
-              <Route path="professional" component={EmploymentTab}/>
-              <Route path="privacy" component={PrivacyTab}/>
+              <Route path="professional" component={EmploymentTab} />
+              <Route path="privacy" component={PrivacyTab} />
             </Route>
-            <Route path="/terms_of_service" component={TermsOfServicePage}/>
+            <Route path="/terms_of_service" component={TermsOfServicePage} />
           </Route>
         </Router>
       </Provider>

--- a/static/js/util/ProfileTab.js
+++ b/static/js/util/ProfileTab.js
@@ -1,18 +1,16 @@
 import React from 'react';
+import _ from 'lodash';
 
 import {
   boundDateField,
   boundTextField,
   boundSelectField,
-  boundMonthField,
-  boundYearField,
   editProfileObjectArray,
   boundStateSelectField,
 } from './profile_edit';
 import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
 import LANGUAGE_CODES from '../language_codes';
 import iso3166 from 'iso-3166-2';
-import _ from 'lodash';
 
 
 class ProfileTab extends React.Component {
@@ -25,8 +23,6 @@ class ProfileTab extends React.Component {
     this.boundStateSelectField = boundStateSelectField.bind(this);
     this.boundDateField = boundDateField.bind(this);
     this.editProfileObjectArray = editProfileObjectArray.bind(this);
-    this.boundMonthField = boundMonthField.bind(this);
-    this.boundYearField = boundYearField.bind(this);
 
     // options we set (for select components)
     let countryOptions = Object.keys(iso3166.data).map(code => ({
@@ -34,19 +30,16 @@ class ProfileTab extends React.Component {
       label: iso3166.data[code]['name']
     }));
     this.countryOptions = _.sortBy(countryOptions, 'label');
-    this.boolOptions = [
-      { value: 'y', label: 'Yes' },
-      { value: 'n', label: 'No' }
-    ];
     this.genderOptions = [
       { value: 'm', label: 'Male' },
       { value: 'f', label: 'Female' },
       { value: 'o', label: 'Other/Prefer not to say' }
     ];
-    this.languageOptions = LANGUAGE_CODES.map(language => ({
+    let languageOptions = LANGUAGE_CODES.map(language => ({
       value: language.alpha2,
       label: language.English
     }));
+    this.languageOptions = _.sortBy(languageOptions, 'label');
     this.privacyOptions = [
       { value: 'public', label: 'Public to the world'},
       { value: 'public_to_mm', label: 'Public to other micromasters students'},

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -1,12 +1,14 @@
 import React from 'react';
-import TextField from 'react-mdl/lib/Textfield';
-import Select from 'react-select';
 import DatePicker from 'react-datepicker';
 import Button from 'react-mdl/lib/Button';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import moment from 'moment';
 import iso3166 from 'iso-3166-2';
 import _ from 'lodash';
+import AutoComplete from 'material-ui/AutoComplete';
+import MenuItem from 'material-ui/MenuItem';
+import TextField from 'material-ui/TextField';
+
 import { DATE_FORMAT } from '../constants';
 
 // utility functions for pushing changes to profile forms back to the
@@ -30,12 +32,16 @@ export function boundTextField(keySet, label) {
     _.set(clone, keySet, e.target.value);
     updateProfile(clone);
   };
+
+  // fullWidth means set width to 100% instead of 256px. This lets us use the
+  // Grid and Cell to manage its size
   return (
     <TextField
-      floatingLabel
-      label={label}
+      name={label}
+      floatingLabelText={label}
       value={_.get(profile, keySet, "")}
-      error={_.get(errors, keySet)}
+      fullWidth={true}
+      errorText={_.get(errors, keySet)}
       onChange={onChange} />
   );
 }
@@ -49,36 +55,103 @@ export function boundSelectField(keySet, label, options) {
     errors,
     updateProfile,
   } = this.props;
-  let onChange = value => {
+
+  // use a temporary edit value to store text currently in the textbox
+  let editKeySet = keySet.concat();
+  editKeySet[editKeySet.length - 1] = editKeySet[editKeySet.length - 1] + "_edit";
+
+  let caseInsensitivePrefixFilter = (searchText, key) => {
+    let index = key.toLowerCase().indexOf(searchText.toLowerCase());
+    return index === 0;
+  };
+
+  let onNewRequest = (optionOrString, index) => {
     let clone = _.cloneDeep(profile);
-    _.set(clone, keySet, value? value.value : '');
+    let toStore;
+    if (index === -1) {
+      // enter was pressed and optionOrString is a string
+      // select first item in dropdown if any are present
+      let filteredOptionValues = options.
+        map(option => option.label).
+        filter(caseInsensitivePrefixFilter.bind(this, optionOrString));
+      if (filteredOptionValues.length > 0) {
+        let option = options.find(option => option.label === filteredOptionValues[0]);
+        toStore = option.value;
+      }
+    } else {
+      // user selected an item in the menu
+      toStore = _.get(optionOrString, ['value', 'props', 'value']);
+    }
+
+    if (toStore !== undefined) {
+      _.set(clone, keySet, toStore);
+    } // else we couldn't figure out what the user wanted to select, so leave it as is
+    _.set(clone, editKeySet, undefined);
+
     updateProfile(clone);
   };
-  return <div>
-    <Select
-      options={options}
-      value={_.get(profile, keySet)}
-      placeholder={label}
-      onChange={onChange} />
-    <span className="validation-error-text">{_.get(errors, keySet)}</span>
-  </div>;
+
+  let selectedValue = _.get(profile, keySet);
+  let selectedOption = options.find(option => option.value === selectedValue);
+  let onUpdateInput = searchText => {
+    let clone = _.cloneDeep(profile);
+    _.set(clone, editKeySet, searchText);
+    updateProfile(clone);
+  };
+  let onBlur = () => {
+    // clear the edit value when we lose focus. In its place we will display
+    // the selected option label if one is selected, or an empty string
+    let clone = _.cloneDeep(profile);
+    _.set(clone, editKeySet, undefined);
+    updateProfile(clone);
+  };
+
+  let convertOption = option => ({
+    text: option.label,
+    value: <MenuItem primaryText={option.label} value={option.value}/>
+  });
+
+  let searchText;
+  let editText = _.get(profile, editKeySet);
+  if (editText !== undefined) {
+    searchText = editText;
+  } else if (selectedOption) {
+    searchText = selectedOption.label;
+  } else {
+    searchText = "";
+  }
+
+
+  return (
+    <AutoComplete
+      ref="autocomplete"
+      animated={false}
+      menuCloseDelay={0}
+      filter={caseInsensitivePrefixFilter}
+      dataSource={options.map(convertOption)}
+      searchText={searchText}
+      floatingLabelText={label}
+      openOnFocus={true}
+      menuStyle={{maxHeight: 300}}
+      fullWidth={true}
+      onNewRequest={onNewRequest}
+      onUpdateInput={onUpdateInput}
+      onBlur={onBlur}
+      errorText={_.get(errors, keySet)}
+    />
+  );
 }
 
+// HACK: we need to import the function above to allow us to mock it for testing
+import { boundSelectField as mockedBoundSelectField } from './profile_edit';
 
 // bind this to this.boundStateSelectField in the constructor of a form component
 // to update select fields
 // pass in the name (used as placeholder), key for profile, and the options.
 export function boundStateSelectField(stateKeySet, countryKeySet, label) {
   const {
-    updateProfile,
-    errors,
     profile,
   } = this.props;
-  let onChange = value => {
-    let clone = _.cloneDeep(profile);
-    _.set(clone, stateKeySet, value ? value.value : null);
-    updateProfile(clone);
-  };
   let options = [];
   let country = _.get(profile, countryKeySet);
   if (iso3166.data[country] !== undefined) {
@@ -89,14 +162,7 @@ export function boundStateSelectField(stateKeySet, countryKeySet, label) {
     options = _.sortBy(options, 'label');
   }
 
-  return <div>
-    <Select
-      options={options}
-      value={_.get(profile, stateKeySet)}
-      placeholder={label}
-      onChange={onChange} />
-    <span className="validation-error-text">{_.get(errors, stateKeySet)}</span>
-  </div>;
+  return mockedBoundSelectField.call(this, stateKeySet, label, options);
 }
 
 // bind this to this.boundDateField in the constructor of a form component
@@ -125,82 +191,6 @@ export function boundDateField(keySet, label) {
     />
     <span className="validation-error-text">{_.get(errors, keySet)}</span>
   </div>;
-}
-export function boundMonthField(keySet, label) {
-  const {updateProfile, errors, profile} = this.props;
-  let onChange = month => {
-    let clone = _.cloneDeep(profile);
-
-    let currentValue = _.get(clone, keySet);
-        // format as ISO-8601
-    let dateValue;
-    if(!month){
-      dateValue = "";
-    }else if (currentValue){
-      dateValue = moment(currentValue).set('month', month.value);
-    } else {
-      dateValue = moment().set('date', 1).set('month', month.value);
-    }
-    if(dateValue.isValid()){
-      _.set(clone, keySet, dateValue.format(DATE_FORMAT));
-    }
-    updateProfile(clone);
-  };
-  let month = _.get(profile, keySet)? moment(_.get(profile, keySet), DATE_FORMAT).month() : "";
-  const monthOptions = [
-    { value: 0, label: 'January'},
-    { value: 1, label: 'February'},
-    { value: 2, label: 'March'},
-    { value: 3, label: 'April'},
-    { value: 4, label: 'May'},
-    { value: 5, label: 'June'},
-    { value: 6, label: 'July'},
-    { value: 7, label: 'August'},
-    { value: 8, label: 'September'},
-    { value: 9, label: 'October'},
-    { value: 10, label: 'November'},
-    {value: 11, label: 'December'}
-  ];
-
-  return <div>
-    <Select
-      options={monthOptions}
-      clearable={false}
-      value={month}
-      placeholder={label}
-      onChange={onChange}
-    />
-    <span className="validation-error-text">{_.get(errors, keySet)}</span>
-  </div>;
-}
-
-export function boundYearField(keySet, label) {
-  const {updateProfile, errors, profile} = this.props;
-  let onChange = e => {
-    let clone = _.cloneDeep(profile);
-    let currentValue = _.get(clone, keySet);
-    let year = e.target.value;
-    // format as ISO-8601
-    let dateValue = '';
-    if (year) {
-      if (currentValue) {
-        dateValue = moment(currentValue).set('year', year);
-      } else {
-        dateValue = moment().set('date', 1).set('year', year);
-      }
-      if (dateValue.isValid()) {
-        _.set(clone, keySet, dateValue.format(DATE_FORMAT));
-      }
-      updateProfile(clone);
-    }
-  };
-  let year = _.get(profile, keySet) ? moment(_.get(profile, keySet), DATE_FORMAT).year() : "";
-  return <div>
-    <TextField
-      label={label}
-      value={year}
-      onChange={onChange}/>
-    <span className="validation-error-text">{_.get(errors, keySet)}</span></div>;
 }
 
 // bind to this.saveAndContinue.bind(this, '/next/url')

--- a/static/js/util/profile_edit_test.js
+++ b/static/js/util/profile_edit_test.js
@@ -1,20 +1,20 @@
+import React from 'react';
 import assert from 'assert';
-import TestUtils from 'react-addons-test-utils';
 import iso3166 from 'iso-3166-2';
 import _ from 'lodash';
-
-import { boundStateSelectField } from '../util/profile_edit';
-import { USER_PROFILE_RESPONSE } from '../constants';
 import moment from 'moment';
+import MenuItem from 'material-ui/MenuItem';
+import sinon from 'sinon';
 
 import {
   boundTextField,
   boundDateField,
   boundSelectField,
-  boundMonthField,
-  boundYearField
+  boundStateSelectField,
 } from './profile_edit';
 import { DATE_FORMAT } from '../constants';
+import { USER_PROFILE_RESPONSE } from '../constants';
+import * as profileEdit from '../util/profile_edit';
 
 describe('Profile Editing utility functions', () => {
   let that;
@@ -50,10 +50,9 @@ describe('Profile Editing utility functions', () => {
     });
 
     it('should correctly set props on itself', () => {
-      assert.deepEqual('First Name', textField.props.label);
-      assert.deepEqual('First name is required', textField.props.error);
+      assert.deepEqual('First Name', textField.props.floatingLabelText);
+      assert.deepEqual('First name is required', textField.props.errorText);
       assert.deepEqual('', textField.props.value);
-      assert.deepEqual(true, textField.props.floatingLabel);
     });
 
     it('should call the updateProfile callback when onChange fires', () => {
@@ -95,76 +94,8 @@ describe('Profile Editing utility functions', () => {
     });
   });
 
-  describe('Bound Month field', () => {
-    let dateField, selectElement, errorText;
-    const monthOptions = [
-      {value: 0, label: 'January'},
-      {value: 1, label: 'February'},
-      {value: 2, label: 'March'},
-      {value: 3, label: 'April'},
-      {value: 4, label: 'May'},
-      {value: 5, label: 'June'},
-      {value: 6, label: 'July'},
-      {value: 7, label: 'August'},
-      {value: 8, label: 'September'},
-      {value: 9, label: 'October'},
-      {value: 10, label: 'November'},
-      {value: 11, label: 'December'}
-    ];
-    beforeEach(() => {
-      dateField = boundMonthField.call(
-        that,
-        ["date_field"],
-        "Month"
-      );
-      selectElement = dateField.props.children[0];
-      errorText = dateField.props.children[1];
-    });
-
-    it('should correctly set props on itself', () => {
-      assert.equal('Month', selectElement.props.placeholder);
-      assert.equal(errorText.type, 'span');
-      assert.deepEqual({
-        className: 'validation-error-text',
-        children: "Date field is required",
-      }, errorText.props);
-    });
-
-    it('should call the updateProfile callback when onChange fires', () => {
-      let cur = moment().set('date', 1);
-      selectElement.props.onChange(monthOptions[cur.month()]);
-      assert.deepEqual(cur.format(DATE_FORMAT), that.props.profile.date_field);
-    });
-  });
-  describe('Bound Year field', () => {
-    let textField, textElement, errorText;
-    beforeEach(() => {
-      textField = boundYearField.call(
-        that,
-        ["date_field"],
-        "Year"
-      );
-      [textElement, errorText] = textField.props.children;
-    });
-
-    it('should correctly set props on itself', () => {
-      assert.deepEqual('Year', textElement.props.label);
-      assert.deepEqual({
-        className: 'validation-error-text',
-        children: "Date field is required"
-      }, errorText.props);
-      assert.deepEqual('', textElement.props.value);
-    });
-
-    it('should call the updateProfile callback when onChange fires', () => {
-      let cur = moment().set('date', 1).set('year', 1995);
-      textElement.props.onChange({target: {value: cur.year()}});
-      assert.deepEqual(cur.format(DATE_FORMAT), that.props.profile.date_field);
-    });
-  });
-
   describe('Bound select field', () => {
-    let selectField, selectElement, errorText;
+    let selectField;
     let genderOptions = [
       {value: 'm', label: 'Male'},
       {value: 'f', label: 'Female'},
@@ -178,27 +109,102 @@ describe('Profile Editing utility functions', () => {
         "Gender",
         genderOptions
       );
-      selectElement = selectField.props.children[0];
-      errorText = selectField.props.children[1];
     });
 
     it('should set props correctly', () => {
-      assert.deepEqual(selectElement.props.options, genderOptions);
-      assert.equal(selectElement.props.placeholder, 'Gender');
-      assert.equal(selectElement.props.value, undefined);
-      assert.deepEqual({
-        className: 'validation-error-text',
-        children: "Gender is required",
-      }, errorText.props);
+      assert.equal(selectField.props.dataSource.length, genderOptions.length);
+      for (let i = 0; i < genderOptions.length; i++) {
+        let item = selectField.props.dataSource[i];
+        let option = genderOptions[i];
+        assert.equal(option.label, item.text);
+        assert.equal(option.label, item.value.props.primaryText);
+        assert.equal(option.value, item.value.props.value);
+      }
+      assert.equal(selectField.props.floatingLabelText, 'Gender');
+      assert.equal(selectField.props.searchText, "");
+      assert.ok(selectField.props.openOnFocus);
+      assert.equal(selectField.props.errorText, "Gender is required");
+
     });
 
-    it('should call the updateProfile callback when onChange fires', () => {
-      selectElement.props.onChange(genderOptions[1]);
+    it('should filter by case insensitive prefix', () => {
+      let filter = selectField.props.filter;
+      assert(filter("mal", "Male"));
+      // prefix doesn't match
+      assert(!filter("mal", "Female"));
+    });
+
+    it('should update the selected option when onNewRequest fires with an option', () => {
+      let option = genderOptions[1];
+      selectField.props.onNewRequest({
+        text: option.label,
+        value: <MenuItem primaryText={option.label} value={option.value} />
+      }, 0);
       assert.equal(that.props.profile.gender, 'f');
+    });
+
+    it('should update the selected option when the enter key is pressed', () => {
+      selectField.props.onNewRequest('other', -1);
+      assert.equal(that.props.profile.gender, 'o');
+    });
+
+    it("should not update the selected option when the enter key is pressed and text doesn't match", () => {
+      that.props.profile.gender = 'm';
+      selectField.props.onNewRequest('x', -1);
+      assert.equal(that.props.profile.gender, 'm');
+    });
+
+    it('should have the correct option selected', () => {
+      that.props.profile.gender = 'f';
+      selectField = boundSelectField.call(
+        that,
+        ['gender'],
+        "Gender",
+        genderOptions
+      );
+
+      assert.equal(selectField.props.searchText, 'Female');
+    });
+
+    it('should keep valid state when onBlur is called', () => {
+      that.props.profile.gender = 'f';
+      that.props.profile.gender_edit = 'text not matching anything';
+      selectField = boundSelectField.call(
+        that,
+        ['gender'],
+        "Gender",
+        genderOptions
+      );
+      selectField.props.onBlur();
+
+      assert.equal(that.props.profile.gender, 'f');
+    });
+
+    it('should update the edit state when onUpdateInput is called', () => {
+      selectField = boundSelectField.call(
+        that,
+        ['gender'],
+        "Gender",
+        genderOptions
+      );
+      selectField.props.onUpdateInput("update input text");
+
+      assert.equal(that.props.profile.gender_edit, "update input text");
     });
   });
 
   describe("Bound state select field", () => {
+    let sandbox, boundSelectFieldSpy;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+
+      boundSelectFieldSpy = sandbox.spy(profileEdit, 'boundSelectField');
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
     it('lists no states when an invalid country is selected', () => {
       const country = "MISSING";
       const state = "MISSING";
@@ -214,16 +220,10 @@ describe('Profile Editing utility functions', () => {
         }
       });
 
-      let result = stateSelectField(["state_key"], ["country_key"], "");
-      let select;
-      for (let child of result.props.children) {
-        if (child.type.displayName === 'Select') {
-          select = child;
-        }
-      }
-
-      assert.equal(select.props.value, state);
-      assert.deepEqual(select.props.options, []);
+      let label = "LABEL";
+      let stateKey = ["state_key"];
+      stateSelectField(stateKey, ["country_key"], label);
+      assert(boundSelectFieldSpy.calledWith(stateKey, label, []));
     });
 
     it('renders a select field with sorted states for the given country', () => {
@@ -246,63 +246,15 @@ describe('Profile Editing utility functions', () => {
         }
       });
 
-      let result = stateSelectField(["state_key"], ["country_key"], placeholder);
-      let select, errorSpan;
-      for (let child of result.props.children) {
-        if (child.type.displayName === 'Select') {
-          select = child;
-        }
-        if (child.props.className === 'validation-error-text') {
-          errorSpan = child;
-        }
-      }
-
-      assert.equal(TestUtils.renderIntoDocument(errorSpan).innerHTML, error);
-      assert.equal(select.props.placeholder, placeholder);
-      assert.equal(select.props.value, state);
-
+      let stateKey = ["state_key"];
+      stateSelectField(stateKey, ["country_key"], placeholder);
       let options = Object.keys(iso3166.data[country].sub).map(code => ({
         value: code,
         label: iso3166.data[country].sub[code].name
       }));
       options = _.sortBy(options, 'label');
-      assert.deepEqual(select.props.options, options);
-    });
 
-    it('updates the state properly', () => {
-      const country = "US";
-      let profile = Object.assign({}, USER_PROFILE_RESPONSE, {
-        state_collection: [
-          {
-            country: "US"
-          }
-        ]
-      });
-
-      let stateSelectField = boundStateSelectField.bind({
-        props: {
-          profile,
-          updateProfile: clone => {
-            profile = clone;
-          }
-        }
-      });
-
-      let result = stateSelectField(
-        ["state_collection", 0, "state"],
-        ["state_collection", 0, "country"],
-        "",
-      );
-      let select;
-      for (let child of result.props.children) {
-        if (child.type.displayName === 'Select') {
-          select = child;
-        }
-      }
-      let newStateCode = "US-TN";
-      select.props.onChange({value: newStateCode, label: "Tennessee"});
-      assert.equal(profile.state_collection[0].country, country);
-      assert.equal(profile.state_collection[0].state, newStateCode);
+      assert(boundSelectFieldSpy.calledWith(stateKey, placeholder, options));
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #277 


#### What's this PR do?
Adds material-ui so we can use the AutoComplete component to replace our select fields. Also updates `boundStateSelectField` to call `boundSelectField` instead of implementing duplicate behavior

#### Where should the reviewer start?

#### How should this be manually tested?
Go to the profile and edit the gender field, or the state/country fields. You should notice these behaviors:
 - the autocomplete now only matches prefixes (case insensitive)
 - when user is not actively typing in the autocomplete, it should always show the currently selected item or a blank string.
 - when the user types some text and presses enter and they have something in the autocomplete, the first item in the autocomplete menu will become the selected item
 - when the user types some text which doesn't match anything and presses enter, it should revert back to whatever was previously selected
 - when user clicks on a selected item, it should become the new selected item
 - user should not be able to clear the field

Weird behaviors:
 - when you press down on the keyboard the autocomplete loses focus and the text field reverts to the currently selected item. Ideally we should let the user choose options by pressing the down key and pressing enter, but I don't know how to distinguish a loss of focus to go to the menu vs a loss of focus to go to another part of the form
#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

