### PR TITLE
Moved education reducers and actions into `ui`

### DIFF
--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -16,10 +16,6 @@ export const RECEIVE_PATCH_USER_PROFILE_SUCCESS = 'RECEIVE_PATCH_USER_PROFILE_SU
 export const RECEIVE_PATCH_USER_PROFILE_FAILURE = 'RECEIVE_PATCH_USER_PROFILE_FAILURE';
 export const UPDATE_PROFILE_VALIDATION = 'UPDATE_PROFILE_VALIDATION';
 
-export const SHOW_EDUCATION_FORM_DIALOG = 'SHOW_EDUCATION_FORM_DIALOG';
-export const HIDE_EDUCATION_FORM_DIALOG = 'HIDE_EDUCATION_FORM_DIALOG';
-export const TOGGLE_EDUCATION_LEVEL = 'TOGGLE_EDUCATION_LEVEL';
-
 // constants for fetch status (these are not action types)
 export const FETCH_FAILURE = 'FETCH_FAILURE';
 export const FETCH_SUCCESS = 'FETCH_SUCCESS';
@@ -41,19 +37,9 @@ export const updateProfile = profile => ({
   type: UPDATE_PROFILE,
   payload: { profile }
 });
-export const openEducationForm = (level, index) => ({
-  type: SHOW_EDUCATION_FORM_DIALOG,
-  payload: { level, index }
-});
-export const closeEducationForm = () => ({type: HIDE_EDUCATION_FORM_DIALOG});
 
 export const startProfileEdit = () => ({ type: START_PROFILE_EDIT });
 export const clearProfileEdit = () => ({ type: CLEAR_PROFILE_EDIT });
-
-export const toggleEducationLevel = educationLevels => ({
-  type: TOGGLE_EDUCATION_LEVEL,
-  payload: { educationLevels }
-});
 
 const requestPatchUserProfile = () => ({ type: REQUEST_PATCH_USER_PROFILE });
 

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -1,38 +1,62 @@
+// general UI actions
 export const CLEAR_UI = 'CLEAR_UI';
-export const UPDATE_DIALOG_TEXT = 'UPDATE_DIALOG_TEXT';
-export const UPDATE_DIALOG_TITLE = 'UPDATE_DIALOG_TITLE';
-export const SET_DIALOG_VISIBILITY = 'SET_DIALOG_VISIBILITY';
-export const SET_WORK_HISTORY_EDIT = 'SET_WORK_HISTORY_EDIT';
-export const SET_WORK_DIALOG_VISIBILITY = 'SET_WORK_DIALOG_VISIBILITY';
-export const SET_WORK_DIALOG_INDEX = 'SET_WORK_DIALOG_INDEX';
-export const TOGGLE_DASHBOARD_EXPANDER = 'TOGGLE_DASHBOARD_EXPANDER';
-
 export const clearUI = () => ({ type: CLEAR_UI });
+
+export const UPDATE_DIALOG_TEXT = 'UPDATE_DIALOG_TEXT';
 export const updateDialogText = text => (
   { type: UPDATE_DIALOG_TEXT, payload: text }
 );
 
+export const UPDATE_DIALOG_TITLE = 'UPDATE_DIALOG_TITLE';
 export const updateDialogTitle = title => (
   { type: UPDATE_DIALOG_TITLE, payload: title }
 );
 
+export const SET_DIALOG_VISIBILITY = 'SET_DIALOG_VISIBILITY';
 export const setDialogVisibility = bool => (
   { type: SET_DIALOG_VISIBILITY, payload: bool }
 );
 
+// work history actions
+export const SET_WORK_HISTORY_EDIT = 'SET_WORK_HISTORY_EDIT';
 export const setWorkHistoryEdit = bool => (
   { type: SET_WORK_HISTORY_EDIT, payload: bool }
 );
 
+export const SET_WORK_DIALOG_VISIBILITY = 'SET_WORK_DIALOG_VISIBILITY';
 export const setWorkDialogVisibility = bool => (
   { type: SET_WORK_DIALOG_VISIBILITY, payload: bool }
 );
 
