### PR TITLE
Added requirement for state_or_territory on PersonalTab

### DIFF
--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -26,8 +26,10 @@ class PersonalTab extends ProfileTab {
       ['gender'],
       ['preferred_language'],
       ['city'],
+      ['state_or_territory'],
       ['country'],
       ['birth_city'],
+      ['birth_state_or_territory'],
       ['birth_country'],
       ['date_of_birth'],
     ],
@@ -38,8 +40,10 @@ class PersonalTab extends ProfileTab {
       'gender': "Gender",
       'preferred_language': "Preferred language",
       'city': "City",
+      'state_or_territory': 'State or Territory',
       'country': "Country",
       'birth_city': 'City',
+      'birth_state_or_territory': 'State or Territory',
       'birth_country': "Country",
       'date_of_birth': "Date of birth"
     }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #288 

#### What's this PR do?

This adds a requirement that the `state_or_territory` and `birth_state_or_territory` fields be filled out on the personal tab. We're currently already requiring the equivalent fields on the employment and education tabs.

#### Where should the reviewer start?

Changes in `PersonalTab`.

#### How should this be manually tested?

Change the profile record in the database to have `state_or_territory = None`, save it, and then reload the dashboard. When you try to advance past the personal tab you should see a warning that the `state_or_territory` field is required. Same thing should happen for `birth_state_or_territory`.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

