### PR TITLE
Switched to social auth username

### DIFF
--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from urllib.parse import urljoin
 
+from backends.edxorg import EdxOrgOAuth2
 from profiles.models import Profile
 from profiles.util import split_name
 
@@ -28,7 +29,7 @@ def update_profile_from_edx(backend, user, response, is_new, *args, **kwargs):  
 
     # this function is completely skipped if the backend is not edx or
     # the user has not created now
-    if backend.name != 'edxorg' or not is_new:
+    if backend.name != EdxOrgOAuth2.name or not is_new:
         return
 
     access_token = response.get('access_token')
@@ -45,8 +46,9 @@ def update_profile_from_edx(backend, user, response, is_new, *args, **kwargs):  
         log.error('No profile found for the user %s', user.username)
         return
 
+    username = user.social_auth.get(provider=EdxOrgOAuth2.name).uid
     user_profile_edx = backend.get_json(
-        urljoin(backend.EDXORG_BASE_URL, '/api/user/v1/accounts/{0}'.format(user.username)),
+        urljoin(backend.EDXORG_BASE_URL, '/api/user/v1/accounts/{0}'.format(username)),
         headers={
             "Authorization": "Bearer {}".format(access_token),
         }

--- a/backends/pipeline_api_test.py
+++ b/backends/pipeline_api_test.py
@@ -52,6 +52,13 @@ class EdxPipelineApiTest(TestCase):
         Set up class
         """
         self.user = UserFactory()
+        self.user.social_auth.create(
+            provider='not_edx',
+        )
+        self.user.social_auth.create(
+            provider=edxorg.EdxOrgOAuth2.name,
+            uid="{}_edx".format(self.user.username),
+        )
         self.user_profile = Profile.objects.get(user=self.user)
 
         self.mocked_edx_profile = {
@@ -75,7 +82,7 @@ class EdxPipelineApiTest(TestCase):
                 'image_url_small': 'https://edx.org/small.jpg'
             },
             'requires_parental_consent': False,
-            'username': self.user.username,
+            'username': self.user.social_auth.get(provider=edxorg.EdxOrgOAuth2.name).uid,
             'year_of_birth': 1986,
             "work_history": [
                 {
@@ -157,7 +164,9 @@ class EdxPipelineApiTest(TestCase):
         mocked_get_json.assert_called_once_with(
             urljoin(
                 edxorg.EdxOrgOAuth2.EDXORG_BASE_URL,
-                '/api/user/v1/accounts/{0}'.format(self.user.username)
+                '/api/user/v1/accounts/{0}'.format(
+                    self.user.social_auth.get(provider=edxorg.EdxOrgOAuth2.name).uid
+                )
             ),
             headers={'Authorization': 'Bearer foo_token'}
         )

--- a/backends/utils_test.py
+++ b/backends/utils_test.py
@@ -12,6 +12,7 @@ from django.test import TestCase
 from requests.exceptions import HTTPError
 
 from backends import utils
+from backends.edxorg import EdxOrgOAuth2
 from profiles.factories import UserFactory
 
 # pylint: disable=protected-access
@@ -27,8 +28,8 @@ class RefreshTest(TestCase):
         cls.user = UserFactory.create()
         # create a social auth for the user
         cls.user.social_auth.create(
-            provider='edxorg',
-            uid=cls.user.username,
+            provider=EdxOrgOAuth2.name,
+            uid="{}_edx".format(cls.user.username),
             extra_data='{"access_token": "fooooootoken", "refresh_token": "baaaarrefresh"}'
         )
 
@@ -38,7 +39,7 @@ class RefreshTest(TestCase):
 
     def update_social_extra_data(self, data):
         """Helper function to update the python social auth extra data"""
-        social_user = self.user.social_auth.get(provider='edxorg')
+        social_user = self.user.social_auth.get(provider=EdxOrgOAuth2.name)
         social_user.extra_data.update(data)
         social_user.save()
         return social_user
@@ -57,7 +58,7 @@ class RefreshTest(TestCase):
     @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
     def test_refresh_no_extradata(self, mock_refresh):
         """The refresh needs to be called because there is not valid timestamps"""
-        social_user = self.user.social_auth.get(provider='edxorg')
+        social_user = self.user.social_auth.get(provider=EdxOrgOAuth2.name)
         social_user.extra_data = {"access_token": "fooooootoken", "refresh_token": "baaaarrefresh"}
         social_user.save()
         utils.refresh_user_token(social_user)
@@ -85,7 +86,7 @@ class RefreshTest(TestCase):
             raise error
 
         mock_refresh.side_effect = raise_http_error
-        social_user = self.user.social_auth.get(provider='edxorg')
+        social_user = self.user.social_auth.get(provider=EdxOrgOAuth2.name)
         with self.assertRaises(utils.InvalidCredentialStored):
             utils._send_refresh_request(social_user)
 
@@ -100,7 +101,7 @@ class RefreshTest(TestCase):
             raise error
 
         mock_refresh.side_effect = raise_http_error
-        social_user = self.user.social_auth.get(provider='edxorg')
+        social_user = self.user.social_auth.get(provider=EdxOrgOAuth2.name)
         with self.assertRaises(utils.InvalidCredentialStored):
             utils._send_refresh_request(social_user)
 
@@ -115,6 +116,6 @@ class RefreshTest(TestCase):
             raise error
 
         mock_refresh.side_effect = raise_http_error
-        social_user = self.user.social_auth.get(provider='edxorg')
+        social_user = self.user.social_auth.get(provider=EdxOrgOAuth2.name)
         with self.assertRaises(HTTPError):
             utils._send_refresh_request(social_user)

--- a/cms/models.py
+++ b/cms/models.py
@@ -38,7 +38,9 @@ class HomePage(Page):
 
         username = None
         if not request.user.is_anonymous():
-            username = request.user.social_auth.get(provider=EdxOrgOAuth2.name).uid
+            social_auths = request.user.social_auth.filter(provider=EdxOrgOAuth2.name)
+            if social_auths.exists():
+                username = social_auths.first().uid
         context = super(HomePage, self).get_context(request)
 
         context["programs"] = Program.objects.filter(live=True)

--- a/cms/models.py
+++ b/cms/models.py
@@ -10,6 +10,7 @@ from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.fields import RichTextField
 from wagtail.wagtailadmin.edit_handlers import FieldPanel
 
+from backends.edxorg import EdxOrgOAuth2
 from micromasters.utils import webpack_dev_server_host
 from courses.models import Program
 from ui.views import get_bundle_url
@@ -35,6 +36,9 @@ class HomePage(Page):
             "host": webpack_dev_server_host(request)
         }
 
+        username = None
+        if not request.user.is_anonymous():
+            username = request.user.social_auth.get(provider=EdxOrgOAuth2.name).uid
         context = super(HomePage, self).get_context(request)
 
         context["programs"] = Program.objects.filter(live=True)
@@ -42,7 +46,7 @@ class HomePage(Page):
         context["public_src"] = get_bundle_url(request, "public.js")
         context["style_public_src"] = get_bundle_url(request, "style_public.js")
         context["authenticated"] = not request.user.is_anonymous()
-        context["username"] = request.user.username
+        context["username"] = username
         context["js_settings_json"] = json.dumps(js_settings)
         context["title"] = self.title
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -55,7 +55,8 @@ class UserDashboard(APIView):
         enrollments = edx_client.enrollments.get_student_enrollments()
         # get a certificates client for the student
         certificates = edx_client.certificates.get_student_certificates(
-            request.user.username, enrollments.get_enrolled_course_ids())
+            user_social.uid, enrollments.get_enrolled_course_ids()
+        )
 
         response_data = []
         for program in Program.objects.filter(live=True):

--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -14,9 +14,9 @@ from django.core.urlresolvers import reverse
 from requests.exceptions import HTTPError
 from rest_framework import status
 from rest_framework.test import APITestCase
-
 from edx_api.enrollments.models import Enrollments
 
+from backends.edxorg import EdxOrgOAuth2
 from courses.factories import (
     ProgramFactory,
     CourseFactory,
@@ -38,8 +38,8 @@ class DashboardTest(APITestCase):
         cls.user = UserFactory.create()
         # create a social auth for the user
         cls.user.social_auth.create(
-            provider='edxorg',
-            uid=cls.user.username,
+            provider=EdxOrgOAuth2.name,
+            uid="{}_edx".format(cls.user.username),
             extra_data='{"access_token": "fooooootoken"}'
         )
 
@@ -188,8 +188,8 @@ class DashboardTokensTest(APITestCase):
         cls.user = UserFactory.create()
         # create a social auth for the user
         cls.user.social_auth.create(
-            provider='edxorg',
-            uid=cls.user.username,
+            provider=EdxOrgOAuth2.name,
+            uid="{}_edx".format(cls.user.username),
             extra_data='{"access_token": "fooooootoken", "refresh_token": "baaaarrefresh"}'
         )
 
@@ -205,7 +205,7 @@ class DashboardTokensTest(APITestCase):
 
     def update_social_extra_data(self, data):
         """Helper function to update the python social auth extra data"""
-        social_user = self.user.social_auth.get(provider='edxorg')
+        social_user = self.user.social_auth.get(provider=EdxOrgOAuth2.name)
         social_user.extra_data.update(data)
         social_user.save()
 

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -11,6 +11,7 @@ from rest_framework.serializers import (
     SerializerMethodField
 )
 
+from backends.edxorg import EdxOrgOAuth2
 from profiles.models import (
     Education,
     Employment,
@@ -124,7 +125,7 @@ class ProfileBaseSerializer(ModelSerializer):
 
     def get_username(self, obj):  # pylint: disable=no-self-use
         """Getter for the username field"""
-        return obj.user.username
+        return obj.user.social_auth.get(provider=EdxOrgOAuth2.name).uid
 
     def get_profile_url_full(self, obj):  # pylint: disable=no-self-use
         """Getter for the profile full image url"""

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -19,7 +19,7 @@ class ProfileViewSet(RetrieveModelMixin, UpdateModelMixin, GenericViewSet):
     # pylint: disable=too-many-return-statements
 
     permission_classes = (CanEditIfOwner, )
-    lookup_field = 'user__username'
+    lookup_field = 'user__social_auth__uid'
     lookup_url_kwarg = 'user'
     queryset = Profile.objects.all()
 

--- a/static/js/containers/LoginButton.js
+++ b/static/js/containers/LoginButton.js
@@ -5,6 +5,8 @@ import SplitButton from 'react-bootstrap/lib/SplitButton';
 import LinkContainer from 'react-router-bootstrap/lib/LinkContainer';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
 
+import { getPreferredName } from '../util/util';
+
 class LoginButton extends React.Component {
   static propTypes = {
     dispatch: React.PropTypes.func.isRequired,
@@ -18,7 +20,7 @@ class LoginButton extends React.Component {
     // and React 15. React 15 removed span tags but react-bootstrap still expects
     // them.
     let title = <span>
-      {profile.preferred_name || SETTINGS.name}
+      {getPreferredName(profile)}
     </span>;
 
     return (

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -20,6 +20,7 @@ import {
   setEducationDegreeLevel,
   setEducationDegreeInclusions,
 } from '../actions/ui';
+import { getPreferredName } from '../util/util';
 import Jumbotron from '../components/Jumbotron';
 
 class ProfilePage extends React.Component {
@@ -148,7 +149,7 @@ class ProfilePage extends React.Component {
       })
     ));
 
-    let text = `Welcome ${profile.preferred_name || SETTINGS.name}, let's
+    let text = `Welcome ${getPreferredName(profile)}, let's
     complete your enrollment to MIT MicroMaster’s.`;
 
     return <div className="card">

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -415,3 +415,12 @@ export function makeProfileImageUrl(profile) {
 
   return imageUrl;
 }
+
+/**
+ * Returns the preferred name or else the username
+ * @param profile {Object} The user profile
+ * @returns {string}
+ */
+export function getPreferredName(profile) {
+  return profile.preferred_name || SETTINGS.name || SETTINGS.username;
+}

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -25,6 +25,7 @@ import {
   validateDay,
   generateNewEducation,
   generateNewWorkHistory,
+  getPreferredName,
 } from '../util/util';
 import PersonalTab from '../components/PersonalTab';
 import EmploymentTab from '../components/EmploymentTab';
@@ -592,6 +593,32 @@ describe('utility functions', () => {
         `${SETTINGS.edx_base_url}static/images/profiles/default_120.png`,
         makeProfileImageUrl({})
       );
+    });
+  });
+
+  describe('getPreferredName', () => {
+    let settingsBackup;
+    beforeEach(() => {
+      settingsBackup = Object.assign({}, SETTINGS);
+    });
+
+    afterEach(() => {
+      Object.assign(SETTINGS, settingsBackup);
+    });
+
+    it('shows profile.preferred_name', () => {
+      assert.equal('profile preferred name', getPreferredName({
+        preferred_name: 'profile preferred name'
+      }));
+    });
+
+    it('uses SETTINGS.name if profile.preferred_name is not available', () => {
+      assert.equal(SETTINGS.name, getPreferredName({}));
+    });
+
+    it('uses SETTINGS.username if SETTINGS.name and profile.preferred_name are not available', () => {
+      SETTINGS.name = '';
+      assert.equal(SETTINGS.username, getPreferredName({}));
     });
   });
 });

--- a/ui/views.py
+++ b/ui/views.py
@@ -9,6 +9,7 @@ from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 
+from backends.edxorg import EdxOrgOAuth2
 from micromasters.utils import webpack_dev_server_host, webpack_dev_server_url
 from ui.decorators import (
     require_mandatory_urls,
@@ -38,14 +39,14 @@ def dashboard(request, *args):  # pylint: disable=unused-argument
     """
     name = ""
     if not request.user.is_anonymous():
-        name = request.user.profile.preferred_name or request.user.username
+        name = request.user.profile.preferred_name
 
     js_settings = {
         "gaTrackingID": settings.GA_TRACKING_ID,
         "reactGaDebug": settings.REACT_GA_DEBUG,
         "authenticated": not request.user.is_anonymous(),
         "name": name,
-        "username": request.user.username,
+        "username": request.user.social_auth.get(provider=EdxOrgOAuth2.name).uid,
         "host": webpack_dev_server_host(request),
         "edx_base_url": settings.EDXORG_BASE_URL
     }

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -1,14 +1,18 @@
 """
 Test end to end django views.
 """
+import json
+
 from django.db.models.signals import post_save
 from django.test import TestCase
 from django.test.client import Client
 from factory.django import mute_signals
 from factory.fuzzy import FuzzyText
 
+from cms.models import HomePage
+from backends.edxorg import EdxOrgOAuth2
 from courses.factories import ProgramFactory
-from profiles.factories import ProfileFactory, UserFactory
+from profiles.factories import ProfileFactory
 from ui.urls import DASHBOARD_URL
 
 
@@ -20,6 +24,25 @@ class TestViews(TestCase):
         """Common test setup"""
         super(TestViews, self).setUp()
         self.client = Client()
+
+    def create_and_login_user(self):
+        """
+        Create and login a user
+        """
+        with mute_signals(post_save):
+            profile = ProfileFactory.create(
+                agreed_to_terms_of_service=True,
+                filled_out=True,
+            )
+        profile.user.social_auth.create(
+            provider='not_edx',
+        )
+        profile.user.social_auth.create(
+            provider=EdxOrgOAuth2.name,
+            uid="{}_edx".format(profile.user.username),
+        )
+        self.client.force_login(profile.user)
+        return profile.user
 
     def test_program_liveness(self):
         """Verify only 'live' program visible on homepage"""
@@ -37,31 +60,75 @@ class TestViews(TestCase):
             status_code=200
         )
 
