### PR TITLE
Added Dashboard splash to profile tabs

### DIFF
--- a/static/js/components/Jumbotron.js
+++ b/static/js/components/Jumbotron.js
@@ -2,19 +2,17 @@
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 
-import CourseList from './CourseList';
 import { makeProfileImageUrl } from '../util/util';
 
-class Dashboard extends React.Component {
+class Jumbotron extends React.Component {
   static propTypes = {
-    profile:    React.PropTypes.object.isRequired,
-    dashboard:  React.PropTypes.object.isRequired,
-    expander: React.PropTypes.object.isRequired,
-    dispatch: React.PropTypes.func.isRequired,
+    profile:      React.PropTypes.object.isRequired,
+    text:         React.PropTypes.string.isRequired,
+    children:     React.PropTypes.object.isRequired,
   };
 
   render() {
-    const { profile, dashboard, expander, dispatch } = this.props;
+    const { profile, text } = this.props;
     let imageUrl = makeProfileImageUrl(profile);
     return <div className="card">
       <Grid className="card-user">
@@ -29,20 +27,15 @@ class Dashboard extends React.Component {
           />
         </Cell>
         <Cell col={5} className="card-name">
-          { profile.preferred_name || SETTINGS.name }
+          { text }
           <div className="card-student-id">
             ID: { profile.pretty_printed_student_id }
           </div>
         </Cell>
       </Grid>
-      <div className="card-header">
-        Your Status
-      </div>
-      <div className="card-copy">
-        <CourseList dashboard={dashboard} expander={expander} dispatch={dispatch} />
-      </div>
+      { this.props.children }
     </div>;
   }
 }
 
-export default Dashboard;
+export default Jumbotron;

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -1,7 +1,8 @@
 /* global SETTINGS: false */
 import React from 'react';
 import { connect } from 'react-redux';
-import Dashboard from '../components/Dashboard';
+import Jumbotron from '../components/Jumbotron';
+import CourseList from '../components/CourseList';
 
 class DashboardPage extends React.Component {
   static propTypes = {
@@ -12,13 +13,25 @@ class DashboardPage extends React.Component {
   };
 
   render() {
-    const { profile, dashboard, expander, dispatch } = this.props;
-    return <Dashboard
-      profile={profile.profile}
-      dashboard={dashboard}
-      expander={expander}
-      dispatch={dispatch}
-    />;
+    const {
+      dashboard,
+      expander,
+      dispatch,
+      profile: { profile },
+    } = this.props;
+    let preferredName = profile.preferredName || SETTINGS.name;
+    return (
+      <Jumbotron profile={profile} text={preferredName}>
+        <div>
+          <div className="card-header">
+            Your Status
+          </div>
+          <div className="card-copy">
+            <CourseList dashboard={dashboard} expander={expander} dispatch={dispatch} />
+          </div>
+        </div>
+      </Jumbotron>
+    );
   }
 }
 

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -20,6 +20,7 @@ import {
   setEducationDegreeLevel,
   setEducationDegreeInclusions,
 } from '../actions/ui';
+import Jumbotron from '../components/Jumbotron';
 
 class ProfilePage extends React.Component {
   static propTypes = {
@@ -147,20 +148,20 @@ class ProfilePage extends React.Component {
       })
     ));
 
+    let text = `Welcome ${profile.preferred_name || SETTINGS.name}, let's
+    complete your enrollment to MIT MicroMaster's.`;
+
     return <div className="card">
-      <div className="card-copy">
-        <h1>Enroll in MIT Micromasters</h1>
-        <p>
-          Please tell us more about yourself so you can participate in the
-          micromasters community and qualify for your micromasters certificate.
-        </p>
-        <Tabs activeTab={this.activeTab()}>
-          {this.makeTabs()}
-        </Tabs>
-        <section>
-          {this.props.children && childrenWithProps}
-        </section>
-      </div>
+      <Jumbotron profile={profile} text={text}>
+        <div className="card-copy">
+          <Tabs activeTab={this.activeTab()}>
+            {this.makeTabs()}
+          </Tabs>
+          <section>
+            {this.props.children && childrenWithProps}
+          </section>
+        </div>
+      </Jumbotron>
     </div>;
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #367 

#### What's this PR do?

this modifies the `Dashboard` component to be useful on the profile as well as on the main dashboard page.

Basically, now it takes an `onProfile` prop, which when `=== true` means that we put the requisite message in the banner, and don't draw the course display.

#### Where should the reviewer start?

Review the changes to `Dashboard.js`, `DashboardPage.js`, and `ProfilePage.js`.

#### How should this be manually tested?

When you're viewing one of the profile steps (personal, education, etc) you should see the stata center banner image, and some welcome text:

![welcome_text](https://cloud.githubusercontent.com/assets/6207644/15480960/2babe67a-20f6-11e6-8001-7b74ff87d5ef.png)

when visiting `/dashboard`, you should see the current behavior:

![normal](https://cloud.githubusercontent.com/assets/6207644/15480985/49bf2186-20f6-11e6-9bb7-cf70dd4efef4.png)



#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

