### PR TITLE
Cleared state field when country field changes

### DIFF
--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -247,7 +247,11 @@ class EducationTab extends ProfileTab {
         </Grid>
         <Grid>
           <Cell col={4}>
-            {this.boundSelectField(keySet('school_country'), 'Country', this.countryOptions)}
+            {this.boundCountrySelectField(
+              keySet('school_state_or_territory'),
+              keySet('school_country'),
+              'Country'
+            )}
           </Cell>
           <Cell col={4}>
             {this.boundStateSelectField(

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -118,7 +118,7 @@ class EmploymentTab extends ProfileTab {
           {this.boundTextField(keySet('company_name'), 'Company Name')}
         </Cell>
         <Cell col={4}>
-          {this.boundSelectField(keySet('country'), 'Country', this.countryOptions)}
+          {this.boundCountrySelectField(keySet('state_or_territory'), keySet('country'), 'Country')}
         </Cell>
         <Cell col={4}>
           {this.boundStateSelectField(keySet('state_or_territory'), keySet('country'), 'State or Territory')}

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -60,13 +60,21 @@ class PersonalTab extends ProfileTab {
         this.languageOptions
       )}</Cell><Cell col={8} />
       <Cell col={4}><h4>Where do you live?</h4></Cell><Cell col={8} />
-      <Cell col={4}>{this.boundSelectField(['country'], 'Country', this.countryOptions)}</Cell><Cell col={8} />
+      <Cell col={4}>{this.boundCountrySelectField(
+        ['state_or_territory'],
+        ['country'],
+        'Country'
+      )}</Cell><Cell col={8} />
       <Cell col={4}>
         {this.boundStateSelectField(['state_or_territory'], ['country'], 'State or Territory')}
       </Cell><Cell col={8} />
       <Cell col={4}>{this.boundTextField(['city'], 'City')}</Cell><Cell col={8} />
       <Cell col={4}><h4>Where were you born?</h4></Cell><Cell col={8} />
-      <Cell col={4}>{this.boundSelectField(['birth_country'], 'Country', this.countryOptions)}</Cell><Cell col={8} />
+      <Cell col={4}>{this.boundCountrySelectField(
+        ['birth_state_or_territory'],
+        ['birth_country'],
+        'Country'
+      )}</Cell><Cell col={8} />
       <Cell col={4}>
         {this.boundStateSelectField(['birth_state_or_territory'], ['birth_country'], 'State or Territory')}
       </Cell><Cell col={8} />

--- a/static/js/util/ProfileTab.js
+++ b/static/js/util/ProfileTab.js
@@ -6,6 +6,7 @@ import {
   boundTextField,
   boundSelectField,
   boundMonthYearField,
+  boundCountrySelectField,
   boundStateSelectField,
   boundRadioGroupField,
   saveAndContinue,
@@ -22,6 +23,7 @@ class ProfileTab extends React.Component {
     // bind our field methods to this
     this.boundTextField = boundTextField.bind(this);
     this.boundSelectField = boundSelectField.bind(this);
+    this.boundCountrySelectField = boundCountrySelectField.bind(this);
     this.boundStateSelectField = boundStateSelectField.bind(this);
     this.boundDateField = boundDateField.bind(this);
     this.boundMonthYearField = boundMonthYearField.bind(this);

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -120,9 +120,11 @@ export function boundTextField(keySet, label) {
  * @param keySet {String[]} Path to the field
  * @param label {String} Label for the field
  * @param options {Object[]} A list of options for the select field
+ * @param onChange {func} Handler which is called when the state changes or is cleared.
+ * Takes the updated profile as argument
  * @returns {ReactElement}
  */
-export function boundSelectField(keySet, label, options) {
+export function boundSelectField(keySet, label, options, onChange) {
   const {
     profile,
     errors,
@@ -162,6 +164,9 @@ export function boundSelectField(keySet, label, options) {
     _.set(clone, editKeySet, undefined);
 
     updateProfile(clone);
+    if (_.isFunction(onChange)) {
+      onChange(clone);
+    }
   };
 
   let selectedValue = _.get(profile, keySet);
@@ -222,7 +227,6 @@ import { boundSelectField as mockedBoundSelectField } from './profile_edit';
 /**
  * Bind this to this.boundStateSelectField in the constructor of a form component
  * to update select fields
- * pass in the name (used as placeholder), key for profile, and the options.
  *
  * @param stateKeySet {String[]} Path to the state field
  * @param countryKeySet {String[]} Path to the country field
@@ -244,6 +248,30 @@ export function boundStateSelectField(stateKeySet, countryKeySet, label) {
   }
 
   return mockedBoundSelectField.call(this, stateKeySet, label, options);
+}
+
+/**
+ * Bind this to this.boundCountrySelectField in the constructor of a form component
+ * to update select fields
+ *
+ * @param stateKeySet {String[]} Path to the state field
+ * @param countryKeySet {String[]} Path to the country field
+ * @param label {String} The label of the field
+ * @returns {ReactElement}
+ */
+export function boundCountrySelectField(stateKeySet, countryKeySet, label) {
+  const {
+    updateProfile,
+  } = this.props;
+
+  const onChange = newProfile => {
+    // clear state field when country field changes
+    let clone = _.cloneDeep(newProfile);
+    _.set(clone, stateKeySet, null);
+    updateProfile(clone);
+  };
+
+  return mockedBoundSelectField.call(this, countryKeySet, label, this.countryOptions, onChange);
 }
 
 /**

--- a/static/js/util/profile_edit_test.js
+++ b/static/js/util/profile_edit_test.js
@@ -11,6 +11,7 @@ import {
   boundDateField,
   boundSelectField,
   boundStateSelectField,
+  boundCountrySelectField,
   boundMonthYearField,
   boundRadioGroupField
 } from './profile_edit';
@@ -278,6 +279,92 @@ describe('Profile Editing utility functions', () => {
       options = _.sortBy(options, 'label');
 
       assert(boundSelectFieldSpy.calledWith(stateKey, placeholder, options));
+    });
+  });
+
+  describe("Bound country select field", () => {
+    let sandbox, boundSelectFieldSpy, countryOptions;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+
+      boundSelectFieldSpy = sandbox.spy(profileEdit, 'boundSelectField');
+
+      countryOptions = Object.keys(iso3166.data).map(code => ({
+        value: code,
+        label: iso3166.data[code]['name']
+      }));
+      countryOptions = _.sortBy(countryOptions, 'label');
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('shows a list of countries', () => {
+      const country = null;
+      const state = null;
+      let profile = Object.assign({}, USER_PROFILE_RESPONSE, {
+        country_key: country,
+        state_key: state
+      });
+
+      let updateProfile = newProfile => {
+        profile = newProfile;
+      };
+
+      let countrySelectField = boundCountrySelectField.bind({
+        props: {
+          profile,
+          updateProfile
+        },
+        countryOptions
+      });
+
+      let stateKeySet = ["state_key"];
+      let countryKeySet = ["country_key"];
+      let label = "LABEL";
+      countrySelectField(stateKeySet, countryKeySet, label);
+
+      let call = boundSelectFieldSpy.getCall(0);
+      assert.deepEqual(call.args[0], countryKeySet);
+      assert.deepEqual(call.args[1], label);
+      assert.deepEqual(call.args[2], countryOptions);
+
+      let onChange = call.args[3];
+      assert(_.isFunction(onChange));
+
+      onChange("change");
+      assert.deepEqual(profile, "change");
+    });
+
+    it('clears the state state when the country changes', () => {
+      const country = 'US';
+      const state = 'US-MA';
+      let profile = Object.assign({}, USER_PROFILE_RESPONSE, {
+        country_key: country,
+        state_key: state
+      });
+
+      let updateProfile = newProfile => {
+        profile = newProfile;
+      };
+
+      let countrySelectField = boundCountrySelectField.bind({
+        props: {
+          profile,
+          updateProfile
+        },
+        countryOptions
+      });
+
+      let stateKeySet = ["state_key"];
+      let countryKeySet = ["country_key"];
+      let label = "LABEL";
+      let field = countrySelectField(stateKeySet, countryKeySet, label);
+      field.props.onNewRequest('Ghana', -1);
+
+      assert.equal(profile.country_key, "GH");
+      assert.equal(profile.state_key, null);
     });
   });
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #383 

#### What's this PR do?
Clear state field state when the country changes. This prevents a subtle bug where the state field appears to clear but its state keeps the previous state/territory

#### Where should the reviewer start?

#### How should this be manually tested?
Change the country in the employment and education and the birth place and current place of the personal tab. In each case don't touch the state field, then try to save it. You should see a validation error for the state indicating that it wasn't selected. (We require the state field for each of these cases, right?)

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

