### PR TITLE
Changed AutoComplete to focus on text field after selecting an item

### DIFF
--- a/static/js/components/AutoComplete.js
+++ b/static/js/components/AutoComplete.js
@@ -269,6 +269,11 @@ class AutoComplete extends Component {
         searchText: searchText,
       });
       this.close();
+      this.setState({
+        focusTextField: true
+      }, () => {
+        this.focus();
+      });
       this.timerTouchTapCloseId = null;
     }, this.props.menuCloseDelay);
   };


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #419

#### What's this PR do?
Focuses the text field after selecting an item. This should let the user tab after pressing enter

#### Where should the reviewer start?

#### How should this be manually tested?
In an AutoComplete component, type some text. Press the down key and highlight an option you want to select. Press enter. The item should be selected and the text field should be focuses. When you press tab you should go to the next field. Also try pressing backspace after pressing enter to select an item, and verify that the behavior is expected.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