+    def test_login_button(self):
+        """Verify that we see a login button if not logged in"""
+        response = self.client.get('/')
+        self.assertContains(response, "Sign in with edX.org")
+
+    def test_sign_out_button(self):
+        """Verify that we see a sign out button if logged in"""
+        self.create_and_login_user()
+        response = self.client.get('/')
+        self.assertContains(response, 'Sign out')
+
+    def test_index_context_anonymous(self):
+        """
+        Assert context values when anonymous
+        """
+        ga_tracking_id = FuzzyText().fuzz()
+        with self.settings(
+            GA_TRACKING_ID=ga_tracking_id,
+        ):
+            response = self.client.get('/')
+            assert response.context['authenticated'] is False
+            assert response.context['username'] is None
+            assert response.context['title'] == HomePage.objects.first().title
+            js_settings = json.loads(response.context['js_settings_json'])
+            assert js_settings['gaTrackingID'] == ga_tracking_id
+
+    def test_index_context_logged_in(self):
+        """
+        Assert context values when logged in
+        """
+        user = self.create_and_login_user()
+        ga_tracking_id = FuzzyText().fuzz()
+        with self.settings(
+            GA_TRACKING_ID=ga_tracking_id,
+        ):
+            response = self.client.get('/')
+            assert response.context['authenticated'] is True
+            assert response.context['username'] == user.social_auth.get(provider=EdxOrgOAuth2.name).uid
+            assert response.context['title'] == HomePage.objects.first().title
+            js_settings = json.loads(response.context['js_settings_json'])
+            assert js_settings['gaTrackingID'] == ga_tracking_id
+
     def test_dashboard_settings(self):
         """
         Assert settings we pass to dashboard
         """
