### PR TITLE
Fixed handling of multiple validation errors for education and work history

### DIFF
--- a/static/js/util/validation.js
+++ b/static/js/util/validation.js
@@ -10,12 +10,15 @@ let handleNestedValidation = (profile, keys, nestedKey) => {
 };
 
 let checkFieldPresence = (profile, requiredFields, messages) => {
-  return Object.assign({}, ...requiredFields.map( keySet => {
+  let errors = {};
+
+  for (let keySet of requiredFields) {
     let val = _.get(profile, keySet);
     if (_.isUndefined(val) || _.isNull(val) || val === "" ) {
-      return _.set({}, keySet,  `${messages[keySet.slice(-1)[0]]} is required`);
+      _.set(errors, keySet,  `${messages[keySet.slice(-1)[0]]} is required`);
     }
-  }));
+  }
+  return errors;
 };
 
 export function personalValidation(profile) {

--- a/static/js/util/validation_test.js
+++ b/static/js/util/validation_test.js
@@ -49,6 +49,18 @@ describe('Profile validation functions', () => {
       clone.education[0].field_of_study = "";
       assert.deepEqual({}, educationValidation(clone));
     });
+
+    it('should show all fields which are required', () => {
+      let clone = _.cloneDeep(USER_PROFILE_RESPONSE);
+      clone.education[0].school_name = '';
+      clone.education[0].school_city = '';
+      assert.deepEqual({
+        education: [{
+          school_name: 'School name is required',
+          school_city: 'City is required'
+        }]
+      }, educationValidation(clone));
+    });
   });
 
   describe('Employment validation', () => {
@@ -67,6 +79,18 @@ describe('Profile validation functions', () => {
       let clone = _.cloneDeep(USER_PROFILE_RESPONSE);
       clone.work_history = undefined;
       assert.deepEqual({}, employmentValidation(clone));
+    });
+
+    it('should show all fields which are required', () => {
+      let clone = _.cloneDeep(USER_PROFILE_RESPONSE);
+      clone.work_history[0].company_name = '';
+      clone.work_history[0].city = '';
+      assert.deepEqual({
+        work_history: [{
+          city: 'City is required',
+          company_name: 'Company Name is required'
+        }]
+      }, employmentValidation(clone));
     });
   });
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #490 

#### What's this PR do?
Fixes bug in `checkFieldPresence` to combine errors correctly. Currently it uses `Object.assign` which won't combine nested values correctly

#### Where should the reviewer start?

#### How should this be manually tested?
Open a new education, then click save without typing anything. All fields should be marked as needing validation

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

