### PR TITLE
Only live programs are available in dashboard

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -58,6 +58,6 @@ class UserDashboard(APIView):
             request.user.username, enrollments.get_enrolled_course_ids())
 
         response_data = []
-        for program in Program.objects.all():
+        for program in Program.objects.filter(live=True):
             response_data.append(get_info_for_program(program, request.user, enrollments, certificates))
         return Response(response_data)


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #337 

#### What's this PR do?
Filters the programs in the dashboard to show only live ones

#### Where should the reviewer start?
`dashboard/views.py`

#### How should this be manually tested?
Create a program with live property set to false and check it does not appear in the dashboard

#### What GIF best describes this PR or how it makes you feel?
![](http://i.giphy.com/ZhlgmSB2BII9O.gif)