### PR TITLE
Fixed two JS console warnings

### DIFF
--- a/static/js/components/CourseList.js
+++ b/static/js/components/CourseList.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import _ from 'lodash';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import RaisedButton from 'material-ui/RaisedButton';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 
@@ -91,7 +90,7 @@ class CourseList extends React.Component {
 
       let applyForMSBtnLabel = `Apply for the ${program.title} Master’s Degree`;
       const btnStyle = {
-        'text-transform': 'none'
+        'textTransform': 'none'
       };
 
       return (
@@ -119,9 +118,7 @@ class CourseList extends React.Component {
             <br/>
             <p>You need to pass {totalCourses - coursesPassed} more courses
               before you can apply for the <strong>{program.title}</strong> Master’s Degree.</p>
-            <MuiThemeProvider>
-                <RaisedButton label={applyForMSBtnLabel} disabled={true} labelStyle={btnStyle} />
-            </MuiThemeProvider>
+            <RaisedButton label={applyForMSBtnLabel} disabled={true} labelStyle={btnStyle} />
           </div>
         </div>
       );


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

I noticed two JS console warnings that were introduced (near as I can tell) in https://github.com/mitodl/micromasters/commit/1dcaf65475ea61ba0c2e8ddc3e3ba932ec2d2af7

if, on master, you visit `/dashboard`, you get these errors in the JS console:

![errors](https://cloud.githubusercontent.com/assets/6207644/15828060/d81006ae-2bdb-11e6-9353-ab67cc5993c7.png)

#### Where should the reviewer start?

check out the changes.

#### How should this be manually tested?

Make sure the JS warnings are gone, and that there are no regressions.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

