### PR TITLE
Refactored profiles reducer to handle multiple profiles

### DIFF
--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -22,55 +22,76 @@ export const FETCH_SUCCESS = 'FETCH_SUCCESS';
 export const FETCH_PROCESSING = 'FETCH_PROCESSING';
 
 // actions for user profile
-const requestGetUserProfile = () => ({ type: REQUEST_GET_USER_PROFILE });
+const requestGetUserProfile = username => ({
+  type: REQUEST_GET_USER_PROFILE,
+  payload: { username }
+});
 
-export const receiveGetUserProfileSuccess = profile =>({
+export const receiveGetUserProfileSuccess = (username, profile) => ({
   type: RECEIVE_GET_USER_PROFILE_SUCCESS,
-  payload: { profile }
+  payload: { profile, username }
 });
 
-const receiveGetUserProfileFailure = () => ({ type: RECEIVE_GET_USER_PROFILE_FAILURE });
+const receiveGetUserProfileFailure = username => ({
+  type: RECEIVE_GET_USER_PROFILE_FAILURE,
+  payload: { username }
+});
 
-export const clearProfile = () => ({ type: CLEAR_PROFILE });
+export const clearProfile = username => ({
+  type: CLEAR_PROFILE,
+  payload: { username }
+});
 
-export const updateProfile = profile => ({
+export const updateProfile = (username, profile) => ({
   type: UPDATE_PROFILE,
-  payload: { profile }
+  payload: { profile, username }
 });
 
-export const startProfileEdit = () => ({ type: START_PROFILE_EDIT });
-export const clearProfileEdit = () => ({ type: CLEAR_PROFILE_EDIT });
+export const startProfileEdit = username => ({
+  type: START_PROFILE_EDIT,
+  payload: { username }
+});
+export const clearProfileEdit = username => ({
+  type: CLEAR_PROFILE_EDIT,
+  payload: { username }
+});
 
-const requestPatchUserProfile = () => ({ type: REQUEST_PATCH_USER_PROFILE });
+const requestPatchUserProfile = username => ({
+  type: REQUEST_PATCH_USER_PROFILE,
+  payload: { username }
+});
 
-const receivePatchUserProfileSuccess = profile => ({
+const receivePatchUserProfileSuccess = (username, profile) => ({
   type: RECEIVE_PATCH_USER_PROFILE_SUCCESS,
-  payload: { profile }
+  payload: { profile, username }
 });
 
-const receivePatchUserProfileFailure = () => ({ type: RECEIVE_PATCH_USER_PROFILE_FAILURE });
+const receivePatchUserProfileFailure = username => ({
+  type: RECEIVE_PATCH_USER_PROFILE_FAILURE,
+  payload: { username }
+});
 
 export const saveProfile = (username, profile) => {
   return dispatch => {
-    dispatch(requestPatchUserProfile());
+    dispatch(requestPatchUserProfile(username));
     return api.patchUserProfile(username, profile).
-      then(newProfile => dispatch(receivePatchUserProfileSuccess(newProfile))).
+      then(newProfile => dispatch(receivePatchUserProfileSuccess(username, newProfile))).
       catch(e => {
-        dispatch(receivePatchUserProfileFailure());
+        dispatch(receivePatchUserProfileFailure(username));
         // propagate exception
         return Promise.reject(e);
       });
   };
 };
-export const updateProfileValidation = errors => ({
+export const updateProfileValidation = (username, errors) => ({
   type: UPDATE_PROFILE_VALIDATION,
-  payload: { errors }
+  payload: { errors, username }
 });
 
-export const validateProfile = (profile, requiredFields, messages) => {
+export const validateProfile = (username, profile, requiredFields, messages) => {
   return dispatch => {
     let errors = util.validateProfile(profile, requiredFields, messages);
-    dispatch(updateProfileValidation(errors));
+    dispatch(updateProfileValidation(username, errors));
     if (_.isEmpty(errors)) {
       return Promise.resolve();
     } else {
@@ -81,11 +102,11 @@ export const validateProfile = (profile, requiredFields, messages) => {
 
 export function fetchUserProfile(username) {
   return dispatch => {
-    dispatch(requestGetUserProfile());
+    dispatch(requestGetUserProfile(username));
     return api.getUserProfile(username).
-      then(json => dispatch(receiveGetUserProfileSuccess(json))).
+      then(json => dispatch(receiveGetUserProfileSuccess(username, json))).
       catch(e => {
-        dispatch(receiveGetUserProfileFailure());
+        dispatch(receiveGetUserProfileFailure(username));
         // propagate exception
         return Promise.reject(e);
       });

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -53,7 +53,7 @@ class App extends React.Component {
 
   componentWillUnmount() {
     const { dispatch } = this.props;
-    dispatch(clearProfile());
+    dispatch(clearProfile(SETTINGS.username));
     dispatch(clearDashboard());
     dispatch(clearUI());
   }
@@ -154,8 +154,14 @@ class App extends React.Component {
 }
 
 const mapStateToProps = (state) => {
+  let profile = {
+    profile: {}
+  };
+  if (state.profiles[SETTINGS.username] !== undefined) {
+    profile = state.profiles[SETTINGS.username];
+  }
   return {
-    userProfile:  state.userProfile,
+    userProfile:  profile,
     dashboard:    state.dashboard,
     ui:           state.ui,
   };

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -23,8 +23,14 @@ class DashboardPage extends React.Component {
 }
 
 const mapStateToProps = (state) => {
+  let profile = {
+    profile: {}
+  };
+  if (state.profiles[SETTINGS.username] !== undefined) {
+    profile = state.profiles[SETTINGS.username];
+  }
   return {
-    profile: state.userProfile,
+    profile: profile,
     dashboard: state.dashboard,
     expander: state.ui.dashboardExpander
   };

--- a/static/js/containers/LoginButton.js
+++ b/static/js/containers/LoginButton.js
@@ -39,8 +39,14 @@ class LoginButton extends React.Component {
 }
 
 const mapStateToProps = (state) => {
+  let profile = {
+    profile: {}
+  };
+  if (state.profiles[SETTINGS.username] !== undefined) {
+    profile = state.profiles[SETTINGS.username];
+  }
   return {
-    profile: state.userProfile.profile
+    profile: profile
   };
 };
 

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -36,11 +36,12 @@ class ProfilePage extends React.Component {
 
   updateProfile(isEdit, profile) {
     const { dispatch } = this.props;
+    const username = SETTINGS.username;
 
     if (!isEdit) {
-      dispatch(startProfileEdit());
+      dispatch(startProfileEdit(username));
     }
-    dispatch(updateProfile(profile));
+    dispatch(updateProfile(username, profile));
   }
 
   setWorkHistoryEdit = (bool) => {
@@ -85,13 +86,15 @@ class ProfilePage extends React.Component {
 
   saveProfile(isEdit, profile, requiredFields, messages) {
     const { dispatch } = this.props;
+    const username = SETTINGS.username;
+
     if (!isEdit) {
       // Validation errors will only show up if we start the edit
-      dispatch(startProfileEdit());
+      dispatch(startProfileEdit(username));
     }
-    return dispatch(validateProfile(profile, requiredFields, messages)).then(() => {
-      return dispatch(saveProfile(SETTINGS.username, profile)).then(() => {
-        dispatch(clearProfileEdit());
+    return dispatch(validateProfile(username, profile, requiredFields, messages)).then(() => {
+      return dispatch(saveProfile(username, profile)).then(() => {
+        dispatch(clearProfileEdit(username));
       });
     });
   }
@@ -162,9 +165,17 @@ class ProfilePage extends React.Component {
   }
 }
 
-const mapStateToProps = state => ({
-  profile:  state.userProfile,
-  ui:       state.ui,
-});
+const mapStateToProps = state => {
+  let profile = {
+    profile: {}
+  };
+  if (state.profiles[SETTINGS.username] !== undefined) {
+    profile = state.profiles[SETTINGS.username];
+  }
+  return {
+    profile: profile,
+    ui: state.ui,
+  };
+};
 
 export default connect(mapStateToProps)(ProfilePage);

--- a/static/js/containers/TermsOfServicePage.js
+++ b/static/js/containers/TermsOfServicePage.js
@@ -53,8 +53,16 @@ class TermsOfServicePage extends React.Component {
   }
 }
 
-const mapStateToProps = state => ({
-  userProfile: state.userProfile
-});
+const mapStateToProps = state => {
+  let profile = {
+    profile: {}
+  };
+  if (state.profiles[SETTINGS.username] !== undefined) {
+    profile = state.profiles[SETTINGS.username];
+  }
+  return {
+    userProfile: profile
+  };
+};
 
 export default connect(mapStateToProps)(TermsOfServicePage);

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -24,72 +24,91 @@ import {
 } from '../actions';
 import { ui } from './ui';
 
-export const INITIAL_USER_PROFILE_STATE = {
-  profile: {}
-};
+export const INITIAL_PROFILES_STATE = {};
 
-export const userProfile = (state = INITIAL_USER_PROFILE_STATE, action) => {
+export const profiles = (state = INITIAL_PROFILES_STATE, action) => {
+  let patchProfile = newProfile => {
+    let clone = Object.assign({}, state);
+    let username = action.payload.username;
+    clone[username] = Object.assign(
+      { profile: {} },
+      clone[username],
+      newProfile
+    );
+    return clone;
+  };
+
+  let getProfile = () => {
+    if (state[action.payload.username] !== undefined) {
+      return state[action.payload.username];
+    }
+    return {};
+  };
+
   switch (action.type) {
   case REQUEST_GET_USER_PROFILE:
-    return Object.assign({}, state, {
+    return patchProfile({
       getStatus: FETCH_PROCESSING
     });
   case RECEIVE_GET_USER_PROFILE_SUCCESS:
-    return Object.assign({}, state, {
+    return patchProfile({
       getStatus: FETCH_SUCCESS,
       profile: action.payload.profile
     });
   case RECEIVE_GET_USER_PROFILE_FAILURE:
-    return Object.assign({}, state, {
+    return patchProfile({
       getStatus: FETCH_FAILURE
     });
-  case CLEAR_PROFILE:
-    return INITIAL_USER_PROFILE_STATE;
+  case CLEAR_PROFILE: {
+    let clone = Object.assign({}, state);
+    delete clone[action.payload.username];
+    return clone;
+  }
   case UPDATE_PROFILE:
-    if (state.edit === undefined) {
+    if (getProfile().edit === undefined) {
       // caller must have dispatched START_PROFILE_EDIT successfully first
       return state;
     }
-    return Object.assign({}, state, {
-      edit: Object.assign({}, state.edit, {
+    return patchProfile({
+      edit: Object.assign({}, getProfile().edit, {
         profile: action.payload.profile
       })
     });
   case START_PROFILE_EDIT:
-    if (state.getStatus !== FETCH_SUCCESS) {
+    if (getProfile().getStatus !== FETCH_SUCCESS) {
       // ignore attempts to edit if we don't have a valid profile to edit yet
       return state;
     }
-    return Object.assign({}, state, {
+    return patchProfile({
       edit: {
-        profile: state.profile,
+        profile: getProfile().profile,
         errors: {}
       }
     });
   case CLEAR_PROFILE_EDIT:
-    return Object.assign({}, state, {
+    return patchProfile({
       edit: undefined
     });
   case REQUEST_PATCH_USER_PROFILE:
-    return Object.assign({}, state, {
+    return patchProfile({
       patchStatus: FETCH_PROCESSING
     });
   case RECEIVE_PATCH_USER_PROFILE_SUCCESS:
-    return Object.assign({}, state, {
+    return patchProfile({
       patchStatus: FETCH_SUCCESS,
       profile: action.payload.profile
     });
   case RECEIVE_PATCH_USER_PROFILE_FAILURE:
-    return Object.assign({}, state, {
+    return patchProfile({
       patchStatus: FETCH_FAILURE
     });
   case UPDATE_PROFILE_VALIDATION:
-    if (state.edit === undefined) {
+    if (getProfile().edit === undefined) {
       // caller must have dispatched START_PROFILE_EDIT successfully first
       return state;
     }
-    return Object.assign({}, state, {
-      edit: Object.assign({}, state.edit, {
+    return patchProfile({
+      edit: Object.assign({}, getProfile().edit, {
         errors: action.payload.errors
       })
     });
@@ -126,7 +145,7 @@ export const dashboard = (state = INITIAL_DASHBOARD_STATE, action) => {
 
 
 export default combineReducers({
-  userProfile,
+  profiles,
   dashboard,
   ui,
 });


### PR DESCRIPTION
#### What are the relevant tickets?
Required for #216 

#### What's this PR do?
Renames the `userProfile` reducer to `profiles` and changes the structure and related actions to use the profile username so we can store multiple profiles.

#### Where should the reviewer start?

#### How should this be manually tested?
Everything should work as before

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

