### PR TITLE
Added field for month/year

### DIFF
--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -201,7 +201,7 @@ class EducationTab extends ProfileTab {
             {this.boundTextField(keySet('field_of_study'), 'Field of Study')}
           </Cell>
           <Cell col={6}>
-            {this.boundDateField(keySet('graduation_date'), 'Graduation Date')}
+            {this.boundMonthYearField(keySet('graduation_date'), 'Graduation Date')}
           </Cell>
         </Grid>
         <Grid>

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -88,10 +88,10 @@ class EmploymentTab extends ProfileTab {
           {this.boundSelectField(keySet('country'), 'Country', this.countryOptions)}
         </Cell>
         <Cell col={12}>
-          {this.boundDateField(keySet('start_date'), 'Start Date')}
+          {this.boundMonthYearField(keySet('start_date'), 'Start Date')}
         </Cell>
         <Cell col={12}>
-          {this.boundDateField(keySet('end_date'), 'End Date')}
+          {this.boundMonthYearField(keySet('end_date'), 'End Date')}
         </Cell>
       </Grid>
     );

--- a/static/js/util/ProfileTab.js
+++ b/static/js/util/ProfileTab.js
@@ -5,6 +5,7 @@ import {
   boundDateField,
   boundTextField,
   boundSelectField,
+  boundMonthYearField,
   editProfileObjectArray,
   boundStateSelectField,
 } from './profile_edit';
@@ -22,6 +23,7 @@ class ProfileTab extends React.Component {
     this.boundSelectField = boundSelectField.bind(this);
     this.boundStateSelectField = boundStateSelectField.bind(this);
     this.boundDateField = boundDateField.bind(this);
+    this.boundMonthYearField = boundMonthYearField.bind(this);
     this.editProfileObjectArray = editProfileObjectArray.bind(this);
 
     // options we set (for select components)

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -268,6 +268,18 @@ export function validateProfileComplete(profile) {
 }
 
 /**
+ * Converts string to int using base 10. Stricter in what is accepted than parseInt
+ * @param value {String} A value to be parsed
+ * @returns {Number|undefined} Either an integer or undefined if parsing didn't work.
+ */
+const filterPositiveInt = value => {
+  if(/^[0-9]+$/.test(value)) {
+    return Number(value);
+  }
+  return undefined;
+};
+
+/**
  * Returns the string with any HTML rendered and then its tags stripped
  * @return {String} rendered text stripped of HTML
  */
@@ -279,4 +291,37 @@ export function makeStrippedHtml(textOrElement) {
   } else {
     return striptags(textOrElement);
   }
+}
+
+/**
+ * Validate a month number
+ * @param {String} string The input string
+ * @returns {Number|undefined} The valid month or undefined if not valid
+ */
+export function validateMonth(string) {
+  let month = filterPositiveInt(string);
+  if (month === undefined) {
+    return undefined;
+  }
+  if (month < 1 || month > 12) {
+    return undefined;
+  }
+  return month;
+}
+
+/**
+ * Validate a year string is an integer and fits into YYYY
+ * @param {String} string The input string
+ * @returns {Number|undefined} The valid year or undefined if not valid
+ */
+export function validateYear(string) {
+  let year = filterPositiveInt(string);
+  if (year === undefined) {
+    return undefined;
+  }
+  if (year < 1 || year > 9999) {
+    // fit into YYYY format
+    return undefined;
+  }
+  return year;
 }

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -17,6 +17,8 @@ import {
   validateProfile,
   validateProfileComplete,
   makeStrippedHtml,
+  validateMonth,
+  validateYear,
 } from '../util/util';
 import PersonalTab from '../components/PersonalTab';
 import EmploymentTab from '../components/EmploymentTab';
@@ -383,6 +385,58 @@ describe('utility functions', () => {
         text: "Please complete your work history information.",
       }];
       assert.deepEqual(validateProfileComplete(profile), expectation);
+    });
+  });
+
+  describe('validateMonth', () => {
+    it('handles months starting with 0 without treating as octal', () => {
+      assert.equal(9, validateMonth("09"));
+    });
+    it('converts strings to numbers', () => {
+      assert.equal(3, validateMonth("3"));
+    });
+    it('returns undefined for invalid months', () => {
+      assert.equal(undefined, validateMonth("-3"));
+      assert.equal(undefined, validateMonth("0"));
+      assert.equal(1, validateMonth("1"));
+      assert.equal(12, validateMonth("12"));
+      assert.equal(undefined, validateMonth("13"));
+    });
+    it('returns undefined if the text is not an integer number', () => {
+      assert.equal(undefined, validateMonth("two"));
+      assert.equal(undefined, validateMonth(""));
+      assert.equal(undefined, validateMonth(null));
+      assert.equal(undefined, validateMonth({}));
+      assert.equal(undefined, validateMonth(undefined));
+      assert.equal(undefined, validateMonth("2e0"));
+      assert.equal(undefined, validateMonth("3-4"));
+      assert.equal(undefined, validateMonth("3.4"));
+    });
+  });
+
+  describe('validateYear', () => {
+    it('handles years starting with 0 without treating as octal', () => {
+      assert.equal(999, validateYear("0999"));
+    });
+    it('converts strings to numbers', () => {
+      assert.equal(3, validateYear("3"));
+    });
+    it('returns undefined for invalid years', () => {
+      assert.equal(undefined, validateYear("-3"));
+      assert.equal(undefined, validateYear("0"));
+      assert.equal(1, validateYear("1"));
+      assert.equal(9999, validateYear("9999"));
+      assert.equal(undefined, validateYear("10000"));
+    });
+    it('returns undefined if the text is not an integer number', () => {
+      assert.equal(undefined, validateYear("two"));
+      assert.equal(undefined, validateYear(""));
+      assert.equal(undefined, validateYear(null));
+      assert.equal(undefined, validateYear({}));
+      assert.equal(undefined, validateYear(undefined));
+      assert.equal(undefined, validateYear("2e0"));
+      assert.equal(undefined, validateYear("3-4"));
+      assert.equal(undefined, validateYear("3.4"));
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #276
#### What's this PR do?
Uses the textfields to bring up month and year fields. Both fields should validate the numbers provided


#### Where should the reviewer start?
`profile_edit.js`

#### How should this be manually tested?
There shouldn't be any odd behavior (at least in the UI):
 - There should be two text fields and a label which look like this: Label MM / YYYY
 - you should be able to edit either textbox independently. If one is blank, there should be a validation error when you click save. After the validation error you should be able to save if you fill in proper values for each textbox.
 - Only numbers 1-12 and 1-9999 should be accepted by the field. You should be able to type in text but it will cause a validation error

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
