### PR TITLE
Fixed urls for enroll and upgdate course in a program

### DIFF
--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -50,8 +50,8 @@ export function makeCourseStatusDisplay(course, now = moment()) {
     courseOrRun = course.runs[0];
   }
 
-  let courseUpgradeUrl = `${SETTINGS.edx_base_url}course_modes/choose/${courseOrRun.course_id}/`;
-  let courseInfoUrl = `${SETTINGS.edx_base_url}courses/${courseOrRun.course_id}/info`;
+  let courseUpgradeUrl = `${SETTINGS.edx_base_url}/course_modes/choose/${courseOrRun.course_id}/`;
+  let courseInfoUrl = `${SETTINGS.edx_base_url}/courses/${courseOrRun.course_id}/about`;
 
   switch (courseOrRun.status) {
   case STATUS_PASSED:


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/323#event-661031580

#### What's this PR do?
- Fix url of enroll button. point it to about/ instead of info/
- Assuming that the edX url in ```.env``` is like  ``http://192.168.33.10:8000``. [Took assumption from bottom of readme](https://github.com/mitodl/micromasters/blob/master/README.md).

#### Where should the reviewer start?
- See ``utils.js``.

#### How should this be manually tested?
- Click on enroll button in course on a program (Dashboard).

@pdpinch @aliceriot @noisecapella 

#### Any background context you want to provide?
This was issue that was ripple of https://github.com/mitodl/micromasters/pull/282.

#### Screenshots (if appropriate)
<img width="1272" alt="screen shot 2016-05-16 at 1 10 41 pm" src="https://cloud.githubusercontent.com/assets/10431250/15284114/d7ff134a-1b68-11e6-8d53-24aa662c8de8.png">
