### PR TITLE
Implemented UI for showing course runs in dashboard

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,7 @@
     "camelcase": [2, {
       "properties": "never"
     }],
+    "guard-for-in": [2]
   },
   "env": {
     "es6": true,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-1": "6.5.0",
     "bootstrap": "3.3.6",
-    "bourbon-neat": "1.7.4",
     "css-loader": "0.23.1",
     "file-loader": "0.8.5",
     "history": "2.1.1",

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -5,6 +5,7 @@ export const SET_DIALOG_VISIBILITY = 'SET_DIALOG_VISIBILITY';
 export const SET_WORK_HISTORY_EDIT = 'SET_WORK_HISTORY_EDIT';
 export const SET_WORK_DIALOG_VISIBILITY = 'SET_WORK_DIALOG_VISIBILITY';
 export const SET_WORK_DIALOG_INDEX = 'SET_WORK_DIALOG_INDEX';
+export const TOGGLE_DASHBOARD_EXPANDER = 'TOGGLE_DASHBOARD_EXPANDER';
 
 export const clearUI = () => ({ type: CLEAR_UI });
 export const updateDialogText = text => (
@@ -30,3 +31,8 @@ export const setWorkDialogVisibility = bool => (
 export const setWorkDialogIndex = index => (
   { type: SET_WORK_DIALOG_INDEX, payload: index }
 );
+
+export const toggleDashboardExpander = (courseId, newValue) => ({
+  type: TOGGLE_DASHBOARD_EXPANDER,
+  payload: { courseId, newValue }
+});

--- a/static/js/components/CourseList.js
+++ b/static/js/components/CourseList.js
@@ -1,20 +1,29 @@
 import React from 'react';
 import _ from 'lodash';
 import Button from 'react-bootstrap/lib/Button';
+import Grid, { Cell } from 'react-mdl/lib/Grid';
 
+import { toggleDashboardExpander } from '../actions/ui';
 import {
   makeCourseStatusDisplay,
   makeCourseProgressDisplay,
+  makeRunStatusDisplay,
 } from '../util/util';
-import { STATUS_PASSED } from '../constants';
+import {
+  STATUS_PASSED,
+  DASHBOARD_COURSE_HEIGHT,
+  DASHBOARD_RUN_HEIGHT,
+} from '../constants';
 
 class CourseList extends React.Component {
   static propTypes = {
     dashboard: React.PropTypes.object.isRequired,
+    expander: React.PropTypes.object.isRequired,
+    dispatch: React.PropTypes.func.isRequired,
   };
 
   render() {
-    const { dashboard } = this.props;
+    const { dashboard, dispatch, expander } = this.props;
 
     let programs = dashboard.programs.map(program => {
       let sortedCourses = _.sortBy(program.courses, 'position_in_program');
@@ -29,37 +38,78 @@ class CourseList extends React.Component {
           coursesPassed++;
         }
 
-        return <ul
+        let courseRuns = [];
+        if (expander[course.id]) {
+          courseRuns = course.runs.map(run =>
+            <Grid style={{height: DASHBOARD_RUN_HEIGHT}} key={run.id}>
+              <Cell
+                col={6}
+                className="course-run-title"
+              >
+                {run.title}
+              </Cell>
+              <Cell col={4} className="course-run-status">
+                {makeRunStatusDisplay(run)}
+              </Cell>
+            </Grid>
+          );
+        }
+
+        let expanderSpan;
+        if (course.runs.length > 0) {
+          const toggleExpander = () => {
+            dispatch(toggleDashboardExpander(course.id, !expander[course.id]));
+          };
+          expanderSpan = <span
+            onClick={toggleExpander}
+            className={`glyphicon glyphicon-chevron-${expander[course.id] ? 'up' : 'down'}`}
+            style={{cursor: "pointer"}}
+          />;
+        }
+
+        let height = DASHBOARD_COURSE_HEIGHT + courseRuns.length * DASHBOARD_RUN_HEIGHT;
+        return <div
           key={course.id}
-          className={"course-list-body course-list-status-" + course.status}
+          className="course-list-body course-list-row"
+          style={{height: height}}
         >
-          <li className="course-title">
-            {course.title}
-          </li>
-          <li className="course-status">
-            {makeCourseStatusDisplay(course)}
-          </li>
-          <li className="course-progress">
-            {makeCourseProgressDisplay(course, isTop, isBottom)}
-          </li>
-        </ul>;
+          <Grid style={{height: DASHBOARD_COURSE_HEIGHT}} className="course-list-center">
+            <Cell col={6} className="course-title">
+              {course.title} {expanderSpan}
+            </Cell>
+            <Cell col={4} className="course-status">
+              {makeCourseStatusDisplay(course)}
+            </Cell>
+            <Cell col={2} className="course-progress">
+              {makeCourseProgressDisplay(course, isTop, isBottom, courseRuns.length)}
+            </Cell>
+          </Grid>
+          {courseRuns}
+        </div>;
       });
 
       return (
-        <div key={program.id}>
-          <div className="course-list">
-            <ul className="course-list-header">
-              <li className="course-title">
-                {program.title}
-              </li>
-              <li className="course-status "/>
-              <li className="course-progress">
-                Progress
-              </li>
-            </ul>
-            {table}
-          </div>
-          <div className="clear-float apply-for-ms">
+        <div key={program.id} className="program">
+          <Grid>
+            <Cell col={8}>
+              <div className="course-list">
+                <Grid
+                  className="course-list-header course-list-center course-list-row"
+                  style={{height: DASHBOARD_COURSE_HEIGHT}}
+                >
+                  <Cell col={6} className="course-title">
+                    {program.title}
+                  </Cell>
+                  <Cell col={4} className="course-status "/>
+                  <Cell col={2} className="course-progress">
+                    Progress
+                  </Cell>
+                </Grid>
+                {table}
+              </div>
+            </Cell>
+          </Grid>
+          <div className="apply-for-ms">
             <br/>
             <p>You need to pass {totalCourses - coursesPassed} more courses
               before you can apply for <strong>{program.title}</strong> Master's Degree.</p>

--- a/static/js/components/CourseList_test.js
+++ b/static/js/components/CourseList_test.js
@@ -21,7 +21,7 @@ describe("CourseList", () => {
 
   it('renders apply for master button and text', () => {
     let renderedComponent = TestUtils.renderIntoDocument(
-      <CourseList dashboard={{programs: DASHBOARD_RESPONSE}} />
+      <CourseList dashboard={{programs: DASHBOARD_RESPONSE}} expander={{}} dispatch={() => {}}/>
     );
     let programBottomDivComponent = TestUtils.scryRenderedDOMComponentsWithClass(
       renderedComponent,
@@ -62,7 +62,7 @@ describe("CourseList", () => {
     let makeCourseStatusDisplaySpy = sandbox.spy(util, 'makeCourseStatusDisplay');
 
     TestUtils.renderIntoDocument(
-      <CourseList dashboard={{programs: DASHBOARD_RESPONSE}} />
+      <CourseList dashboard={{programs: DASHBOARD_RESPONSE}} expander={{}} dispatch={() => {}} />
     );
 
     let callCount = 0;

--- a/static/js/components/Dashboard.js
+++ b/static/js/components/Dashboard.js
@@ -1,5 +1,6 @@
 /* global SETTINGS: false */
 import React from 'react';
+import Grid, { Cell } from 'react-mdl/lib/Grid';
 import CourseList from './CourseList';
 import UserImage from './UserImage';
 
@@ -7,10 +8,12 @@ class Dashboard extends React.Component {
   static propTypes = {
     profile:    React.PropTypes.object.isRequired,
     dashboard:  React.PropTypes.object.isRequired,
+    expander: React.PropTypes.object.isRequired,
+    dispatch: React.PropTypes.func.isRequired,
   };
 
   render() {
-    const { profile, dashboard } = this.props;
+    const { profile, dashboard, expander, dispatch } = this.props;
     let imageUrl = (SETTINGS.edx_base_url + '/static/images/profiles/default_120.png').
     //replacing multiple "/" with a single forward slash, excluding the ones following the colon
     replace(/([^:]\/)\/+/g, "$1");
@@ -18,22 +21,22 @@ class Dashboard extends React.Component {
       imageUrl = profile.profile_url_large;
     }
     return <div className="card">
-      <div className="card-user">
-        <div className="card-image-box">
+      <Grid className="card-user">
+        <Cell col={2} className="card-image-box">
             <UserImage imageUrl={imageUrl}/>
-        </div>
-        <div className="card-name">
+        </Cell>
+        <Cell col={5} className="card-name">
           { profile.preferred_name || SETTINGS.name }
           <div className="card-student-id">
             ID: { profile.pretty_printed_student_id }
           </div>
-        </div>
-      </div>
+        </Cell>
+      </Grid>
       <div className="card-header">
         Your Status
       </div>
       <div className="card-copy">
-        <CourseList dashboard={dashboard} />
+        <CourseList dashboard={dashboard} expander={expander} dispatch={dispatch} />
       </div>
     </div>;
   }

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -85,6 +85,73 @@ export const DASHBOARD_RESPONSE = [
     "id": 2
   },
   {
+    "description": "Not passed program",
+    "title": "Not passed program",
+    "courses": [
+      {
+        "prerequisites": "",
+        "runs": [
+          {
+            "position": 1,
+            "title": "Gio Test Course #15",
+            "course_id": "course-v1:odl+GIO101+CR-FALL15",
+            "status": "not-passed",
+            "id": 199
+          },
+          {
+            "position": 2,
+            "title": "Gio Test Course #14",
+            "course_id": "course-v1:odl+GIO101+FALL14",
+            "status": "not-passed",
+            "id": 399
+          },
+          {
+            "certificate_url": "www.google.com",
+            "title": "Gio Test Course #13",
+            "status": "passed",
+            "position": 3,
+            "grade": "0.66",
+            "course_id": "course-v1:odl+GIO101+FALL13",
+            "id": 299
+          }
+        ],
+        "position_in_program": 0,
+        "title": "Gio Course",
+        "status": "not-offered",
+        "description": "",
+        "id": 199
+      },
+      {
+        "prerequisites": "",
+        "runs": [],
+        "position_in_program": 1,
+        "title": "8.MechCx Advanced Introductory Classical Mechanics",
+        "status": "not-offered",
+        "description": "",
+        "id": 299
+      },
+      {
+        "prerequisites": "",
+        "runs": [],
+        "position_in_program": 2,
+        "title": "EDX Demo course",
+        "status": "not-offered",
+        "description": "",
+        "id": 399
+      },
+      {
+        "prerequisites": "",
+        "runs": [],
+        "position_in_program": 3,
+        "title": "Peter Course",
+        "status": "not-offered",
+        "description": "",
+        "id": 499
+      }
+    ],
+    "id": 799
+  },
+  {
     "courses": [
       {
         "id": 3,
@@ -163,3 +230,6 @@ export const DASHBOARD_RESPONSE = [
 ];
 
 export const DATE_FORMAT = 'YYYY-MM-DD';
+
+export const DASHBOARD_COURSE_HEIGHT = 70;
+export const DASHBOARD_RUN_HEIGHT = 40;

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -8,13 +8,16 @@ class DashboardPage extends React.Component {
     profile:    React.PropTypes.object.isRequired,
     dashboard:  React.PropTypes.object.isRequired,
     dispatch:   React.PropTypes.func.isRequired,
+    expander: React.PropTypes.object.isRequired,
   };
 
   render() {
-    const { profile, dashboard } = this.props;
+    const { profile, dashboard, expander, dispatch } = this.props;
     return <Dashboard
       profile={profile.profile}
       dashboard={dashboard}
+      expander={expander}
+      dispatch={dispatch}
     />;
   }
 }
@@ -23,6 +26,7 @@ const mapStateToProps = (state) => {
   return {
     profile: state.userProfile,
     dashboard: state.dashboard,
+    expander: state.ui.dashboardExpander
   };
 };
 

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -13,7 +13,9 @@ import { USER_PROFILE_RESPONSE } from '../constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
 import * as api from '../util/api';
 
-describe("ProfilePage", () => {
+describe("ProfilePage", function() {
+  this.timeout(5000);  // eslint-disable-line no-invalid-this
+
   let listenForActions, renderComponent, helper, patchUserProfileStub;
   beforeEach(() => {
     helper = new IntegrationTestHelper();

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -6,11 +6,13 @@ import {
   SET_WORK_HISTORY_EDIT,
   SET_WORK_DIALOG_VISIBILITY,
   SET_WORK_DIALOG_INDEX,
+  TOGGLE_DASHBOARD_EXPANDER,
 } from '../actions/ui';
 
 export const INITIAL_UI_STATE = {
   workHistoryEdit: true,
   workDialogVisibility: false,
+  dashboardExpander: {}
 };
 
 export const ui = (state = INITIAL_UI_STATE, action) => {
@@ -53,6 +55,13 @@ export const ui = (state = INITIAL_UI_STATE, action) => {
     });
   case CLEAR_UI:
     return INITIAL_UI_STATE;
+  case TOGGLE_DASHBOARD_EXPANDER: {
+    let clone = Object.assign({}, state.dashboardExpander);
+    clone[action.payload.courseId] = action.payload.newValue;
+    return Object.assign({}, state, {
+      dashboardExpander: clone
+    });
+  }
   default:
     return state;
   }

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -6,6 +6,7 @@ import {
   SET_WORK_HISTORY_EDIT,
   SET_WORK_DIALOG_VISIBILITY,
   SET_WORK_DIALOG_INDEX,
+  TOGGLE_DASHBOARD_EXPANDER,
 
   clearUI,
   updateDialogText,
@@ -14,6 +15,7 @@ import {
   setWorkHistoryEdit,
   setWorkDialogVisibility,
   setWorkDialogIndex,
+  toggleDashboardExpander,
 } from '../actions/ui';
 import { INITIAL_UI_STATE } from '../reducers/ui';
 
@@ -94,6 +96,24 @@ describe('ui reducers', () => {
 
       dispatchThen(setWorkDialogIndex(5), [SET_WORK_DIALOG_INDEX]).then(state => {
         assert.equal(state.workDialogIndex, 5);
+        done();
+      });
+    });
+  });
+
+  describe('dashboard expander', () => {
+    it('has an empty default state', done => {
+      dispatchThen({type: "undefined"}, []).then(state => {
+        assert.deepEqual(state.dashboardExpander, {});
+        done();
+      });
+    });
+
+    it('toggles a course expander', done => {
+      dispatchThen(toggleDashboardExpander(3, true), [TOGGLE_DASHBOARD_EXPANDER]).then(state => {
+        assert.deepEqual(state.dashboardExpander, {
+          3: true
+        });
         done();
       });
     });

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -12,11 +12,14 @@ import EmploymentTab from '../components/EmploymentTab';
 import PrivacyTab from '../components/PrivacyTab';
 
 import {
+  STATUS_NOT_OFFERED,
   STATUS_PASSED,
   STATUS_NOT_PASSED,
   STATUS_VERIFIED_NOT_COMPLETED,
   STATUS_ENROLLED_NOT_VERIFIED,
   STATUS_OFFERED_NOT_ENROLLED,
+  DASHBOARD_COURSE_HEIGHT,
+  DASHBOARD_RUN_HEIGHT,
 } from '../constants';
 
 export function sendGoogleAnalyticsEvent(category, action, label, value) {
@@ -45,33 +48,29 @@ function asPercent(number) {
  * @returns {ReactElement} Some React element or string to display for course status
  */
 export function makeCourseStatusDisplay(course, now = moment()) {
-  let courseOrRun = course;
+  let firstRun = {};
   if (course.runs.length > 0) {
-    courseOrRun = course.runs[0];
+    firstRun = course.runs[0];
   }
 
-  let courseUpgradeUrl = `${SETTINGS.edx_base_url}/course_modes/choose/${courseOrRun.course_id}/`;
-  let courseInfoUrl = `${SETTINGS.edx_base_url}/courses/${courseOrRun.course_id}/about`;
-
-  switch (courseOrRun.status) {
+  switch (course.status) {
   case STATUS_PASSED:
-  case STATUS_NOT_PASSED:
     return <span className="course-list-grade">
-      {asPercent(courseOrRun.grade)}
+      {asPercent(firstRun.grade)}
     </span>;
 
   case STATUS_VERIFIED_NOT_COMPLETED: {
-    if (!courseOrRun.course_start_date) {
+    if (!firstRun.course_start_date) {
       // Invalid case, API should always send a valid course start date
       return "";
     }
 
-    let courseStartDate = moment(courseOrRun.course_start_date);
+    let courseStartDate = moment(firstRun.course_start_date);
     if (courseStartDate.isAfter(now, 'day')) {
       return "Course starting: " + courseStartDate.format("M/D/Y");
     }
 
-    let grade = courseOrRun.grade;
+    let grade = firstRun.grade;
     if (grade === undefined || grade === null) {
       // Grade defaults to 0%
       grade = 0;
@@ -81,12 +80,14 @@ export function makeCourseStatusDisplay(course, now = moment()) {
     </span>;
   }
   case STATUS_ENROLLED_NOT_VERIFIED: {
-    if (!courseOrRun.verification_date) {
+    if (!firstRun.verification_date) {
       // Invalid case, API should always send a valid verification date
       return "";
     }
 
-    let verificationDate = moment(courseOrRun.verification_date);
+    let courseUpgradeUrl = `${SETTINGS.edx_base_url}/course_modes/choose/${firstRun.course_id}/`;
+
+    let verificationDate = moment(firstRun.verification_date);
     if (verificationDate.isAfter(now, 'day')) {
       return <Button bsStyle="success" href={courseUpgradeUrl} target="_blank">UPGRADE TO VERIFIED</Button>;
     } else {
@@ -95,11 +96,13 @@ export function makeCourseStatusDisplay(course, now = moment()) {
     }
   }
   case STATUS_OFFERED_NOT_ENROLLED: {
-    if (!courseOrRun.enrollment_start_date) {
-      return courseOrRun.fuzzy_enrollment_start_date;
+    let courseInfoUrl = `${SETTINGS.edx_base_url}/courses/${firstRun.course_id}/about`;
+
+    if (!firstRun.enrollment_start_date) {
+      return firstRun.fuzzy_enrollment_start_date;
     }
 
-    let enrollmentDate = moment(courseOrRun.enrollment_start_date);
+    let enrollmentDate = moment(firstRun.enrollment_start_date);
     if (enrollmentDate.isAfter(now, 'day')) {
       return "Enrollment starting: " + enrollmentDate.format("M/D/Y");
     } else {
@@ -117,47 +120,49 @@ export function makeCourseStatusDisplay(course, now = moment()) {
  * @param {object} course A course coming from the dashboard
  * @param {bool} isFirst If false, draw a line up to the previous course
  * @param {bool} isLast If false, draw a line down to the next course
+ * @param {Number} numRuns The number of course runs to draw a line past
  * @returns {ReactElement} Some React element or string to display for course status
  */
-export function makeCourseProgressDisplay(course, isFirst, isLast) {
-  let courseOrRun = course;
-  if (course.runs.length > 0) {
-    courseOrRun = course.runs[0];
-  }
-
-  let height = 70, outerRadius = 10, innerRadius = 8, width = 30, color="#7fbaec";
-  let centerX = width/2, centerY = height/2;
+export function makeCourseProgressDisplay(course, isFirst, isLast, numRuns) {
+  let outerRadius = 10, innerRadius = 8, width = 30;
+  let totalHeight = DASHBOARD_COURSE_HEIGHT + numRuns * DASHBOARD_RUN_HEIGHT;
+  let centerX = width/2, centerY = DASHBOARD_COURSE_HEIGHT/2;
+  const blue = "#7fbaec";
+  const red = "#dc1c2e";
 
   let topLine;
   if (!isFirst) {
     topLine = <line
+      className="top-line"
       x1={centerX}
       x2={centerX}
       y1={0}
       y2={centerY - outerRadius}
-      stroke={color}
+      stroke={blue}
       strokeWidth={1}
     />;
   }
   let bottomLine;
   if (!isLast) {
     bottomLine = <line
+      className="bottom-line"
       x1={centerX}
       x2={centerX}
       y1={centerY + outerRadius}
-      y2={height}
-      stroke={color}
+      y2={totalHeight}
+      stroke={blue}
       strokeWidth={1}
     />;
   }
 
   let alt = "Course not started";
+  let circleColor = blue; // light blue
   let innerElement;
-  if (courseOrRun.status === STATUS_PASSED) {
+  if (course.status === STATUS_PASSED) {
     // full circle to indicate course passed
     alt = "Course passed";
-    innerElement = <circle cx={centerX} cy={centerY} r={innerRadius} fill={color} />;
-  } else if (courseOrRun.status === STATUS_VERIFIED_NOT_COMPLETED) {
+    innerElement = <circle cx={centerX} cy={centerY} r={innerRadius} fill={blue} />;
+  } else if (course.status === STATUS_VERIFIED_NOT_COMPLETED) {
     alt = "Course started";
     // semi circle on the left side
     // see path docs: https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#Arcs
@@ -167,17 +172,38 @@ export function makeCourseProgressDisplay(course, isFirst, isLast) {
     ].join(" ");
     innerElement = <path
       d={path}
-      fill={color}
+      fill={blue}
     />;
+  } else if (course.status === STATUS_NOT_OFFERED) {
+    // A course is failed if the first run is NOT_PASSED
+    if (course.runs.length > 0 && course.runs[0].status === STATUS_NOT_PASSED) {
+      circleColor = red;
+    }
   }
 
-  return <svg style={{width: width, height: height}}>
+  return <svg style={{width: width, height: totalHeight}}>
     <desc>{alt}</desc>
-    <circle cx={centerX} cy={centerY} r={outerRadius} stroke={color} fillOpacity={0} />
+    <circle cx={centerX} cy={centerY} r={outerRadius} stroke={circleColor} fillOpacity={0} />
     {innerElement}
     {topLine}
     {bottomLine}
   </svg>;
+}
+
+/**
+ * Display status for a course run
+ * @param run {Object} A course run
+ * @returns {ReactElement}
+ */
+export function makeRunStatusDisplay(run) {
+  switch (run.status) {
+  case STATUS_PASSED:
+    return "Passed";
+  case STATUS_NOT_PASSED:
+    return "Not passed";
+  default:
+    return "";
+  }
 }
 
 /* eslint-disable camelcase */

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -14,6 +14,7 @@ import {
 import {
   makeCourseStatusDisplay,
   makeCourseProgressDisplay,
+  makeRunStatusDisplay,
   validateProfile,
   validateProfileComplete,
   makeStrippedHtml,
@@ -48,25 +49,33 @@ describe('utility functions', () => {
       return makeStrippedHtml(textOrElement);
     };
 
-    it('is a passed a course', () => {
+    it('is a passed course', () => {
       assert.equal(renderCourseStatusDisplay({
         status: STATUS_PASSED,
-        grade: 0.34
+        runs: [{
+          grade: 0.34
+        }]
       }), "34%");
       assert.equal(renderCourseStatusDisplay({
-        status: STATUS_PASSED
+        status: STATUS_PASSED,
+        runs: []
       }), "");
       assert.equal(renderCourseStatusDisplay({
         status: STATUS_PASSED,
-        grade: null
+        runs: [{
+          grade: null
+        }]
       }), "");
     });
 
     it("is a failed course", () => {
       assert.equal(renderCourseStatusDisplay({
-        status: STATUS_NOT_PASSED,
-        grade: 0.99999
-      }), "100%");
+        status: STATUS_NOT_OFFERED,
+        runs: [{
+          status: STATUS_NOT_PASSED,
+          grade: 0.99999,
+        }]
+      }), "");
       assert.equal(renderCourseStatusDisplay({
         status: STATUS_NOT_PASSED
       }), "");
@@ -74,14 +83,17 @@ describe('utility functions', () => {
 
     it("is a verified course without a course start date", () => {
       assert.equal(renderCourseStatusDisplay({
-        status: STATUS_VERIFIED_NOT_COMPLETED
+        status: STATUS_VERIFIED_NOT_COMPLETED,
+        runs: []
       }), "");
     });
 
     it("is a verified course with a course start date of tomorrow", () => {
       assert.equal(renderCourseStatusDisplay({
         status: STATUS_VERIFIED_NOT_COMPLETED,
-        course_start_date: tomorrow
+        runs: [{
+          course_start_date: tomorrow
+        }]
       }, moment(today)), "Course starting: 4/1/2016");
     });
 
@@ -89,15 +101,19 @@ describe('utility functions', () => {
       // Note the lack of grade field
       assert.equal(renderCourseStatusDisplay({
         status: STATUS_VERIFIED_NOT_COMPLETED,
-        course_start_date: today
+        runs: [{
+          course_start_date: today
+        }]
       }, moment(today)), "0%");
     });
 
     it("is a verified course with a course start date of yesterday", () => {
       assert.equal(renderCourseStatusDisplay({
         status: STATUS_VERIFIED_NOT_COMPLETED,
-        course_start_date: yesterday,
-        grade: 0.33333
+        runs: [{
+          course_start_date: yesterday,
+          grade: 0.33333
+        }]
       }, moment(today)), "33%");
     });
 
@@ -111,7 +127,9 @@ describe('utility functions', () => {
       assert.equal(
         renderCourseStatusDisplay({
           status: STATUS_ENROLLED_NOT_VERIFIED,
-          verification_date: tomorrow
+          runs: [{
+            verification_date: tomorrow
+          }]
         }, moment(today)),
         "UPGRADE TO VERIFIED"
       );
@@ -120,28 +138,36 @@ describe('utility functions', () => {
     it("is an enrolled course with a verification date of today", () => {
       assert.equal(renderCourseStatusDisplay({
         status: STATUS_ENROLLED_NOT_VERIFIED,
-        verification_date: today
+        runs: [{
+          verification_date: today
+        }]
       }, moment(today)), "");
     });
 
     it("is an enrolled course with a verification date of yesterday", () => {
       assert.equal(renderCourseStatusDisplay({
         status: STATUS_ENROLLED_NOT_VERIFIED,
-        verification_date: yesterday
+        runs: [{
+          verification_date: yesterday
+        }]
       }, moment(today)), "");
     });
 
     it("is an offered course with no enrollment start date", () => {
       assert.equal(renderCourseStatusDisplay({
         status: STATUS_OFFERED_NOT_ENROLLED,
-        fuzzy_enrollment_start_date: "fuzzy start date"
+        runs: [{
+          fuzzy_enrollment_start_date: "fuzzy start date"
+        }]
       }), "fuzzy start date");
     });
 
     it("is an offered course with an enrollment date of tomorrow", () => {
       assert.equal(renderCourseStatusDisplay({
         status: STATUS_OFFERED_NOT_ENROLLED,
-        enrollment_start_date: tomorrow
+        runs: [{
+          enrollment_start_date: tomorrow
+        }]
       }, moment(today)), "Enrollment starting: 4/1/2016");
     });
 
@@ -149,7 +175,9 @@ describe('utility functions', () => {
       assert.equal(
         renderCourseStatusDisplay({
           status: STATUS_OFFERED_NOT_ENROLLED,
-          enrollment_start_date: today
+          runs: [{
+            enrollment_start_date: today
+          }]
         }, moment(today)),
         "ENROLL"
       );
@@ -159,22 +187,24 @@ describe('utility functions', () => {
       assert.equal(
         renderCourseStatusDisplay({
           status: STATUS_OFFERED_NOT_ENROLLED,
-          enrollment_start_date: yesterday
+          runs: [{
+            enrollment_start_date: yesterday
+          }]
         }, moment(today)),
         "ENROLL"
       );
     });
 
-    it("is a run, not a course. If there are any runs the first run should be picked", () => {
+    it("doesn't show any special message even if the run is not passed", () => {
+      // we do show this information in the progress circle and in the expander
       assert.equal(
         renderCourseStatusDisplay({
           status: STATUS_NOT_OFFERED,
           runs: [{
-            status: STATUS_OFFERED_NOT_ENROLLED,
-            enrollment_start_date: yesterday
+            status: STATUS_NOT_PASSED
           }]
         }, moment(today)),
-        "ENROLL"
+        ""
       );
     });
 
@@ -192,40 +222,38 @@ describe('utility functions', () => {
   });
 
   describe("makeCourseStatusDisplay", () => {
-    let renderCourseProgressDisplay = (course, ...args) => {
-      if (course.runs === undefined) {
-        course.runs = [];
+    let passedCourse = {
+      status: STATUS_PASSED,
+      runs: []
+    };
+    let notPassedCourse = {
+      status: STATUS_NOT_OFFERED,
+      runs: [{
+        status: STATUS_NOT_PASSED
+      }]
+    };
+    let inProgressCourse = {
+      status: STATUS_VERIFIED_NOT_COMPLETED
+    };
+    
+    let renderCourseProgressDisplay = (course, isTop, isBottom, numRuns) => {
+      if (numRuns === undefined) {
+        numRuns = 0;
       }
-      let textOrElement = makeCourseProgressDisplay(course, ...args);
+      let textOrElement = makeCourseProgressDisplay(course, isTop, isBottom, numRuns);
       return makeStrippedHtml(textOrElement);
     };
 
     it('is a course which is passed', () => {
       assert.equal(
-        renderCourseProgressDisplay({
-          status: STATUS_PASSED
-        }),
-        "Course passed"
-      );
-    });
-
-    it('is a run which is passed. In this case the course status is ignored', () => {
-      assert.equal(
-        renderCourseProgressDisplay({
-          status: STATUS_NOT_OFFERED,
-          runs: [{
-            status: STATUS_PASSED
-          }]
-        }),
+        renderCourseProgressDisplay(passedCourse),
         "Course passed"
       );
     });
 
     it('is a course which is in progress', () => {
       assert.equal(
-        renderCourseProgressDisplay({
-          status: STATUS_VERIFIED_NOT_COMPLETED
-        }),
+        renderCourseProgressDisplay(inProgressCourse),
         "Course started"
       );
     });
@@ -239,10 +267,66 @@ describe('utility functions', () => {
       ]) {
         assert.equal(
           renderCourseProgressDisplay({
-            status: status
+            status: status,
+            runs: []
           }),
           "Course not started"
         );
+      }
+    });
+
+    it('is a course which is not-passed', () => {
+      assert.equal(
+        renderCourseProgressDisplay(notPassedCourse),
+        "Course not started"
+      );
+    });
+    
+    let getLines = progress => {
+      let topLine = false, bottomLine = false;
+
+      for (let child of progress.props.children) {
+        if (React.isValidElement(child)) {
+          if (child.props.className === "top-line") {
+            topLine = true;
+          }
+          if (child.props.className === "bottom-line") {
+            bottomLine = true;
+          }
+        }
+      }
+
+      return [topLine, bottomLine];
+    };
+
+    it('draws lines going up and down correctly', () => {
+      for (let isFirst of [true, false]) {
+        for (let isLast of [true, false]) {
+          let progress = makeCourseProgressDisplay(passedCourse, isFirst, isLast, 10);
+          let lines = getLines(progress);
+          assert.deepEqual(lines, [!isFirst, !isLast]);
+        }
+      }
+    });
+  });
+
+  describe("makeRunStatusDisplay", () => {
+    it('shows Course passed when a course is passed', () => {
+      assert.equal("Passed", makeRunStatusDisplay({ status: STATUS_PASSED }));
+    });
+
+    it('shows Course not passed when a course is not passed', () => {
+      assert.equal("Not passed", makeRunStatusDisplay({ status: STATUS_NOT_PASSED }));
+    });
+
+    it('returns an empty string for all other statuses', () => {
+      for (let status of [
+        STATUS_ENROLLED_NOT_VERIFIED,
+        STATUS_NOT_OFFERED,
+        STATUS_OFFERED_NOT_ENROLLED,
+        STATUS_VERIFIED_NOT_COMPLETED,
+      ]) {
+        assert.equal("", makeRunStatusDisplay({ status: status }));
       }
     });
   });

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -1,4 +1,4 @@
-.validation-wrapper {
+c.validation-wrapper {
   padding-bottom: 10px;
 }
 .validation-error-text {
@@ -6,8 +6,6 @@
   font-size: smaller;
 }
 .main-content {
-  @include outer-container;
-
   padding: 20px 0px;
 
   .card {
@@ -18,9 +16,7 @@
       background-color: darkslategrey;
       background-image: url(/static/images/mit-stata-center.png);
       background-position: 50% 50%;
-      @include span-columns(12);
       .card-image-box {
-        @include span-columns(2);
         min-width: 190px;
         height: 220px;
         padding-top: 40px;
@@ -38,7 +34,6 @@
         line-height: 35px;
         height: 100px;
         font-weight: 400;
-        @include span-columns(5);
 
         .card-student-id {
           font-size: 18px;
@@ -53,36 +48,61 @@
       font-size: x-large;
       color: #b34a4c;
       font-weight: bold;
-      @include span-columns(12);
     }
 
     .card-copy {
-      @include outer-container;
       padding: 25px;
     }
   }
 }
 
-.clear-float {
-  clear: both;
-}
-
 .course-list {
-  @include outer-container;
-  @include span-columns(8);
   border: 1px solid grey;
   margin: 10px 0;
 
-  ul {
-    @include span-columns(8 of 8);
+  .mdl-grid {
+    padding: 0 !important;
+  }
+
+  .course-list-row {
     border-bottom: 1px solid lightgray;
     margin: 0px;
-    display: flex;
-    align-items: center;
-    height: 70px; // same as progress indicator, see makeCourseProgressDisplay
   }
-  ul:last-child {
+  .course-list-row:last-child {
     border-bottom: 0px;
+  }
+
+  .course-list-center {
+    display: flex;
+
+    .course-title {
+      align-self: center;
+      padding-left: 20px;
+    }
+
+    .course-status {
+      align-self: center;
+    }
+
+    .course-progress {
+      margin-top: 0 !important;
+      margin-bottom: 0 !important;
+    }
+
+    &.course-list-header {
+      .course-progress {
+        align-self: center;
+      }
+    }
+
+  }
+
+  .course-run-title {
+    padding-left: 30px;
+  }
+
+  .course-run-status {
+    text-align: right;
   }
 
   li {
@@ -106,19 +126,7 @@
     }
   }
 
-  .course-title {
-    @include span-columns(4 of 8);
-    @include omega(3n);
-  }
-
-  .course-status {
-    @include span-columns(3 of 8);
-    @include omega(3n);
-  }
-
   .course-progress {
-    @include span-columns(1 of 8);
-    @include omega(3n);
     text-align: center;
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #223 

#### What's this PR do?
Shows course runs in dashboard and handles the not passed behavior more accurately. 

#### Where should the reviewer start?

#### How should this be manually tested?
Add a course which is not passed to your local server, then view the dashboard. You should see a red circle next to the course, and a expander link which would allow you to see individual runs.

#### Any background context you want to provide?

#### Screenshots (if appropriate)
![screenshot from 2016-05-18 13-43-09](https://cloud.githubusercontent.com/assets/863262/15369004/9f4a2106-1cfe-11e6-803e-804e42028992.png)

#### What GIF best describes this PR or how it makes you feel?

