### PR TITLE
Moved profile privacy hint to new line

### DIFF
--- a/static/js/components/PrivacyTab.js
+++ b/static/js/components/PrivacyTab.js
@@ -20,10 +20,9 @@ class PrivacyTab extends ProfileFormFields {
             We care about your privacy.
           </Cell>
         </Grid>
-        <br/><br/>
         <Grid className="profile-tab-grid">
           <Cell col={12}>
-            <span className="header-privacy-tab">Who can see your profile?</span>
+            <h4>Who can see your profile?</h4>
             { this.boundRadioGroupField(['account_privacy'], '', this.privacyOptions) } <br />
           </Cell>
           <Cell col={12}>

--- a/static/js/util/ProfileFormFields.js
+++ b/static/js/util/ProfileFormFields.js
@@ -43,12 +43,12 @@ export default class ProfileFormFields extends React.Component {
     }));
     this.languageOptions = _.sortBy(languageOptions, 'label');
     this.privacyOptions = [
-      { value: 'public', label: 'Public to the world', helper: `We will publish your MicroMaster’s 
-        profile on our website.` },
-      { value: 'public_to_mm', label: "Public to other MicroMaster’s students", helper: `Your MicroMaster’s profile 
-        will only be viewable by other learners in your program, and by MIT faculity and staff.` },
-      { value: 'private', label: 'Private', helper: `Your MicroMaster’s profile will be viewable only by 
-        MIT faculty and staff.` }
+      { value: 'public', label: 'Public to the world', helper: `Your MicroMaster’s profile will be 
+        visible to all website visitors.` },
+      { value: 'public_to_mm', label: "Public to other MicroMaster’s students", helper: `Your profile will be 
+        visible to other MicroMaster’s learners, and to MIT faculty and staff.` },
+      { value: 'private', label: 'Private', helper: `Your MicroMaster’s profile will only 
+        be visible to MIT faculty and staff.` }
     ];
     this.educationLevelOptions = [
       {value: HIGH_SCHOOL, label: "High school"},

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -46,11 +46,12 @@ export function boundRadioGroupField(keySet, label, options) {
   const radioButtons = options.map(obj => {
     let helper = "";
     if (obj.helper) {
-      helper = `- ${obj.helper}`;
+      helper = `${obj.helper}`;
     }
     let label = (
       <span className="radio-label">
-        {obj.label}<span className="radio-label-hint">{helper}</span>
+        {obj.label}
+        <p className="radio-label-hint">{helper}</p>
       </span>
     );
 

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -269,11 +269,8 @@ c.validation-wrapper {
   font-weight: 400;
   .radio-label-hint {
     font-size: small;
-    color: #9196A0;
+    color: #555555;
   }
-}
-.header-privacy-tab {
-  color: #A2AAB3;
 }
 
 .terms-of-service-main {


### PR DESCRIPTION
#### What are the relevant tickets?
Resolved https://github.com/mitodl/micromasters/issues/477

#### What's this PR do?
- Moved hint of radio button of privacy tab inside profile page to the new line.

#### Where should the reviewer start?
- profile_edits.js

#### How should this be manually tested?
- open /profile/privacy

@pdpinch @aliceriot @noisecapella 

#### Screenshots (if appropriate)

![screen shot 2016-06-07 at 5 12 48 pm](https://cloud.githubusercontent.com/assets/10431250/15857219/a5a0f752-2cd3-11e6-8fd9-c390269a0ebe.png)
