### PR TITLE
Redirect to profile if the profile is not complete

### DIFF
--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -5,7 +5,7 @@ export const MASTERS = 'm';
 export const DOCTORATE = 'p';
 
 export const USER_PROFILE_RESPONSE = {
-  "filled_out": false,
+  "filled_out": true,
   "agreed_to_terms_of_service": true,
   "account_privacy": "all_users",
   "email_optin": false,

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -41,6 +41,7 @@ class App extends React.Component {
     this.fetchUserProfile(SETTINGS.username);
     this.fetchDashboard();
     this.requireTermsOfService();
+    this.requireProfileFilledOut();
     this.requireCompleteProfile();
   }
 
@@ -48,6 +49,7 @@ class App extends React.Component {
     this.fetchUserProfile(SETTINGS.username);
     this.fetchDashboard();
     this.requireTermsOfService();
+    this.requireProfileFilledOut();
     this.requireCompleteProfile();
   }
 
@@ -80,6 +82,18 @@ class App extends React.Component {
       !(TERMS_OF_SERVICE_REGEX.test(pathname))
     ) {
       this.context.router.push('/terms_of_service');
+    }
+  }
+
+  requireProfileFilledOut() {
+    const { userProfile, location: { pathname } } = this.props;
+    if (
+      userProfile.getStatus === FETCH_SUCCESS &&
+      !userProfile.profile.filled_out &&
+      !(TERMS_OF_SERVICE_REGEX.test(pathname)) &&
+      !(PROFILE_REGEX.test(pathname))
+    ) {
+      this.context.router.push('/profile');
     }
   }
 

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -18,7 +18,7 @@ import IntegrationTestHelper from '../util/integration_test_helper';
 
 describe('App', () => {
   let listenForActions, renderComponent, helper;
-  let dialogActions; 
+  let dialogActions;
 
   beforeEach(() => {
     helper = new IntegrationTestHelper();
@@ -53,6 +53,18 @@ describe('App', () => {
       helper.profileGetStub.returns(Promise.resolve(response));
 
       renderComponent("/dashboard", dialogActions).then(() => {
+        assert.equal(helper.currentLocation.pathname, "/profile/personal");
+        done();
+      });
+    });
+
+    it('redirects to /profile if profile is not filled out', done => {
+      let response = Object.assign({}, USER_PROFILE_RESPONSE, {
+        filled_out: false
+      });
+      helper.profileGetStub.returns(Promise.resolve(response));
+
+      renderComponent("/dashboard", []).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile/personal");
         done();
       });

--- a/static/js/containers/TermsOfServicePage_test.js
+++ b/static/js/containers/TermsOfServicePage_test.js
@@ -36,6 +36,20 @@ describe("TermsOfService", () => {
     });
   });
 
+  it("requires terms of service if user hasn't already agreed to it even if profile is not complete", done => {
+    let response = Object.assign({}, USER_PROFILE_RESPONSE, {
+      agreed_to_terms_of_service: false,
+      filled_out: false
+    });
+    helper.profileGetStub.returns(Promise.resolve(response));
+
+    renderComponent("/dashboard").then(() => {
+      assert.equal(helper.currentLocation.pathname, "/terms_of_service");
+
+      done();
+    });
+  });
+
   it("agrees to terms of service", done => {
     let response = Object.assign({}, USER_PROFILE_RESPONSE, {
       agreed_to_terms_of_service: false

--- a/ui/decorators.py
+++ b/ui/decorators.py
@@ -5,23 +5,32 @@ from functools import wraps
 
 from django.shortcuts import redirect
 
+from ui.url_utils import (
+    PROFILE_URL,
+    TERMS_OF_SERVICE_URL,
+)
 
-def require_terms_of_service(func):
+
+def require_mandatory_urls(func):
     """
     If user profile does not have terms of service, redirect to terms of service
+    If user profile is not filled out, redirect to profile
     """
     @wraps(func)
     def wrapper(request, *args, **kwargs):
         """
-        Wrapper for require_terms_of_service
+        Wrapper for check mandatory parts of the app
 
         Args:
             request (django.http.request.HttpRequest): A request
         """
-        if not request.user.is_anonymous() and request.path != '/terms_of_service/':
-            profile = request.user.profile
-            if not profile.agreed_to_terms_of_service:
-                return redirect('/terms_of_service/')
+        if not request.user.is_anonymous():
+            if request.path != TERMS_OF_SERVICE_URL:
+                profile = request.user.profile
+                if not profile.agreed_to_terms_of_service:
+                    return redirect(TERMS_OF_SERVICE_URL)
+                if not request.path.startswith(PROFILE_URL) and not profile.filled_out:
+                    return redirect(PROFILE_URL)
 
         return func(request, *args, **kwargs)
     return wrapper

--- a/ui/decorators_test.py
+++ b/ui/decorators_test.py
@@ -7,8 +7,9 @@ from django.test import TestCase
 from factory.django import mute_signals
 
 from profiles.factories import ProfileFactory
-from ui.urls import (
+from ui.url_utils import (
     DASHBOARD_URL,
+    PROFILE_URL,
     TERMS_OF_SERVICE_URL,
 )
 
@@ -24,7 +25,10 @@ class DecoratorTests(TestCase):
         they should be redirected to /terms_of_service
         """
         with mute_signals(post_save):
-            profile = ProfileFactory.create(agreed_to_terms_of_service=False)
+            profile = ProfileFactory.create(
+                agreed_to_terms_of_service=False,
+                filled_out=True,
+            )
         self.client.force_login(profile.user)
 
         resp = self.client.get(DASHBOARD_URL)
@@ -36,10 +40,42 @@ class DecoratorTests(TestCase):
         """
 
         with mute_signals(post_save):
-            profile = ProfileFactory.create(agreed_to_terms_of_service=False)
+            profile = ProfileFactory.create(
+                agreed_to_terms_of_service=False,
+                filled_out=True,
+            )
         self.client.force_login(profile.user)
 
         resp = self.client.get(TERMS_OF_SERVICE_URL)
+        assert resp.status_code == 200
+
+    def test_redirect_profile(self):
+        """
+        If user has not completed the profile, they should be redirected to the profile
+        """
+        with mute_signals(post_save):
+            profile = ProfileFactory.create(
+                agreed_to_terms_of_service=True,
+                filled_out=False
+            )
+        self.client.force_login(profile.user)
+
+        resp = self.client.get(DASHBOARD_URL)
+        self.assertRedirects(resp, PROFILE_URL)
+
+    def test_no_redirect_profile(self):
+        """
+        If user is going to /profile anyway, don't redirect them
+        """
+
+        with mute_signals(post_save):
+            profile = ProfileFactory.create(
+                agreed_to_terms_of_service=True,
+                filled_out=False,
+            )
+        self.client.force_login(profile.user)
+
+        resp = self.client.get(PROFILE_URL)
         assert resp.status_code == 200
 
     def test_no_redirect(self):
@@ -48,8 +84,26 @@ class DecoratorTests(TestCase):
         """
 
         with mute_signals(post_save):
-            profile = ProfileFactory.create(agreed_to_terms_of_service=True)
+            profile = ProfileFactory.create(
+                agreed_to_terms_of_service=True,
+                filled_out=True,
+            )
         self.client.force_login(profile.user)
 
         resp = self.client.get(DASHBOARD_URL)
         assert resp.status_code == 200
+
+    def test_redirect_to_terms_of_service_first(self):
+        """
+        If user has not filled out terms of service and not the profile,
+        they are redirected to the terms of service first
+        """
+        with mute_signals(post_save):
+            profile = ProfileFactory.create(
+                agreed_to_terms_of_service=False,
+                filled_out=False,
+            )
+        self.client.force_login(profile.user)
+
+        resp = self.client.get(DASHBOARD_URL)
+        self.assertRedirects(resp, TERMS_OF_SERVICE_URL)

--- a/ui/url_utils.py
+++ b/ui/url_utils.py
@@ -1,0 +1,7 @@
+"""
+Utils for URLs (to avoid circular imports)
+"""
+
+DASHBOARD_URL = '/dashboard/'
+PROFILE_URL = '/profile/'
+TERMS_OF_SERVICE_URL = '/terms_of_service/'

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -3,19 +3,18 @@ URLs for ui
 """
 from django.conf.urls import url
 
+from ui.url_utils import (
+    DASHBOARD_URL,
+    PROFILE_URL,
+    TERMS_OF_SERVICE_URL,
+)
 from ui.views import dashboard
-
-DASHBOARD_URL = '/dashboard/'
-PROFILE_URL = '/profile/'
-PROFILE_PERSONAL_URL = '/profile/personal/'
-TERMS_OF_SERVICE_URL = '/terms_of_service/'
 
 dashboard_urlpatterns = [
     url(r'^{}'.format(dashboard_url.lstrip("/")), dashboard, name='ui-dashboard')
     for dashboard_url in [
         DASHBOARD_URL,
         PROFILE_URL,
-        PROFILE_PERSONAL_URL,
         TERMS_OF_SERVICE_URL,
     ]
 ]

--- a/ui/views.py
+++ b/ui/views.py
@@ -9,7 +9,9 @@ from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 
-from ui.decorators import require_terms_of_service
+from ui.decorators import (
+    require_mandatory_urls,
+)
 
 log = logging.getLogger(__name__)
 
@@ -29,7 +31,7 @@ def get_bundle_url(request, bundle_name):
         return static("bundles/{bundle}".format(bundle=bundle_name))
 
 
-@require_terms_of_service
+@require_mandatory_urls
 @login_required()
 def dashboard(request, *args):  # pylint: disable=unused-argument
     """

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -43,7 +43,8 @@ class TestViews(TestCase):
         """
         with mute_signals(post_save):
             profile = ProfileFactory.create(
-                agreed_to_terms_of_service=True
+                agreed_to_terms_of_service=True,
+                filled_out=True,
             )
         self.client.force_login(profile.user)
 
@@ -74,7 +75,11 @@ class TestViews(TestCase):
         """Verify that we let an authenticated user through to '/dashboard'"""
         with mute_signals(post_save):
             user = UserFactory.create()
-            ProfileFactory.create(user=user, agreed_to_terms_of_service=True)
+            ProfileFactory.create(
+                user=user,
+                agreed_to_terms_of_service=True,
+                filled_out=True,
+            )
         self.client.force_login(user)
         response = self.client.get(DASHBOARD_URL)
         self.assertContains(


### PR DESCRIPTION
#### What are the relevant tickets?
closes #227 

#### What's this PR do?
Redirects the user to the profile page if the profile is not complete

#### Where should the reviewer start?
`ui/decorators.py`

#### How should this be manually tested?
uncheck `Filled out` and `Agreed to terms of service` from the user profile and test that the user is redirected first to the terms of service and then to the profile.

#### What GIF best describes this PR or how it makes you feel?
![](http://i.giphy.com/pzC4JPfrCSY24.gif)
