### PR TITLE
Added fake values for employment and education constants

### DIFF
--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -1,3 +1,9 @@
+export const HIGH_SCHOOL = 'hs';
+export const ASSOCIATE = 'a';
+export const BACHELORS = 'b';
+export const MASTERS = 'm';
+export const DOCTORATE = 'p';
+
 export const USER_PROFILE_RESPONSE = {
   "filled_out": false,
   "agreed_to_terms_of_service": true,
@@ -20,7 +26,47 @@ export const USER_PROFILE_RESPONSE = {
   "date_of_birth": '1984-04-13',
   "preferred_language": 'en',
   "gender": "f",
-  "pretty_printed_student_id": "MMM000011"
+  "pretty_printed_student_id": "MMM000011",
+  "work_history": [{
+    "id": 1,
+    "city": "Cambridge",
+    "state_or_territory": "US-MA",
+    "country": "US",
+    "company_name": "MIT",
+    "position": "Software Developer",
+    "industry": "Education",
+    "start_date": "1982-02-02",
+    "end_date": "7654-03-21"
+  }, {
+    "id": 2,
+    "city": "New York",
+    "state_or_territory": "US-NY",
+    "country": "US",
+    "company_name": "Planet Express",
+    "position": "Delivery",
+    "industry": "Shipping",
+    "start_date": "3000-01-01",
+    "end_date": "4000-01-01"
+  }],
+  "education": [{
+    "id": 1,
+    "degree_name": HIGH_SCHOOL,
+    "graduation_date": "2013-05-01",
+    "field_of_study": "Computer Science",
+    "school_name": "MIT",
+    "school_city": "Cambridge",
+    "school_state_or_territory": "US-MA",
+    "school_country": "US"
+  }, {
+    "id": 2,
+    "degree_name": BACHELORS,
+    "graduation_date": "1975-12-01",
+    "field_of_study": "Philosophy",
+    "school_name": "Harvard",
+    "school_city": "Cambridge",
+    "school_state_or_territory": "US-MA",
+    "school_country": "US"
+  }]
 };
 
 export const STATUS_PASSED = 'passed';
@@ -115,11 +161,5 @@ export const DASHBOARD_RESPONSE = [
     "id": 3
   },
 ];
-
-export const HIGH_SCHOOL = 'hs';
-export const ASSOCIATE = 'a';
-export const BACHELORS = 'b';
-export const MASTERS = 'm';
-export const DOCTORATE = 'p';
 
 export const DATE_FORMAT = 'YYYY-MM-DD';

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -3,6 +3,7 @@ import '../global_init';
 
 import ReactDOM from 'react-dom';
 import assert from 'assert';
+import _ from 'lodash';
 
 import { CLEAR_DASHBOARD, CLEAR_PROFILE, } from '../actions';
 import {
@@ -14,7 +15,6 @@ import {
 
 import { USER_PROFILE_RESPONSE } from '../constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
-import EmploymentTab from '../components/EmploymentTab';
 
 describe('App', () => {
   let listenForActions, renderComponent, helper;
@@ -59,16 +59,10 @@ describe('App', () => {
     });
 
     it('redirects to /profile/professional if a field is missing there', done => {
-      // USER_PROFILE_RESPONSE doesn't have `current_employed`
-      let workHistory = {};
-      EmploymentTab.nestedValidationKeys.forEach( k => {
-        workHistory[k] = k === "city" ? "" : "filled in";
-      });
+      let profile = _.cloneDeep(USER_PROFILE_RESPONSE);
+      profile.work_history[1].city = "";
 
-      let response = Object.assign({}, USER_PROFILE_RESPONSE, {
-        work_history: [workHistory]
-      });
-      helper.profileGetStub.returns(Promise.resolve(response));
+      helper.profileGetStub.returns(Promise.resolve(profile));
 
       renderComponent("/dashboard", dialogActions).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile/professional");
@@ -89,15 +83,11 @@ describe('App', () => {
     });
 
     it("checks work_history if currently_employed = 'yes'", done => {
-      let workHistory = {};
-      EmploymentTab.nestedValidationKeys.forEach( k => {
-        workHistory[k] = k === "city" ? undefined : "filled in";
-      });
-      let response = Object.assign({}, USER_PROFILE_RESPONSE, {
-        currently_employed: "yes",
-        work_history: [workHistory]
-      });
-      helper.profileGetStub.returns(Promise.resolve(response));
+      let profile = _.cloneDeep(USER_PROFILE_RESPONSE);
+      profile.work_history[1].city = "";
+      profile.currently_employed = "yes";
+
+      helper.profileGetStub.returns(Promise.resolve(profile));
 
       renderComponent("/dashboard", dialogActions).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile/professional");
@@ -136,15 +126,11 @@ describe('App', () => {
     });
 
     it('sets a dialog with appropriate text for professional info', done => {
-      let workHistory = {};
-      EmploymentTab.nestedValidationKeys.forEach( k => {
-        workHistory[k] = k === "city" ? undefined : "filled in";
-      });
-      let response = Object.assign({}, USER_PROFILE_RESPONSE, {
-        currently_employed: "yes",
-        work_history: [workHistory]
-      });
-      helper.profileGetStub.returns(Promise.resolve(response));
+      let profile = _.cloneDeep(USER_PROFILE_RESPONSE);
+      profile.work_history[1].city = undefined;
+      profile.currently_employed = "yes";
+
+      helper.profileGetStub.returns(Promise.resolve(profile));
 
       renderComponent("/dashboard", dialogActions).then(() => {
         let state = helper.store.getState();


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #343 

#### What's this PR do?
The warning came from using fake value `"filled in"` to populate employment fields. The error came from when moment.js parsed this field as a date. This adds fake employment and education data to `USER_PROFILE_RESPONSE` and updates the tests to use one of the default 

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?
I noticed that we test that redirecting to the work history field on validation error works but we don't have tests for this for the education tab. Not sure if #314 will make this unnecessary

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

