### PR TITLE
Updated personal tab to match mockups

### DIFF
--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -49,42 +49,83 @@ class PersonalTab extends ProfileTab {
   }
 
   render() {
-    return <Grid className="profile-tab-grid">
-      <Cell col={4}>{this.boundTextField(["first_name"], "Given name")}</Cell><Cell col={8} />
-      <Cell col={4}>{this.boundTextField(["last_name"], "Family name")}</Cell><Cell col={8} />
-      <Cell col={4}>{this.boundTextField(["preferred_name"], "Preferred name")}</Cell><Cell col={8} />
-      <Cell col={4}>{this.boundSelectField(['gender'], 'Gender', this.genderOptions)}</Cell><Cell col={8} />
-      <Cell col={4}>{this.boundSelectField(
-        ['preferred_language'],
-        'Preferred language',
-        this.languageOptions
-      )}</Cell><Cell col={8} />
-      <Cell col={4}><h4>Where do you live?</h4></Cell><Cell col={8} />
-      <Cell col={4}>{this.boundCountrySelectField(
-        ['state_or_territory'],
-        ['country'],
-        'Country'
-      )}</Cell><Cell col={8} />
-      <Cell col={4}>
-        {this.boundStateSelectField(['state_or_territory'], ['country'], 'State or Territory')}
-      </Cell><Cell col={8} />
-      <Cell col={4}>{this.boundTextField(['city'], 'City')}</Cell><Cell col={8} />
-      <Cell col={4}><h4>Where were you born?</h4></Cell><Cell col={8} />
-      <Cell col={4}>{this.boundCountrySelectField(
-        ['birth_state_or_territory'],
-        ['birth_country'],
-        'Country'
-      )}</Cell><Cell col={8} />
-      <Cell col={4}>
-        {this.boundStateSelectField(['birth_state_or_territory'], ['birth_country'], 'State or Territory')}
-      </Cell><Cell col={8} />
-      <Cell col={4}>{this.boundTextField(['birth_city'], 'City')}</Cell><Cell col={8} />
-      <Cell col={4}>{this.boundDateField(['date_of_birth'], 'Date of birth')}</Cell><Cell col={8} />
-
-      <Button raised onClick={this.saveAndContinue} className="profile-save-and-continue">
-        <span>Save and Continue</span>
-      </Button>
-    </Grid>;
+    return <div>
+      <Grid className="profile-splash">
+        <Cell col={12}>
+          Please tell us more about yourself so you can participate in the MicroMaster's
+          community and qualify for your MicroMaster's certificate.
+        </Cell>
+      </Grid>
+      <Grid className="profile-tab-grid">
+        <Cell col={1} />
+        <Cell col={10}>
+          <Grid className="profile-tab-card-grid">
+            <Cell col={6}>
+              {this.boundTextField(["first_name"], "Given name")}
+            </Cell>
+            <Cell col={6}>
+              {this.boundTextField(["last_name"], "Family name")}
+            </Cell>
+            <Cell col={12}>
+              {this.boundTextField(["preferred_name"], "Preferred name")}
+            </Cell>
+            <Cell col={12}>
+              {this.boundDateField(['date_of_birth'], 'Date of birth')}
+            </Cell>
+            <Cell col={12} className="profile-gender-group">
+              {this.boundRadioGroupField(['gender'], 'Gender', this.genderOptions)}
+            </Cell>
+            <Cell col={12}>
+              {this.boundSelectField(
+                ['preferred_language'],
+                'Preferred language',
+                this.languageOptions
+              )}
+            </Cell>
+            <Cell col={12}>
+              <h4>Currently Living</h4>
+            </Cell>
+            <Cell col={4}>
+              {this.boundCountrySelectField(['state_or_territory'], ['country'], 'Country')}
+            </Cell>
+            <Cell col={4}>
+              {this.boundStateSelectField(['state_or_territory'], ['country'], 'State or Territory')}
+            </Cell>
+            <Cell col={4}>
+              {this.boundTextField(['city'], 'City')}
+            </Cell>
+            <Cell col={12}>
+              <h4>Where were you born?</h4>
+            </Cell>
+            <Cell col={4}>
+              {this.boundCountrySelectField(
+                ['birth_state_or_territory'],
+                ['birth_country'],
+                'Country'
+              )}</Cell>
+            <Cell col={4}>
+              {this.boundStateSelectField(['birth_state_or_territory'], ['birth_country'], 'State or Territory')}
+            </Cell>
+            <Cell col={4}>
+              {this.boundTextField(['birth_city'], 'City')}
+            </Cell>
+          </Grid>
+        </Cell>
+        <Cell col={1} />
+        <Cell col={1} />
+        <Cell col={10}>
+          <Button
+            raised
+            colored
+            className="profile-save-and-continue"
+            onClick={this.saveAndContinue}
+          >
+            <span>Save and Continue</span>
+          </Button>
+        </Cell>
+        <Cell col={1} />
+      </Grid>
+    </div>;
   }
 }
 

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -46,14 +46,19 @@ export function boundRadioGroupField(keySet, label, options) {
     };
 
     const radioButtons = options.map(obj => {
+      let helper = "";
+      if (obj.helper) {
+        helper = `- ${obj.helper}`;
+      }
       let label = (
         <span className="radio-label">
-          {obj.label}<span className="radio-label-hint"> - {obj.helper}</span>
+          {obj.label}<span className="radio-label-hint">{helper}</span>
         </span>
       );
 
       return (
         <RadioButton
+          className="profile-radio-button"
           key={obj.value}
           labelStyle={styles.labelStyle}
           value={obj.value}
@@ -63,6 +68,7 @@ export function boundRadioGroupField(keySet, label, options) {
 
     return (
       <RadioButtonGroup
+        className="profile-radio-group"
         name={label}
         onChange={onChange}
         defaultSelected={defaultSelected}>

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -318,9 +318,14 @@ c.validation-wrapper {
   background-color: #f9f9f9 !important;
 }
 
-.profile-add-button {
-  background-color: #0cbd8a !important;
-  bottom: -25px;
-  position: absolute;
-  right: -40%;
+// CSS magic to make the radio buttons show up next to each other
+.profile-gender-group {
+  display: block !important;
+  .profile-radio-button {
+    width: unset !important;
+    display: inline-block !important;
+    label {
+      width: unset !important;
+    }
+  }
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #217 

#### What's this PR do?
Restyles the personal tab according to mockups.

Note that the email consent text is part of the terms of service so it's not present in the personal tab

#### Where should the reviewer start?

#### How should this be manually tested?
Make sure that the personal tab still works as expected, it matches the mockups in the linked issue, and it's consistent with the other tabs.

#### Any background context you want to provide?

#### Screenshots (if appropriate)
![screenshot from 2016-05-25 14-59-44](https://cloud.githubusercontent.com/assets/863262/15552634/5926f7ea-2289-11e6-9fff-f9853c3d599e.png)


#### What GIF best describes this PR or how it makes you feel?
