### PR TITLE
Added previous button to profile pages

### DIFF
--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -12,7 +12,7 @@ import moment from 'moment';
 
 import ProfileFormFields from '../util/ProfileFormFields';
 import { generateNewEducation } from "../util/util";
-import { saveAndContinue } from '../util/profile_edit';
+import { saveProfileStep } from '../util/profile_edit';
 import { HIGH_SCHOOL } from '../constants';
 
 class EducationTab extends ProfileFormFields {
@@ -23,8 +23,10 @@ class EducationTab extends ProfileFormFields {
       this.educationLevelLabels[level.value] = level.label;
     });
   }
-  nextUrl = "/profile/professional";
 
+  prevUrl = "/profile/personal";
+  nextUrl = "/profile/professional";
+  
   static propTypes = {
     profile:                        React.PropTypes.object,
     ui:                             React.PropTypes.object,
@@ -134,7 +136,7 @@ class EducationTab extends ProfileFormFields {
   };
 
   saveEducationForm = () => {
-    saveAndContinue.call(this, EducationTab.validation).then(() => {
+    saveProfileStep.call(this).then(() => {
       this.clearEducationEdit();
     });
   };
@@ -288,19 +290,10 @@ class EducationTab extends ProfileFormFields {
         >
           {this.editEducationForm(educationDegreeLevel)}
         </Dialog>
-
         {levelsGrid}
-
         <Cell col={1} />
         <Cell col={10}>
-          <Button
-            raised
-            colored
-            className="profile-save-and-continue"
-            onClick={this.saveAndContinue}
-          >
-            <span>Save and Continue</span>
-          </Button>
+          {this.progressControls()}
         </Cell>
         <Cell col={1} />
       </Grid>

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -10,7 +10,7 @@ import IconButton from 'react-mdl/lib/IconButton';
 import _ from 'lodash';
 import moment from 'moment';
 
-import { saveAndContinue } from '../util/profile_edit';
+import { saveProfileStep } from '../util/profile_edit';
 import { generateNewWorkHistory } from '../util/util';
 import ProfileFormFields from '../util/ProfileFormFields';
 
@@ -23,7 +23,7 @@ class EmploymentForm extends ProfileFormFields {
   }
 
   saveWorkHistoryEntry = () => {
-    saveAndContinue.call(this).then(() => {
+    saveProfileStep.call(this).then(() => {
       this.closeWorkDialog();
     });
   }

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
-import Button from 'react-mdl/lib/Button';
 
 import EmploymentForm from './EmploymentForm';
 import ProfileFormFields from '../util/ProfileFormFields';
 
 class EmploymentTab extends ProfileFormFields {
+  prevUrl = "/profile/education";
   nextUrl = "/profile/privacy";
 
   render () {
@@ -24,13 +24,7 @@ class EmploymentTab extends ProfileFormFields {
           <Cell col={1}></Cell>
           <Cell col={1}></Cell>
           <Cell col={10}>
-            <Button
-              raised
-              colored
-              className="profile-save-and-continue"
-              onClick={this.saveAndContinue}>
-              <span>Save and Continue</span>
-            </Button>
+            {this.progressControls()}
           </Cell>
           <Cell col={1}></Cell>
         </Grid>

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -1,13 +1,9 @@
 import React from 'react';
-import Button from 'react-mdl/lib/Button';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 
 import ProfileFormFields from '../util/ProfileFormFields';
 
 class PersonalTab extends ProfileFormFields {
-  constructor(props) {
-    super(props);
-  }
   nextUrl = "/profile/education";
 
   static propTypes = {
@@ -83,14 +79,7 @@ class PersonalTab extends ProfileFormFields {
         <Cell col={1} />
         <Cell col={1} />
         <Cell col={10}>
-          <Button
-            raised
-            colored
-            className="profile-save-and-continue"
-            onClick={this.saveAndContinue}
-          >
-            <span>Save and Continue</span>
-          </Button>
+          {this.progressControls()}
         </Cell>
         <Cell col={1} />
       </Grid>

--- a/static/js/components/PrivacyTab.js
+++ b/static/js/components/PrivacyTab.js
@@ -1,14 +1,12 @@
 import React from 'react';
-import Button from 'react-mdl/lib/Button';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 
 import ProfileFormFields from '../util/ProfileFormFields';
 
 class PrivacyTab extends ProfileFormFields {
-  constructor(props) {
-    super(props);
-  }
+  prevUrl = "/profile/professional";
   nextUrl = "/dashboard";
+  isLastTab = true;
 
   static propTypes = {
     profile:        React.PropTypes.object,
@@ -29,9 +27,9 @@ class PrivacyTab extends ProfileFormFields {
           <Cell col={12}>
             <span className="header-privacy-tab">Who can see your profile?</span>
             { this.boundRadioGroupField(['account_privacy'], '', this.privacyOptions) } <br />
-            <Button raised colored className="profile-save-and-continue" onClick={this.saveAndContinue}>
-              I’m Done!
-            </Button>
+          </Cell>
+          <Cell col={12}>
+            {this.progressControls()}
           </Cell>
         </Grid>
       </div>

--- a/static/js/util/ProfileFormFields.js
+++ b/static/js/util/ProfileFormFields.js
@@ -8,12 +8,13 @@ import {
   boundCountrySelectField,
   boundStateSelectField,
   boundRadioGroupField,
-  saveAndContinue,
+  saveProfileStep,
 } from './profile_edit';
 import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
 import LANGUAGE_CODES from '../language_codes';
 import INDUSTRIES from '../industries';
 import iso3166 from 'iso-3166-2';
+import Button from 'react-mdl/lib/Button';
 
 export default class ProfileFormFields extends React.Component {
   constructor(props) {
@@ -64,11 +65,39 @@ export default class ProfileFormFields extends React.Component {
     }));
   }
 
+  stepBack = () => {
+    this.context.router.push(this.prevUrl);
+  };
+
   saveAndContinue = () => {
-    let lastTab = this.nextUrl === "/dashboard";
-    saveAndContinue.call(this, lastTab).then(() => {
+    saveProfileStep.call(this, this.isLastTab).then(() => {
       this.context.router.push(this.nextUrl);
     });
+  };
+
+  progressControls = () => {
+    let prevButton, nextButton;
+    if(this.prevUrl) {
+      prevButton = <Button
+        raised
+        className="progress-button previous"
+        onClick={this.stepBack}>
+        <span>Previous</span>
+      </Button>;
+    }
+    if(this.nextUrl) {
+      nextButton = <Button
+        raised
+        colored
+        className="progress-button next"
+        onClick={this.saveAndContinue}>
+        <span>{this.isLastTab ? "I'm Done!" : "Save and Continue"}</span>
+      </Button>;
+    }
+    return <div>
+        {prevButton}
+        {nextButton}
+      </div>;
   };
 
   static contextTypes = {

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -438,17 +438,17 @@ export function boundDateField(keySet, label, omitDay) {
 }
 
 /**
- * Saves the profile and returns a promise, taking an optional function
+   * Saves the profile and returns a promise, taking an optional function
  * to retrieve keys for validation of nested fields (e.g. profile.work_history)
  *
- * @param finalStep {bool} If true, this is the last tab in the profile
+ * @param isLastStep {bool} If true, this is the last tab in the profile
  */
-export function saveAndContinue(finalStep) {
+export function saveProfileStep(isLastStep=false) {
   const { saveProfile, profile } = this.props;
   let clone = Object.assign({}, profile, {
-    filled_out: profile.filled_out || finalStep
+    filled_out: profile.filled_out || isLastStep
   });
-  if (finalStep) {
+  if (isLastStep) {
     // user has also seen email consent message at this point
     clone.email_optin = true;
   }

--- a/static/js/util/profile_edit_test.js
+++ b/static/js/util/profile_edit_test.js
@@ -12,7 +12,7 @@ import {
   boundStateSelectField,
   boundCountrySelectField,
   boundRadioGroupField,
-  saveAndContinue,
+  saveProfileStep,
 } from './profile_edit';
 import { USER_PROFILE_RESPONSE } from '../constants';
 import * as profileEdit from '../util/profile_edit';
@@ -664,7 +664,7 @@ describe('Profile Editing utility functions', () => {
     });
   });
 
-  describe('saveAndContinue', () => {
+  describe('saveProfileStep', () => {
     const saveProfileReturnValue = "value";
     beforeEach(() => {
       that.props.saveProfile = sandbox.stub();
@@ -673,7 +673,7 @@ describe('Profile Editing utility functions', () => {
     });
 
     it('saves with finalStep as true', () => {
-      let ret = saveAndContinue.call(that, true);
+      let ret = saveProfileStep.call(that, true);
 
       let clone = Object.assign({}, that.props.profile, {
         filled_out: true,

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -145,15 +145,21 @@ c.validation-wrapper {
     font-weight: 400;
   }
 }
-.mdl-button.profile-save-and-continue {
-  background: #4C8399!important;
+.mdl-button.progress-button {
   text-transform: none;
   font-size: 16px;
   font-weight: 400;
   height: 50px;
   min-width: 200px;
+  margin-right: 5px;
   span {
     padding: 10px;
+  }
+  &.previous {
+    background: #F9F9F9 !important;
+  }
+  &.next {
+    background: #4C8399 !important;
   }
 }
 .profile-tab-grid {


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #375 

#### What's this PR do?

adds the 'previous' button to appropriate profile pages. this accounts for a new profile navigation along with #369 

#### How should this be manually tested?

fill out a profile starting with /profile/personal and use the "Previous" and "Save And Continue" buttons

#### Screenshots (if appropriate)

![ss 2016-05-31 at 10 54 08 am](https://cloud.githubusercontent.com/assets/14932219/15682552/4588a79a-272c-11e6-9bed-fdc5a6757e60.png)
![ss 2016-05-31 at 10 54 18 am](https://cloud.githubusercontent.com/assets/14932219/15682553/458a7e26-272c-11e6-8799-a0df9fbf0535.png)
![ss 2016-05-31 at 10 54 28 am](https://cloud.githubusercontent.com/assets/14932219/15682554/458a88f8-272c-11e6-88a2-0de48adccbfb.png)
