### PR TITLE
Fixed selectfield when onNewRequest and onFocus both occur before a rerender

### DIFF
--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -68,7 +68,6 @@ export function boundTextField(keySet, label) {
  */
 export function boundSelectField(keySet, label, options) {
   const {
-    profile,
     errors,
     updateProfile,
   } = this.props;
@@ -83,7 +82,7 @@ export function boundSelectField(keySet, label, options) {
   };
 
   let onNewRequest = (optionOrString, index) => {
-    let clone = _.cloneDeep(profile);
+    let clone = _.cloneDeep(this.props.profile);
     let toStore;
     if (index === -1) {
       // enter was pressed and optionOrString is a string
@@ -108,17 +107,17 @@ export function boundSelectField(keySet, label, options) {
     updateProfile(clone);
   };
 
-  let selectedValue = _.get(profile, keySet);
+  let selectedValue = _.get(this.props.profile, keySet);
   let selectedOption = options.find(option => option.value === selectedValue);
   let onUpdateInput = searchText => {
-    let clone = _.cloneDeep(profile);
+    let clone = _.cloneDeep(this.props.profile);
     _.set(clone, editKeySet, searchText);
     updateProfile(clone);
   };
   let onBlur = () => {
     // clear the edit value when we lose focus. In its place we will display
     // the selected option label if one is selected, or an empty string
-    let clone = _.cloneDeep(profile);
+    let clone = _.cloneDeep(this.props.profile);
     _.set(clone, editKeySet, undefined);
     updateProfile(clone);
   };
@@ -129,7 +128,7 @@ export function boundSelectField(keySet, label, options) {
   });
 
   let searchText;
-  let editText = _.get(profile, editKeySet);
+  let editText = _.get(this.props.profile, editKeySet);
   if (editText !== undefined) {
     searchText = editText;
   } else if (selectedOption) {
@@ -234,7 +233,6 @@ export function boundDateField(keySet, label) {
  */
 export function boundMonthYearField(keySet, label) {
   const {
-    profile,
     errors,
     updateProfile,
   } = this.props;
@@ -245,7 +243,7 @@ export function boundMonthYearField(keySet, label) {
 
   // Get the moment object from the state, or null if not available
   let getDate = () => {
-    let formattedDate = _.get(profile, keySet);
+    let formattedDate = _.get(this.props.profile, keySet);
 
     if (formattedDate !== undefined && formattedDate !== null) {
       return moment(formattedDate, DATE_FORMAT);
@@ -256,7 +254,7 @@ export function boundMonthYearField(keySet, label) {
   // Get a tuple { month, year } which contains the values being edited in the textbox
   // values may be strings or numbers. Otherwise return empty object.
   let getMonthYear = () => {
-    let monthYear = _.get(profile, editKeySet, {});
+    let monthYear = _.get(this.props.profile, editKeySet, {});
 
     if (_.isEmpty(monthYear)) {
       let date = getDate();
@@ -275,7 +273,7 @@ export function boundMonthYearField(keySet, label) {
   // representation instead in a temporary edit value and store null in place of the
   // date format.
   let setNewDate = (month, year) => {
-    let clone = _.cloneDeep(profile);
+    let clone = _.cloneDeep(this.props.profile);
 
     let monthYear = getMonthYear();
     // Update monthYear with the typed text. Typically only month or year will

--- a/static/js/util/profile_edit_test.js
+++ b/static/js/util/profile_edit_test.js
@@ -193,6 +193,13 @@ describe('Profile Editing utility functions', () => {
 
       assert.equal(that.props.profile.gender_edit, "update input text");
     });
+
+    it("can call onNewRequest and onFocus without colliding into each other", () => {
+      selectField.props.onNewRequest('other', -1);
+      selectField.props.onBlur();
+
+      assert.equal(that.props.profile.gender, 'o');
+    });
   });
 
   describe("Bound state select field", () => {
@@ -358,8 +365,6 @@ describe('Profile Editing utility functions', () => {
     
     it("updates the formatted date if month and year are valid", () => {
       monthTextField.props.onChange({target: {value: "12"}});
-      [labelField, __, monthTextField, __, yearTextField, errorSpan] = renderMonthYearField();
-
       yearTextField.props.onChange({target: {value: "2077"}});
 
       assert.equal(that.props.profile.date_of_birth, "2077-12-01");
@@ -368,7 +373,6 @@ describe('Profile Editing utility functions', () => {
 
     it("stores text in date_of_birth_edit if it's not a valid date", () => {
       that.props.profile.date_of_birth = "2066-02-28";
-      [labelField, __, monthTextField, __, yearTextField, errorSpan] = renderMonthYearField();
       monthTextField.props.onChange({target: {value: "13"}});
       [labelField, __, monthTextField, __, yearTextField, errorSpan] = renderMonthYearField();
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #319
#### What's this PR do?
Fixes a bug in the `boundSelectField` implementation. Since `boundSelectField` is called on every render the callbacks would only get a new copy of the props on every render. This changes each field which does a nontrivial modification of the profile to always get `this.props.profile` instead of using the one created when the function was executed.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
