### PR TITLE
added edx_course_key to courserun list display in admin

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -1,36 +1,58 @@
-"""Admin views for Courses & Programs"""
+"""
+Admin views for Courses & Programs
+"""
+
 from django.contrib import admin
-from .models import Course, CourseRun, Program
+
+from courses.models import Course, CourseRun, Program
 
 
-class ProgramAdmin(admin.ModelAdmin):
-    """ModelAdmin for Programs"""
-    list_display = ('title', 'live',)
-    list_filter = ('live',)
+class CourseInline(admin.StackedInline):
+    """Admin Inline for Course objects"""
+    model = Course
+    extra = 1
+    show_change_link = True
 
 
 class CourseRunInline(admin.StackedInline):
     """Admin Inline for CourseRun objects"""
     model = CourseRun
     extra = 1
+    show_change_link = True
+
+
+class ProgramAdmin(admin.ModelAdmin):
+    """ModelAdmin for Programs"""
+    list_display = ('title', 'live',)
+    list_filter = ('live',)
+    inlines = [CourseInline]
 
 
 class CourseAdmin(admin.ModelAdmin):
     """ModelAdmin for Courses"""
-    list_display = ('title', 'position_in_program',)
+    list_display = ('title', 'program_title', 'position_in_program',)
     list_filter = ('program__live',)
     inlines = [CourseRunInline]
-    ordering = ('position_in_program',)
+    ordering = ('program__title', 'position_in_program',)
+
+    def program_title(self, course):  # pylint: disable=no-self-use
+        """Getter for the foreign key element"""
+        return course.program.title
 
 
 class CourseRunAdmin(admin.ModelAdmin):
     """ModelAdmin for Courses"""
-    list_display = ('title', 'edx_course_key', 'program',)
+    list_display = ('title', 'edx_course_key', 'course', 'program',)
     list_filter = ('course__program__live',)
+    ordering = ('course__title', 'course__program__title', 'course__position_in_program',)
 
     def program(self, run):  # pylint: disable=no-self-use
         """method to show program for list display."""
-        return run.course.program
+        return run.course.program.title
+
+    def course(self, run):  # pylint: disable=no-self-use
+        """Getter for course foreign key"""
+        return run.course.title
 
 
 admin.site.register(CourseRun, CourseRunAdmin)

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -17,7 +17,7 @@ class CourseRunInline(admin.StackedInline):
 
 class CourseAdmin(admin.ModelAdmin):
     """ModelAdmin for Courses"""
-    list_display = ('position_in_program', 'title',)
+    list_display = ('title', 'position_in_program',)
     list_filter = ('program__live',)
     inlines = [CourseRunInline]
     ordering = ('position_in_program',)
@@ -25,7 +25,7 @@ class CourseAdmin(admin.ModelAdmin):
 
 class CourseRunAdmin(admin.ModelAdmin):
     """ModelAdmin for Courses"""
-    list_display = ('title', 'program',)
+    list_display = ('title', 'edx_course_key', 'program',)
     list_filter = ('course__program__live',)
 
     def program(self, run):  # pylint: disable=no-self-use


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #324 

#### What's this PR do?

Adds edx_course_key to the courserun list display in admin.
Changes the order of fields in course list display, to make it consistent with other admin lists.

#### Where should the reviewer start?

By the time the reviewer starts, they will be done. 

#### How should this be manually tested?

Take a look at /admin/courses/courserun/ and /admin/courses/course/

#### Any background context you want to provide?

There's a lot of courseruns with the same name, so we need some way to differentiate them in list view. 

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

![learning to play guitar](http://i.giphy.com/11Yk9JTCICDEUE.gif)
