### PR TITLE
Changed all class properties to use es7 class property syntax

### DIFF
--- a/static/js/components/CourseList.js
+++ b/static/js/components/CourseList.js
@@ -9,6 +9,10 @@ import {
 import { STATUS_PASSED } from '../constants';
 
 class CourseList extends React.Component {
+  static propTypes = {
+    dashboard: React.PropTypes.object.isRequired,
+  };
+
   render() {
     const { dashboard } = this.props;
 
@@ -70,9 +74,5 @@ class CourseList extends React.Component {
     </div>;
   }
 }
-
-CourseList.propTypes = {
-  dashboard: React.PropTypes.object.isRequired,
-};
 
 export default CourseList;

--- a/static/js/components/Dashboard.js
+++ b/static/js/components/Dashboard.js
@@ -4,6 +4,10 @@ import CourseList from './CourseList';
 import UserImage from './UserImage';
 
 class Dashboard extends React.Component {
+  static propTypes = {
+    profile:    React.PropTypes.object.isRequired,
+    dashboard:  React.PropTypes.object.isRequired,
+  };
 
   render() {
     const { profile, dashboard } = this.props;
@@ -34,10 +38,5 @@ class Dashboard extends React.Component {
     </div>;
   }
 }
-
-Dashboard.propTypes = {
-  profile: React.PropTypes.object.isRequired,
-  dashboard: React.PropTypes.object.isRequired,
-};
 
 export default Dashboard;

--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -20,7 +20,6 @@ import Dialog from 'material-ui/Dialog';
 class EducationTab extends ProfileTab {
   constructor(props) {
     super(props);
-
     this.educationLevelLabels = {};
     this.educationLevelOptions.forEach(level => {
       this.educationLevelLabels[level.value] = level.label;
@@ -53,6 +52,7 @@ class EducationTab extends ProfileTab {
       'school_country': 'Country'
     }
   };
+
   static nestedValidationKeys = [
     'degree_name',
     'graduation_date',
@@ -63,8 +63,8 @@ class EducationTab extends ProfileTab {
     'school_state_or_territory',
     'school_country'
   ];
-  static validation(profile, requiredFields) {
 
+  static validation(profile, requiredFields) {
     let nestedFields = (index) => {
       let keySet = (key) => ['education', index, key];
       return EducationTab.nestedValidationKeys.map(key => keySet(key));
@@ -229,7 +229,6 @@ class EducationTab extends ProfileTab {
     </Grid>;
   }
 }
-
 
 const mapStateToProps = state => ({
   educationDialog: state.educationDialog,

--- a/static/js/components/Header.js
+++ b/static/js/components/Header.js
@@ -3,6 +3,10 @@ import LoginButton from '../containers/LoginButton';
 import { Navbar } from 'react-bootstrap';
 
 class Header extends React.Component {
+  static propTypes = {
+    empty: React.PropTypes.bool
+  };
+
   render () {
     const { empty } = this.props;
     let content;
@@ -26,9 +30,5 @@ class Header extends React.Component {
     );
   }
 }
-
-Header.propTypes = {
-  empty: React.PropTypes.bool
-};
 
 export default Header;

--- a/static/js/components/UserImage.js
+++ b/static/js/components/UserImage.js
@@ -2,6 +2,10 @@
 import React from 'react';
 
 class UserImage extends React.Component {
+  static propTypes = {
+    imageUrl: React.PropTypes.string.isRequired
+  };
+
   render() {
     const { imageUrl } = this.props;
 
@@ -11,7 +15,4 @@ class UserImage extends React.Component {
   }
 }
 
-UserImage.propTypes = {
-  imageUrl: React.PropTypes.string.isRequired
-};
 export default UserImage;

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -4,6 +4,12 @@ import { connect } from 'react-redux';
 import Dashboard from '../components/Dashboard';
 
 class DashboardPage extends React.Component {
+  static propTypes = {
+    profile:    React.PropTypes.object.isRequired,
+    dashboard:  React.PropTypes.object.isRequired,
+    dispatch:   React.PropTypes.func.isRequired,
+  };
+
   render() {
     const { profile, dashboard } = this.props;
     return <Dashboard
@@ -18,12 +24,6 @@ const mapStateToProps = (state) => {
     profile: state.userProfile,
     dashboard: state.dashboard,
   };
-};
-
-DashboardPage.propTypes = {
-  profile: React.PropTypes.object.isRequired,
-  dashboard: React.PropTypes.object.isRequired,
-  dispatch: React.PropTypes.func.isRequired
 };
 
 export default connect(mapStateToProps)(DashboardPage);

--- a/static/js/containers/LoginButton.js
+++ b/static/js/containers/LoginButton.js
@@ -6,6 +6,11 @@ import LinkContainer from 'react-router-bootstrap/lib/LinkContainer';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
 
 class LoginButton extends React.Component {
+  static propTypes = {
+    dispatch: React.PropTypes.func.isRequired,
+    profile:  React.PropTypes.object.isRequired,
+  };
+
   render() {
     const { profile } = this.props;
 
@@ -41,11 +46,6 @@ class LoginButton extends React.Component {
     );
   }
 }
-
-LoginButton.propTypes = {
-  dispatch: React.PropTypes.func.isRequired,
-  profile: React.PropTypes.object.isRequired
-};
 
 const mapStateToProps = (state) => {
   return {

--- a/static/js/containers/TermsOfServicePage.js
+++ b/static/js/containers/TermsOfServicePage.js
@@ -6,6 +6,16 @@ import { connect } from 'react-redux';
 import { saveProfile, FETCH_SUCCESS } from '../actions';
 
 class TermsOfServicePage extends React.Component {
+  static propTypes = {
+    dispatch:     React.PropTypes.func.isRequired,
+    userProfile:  React.PropTypes.object.isRequired,
+    history:      React.PropTypes.object.isRequired,
+  };
+
+  static contextTypes = {
+    router:   React.PropTypes.object.isRequired
+  };
+
   handleAgree() {
     const { dispatch, userProfile } = this.props;
     if (userProfile.getStatus !== FETCH_SUCCESS) {
@@ -46,15 +56,5 @@ class TermsOfServicePage extends React.Component {
 const mapStateToProps = state => ({
   userProfile: state.userProfile
 });
-
-TermsOfServicePage.propTypes = {
-  dispatch: React.PropTypes.func.isRequired,
-  userProfile: React.PropTypes.object.isRequired,
-  history: React.PropTypes.object.isRequired
-};
-
-TermsOfServicePage.contextTypes = {
-  router:   React.PropTypes.object.isRequired
-};
 
 export default connect(mapStateToProps)(TermsOfServicePage);


### PR DESCRIPTION
#### What are the relevant tickets?

closes #330 

#### What's this PR do?

This moves all class properties to the newer class property syntax, which uses the `static` keyword and looks like this:

```js
class Foo {
  static someClassProperty = 12;
}
```

as opposed to the older syntax:

```js
class Foo {
  ...
}

Foo.someClassProperty = 12;
```

the newer syntax moves the class properties into the body of the class declaration, meaning that the property declarations are closer to the code they relate to. On classes that extend `React.Component` we can declare our `propTypes` and `defaultProps` as class properties:

```js
class Foobar extends React.Component {
  static propTypes = {
    foobar:  React.PropTypes.func.isRequired,
  }

  static defaultProps = {
    foobar: () => console.log("FOOBAR");
  }
}
```

It's a bit more readable and just generally nicer to work with. This syntax is a [stage-1 proposal](https://github.com/jeffmo/es-class-fields-and-static-properties), which we're able to use by adding the `stage-1` preset to Babel (see `.babelrc`).

#### Where should the reviewer start?

review the changes, make sure I didn't make any typos :P

#### How should this be manually tested?

click around and make sure everything works!

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
