### PR TITLE
Made personal info editable on user page

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -60,3 +60,8 @@ export const SET_EDUCATION_DEGREE_INCLUSIONS = 'SET_EDUCATION_DEGREE_INCLUSIONS'
 export const setEducationDegreeInclusions = degreeInclusions => (
   { type: SET_EDUCATION_DEGREE_INCLUSIONS, payload: degreeInclusions }
 );
+
+export const SET_USER_PAGE_DIALOG_VISIBILITY = 'SET_USER_PAGE_DIALOG_VISIBILITY';
+export const setUserPageDialogVisibility = bool => (
+  { type: SET_USER_PAGE_DIALOG_VISIBILITY, payload: bool }
+);

--- a/static/js/components/CourseList_test.js
+++ b/static/js/components/CourseList_test.js
@@ -4,6 +4,8 @@ import TestUtils from 'react-addons-test-utils';
 import sinon from 'sinon';
 import assert from 'assert';
 import _ from 'lodash';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
 import CourseList from './CourseList';
 import * as util from '../util/util';
@@ -21,7 +23,9 @@ describe("CourseList", () => {
 
   it('renders apply for master button and text', () => {
     let renderedComponent = TestUtils.renderIntoDocument(
-      <CourseList dashboard={{programs: DASHBOARD_RESPONSE}} expander={{}} dispatch={() => {}}/>
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <CourseList dashboard={{programs: DASHBOARD_RESPONSE}} expander={{}} dispatch={() => {}}/>
+      </MuiThemeProvider>
     );
     let programBottomDivComponent = TestUtils.scryRenderedDOMComponentsWithClass(
       renderedComponent,
@@ -61,7 +65,9 @@ describe("CourseList", () => {
     let makeCourseStatusDisplaySpy = sandbox.spy(util, 'makeCourseStatusDisplay');
 
     TestUtils.renderIntoDocument(
-      <CourseList dashboard={{programs: DASHBOARD_RESPONSE}} expander={{}} dispatch={() => {}} />
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <CourseList dashboard={{programs: DASHBOARD_RESPONSE}} expander={{}} dispatch={() => {}} />
+      </MuiThemeProvider>
     );
 
     let callCount = 0;

--- a/static/js/components/PersonalForm.js
+++ b/static/js/components/PersonalForm.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import Grid, { Cell } from 'react-mdl/lib/Grid';
+
+import ProfileFormFields from '../util/ProfileFormFields';
+
+export default class PersonalForm extends ProfileFormFields {
+  static propTypes = {
+    profile:        React.PropTypes.object,
+    errors:         React.PropTypes.object,
+    saveProfile:    React.PropTypes.func,
+    updateProfile:  React.PropTypes.func,
+  };
+
+  render() {
+    return (
+      <Grid className="profile-tab-card-grid">
+        <Cell col={6}>
+          {this.boundTextField(["first_name"], "Given name")}
+        </Cell>
+        <Cell col={6}>
+          {this.boundTextField(["last_name"], "Family name")}
+        </Cell>
+        <Cell col={12}>
+          {this.boundTextField(["preferred_name"], "Preferred name")}
+        </Cell>
+        <Cell col={12}>
+          {this.boundDateField(['date_of_birth'], 'Date of birth')}
+        </Cell>
+        <Cell col={12} className="profile-gender-group">
+          {this.boundRadioGroupField(['gender'], 'Gender', this.genderOptions)}
+        </Cell>
+        <Cell col={12}>
+          {this.boundSelectField(
+            ['preferred_language'],
+            'Preferred language',
+            this.languageOptions
+          )}
+        </Cell>
+        <Cell col={12}>
+          <h4>Currently Living</h4>
+        </Cell>
+        <Cell col={4}>
+          {this.boundCountrySelectField(['state_or_territory'], ['country'], 'Country')}
+        </Cell>
+        <Cell col={4}>
+          {this.boundStateSelectField(['state_or_territory'], ['country'], 'State or Territory')}
+        </Cell>
+        <Cell col={4}>
+          {this.boundTextField(['city'], 'City')}
+        </Cell>
+        <Cell col={12}>
+          <h4>Where were you born?</h4>
+        </Cell>
+        <Cell col={4}>
+          {this.boundCountrySelectField(
+            ['birth_state_or_territory'],
+            ['birth_country'],
+            'Country'
+          )}</Cell>
+        <Cell col={4}>
+          {this.boundStateSelectField(['birth_state_or_territory'], ['birth_country'], 'State or Territory')}
+        </Cell>
+        <Cell col={4}>
+          {this.boundTextField(['birth_city'], 'City')}
+        </Cell>
+      </Grid>
+    );
+  }
+}

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 
 import ProfileFormFields from '../util/ProfileFormFields';
+import PersonalForm from './PersonalForm';
 
 class PersonalTab extends ProfileFormFields {
   nextUrl = "/profile/education";
@@ -24,57 +25,7 @@ class PersonalTab extends ProfileFormFields {
       <Grid className="profile-tab-grid">
         <Cell col={1} />
         <Cell col={10}>
-          <Grid className="profile-tab-card-grid">
-            <Cell col={6}>
-              {this.boundTextField(["first_name"], "Given name")}
-            </Cell>
-            <Cell col={6}>
-              {this.boundTextField(["last_name"], "Family name")}
-            </Cell>
-            <Cell col={12}>
-              {this.boundTextField(["preferred_name"], "Preferred name")}
-            </Cell>
-            <Cell col={12}>
-              {this.boundDateField(['date_of_birth'], 'Date of birth')}
-            </Cell>
-            <Cell col={12} className="profile-gender-group">
-              {this.boundRadioGroupField(['gender'], 'Gender', this.genderOptions)}
-            </Cell>
-            <Cell col={12}>
-              {this.boundSelectField(
-                ['preferred_language'],
-                'Preferred language',
-                this.languageOptions
-              )}
-            </Cell>
-            <Cell col={12}>
-              <h4>Currently Living</h4>
-            </Cell>
-            <Cell col={4}>
-              {this.boundCountrySelectField(['state_or_territory'], ['country'], 'Country')}
-            </Cell>
-            <Cell col={4}>
-              {this.boundStateSelectField(['state_or_territory'], ['country'], 'State or Territory')}
-            </Cell>
-            <Cell col={4}>
-              {this.boundTextField(['city'], 'City')}
-            </Cell>
-            <Cell col={12}>
-              <h4>Where were you born?</h4>
-            </Cell>
-            <Cell col={4}>
-              {this.boundCountrySelectField(
-                ['birth_state_or_territory'],
-                ['birth_country'],
-                'Country'
-              )}</Cell>
-            <Cell col={4}>
-              {this.boundStateSelectField(['birth_state_or_territory'], ['birth_country'], 'State or Territory')}
-            </Cell>
-            <Cell col={4}>
-              {this.boundTextField(['birth_city'], 'City')}
-            </Cell>
-          </Grid>
+          <PersonalForm {...this.props} />
         </Cell>
         <Cell col={1} />
         <Cell col={1} />

--- a/static/js/components/User.js
+++ b/static/js/components/User.js
@@ -7,21 +7,37 @@ import iso3166 from 'iso-3166-2';
 import { makeProfileImageUrl } from '../util/util';
 import EmploymentForm from './EmploymentForm';
 import EducationForm from './EducationForm';
+import UserPagePersonalDialog from './UserPagePersonalDialog.js';
 
 export default class User extends React.Component {
   static propTypes = {
-    profile: React.PropTypes.object
+    profile:                      React.PropTypes.object,
+    setUserPageDialogVisibility:  React.PropTypes.func,
+    ui:                           React.PropTypes.object,
   };
+
+  toggleShowPersonalDialog = () => {
+    const {
+      setUserPageDialogVisibility,
+      ui: { userPageDialogVisibility }
+    } = this.props;
+    setUserPageDialogVisibility(!userPageDialogVisibility);
+  }
 
   render() {
     const { profile } = this.props;
 
-    let getStateName = () => (
-      iso3166.subdivision(profile.state_or_territory).name
-    );
+    let getStateName = () => {
+      if ( profile.state_or_territory ) {
+        return iso3166.subdivision(profile.state_or_territory).name;
+      } else {
+        return '';
+      }
+    };
 
     let imageUrl = makeProfileImageUrl(profile);
     return <div className="card">
+      <UserPagePersonalDialog {...this.props} />
       <Grid className="card-user">
         <Cell col={5} />
         <Cell col={2} className="card-image-box">
@@ -46,7 +62,7 @@ export default class User extends React.Component {
           { profile.city }, { getStateName() }
         </span>
         <CardMenu>
-          <IconButton name="edit" />
+          <IconButton name="edit" onClick={this.toggleShowPersonalDialog}/>
         </CardMenu>
       </Card>
 

--- a/static/js/components/UserPagePersonalDialog.js
+++ b/static/js/components/UserPagePersonalDialog.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import Dialog from 'material-ui/Dialog';
+import Button from 'react-mdl/lib/Button';
+
+import { saveProfileStep } from '../util/profile_edit';
+import PersonalForm from './PersonalForm';
+
+export default class UserPagePersonalDialog extends React.Component {
+  static propTypes = {
+    setUserPageDialogVisibility:  React.PropTypes.func,
+    ui:                           React.PropTypes.object,
+    clearProfileEdit:             React.PropTypes.func,
+  };
+
+  closePersonalDialog = () => {
+    const { setUserPageDialogVisibility, clearProfileEdit } = this.props;
+    setUserPageDialogVisibility(false);
+    clearProfileEdit();
+  };
+
+  savePersonalInfo = () => {
+    saveProfileStep.call(this).then(() => {
+      this.closePersonalDialog();
+    });
+  };
+
+  render () {
+    const { ui: { userPageDialogVisibility } } = this.props;
+    const actions = [
+      <Button
+        type='button'
+        key='cancel'
+        className='cancel-button'
+        onClick={this.closePersonalDialog}>
+        Cancel
+      </Button>,
+      <Button
+        key='save'
+        type='button'
+        className='save-button'
+        onClick={this.savePersonalInfo}>
+        Save
+      </Button>
+    ];
+
+    return (
+      <Dialog
+        open={userPageDialogVisibility}
+        onRequestClose={this.closePersonalDialog}
+        actions={actions}
+        autoScrollBodyContent={true}>
+        <PersonalForm {...this.props} />
+      </Dialog>
+    );
+  }
+}

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -17,6 +17,7 @@ import {
   setEducationDialogIndex,
   setEducationDegreeLevel,
   setEducationDegreeInclusions,
+  setUserPageDialogVisibility,
 } from '../actions/ui';
 
 class ProfileFormContainer extends React.Component {
@@ -55,6 +56,11 @@ class ProfileFormContainer extends React.Component {
       dispatch(startProfileEdit(username));
     }
     dispatch(updateProfile(username, profile));
+  }
+
+  setUserPageDialogVisibility = bool => {
+    const { dispatch } = this.props;
+    dispatch(setUserPageDialogVisibility(bool));
   }
 
   setWorkHistoryEdit = (bool) => {
@@ -142,6 +148,7 @@ class ProfileFormContainer extends React.Component {
         setEducationDegreeLevel: this.setEducationDegreeLevel,
         setEducationDegreeInclusions: this.setEducationDegreeInclusions,
         fetchProfile: this.fetchProfile,
+        setUserPageDialogVisibility: this.setUserPageDialogVisibility,
       })
     ));
   }

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -19,6 +19,7 @@ import {
   SET_EDUCATION_DEGREE_LEVEL,
   SET_EDUCATION_DIALOG_INDEX,
   SET_EDUCATION_DIALOG_VISIBILITY,
+  SET_USER_PAGE_DIALOG_VISIBILITY,
 } from '../actions/ui';
 import IntegrationTestHelper from '../util/integration_test_helper';
 import * as api from '../util/api';
@@ -186,6 +187,32 @@ describe("UserPage", () => {
           SET_WORK_DIALOG_VISIBILITY
         ], () => {
           TestUtils.Simulate.click(editButton);
+        }).then(() => {
+          done();
+        });
+      });
+    });
+  });
+
+  describe('Personal Info', () => {
+    it('should show name and location', done => {
+      renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+        let name = div.getElementsByClassName('users-name')[0].textContent;
+        assert.deepEqual(name, USER_PROFILE_RESPONSE.preferred_name);
+
+        let location = div.getElementsByClassName('users-location')[0].textContent;
+
+        assert.deepEqual(location, `${USER_PROFILE_RESPONSE.city}, `);
+        done();
+      });
+    });
+
+    it('should let you edit personal info', done => {
+      renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+        let personalButton = div.getElementsByClassName('material-icons')[0];
+
+        listenForActions([SET_USER_PAGE_DIALOG_VISIBILITY], () => {
+          TestUtils.Simulate.click(personalButton);
         }).then(() => {
           done();
         });

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -14,6 +14,8 @@ import {
   SET_EDUCATION_DIALOG_INDEX,
   SET_EDUCATION_DEGREE_LEVEL,
   SET_EDUCATION_DEGREE_INCLUSIONS,
+
+  SET_USER_PAGE_DIALOG_VISIBILITY,
 } from '../actions/ui';
 import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
 
@@ -31,6 +33,7 @@ export const INITIAL_UI_STATE = {
     [MASTERS]: false,
     [DOCTORATE]: false,
   },
+  userPageDialogVisibility: false,
 };
 
 export const ui = (state = INITIAL_UI_STATE, action) => {
@@ -94,6 +97,11 @@ export const ui = (state = INITIAL_UI_STATE, action) => {
     clone[action.payload.courseId] = action.payload.newValue;
     return Object.assign({}, state, {
       dashboardExpander: clone
+    });
+  }
+  case SET_USER_PAGE_DIALOG_VISIBILITY: {
+    return Object.assign({}, state, {
+      userPageDialogVisibility: action.payload
     });
   }
   default:

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -11,6 +11,7 @@ import {
   SET_EDUCATION_DIALOG_INDEX,
   SET_EDUCATION_DEGREE_LEVEL,
   SET_EDUCATION_DEGREE_INCLUSIONS,
+  SET_USER_PAGE_DIALOG_VISIBILITY,
 
   clearUI,
   updateDialogText,
@@ -24,6 +25,7 @@ import {
   setEducationDialogIndex,
   setEducationDegreeLevel,
   setEducationDegreeInclusions,
+  setUserPageDialogVisibility,
 } from '../actions/ui';
 import { INITIAL_UI_STATE } from '../reducers/ui';
 import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
@@ -181,6 +183,15 @@ describe('ui reducers', () => {
       };
       dispatchThen(setEducationDegreeInclusions(newInclusions), [SET_EDUCATION_DEGREE_INCLUSIONS]).then(state => {
         assert.deepEqual(state.educationDegreeInclusions, newInclusions);
+        done();
+      });
+    });
+  });
+
+  describe('user page', () => {
+    it('should let you set the user page dialog visibility', done => {
+      dispatchThen(setUserPageDialogVisibility(true), [SET_USER_PAGE_DIALOG_VISIBILITY]).then(state => {
+        assert.deepEqual(state.userPageDialogVisibility, true);
         done();
       });
     });


### PR DESCRIPTION
#### What are the relevant tickets?

closes #391 

#### What's this PR do?

This PR adds the ability to edit personal information by clicking the 'edit' button on the users page. This entails:

- moving the personal form fields to a new class (`PersonalForm`)
- creating a shim class to place the `PersonalForm` in a dialog (`UserPagePersonalDialog`)
- actions and reducers to show / hide the dialog

#### Where should the reviewer start?

I would review the changes to `User` and the new `PersonalForm`.

#### How should this be manually tested?

Make sure there are no regressions in the ability to edit at `/profile/personal`. Make sure you can edit everything in the same way on `/users/${username}`.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

