### PR TITLE
Marked profile as incomplete when it's being filled out and complete when past the last tab

### DIFF
--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -155,9 +155,6 @@ class ProfileSerializer(ModelSerializer):
             'edx_level_of_education',
             'education'
         )
-        read_only_fields = (
-            'filled_out',
-        )
 
 
 class ProfileLimitedSerializer(ModelSerializer):

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -103,12 +103,6 @@ class ProfileTests(TestCase):
             'profile_url_small': profile.profile_url_small,
         }
 
-    def test_readonly(self):
-        """
-        Test that certain fields cannot be altered
-        """
-        assert ProfileSerializer.Meta.read_only_fields == ('filled_out',)
-
     def test_add_education(self):
         """
         Test that we handle adding an Education correctly

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -1,0 +1,92 @@
+/* global SETTINGS: false */
+import '../global_init';
+import TestUtils from 'react-addons-test-utils';
+import assert from 'assert';
+
+import {
+  REQUEST_PATCH_USER_PROFILE,
+  RECEIVE_PATCH_USER_PROFILE_SUCCESS,
+  START_PROFILE_EDIT,
+  UPDATE_PROFILE_VALIDATION
+} from '../actions';
+import { USER_PROFILE_RESPONSE } from '../constants';
+import IntegrationTestHelper from '../util/integration_test_helper';
+import * as api from '../util/api';
+
+describe("ProfilePage", () => {
+  let listenForActions, renderComponent, helper, patchUserProfileStub;
+  beforeEach(() => {
+    helper = new IntegrationTestHelper();
+    listenForActions = helper.listenForActions.bind(helper);
+    renderComponent = helper.renderComponent.bind(helper);
+
+    patchUserProfileStub = helper.sandbox.stub(api, 'patchUserProfile');
+  });
+
+  afterEach(() => {
+    helper.cleanup();
+  });
+
+  it('marks email_optin and filled_out when saving this page', done => {
+    renderComponent("/profile/privacy").then(([component, div]) => {  // eslint-disable-line no-unused-vars
+      let button = div.querySelectorAll("button")[1];
+      assert.equal(button.innerHTML, "Save and continue");
+
+      let updatedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+        email_optin: true,
+        filled_out: true
+      });
+
+      patchUserProfileStub.throws("Invalid arguments");
+      patchUserProfileStub.withArgs(SETTINGS.username, updatedProfile).returns(Promise.resolve(updatedProfile));
+
+      listenForActions([
+        REQUEST_PATCH_USER_PROFILE,
+        RECEIVE_PATCH_USER_PROFILE_SUCCESS,
+        START_PROFILE_EDIT,
+        UPDATE_PROFILE_VALIDATION
+      ], () => {
+        TestUtils.Simulate.click(button);
+      }).then(() => {
+        done();
+      });
+    });
+  });
+
+  for (let page of ['personal', 'education', 'professional']) {
+    it(`marks filled_out = false when saving on /profile/${page}`, done => {
+      helper.profileGetStub.returns(
+        Promise.resolve(
+          Object.assign({}, USER_PROFILE_RESPONSE, {
+            filled_out: true
+          })
+        )
+      );
+
+      renderComponent(`/profile/${page}`).then(([component, div]) => {  // eslint-disable-line no-unused-vars
+        let buttons = div.querySelectorAll("button");
+        let button = Array.from(buttons).find(
+          button => button.innerHTML.indexOf("Save") !== -1
+        );
+
+        let updatedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+          filled_out: false
+        });
+
+        patchUserProfileStub.throws("Invalid arguments");
+        patchUserProfileStub.withArgs(SETTINGS.username, updatedProfile).returns(Promise.resolve(updatedProfile));
+
+        listenForActions([
+          REQUEST_PATCH_USER_PROFILE,
+          RECEIVE_PATCH_USER_PROFILE_SUCCESS,
+          START_PROFILE_EDIT,
+          UPDATE_PROFILE_VALIDATION
+        ], () => {
+          TestUtils.Simulate.click(button);
+        }).then(() => {
+          done();
+        });
+      });
+    });
+  }
+});

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -7,3 +7,6 @@ global.SETTINGS = {
 
 // Make sure window and document are available for testing
 require('jsdom-global')();
+
+// required for interacting with react-mdl components
+require('react-mdl/extra/material.js');

--- a/static/js/util/ProfileTab.js
+++ b/static/js/util/ProfileTab.js
@@ -56,7 +56,8 @@ class ProfileTab extends React.Component {
   }
 
   saveAndContinue = () => {
-    saveAndContinue.call(this, this.constructor.prototype.validation).then(() => {
+    let lastTab = this.nextUrl === "/dashboard";
+    saveAndContinue.call(this, this.constructor.prototype.validation, lastTab).then(() => {
       this.context.router.push(this.nextUrl);
     });
   }

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -340,8 +340,9 @@ export function boundMonthYearField(keySet, label) {
  * to retrieve keys for validation of nested fields (e.g. profile.work_history)
  *
  * @param nestedValidationCallback {func} If present, a function to retrieve validation fields
+ * @param finalStep {bool} If true, this is the last tab in the profile
  */
-export function saveAndContinue(nestedValidationCallback) {
+export function saveAndContinue(nestedValidationCallback, finalStep) {
   const {
     saveProfile,
     profile,
@@ -356,5 +357,13 @@ export function saveAndContinue(nestedValidationCallback) {
     fields = requiredFields;
   }
 
-  return saveProfile(profile, fields, validationMessages);
+  let clone = Object.assign({}, profile, {
+    filled_out: !!finalStep
+  });
+  if (finalStep) {
+    // user has also seen email consent message at this point
+    clone.email_optin = true;
+  }
+
+  return saveProfile(clone, fields, validationMessages);
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #233 


#### What's this PR do?
If the user clicks the save button on a profile page, it will send a `filled_out`: false along with the rest of the data, which will force them to complete the rest of the profile. When they get to the last tab and click Save, it will send `filled_out`: true and `email_optin`: true.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
