### PR TITLE
Docker with python35

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM python:3.5
 MAINTAINER ODL DevOps <mitx-devops@mit.edu>
 
 

--- a/apt.txt
+++ b/apt.txt
@@ -5,6 +5,7 @@ libpq-dev
 python3-dev
 libjpeg-dev
 zlib1g-dev
+net-tools
 
 # developer requirements
 postgresql-client

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,3 +9,4 @@ pytest-pylint==0.4.0
 pytest==2.8.2
 semantic-version==2.4.2
 ipdb
+pdbpp

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34
+envlist = py35
 skip_missing_interpreters = True
 skipsdist = True
 


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #458
#### What's this PR do?
Switches docker to python 3.5

#### How should this be manually tested?
everything should work as is but using python 3.5: one way to test is to run `docker-compose run web tox`
