### PR TITLE
Replace MicroMaster's certificate text with MicroMaster's credential in app

### DIFF
--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -52,8 +52,8 @@ class PersonalTab extends ProfileTab {
     return <div>
       <Grid className="profile-splash">
         <Cell col={12}>
-          Please tell us more about yourself so you can participate in the MicroMaster's
-          community and qualify for your MicroMaster's certificate.
+          Please tell us more about yourself so you can participate in the MicroMaster’s
+          community and qualify for your MicroMaster’s credential.
         </Cell>
       </Grid>
       <Grid className="profile-tab-grid">


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/381

#### What's this PR do?
- Replace text "MicroMaster's certificate" with "MicroMaster's credential".

#### Where should the reviewer start?
- Personal Tab
@aliceriot @pdpinch @noisecapella 
#### How should this be manually tested?
- open /profile, see header of personal tab.

#### Screenshots (if appropriate)
<img width="1030" alt="screen shot 2016-05-27 at 3 08 01 pm" src="https://cloud.githubusercontent.com/assets/10431250/15605078/13f4dbc0-241d-11e6-9a1e-19d114f8ab18.png">
