### PR TITLE
Replaced react-datepicker with textfields

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "react": "~15.1.0",
     "react-addons-test-utils": "~15.1.0",
     "react-bootstrap": "0.29.3",
-    "react-datepicker": "0.27.0",
     "react-dom": "~15.1.0",
     "react-ga": "1.4.1",
     "react-hot-loader": "1.3.0",

--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -209,7 +209,7 @@ class EducationTab extends ProfileTab {
         {this.boundTextField(keySet('field_of_study'), 'Field of Study')}
       </Cell>
       <Cell col={6}>
-        {this.boundMonthYearField(keySet('graduation_date'), 'Graduation Date')}
+        {this.boundDateField(keySet('graduation_date'), 'Graduation Date', true)}
       </Cell>
       <Cell col={6}>
         {this.boundTextField(keySet('school_name'), 'School Name')}

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -133,10 +133,10 @@ class EmploymentTab extends ProfileTab {
           {this.boundTextField(keySet('position'), 'Position')}
         </Cell>
         <Cell col={6}>
-          {this.boundMonthYearField(keySet('start_date'), 'Start Date')}
+          {this.boundDateField(keySet('start_date'), 'Start Date', true)}
         </Cell>
         <Cell col={6}>
-          {this.boundMonthYearField(keySet('end_date'), 'End Date')}
+          {this.boundDateField(keySet('end_date'), 'End Date', true)}
           <span className="end-date-hint">
             Leave blank if this is a current position
           </span>

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -230,7 +230,7 @@ export const DASHBOARD_RESPONSE = [
   },
 ];
 
-export const DATE_FORMAT = 'YYYY-MM-DD';
+export const ISO_8601_FORMAT = 'YYYY-MM-DD';
 
 export const DASHBOARD_COURSE_HEIGHT = 70;
 export const TERMS_CARD_ROW_HEIGHT = 70;

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -11,9 +11,7 @@ import { makeDashboardRoutes } from './dashboard_routes';
 import 'style!css!react-mdl/extra/material.css';
 import 'react-mdl/extra/material.js';
 
-// requirement for react-datepicker
-import 'style!css!react-datepicker/dist/react-datepicker.css';
-
+// Object.entries polyfill
 import entries from 'object.entries';
 if (!Object.entries) {
   entries.shim();

--- a/static/js/util/ProfileTab.js
+++ b/static/js/util/ProfileTab.js
@@ -5,7 +5,6 @@ import {
   boundDateField,
   boundTextField,
   boundSelectField,
-  boundMonthYearField,
   boundCountrySelectField,
   boundStateSelectField,
   boundRadioGroupField,
@@ -26,7 +25,6 @@ class ProfileTab extends React.Component {
     this.boundCountrySelectField = boundCountrySelectField.bind(this);
     this.boundStateSelectField = boundStateSelectField.bind(this);
     this.boundDateField = boundDateField.bind(this);
-    this.boundMonthYearField = boundMonthYearField.bind(this);
     this.boundRadioGroupField = boundRadioGroupField.bind(this);
 
     // options we set (for select components)

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -355,15 +355,28 @@ export function makeStrippedHtml(textOrElement) {
 }
 
 /**
+ * Validate a day of month
+ * @param {String} string The input string
+ * @returns {Number|undefined} The valid date if a valid date value or undefined if not valid
+ */
+export function validateDay(string) {
+  let date = filterPositiveInt(string);
+  if (date === undefined) {
+    return undefined;
+  }
+  // More complicated cases like Feb 29 are handled in moment.js isValid
+  if (date < 1 || date > 31) {
+    return undefined;
+  }
+  return date;
+}
+
+/**
  * Validate a month number
  * @param {String} string The input string
- * @returns {Number|undefined} The valid month if a valid month value,
- * an empty string if input is an empty string, or undefined if not valid
+ * @returns {Number|undefined} The valid month if a valid month value or undefined if not valid
  */
 export function validateMonth(string) {
-  if ( string === "" ) {
-    return string;
-  }
   let month = filterPositiveInt(string);
   if (month === undefined) {
     return undefined;
@@ -377,13 +390,9 @@ export function validateMonth(string) {
 /**
  * Validate a year string is an integer and fits into YYYY
  * @param {String} string The input string
- * @returns {Number|undefined} The valid year if a valid year value, an
- * emtpy string if the input is an empty string, or undefined if not valid
+ * @returns {Number|undefined} The valid year if a valid year value or undefined if not valid
  */
 export function validateYear(string) {
-  if ( string === "" ) {
-    return string;
-  }
   let year = filterPositiveInt(string);
   if (year === undefined) {
     return undefined;

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -22,6 +22,7 @@ import {
   makeProfileImageUrl,
   validateMonth,
   validateYear,
+  validateDay,
   generateNewEducation,
   generateNewWorkHistory,
 } from '../util/util';
@@ -486,6 +487,7 @@ describe('utility functions', () => {
       assert.equal(undefined, validateMonth("13"));
     });
     it('returns undefined if the text is not an integer number', () => {
+      assert.equal(undefined, validateMonth(""));
       assert.equal(undefined, validateMonth("two"));
       assert.equal(undefined, validateMonth(null));
       assert.equal(undefined, validateMonth({}));
@@ -493,10 +495,6 @@ describe('utility functions', () => {
       assert.equal(undefined, validateMonth("2e0"));
       assert.equal(undefined, validateMonth("3-4"));
       assert.equal(undefined, validateMonth("3.4"));
-    });
-
-    it('returns an empty string if passed an empty string', () => {
-      assert.equal("", validateMonth(""));
     });
   });
 
@@ -515,6 +513,7 @@ describe('utility functions', () => {
       assert.equal(undefined, validateYear("10000"));
     });
     it('returns undefined if the text is not an integer number', () => {
+      assert.equal(undefined, validateYear(""));
       assert.equal(undefined, validateYear("two"));
       assert.equal(undefined, validateYear(null));
       assert.equal(undefined, validateYear({}));
@@ -523,12 +522,34 @@ describe('utility functions', () => {
       assert.equal(undefined, validateYear("3-4"));
       assert.equal(undefined, validateYear("3.4"));
     });
-
-    it('returns an empty string if passed an empty string', () => {
-      assert.equal("", validateYear(""));
-    });
   });
   
+  describe('validateDate', () => {
+    it('handles dates starting with 0 without treating as octal', () => {
+      assert.equal(1, validateDay("01"));
+    });
+    it('converts strings to numbers', () => {
+      assert.equal(3, validateDay("3"));
+    });
+    it('returns undefined for invalid dates', () => {
+      assert.equal(undefined, validateDay("-3"));
+      assert.equal(undefined, validateDay("0"));
+      assert.equal(1, validateDay("1"));
+      assert.equal(31, validateDay("31"));
+      assert.equal(undefined, validateDay("32"));
+    });
+    it('returns undefined if the text is not an integer number', () => {
+      assert.equal(undefined, validateDay(""));
+      assert.equal(undefined, validateDay("two"));
+      assert.equal(undefined, validateDay(null));
+      assert.equal(undefined, validateDay({}));
+      assert.equal(undefined, validateDay(undefined));
+      assert.equal(undefined, validateDay("2e0"));
+      assert.equal(undefined, validateDay("3-4"));
+      assert.equal(undefined, validateDay("3.4"));
+    });
+  });
+
   describe('generateNewWorkHistory', () => {
     it('generates a new work history object', () => {
       assert.deepEqual(generateNewWorkHistory(), {


### PR DESCRIPTION
#### What are the relevant tickets?
Rebased on #401 
Fixes #378

#### What's this PR do?
Removes react-datepicker, changes boundMonthYearField, and adds a date textbox

#### Where should the reviewer start?

#### How should this be manually tested?
This is only present in the date of birth field in the personal tab. You should see this behavior:
 - a validation error should be shown after save if the date is missing or invalid
 - If the user clears one text field, all fields should clear at the same time
 - The user should be able to save a valid date
 - When the user refreshes the browser the date should show up correctly
 - The label should show up above the text fields
 - There should be MM DD YYYY hint text in the text fields

#### Any background context you want to provide?

#### Screenshots (if appropriate)
![screenshot from 2016-05-24 15-19-37](https://cloud.githubusercontent.com/assets/863262/15516907/f4bed294-21c2-11e6-8d71-c2e3107c315e.png)

#### What GIF best describes this PR or how it makes you feel?