-        with mute_signals(post_save):
-            profile = ProfileFactory.create(
-                agreed_to_terms_of_service=True,
-                filled_out=True,
-            )
-        self.client.force_login(profile.user)
+        user = self.create_and_login_user()
 
         ga_tracking_id = FuzzyText().fuzz()
         react_ga_debug = FuzzyText().fuzz()
         edx_base_url = FuzzyText().fuzz()
+        host = FuzzyText().fuzz()
         with self.settings(
             GA_TRACKING_ID=ga_tracking_id,
             REACT_GA_DEBUG=react_ga_debug,
-            EDXORG_BASE_URL=edx_base_url
+            EDXORG_BASE_URL=edx_base_url,
+            WEBPACK_DEV_SERVER_HOST=host
         ):
             resp = self.client.get(DASHBOARD_URL)
-            self.assertContains(resp, ga_tracking_id)
-            self.assertContains(resp, react_ga_debug)
-            self.assertContains(resp, edx_base_url)
-            self.assertContains(resp, profile.preferred_name)
-            self.assertContains(resp, profile.user.username)
+            js_settings = json.loads(resp.context['js_settings_json'])
+            assert js_settings == {
+                'gaTrackingID': ga_tracking_id,
+                'reactGaDebug': react_ga_debug,
+                'authenticated': True,
+                'name': user.profile.preferred_name,
+                'username': user.social_auth.get(provider=EdxOrgOAuth2.name).uid,
+                'host': host,
+                'edx_base_url': edx_base_url
+            }
 
     def test_unauthenticated_user_redirect(self):
         """Verify that an unauthenticated user can't visit '/dashboard'"""
