### PR TITLE
Switched to old OAUTH endpoints for edX

### DIFF
--- a/backends/edxorg.py
+++ b/backends/edxorg.py
@@ -18,8 +18,8 @@ class EdxOrgOAuth2(BaseOAuth2):
     EDXORG_BASE_URL = settings.EDXORG_BASE_URL
 
     # Settings for Django OAUTH toolkit
-    AUTHORIZATION_URL = urljoin(EDXORG_BASE_URL, '/_o/authorize/')
-    ACCESS_TOKEN_URL = urljoin(EDXORG_BASE_URL, '/_o/token/')
+    AUTHORIZATION_URL = urljoin(EDXORG_BASE_URL, '/oauth2/authorize/')
+    ACCESS_TOKEN_URL = urljoin(EDXORG_BASE_URL, '/oauth2/access_token/')
     DEFAULT_SCOPE = ['read', 'write']
 
     ACCESS_TOKEN_METHOD = 'POST'


### PR DESCRIPTION
#### What are the relevant tickets?
closes #456 
closes #460

#### What's this PR do?
changes the OAUTH backend URLs to the old ones, given that edX just merged the PR https://github.com/edx/edx-platform/pull/12595

#### How should this be manually tested?
you need to have the latest edX master, then using the Django Oauth Toolkit credentials, verify that the login works.

#### What GIF best describes this PR or how it makes you feel?
![](https://cdesertroseauthor.files.wordpress.com/2015/07/rewind.gif)