+export const SET_WORK_DIALOG_INDEX = 'SET_WORK_DIALOG_INDEX';
 export const setWorkDialogIndex = index => (
   { type: SET_WORK_DIALOG_INDEX, payload: index }
 );
 
+// dashboard actions
+export const TOGGLE_DASHBOARD_EXPANDER = 'TOGGLE_DASHBOARD_EXPANDER';
 export const toggleDashboardExpander = (courseId, newValue) => ({
   type: TOGGLE_DASHBOARD_EXPANDER,
   payload: { courseId, newValue }
 });
+
+// education actions
+export const SET_EDUCATION_DIALOG_VISIBILITY = 'SET_EDUCATION_DIALOG_VISIBILITY';
+export const setEducationDialogVisibility = bool => (
+  { type: SET_EDUCATION_DIALOG_VISIBILITY, payload: bool }
+);
+
+export const SET_EDUCATION_DIALOG_INDEX = 'SET_EDUCATION_DIALOG_INDEX';
+export const setEducationDialogIndex = index => (
+  { type: SET_EDUCATION_DIALOG_INDEX, payload: index }
+);
+
+export const SET_EDUCATION_DEGREE_LEVEL = 'SET_EDUCATION_DEGREE_LEVEL';
+export const setEducationDegreeLevel = level => (
+  { type: SET_EDUCATION_DEGREE_LEVEL, payload: level }
+);
+
+export const SET_EDUCATION_DEGREE_INCLUSIONS = 'SET_EDUCATION_DEGREE_INCLUSIONS';
+export const setEducationDegreeInclusions = degreeInclusions => (
+  { type: SET_EDUCATION_DEGREE_INCLUSIONS, payload: degreeInclusions }
+);

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -15,6 +15,10 @@ import {
   setWorkHistoryEdit,
   setWorkDialogVisibility,
   setWorkDialogIndex,
+  setEducationDialogVisibility,
+  setEducationDialogIndex,
+  setEducationDegreeLevel,
+  setEducationDegreeInclusions,
 } from '../actions/ui';
 
 class ProfilePage extends React.Component {
@@ -57,6 +61,26 @@ class ProfilePage extends React.Component {
   clearProfileEdit = () => {
     const { dispatch } = this.props;
     dispatch(clearProfileEdit());
+  }
+
+  setEducationDialogVisibility = bool => {
+    const { dispatch } = this.props;
+    dispatch(setEducationDialogVisibility(bool));
+  }
+
+  setEducationDialogIndex = index => {
+    const { dispatch } = this.props;
+    dispatch(setEducationDialogIndex(index));
+  }
+
+  setEducationDegreeLevel = level => {
+    const { dispatch } = this.props;
+    dispatch(setEducationDegreeLevel(level));
+  }
+
+  setEducationDegreeInclusions = inclusions => {
+    const { dispatch } = this.props;
+    dispatch(setEducationDegreeInclusions(inclusions));
   }
 
   saveProfile(isEdit, profile, requiredFields, messages) {
@@ -113,6 +137,10 @@ class ProfilePage extends React.Component {
         setWorkDialogVisibility: this.setWorkDialogVisibility,
         setWorkDialogIndex: this.setWorkDialogIndex,
         clearProfileEdit: this.clearProfileEdit,
+        setEducationDialogVisibility: this.setEducationDialogVisibility,
+        setEducationDialogIndex: this.setEducationDialogIndex,
+        setEducationDegreeLevel: this.setEducationDegreeLevel,
+        setEducationDegreeInclusions: this.setEducationDegreeInclusions,
       })
     ));
 

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -13,10 +13,6 @@ import {
   RECEIVE_PATCH_USER_PROFILE_FAILURE,
   UPDATE_PROFILE_VALIDATION,
 
-  SHOW_EDUCATION_FORM_DIALOG,
-  HIDE_EDUCATION_FORM_DIALOG,
-  TOGGLE_EDUCATION_LEVEL,
-
   REQUEST_DASHBOARD,
   RECEIVE_DASHBOARD_SUCCESS,
   RECEIVE_DASHBOARD_FAILURE,
@@ -26,47 +22,7 @@ import {
   FETCH_PROCESSING,
   FETCH_SUCCESS,
 } from '../actions';
-import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
 import { ui } from './ui';
-
-export const INITIAL_DIALOG_STATE = {
-  openDialog: false,
-  degreeLevel: '',
-  educationIndex: null,
-  educationId: null
-};
-export const educationDialog = (state = INITIAL_DIALOG_STATE, action) => {
-  switch (action.type) {
-  case SHOW_EDUCATION_FORM_DIALOG:
-    return Object.assign({}, state, {
-      openDialog: true,
-      degreeLevel: action.payload.level,
-      educationIndex: action.payload.index
-    });
-  case HIDE_EDUCATION_FORM_DIALOG:
-    return INITIAL_DIALOG_STATE;
-  default:
-    return state;
-  }
-};
-
-export const INITIAL_EDUCATION_LEVEL_STATE = {};
-INITIAL_EDUCATION_LEVEL_STATE[HIGH_SCHOOL] = true;
-INITIAL_EDUCATION_LEVEL_STATE[ASSOCIATE] = true;
-INITIAL_EDUCATION_LEVEL_STATE[BACHELORS] = true;
-INITIAL_EDUCATION_LEVEL_STATE[MASTERS] = false;
-INITIAL_EDUCATION_LEVEL_STATE[DOCTORATE] = false;
-
-export const educationLevels = (state = INITIAL_EDUCATION_LEVEL_STATE, action) => {
-  switch (action.type) {
-  case TOGGLE_EDUCATION_LEVEL:
-    return action.payload.educationLevels;
-  
-  default:
-    return state;
-  }
-};
-
 
 export const INITIAL_USER_PROFILE_STATE = {
   profile: {}
@@ -173,6 +129,4 @@ export default combineReducers({
   userProfile,
   dashboard,
   ui,
-  educationDialog,
-  educationLevels
 });

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -3,16 +3,34 @@ import {
   UPDATE_DIALOG_TEXT,
   UPDATE_DIALOG_TITLE,
   SET_DIALOG_VISIBILITY,
+
   SET_WORK_HISTORY_EDIT,
   SET_WORK_DIALOG_VISIBILITY,
   SET_WORK_DIALOG_INDEX,
+
   TOGGLE_DASHBOARD_EXPANDER,
+
+  SET_EDUCATION_DIALOG_VISIBILITY,
+  SET_EDUCATION_DIALOG_INDEX,
+  SET_EDUCATION_DEGREE_LEVEL,
+  SET_EDUCATION_DEGREE_INCLUSIONS,
 } from '../actions/ui';
+import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
 
 export const INITIAL_UI_STATE = {
-  workHistoryEdit: true,
-  workDialogVisibility: false,
-  dashboardExpander: {}
+  workHistoryEdit:            true,
+  workDialogVisibility:       false,
+  dashboardExpander:          {},
+  educationDialogVisibility:  false,
+  educationDialogIndex:       null,
+  educationDegreeLevel:       '',
+  educationDegreeInclusions:  {
+    [HIGH_SCHOOL]: true,
+    [ASSOCIATE]: true,
+    [BACHELORS]: true,
+    [MASTERS]: false,
+    [DOCTORATE]: false,
+  },
 };
 
 export const ui = (state = INITIAL_UI_STATE, action) => {
@@ -52,6 +70,22 @@ export const ui = (state = INITIAL_UI_STATE, action) => {
   case SET_WORK_DIALOG_INDEX:
     return Object.assign({}, state, {
       workDialogIndex: action.payload
+    });
+  case SET_EDUCATION_DIALOG_VISIBILITY:
+    return Object.assign({}, state, {
+      educationDialogVisibility: action.payload
+    });
+  case SET_EDUCATION_DIALOG_INDEX:
+    return Object.assign({}, state, {
+      educationDialogIndex: action.payload
+    });
+  case SET_EDUCATION_DEGREE_LEVEL:
+    return Object.assign({}, state, {
+      educationDegreeLevel: action.payload
+    });
+  case SET_EDUCATION_DEGREE_INCLUSIONS:
+    return Object.assign({}, state, {
+      educationDegreeInclusions: action.payload
     });
   case CLEAR_UI:
     return INITIAL_UI_STATE;

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -7,6 +7,10 @@ import {
   SET_WORK_DIALOG_VISIBILITY,
   SET_WORK_DIALOG_INDEX,
   TOGGLE_DASHBOARD_EXPANDER,
+  SET_EDUCATION_DIALOG_VISIBILITY,
+  SET_EDUCATION_DIALOG_INDEX,
+  SET_EDUCATION_DEGREE_LEVEL,
+  SET_EDUCATION_DEGREE_INCLUSIONS,
 
   clearUI,
   updateDialogText,
@@ -16,8 +20,13 @@ import {
   setWorkDialogVisibility,
   setWorkDialogIndex,
   toggleDashboardExpander,
+  setEducationDialogVisibility,
+  setEducationDialogIndex,
+  setEducationDegreeLevel,
+  setEducationDegreeInclusions,
 } from '../actions/ui';
 import { INITIAL_UI_STATE } from '../reducers/ui';
+import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
 
 import configureTestStore from 'redux-asserts';
 import rootReducer from '../reducers';
@@ -40,27 +49,6 @@ describe('ui reducers', () => {
     dispatchThen = null;
   });
 
-  it('should set a dialog title', done => {
-    dispatchThen(updateDialogTitle('A title'), [UPDATE_DIALOG_TITLE]).then(state => {
-      assert.equal(state.dialog.title, 'A title');
-      done();
-    });
-  });
-
-  it('should set dialog text', done => {
-    dispatchThen(updateDialogText('Some Text'), [UPDATE_DIALOG_TEXT]).then(state => {
-      assert.equal(state.dialog.text, 'Some Text');
-      done();
-    });
-  });
-
-  it('should set dialog visibility', done => {
-    dispatchThen(setDialogVisibility(true), [SET_DIALOG_VISIBILITY]).then(state => {
-      assert.equal(state.dialog.visible, true);
-      done();
-    });
-  });
-
   it('should clear the ui', done => {
     dispatchThen(clearUI(), [CLEAR_UI]).then(state => {
       assert.deepEqual(state, INITIAL_UI_STATE);
@@ -68,35 +56,60 @@ describe('ui reducers', () => {
     });
   });
 
-  it('should set the work history dialog visibility', done => {
-    dispatchThen(setWorkDialogVisibility(true), [SET_WORK_DIALOG_VISIBILITY]).then(state => {
-      assert.equal(state.workDialogVisibility, true);
+  describe('dialog reducers', () => {
+    it('should set a dialog title', done => {
+      dispatchThen(updateDialogTitle('A title'), [UPDATE_DIALOG_TITLE]).then(state => {
+        assert.equal(state.dialog.title, 'A title');
+        done();
+      });
+    });
 
-      dispatchThen(setWorkDialogVisibility(false), [SET_WORK_DIALOG_VISIBILITY]).then(state => {
-        assert.equal(state.workDialogVisibility, false);
+    it('should set dialog text', done => {
+      dispatchThen(updateDialogText('Some Text'), [UPDATE_DIALOG_TEXT]).then(state => {
+        assert.equal(state.dialog.text, 'Some Text');
+        done();
+      });
+    });
+
+    it('should set dialog visibility', done => {
+      dispatchThen(setDialogVisibility(true), [SET_DIALOG_VISIBILITY]).then(state => {
+        assert.equal(state.dialog.visible, true);
         done();
       });
     });
   });
 
-  it('should set work history edit', done => {
-    dispatchThen(setWorkHistoryEdit(true), [SET_WORK_HISTORY_EDIT]).then(state => {
-      assert.equal(state.workHistoryEdit, true);
+  describe('work_history reducers', () => {
+    it('should set the work history dialog visibility', done => {
+      dispatchThen(setWorkDialogVisibility(true), [SET_WORK_DIALOG_VISIBILITY]).then(state => {
+        assert.equal(state.workDialogVisibility, true);
 
-      dispatchThen(setWorkHistoryEdit(false), [SET_WORK_HISTORY_EDIT]).then(state => {
-        assert.equal(state.workHistoryEdit, false);
-        done();
+        dispatchThen(setWorkDialogVisibility(false), [SET_WORK_DIALOG_VISIBILITY]).then(state => {
+          assert.equal(state.workDialogVisibility, false);
+          done();
+        });
       });
     });
-  });
 
-  it('should set a work history dialog index', done => {
-    dispatchThen(setWorkDialogIndex(2), [SET_WORK_DIALOG_INDEX]).then(state => {
-      assert.equal(state.workDialogIndex, 2);
+    it('should set work history edit', done => {
+      dispatchThen(setWorkHistoryEdit(true), [SET_WORK_HISTORY_EDIT]).then(state => {
+        assert.equal(state.workHistoryEdit, true);
 
-      dispatchThen(setWorkDialogIndex(5), [SET_WORK_DIALOG_INDEX]).then(state => {
-        assert.equal(state.workDialogIndex, 5);
-        done();
+        dispatchThen(setWorkHistoryEdit(false), [SET_WORK_HISTORY_EDIT]).then(state => {
+          assert.equal(state.workHistoryEdit, false);
+          done();
+        });
+      });
+    });
+
+    it('should set a work history dialog index', done => {
+      dispatchThen(setWorkDialogIndex(2), [SET_WORK_DIALOG_INDEX]).then(state => {
+        assert.equal(state.workDialogIndex, 2);
+
+        dispatchThen(setWorkDialogIndex(5), [SET_WORK_DIALOG_INDEX]).then(state => {
+          assert.equal(state.workDialogIndex, 5);
+          done();
+        });
       });
     });
   });
@@ -114,6 +127,60 @@ describe('ui reducers', () => {
         assert.deepEqual(state.dashboardExpander, {
           3: true
         });
+        done();
+      });
+    });
+  });
+
+  describe('education reducers', () => {
+    it('has a default state', done => {
+      dispatchThen({type: "undefined"}, []).then(state => {
+        assert.deepEqual(state.educationDialogVisibility, false);
+        assert.deepEqual(state.educationDialogIndex, null);
+        assert.deepEqual(state.educationDegreeLevel, '');
+        assert.deepEqual(
+          state.educationDegreeInclusions, {
+            [HIGH_SCHOOL]: true,
+            [ASSOCIATE]: true,
+            [BACHELORS]: true,
+            [MASTERS]: false,
+            [DOCTORATE]: false,
+          });
+        done();
+      });
+    });
+
+    it('should let you set education dialog visibility', done => {
+      dispatchThen(setEducationDialogVisibility(true), [SET_EDUCATION_DIALOG_VISIBILITY]).then(state => {
+        assert.deepEqual(state.educationDialogVisibility, true);
+        done();
+      });
+    });
+
+    it('should let you set education degree level', done => {
+      dispatchThen(setEducationDegreeLevel('foobar'), [SET_EDUCATION_DEGREE_LEVEL]).then(state => {
+        assert.deepEqual(state.educationDegreeLevel, 'foobar');
+        done();
+      });
+    });
+
+    it('should let you set education dialog index', done => {
+      dispatchThen(setEducationDialogIndex(3), [SET_EDUCATION_DIALOG_INDEX]).then(state => {
+        assert.deepEqual(state.educationDialogIndex, 3);
+        done();
+      });
+    });
+
+    it('should let you set degree inclusions', done => {
+      let newInclusions = {
+        [HIGH_SCHOOL]: true,
+        [ASSOCIATE]: false,
+        [BACHELORS]: true,
+        [MASTERS]: true,
+        [DOCTORATE]: true,
+      };
+      dispatchThen(setEducationDegreeInclusions(newInclusions), [SET_EDUCATION_DEGREE_INCLUSIONS]).then(state => {
+        assert.deepEqual(state.educationDegreeInclusions, newInclusions);
         done();
       });
     });


### PR DESCRIPTION
#### What are the relevant tickets?

closes #329 

#### What's this PR do?

This moves the reducers and actions relating to the education step of the profile to the UI reducer.

#### Where should the reviewer start?

Read through all the new actions, make sure they all make sense. Read the changes to the `EducationTab` class - this no longer is connected directly to the store but receives a bunch of setters (and the `ui` object) from it's parent.

#### How should this be manually tested?

Make sure there are no regressions on the education step.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