@@ -73,14 +140,7 @@ class TestViews(TestCase):
 
     def test_authenticated_user_doesnt_redirect(self):
         """Verify that we let an authenticated user through to '/dashboard'"""
-        with mute_signals(post_save):
-            user = UserFactory.create()
-            ProfileFactory.create(
-                user=user,
-                agreed_to_terms_of_service=True,
-                filled_out=True,
-            )
-        self.client.force_login(user)
+        self.create_and_login_user()
         response = self.client.get(DASHBOARD_URL)
         self.assertContains(
             response,
@@ -106,3 +166,6 @@ class TestViews(TestCase):
                     expected_url,
                     status_code=200
                 )
+
+                js_settings = json.loads(response.context['js_settings_json'])
+                assert js_settings['host'] == 'foo_server'


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #239

#### What's this PR do?
Uses the username stored in the social auth model instead of the one attached to the `User` model. In logging we still use `user.username` but in all other places we should use the one attached to the edx social auth model instead. Tests are updated to provide a different username for the social auth model.

Also, the logic to show either the username or preferred name was moved out of the server into the JS in the function `getPreferredName`.

#### Where should the reviewer start?
backends/pipeline_api.py

#### How should this be manually tested?
 - Find a user who has an account on edX but who has not yet logged into edX via MicroMaster's. If necessary, delete an existing user from MM using the Django shell first.
 - Create a new user using the Django admin, or the shell, or using createsuperuser. Do not create it by logging in. The user must have the same username as your edX user.
 - Log into MM using the web site. Everything should work as expected. You should see your username without any characters appended.
 - In the Django shell, verify that a user was created such that `user.social_auth.get(provider='edxorg').uid` is your username but `user.username` has some extra random characters appended to it.
 - Fill out the profile and make sure everything works like before.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

