### PR TITLE
Fixed webpack_if_prod script to make it OSX-friendly

### DIFF
--- a/webpack_if_prod.sh
+++ b/webpack_if_prod.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-set -euf -o pipefail
-if [[ "$NODE_ENV" != "development" ]]
+set -ef -o pipefail
+if [[ "$NODE_ENV" != "" && "$NODE_ENV" != "development" ]]
 then
     node node_modules/webpack/bin/webpack.js --config webpack.config.prod.js --bail
 fi


### PR DESCRIPTION
Noticed this bug when running `npm install` locally. The -u flag requires env variables to be set. There's no reason for us to require that (at least not that I know of). Now that this script is going to be run in OSX host machines as well as Docker containers, this change was necessary