### PR TITLE
Removed onBlur callback from AutoComplete

### DIFF
--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -115,13 +115,6 @@ export function boundSelectField(keySet, label, options) {
     _.set(clone, editKeySet, searchText);
     updateProfile(clone);
   };
-  let onBlur = () => {
-    // clear the edit value when we lose focus. In its place we will display
-    // the selected option label if one is selected, or an empty string
-    let clone = _.cloneDeep(profile);
-    _.set(clone, editKeySet, undefined);
-    updateProfile(clone);
-  };
 
   let convertOption = option => ({
     text: option.label,
@@ -153,7 +146,6 @@ export function boundSelectField(keySet, label, options) {
       fullWidth={true}
       onNewRequest={onNewRequest}
       onUpdateInput={onUpdateInput}
-      onBlur={onBlur}
       errorText={_.get(errors, keySet)}
     />
   );

--- a/static/js/util/profile_edit_test.js
+++ b/static/js/util/profile_edit_test.js
@@ -168,20 +168,6 @@ describe('Profile Editing utility functions', () => {
       assert.equal(selectField.props.searchText, 'Female');
     });
 
-    it('should keep valid state when onBlur is called', () => {
-      that.props.profile.gender = 'f';
-      that.props.profile.gender_edit = 'text not matching anything';
-      selectField = boundSelectField.call(
-        that,
-        ['gender'],
-        "Gender",
-        genderOptions
-      );
-      selectField.props.onBlur();
-
-      assert.equal(that.props.profile.gender, 'f');
-    });
-
     it('should update the edit state when onUpdateInput is called', () => {
       selectField = boundSelectField.call(
         that,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #319 

#### What's this PR do?
The onBlur and onNewRequest callbacks were modifying the same copy of `profile`. This removes `onBlur` which means the field will not show the currently selected state anymore when a user focuses away from the field. It will fix the down key behavior however

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?
I filed #327 to provide a better fix for this

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

