### PR TITLE
Added middleware to redirect canceled authorizations

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -120,6 +120,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
     'wagtail.wagtailcore.middleware.SiteMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
+    'social.apps.django_app.middleware.SocialAuthExceptionMiddleware',
 )
 
 AUTHENTICATION_BACKENDS = (
@@ -174,6 +175,7 @@ SOCIAL_AUTH_EDXORG_EXTRA_DATA = ['updated_at']
 
 LOGIN_REDIRECT_URL = '/dashboard'
 LOGIN_URL = '/'
+LOGIN_ERROR_URL = '/'
 
 ROOT_URLCONF = 'micromasters.urls'
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #169 

#### What's this PR do?
When the user logs into a server and clicks 'Cancel', they currently get a 500 error on micromasters. This will cause it to redirect to the home page instead.

#### Where should the reviewer start?

#### How should this be manually tested?
Run your local instance with `DEBUG = False`. Log into the sandbox or your devstack and cancel the authorization when it asks for read and write scope. You should be redirected to `/` instead of getting a 500 error

#### Any background context you want to provide?
This will silence oauth authorization exceptions in general


#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

