### PR TITLE
Fixed profile submission to wait for a 200

### DIFF
--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -69,7 +69,11 @@ export const saveProfile = (username, profile) => {
     dispatch(requestPatchUserProfile());
     return api.patchUserProfile(username, profile).
       then(newProfile => dispatch(receivePatchUserProfileSuccess(newProfile))).
-      catch(() => dispatch(receivePatchUserProfileFailure()));
+      catch(e => {
+        dispatch(receivePatchUserProfileFailure());
+        // propagate exception
+        return Promise.reject(e);
+      });
   };
 };
 export const updateProfileValidation = errors => ({
@@ -94,7 +98,11 @@ export function fetchUserProfile(username) {
     dispatch(requestGetUserProfile());
     return api.getUserProfile(username).
       then(json => dispatch(receiveGetUserProfileSuccess(json))).
-      catch(()=> dispatch(receiveGetUserProfileFailure()));
+      catch(e => {
+        dispatch(receiveGetUserProfileFailure());
+        // propagate exception
+        return Promise.reject(e);
+      });
   };
 }
 
@@ -117,6 +125,10 @@ export function fetchDashboard() {
     dispatch(requestDashboard());
     return api.getDashboard().
       then(dashboard => dispatch(receiveDashboardSuccess(dashboard))).
-      catch(() => dispatch(receiveDashboardFailure()));
+      catch(e => {
+        dispatch(receiveDashboardFailure());
+        // propagate exception
+        return Promise.reject(e);
+      });
   };
 }

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -66,7 +66,7 @@ class ProfilePage extends React.Component {
       dispatch(startProfileEdit());
     }
     return dispatch(validateProfile(profile, requiredFields, messages)).then(() => {
-      dispatch(saveProfile(SETTINGS.username, profile)).then(() => {
+      return dispatch(saveProfile(SETTINGS.username, profile)).then(() => {
         dispatch(clearProfileEdit());
       });
     });

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -97,7 +97,10 @@ describe('reducers', () => {
 
         assert.ok(getUserProfileStub.calledWith('jane'));
 
-        done();
+        // assert that it returns a rejected promise on failure
+        store.dispatch(fetchUserProfile('jane')).catch(() => {
+          done();
+        });
       });
     });
 
@@ -131,7 +134,10 @@ describe('reducers', () => {
 
         assert.ok(patchUserProfileStub.calledWith('jane', USER_PROFILE_RESPONSE));
 
-        done();
+        // assert that it returns a rejected promise on failure
+        store.dispatch(saveProfile('jane', USER_PROFILE_RESPONSE)).catch(() => {
+          done();
+        });
       });
     });
 
@@ -336,7 +342,10 @@ describe('reducers', () => {
       dispatchThen(fetchDashboard(), [REQUEST_DASHBOARD, RECEIVE_DASHBOARD_FAILURE]).then(dashboardState => {
         assert.equal(dashboardState.fetchStatus, FETCH_FAILURE);
 
-        done();
+        // assert that it returns a rejected promise on failure
+        store.dispatch(fetchDashboard()).catch(() => {
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #270

#### What's this PR do?
When we add `catch` to a `Promise` without returning another rejected `Promise`, future promises are resolved with that return value. This meant that even when the API function returned the rejected promise, the action dispatcher function returned a resolved promise.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

