### PR TITLE
Added confirmation dialog when deleting education and work entries

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -65,3 +65,18 @@ export const SET_USER_PAGE_DIALOG_VISIBILITY = 'SET_USER_PAGE_DIALOG_VISIBILITY'
 export const setUserPageDialogVisibility = bool => (
   { type: SET_USER_PAGE_DIALOG_VISIBILITY, payload: bool }
 );
+
+export const SET_SHOW_EDUCATION_DELETE_DIALOG = 'SET_SHOW_EDUCATION_DELETE_DIALOG';
+export const setShowEducationDeleteDialog = bool => (
+  { type: SET_SHOW_EDUCATION_DELETE_DIALOG, payload: bool }
+);
+
+export const SET_SHOW_WORK_DELETE_DIALOG = 'SET_SHOW_WORK_DELETE_DIALOG';
+export const setShowWorkDeleteDialog = bool => (
+  { type: SET_SHOW_WORK_DELETE_DIALOG, payload: bool }
+);
+
+export const SET_DELETION_INDEX = 'SET_DELETION_INDEX';
+export const setDeletionIndex = index => (
+  { type: SET_DELETION_INDEX, payload: index }
+);

--- a/static/js/components/ConfirmDeletion.js
+++ b/static/js/components/ConfirmDeletion.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import Dialog from 'material-ui/Dialog';
+import Button from 'react-mdl/lib/Button';
+
+export default class ConfirmDeletion extends React.Component {
+  static propTypes = {
+    close:        React.PropTypes.func,
+    deleteEntry:  React.PropTypes.func,
+    open:         React.PropTypes.bool,
+  };
+
+  deleteAndClose = () => {
+    const { close, deleteEntry } = this.props;
+    deleteEntry();
+    close();
+  };
+
+  render () {
+    const { close, open } = this.props;
+    let actions = [
+      <Button
+        type='button'
+        key='close'
+        className="cancel-button"
+        onClick={close}>
+        No
+      </Button>,
+      <Button
+        key='delete'
+        type='button'
+        className="delete-button"
+        onClick={this.deleteAndClose}>
+        Yes
+      </Button>
+    ];
+    return (
+      <Dialog
+        className={"deletion-confirmation"}
+        open={open}
+        onRequestClose={close}
+        actions={actions}
+        autoScrollBodyContent={true}
+      >
+        Delete this entry?
+      </Dialog>
+    );
+  }
+}

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -14,6 +14,7 @@ import ProfileFormFields from '../util/ProfileFormFields';
 import { generateNewEducation } from "../util/util";
 import { saveProfileStep } from '../util/profile_edit';
 import { HIGH_SCHOOL } from '../constants';
+import ConfirmDeletion from './ConfirmDeletion';
 
 class EducationForm extends ProfileFormFields {
   constructor(props) {
@@ -57,10 +58,10 @@ class EducationForm extends ProfileFormFields {
     setEducationDialogVisibility(true);
   };
 
-  deleteEducationEntry = index => {
-    const { saveProfile, profile } = this.props;
+  deleteEducationEntry = () => {
+    const { saveProfile, profile, deletionIndex } = this.props;
     let clone = _.cloneDeep(profile);
-    clone['education'].splice(index, 1);
+    clone['education'].splice(deletionIndex, 1);
     saveProfile(clone);
   };
 
@@ -94,7 +95,7 @@ class EducationForm extends ProfileFormFields {
       return;
     }
 
-    let deleteEntry = () => this.deleteEducationEntry(index);
+    let deleteEntry = () => this.openEducationDeleteDialog(index);
     let editEntry = () => this.openEditEducationForm(index);
     let validationAlert = () => {
       if (_.get(errors, ['education', index])) {
@@ -112,8 +113,8 @@ class EducationForm extends ProfileFormFields {
       </Cell>
       <Cell col={2} className="profile-row-icons">
         {validationAlert()}
-        <IconButton name="edit" onClick={editEntry} />
-        <IconButton name="delete" onClick={deleteEntry} />
+        <IconButton className="edit-button" name="edit" onClick={editEntry} />
+        <IconButton className="delete-button" name="delete" onClick={deleteEntry} />
       </Cell>
     </Grid>;
   };
@@ -216,6 +217,7 @@ class EducationForm extends ProfileFormFields {
         educationDialogVisibility,
         educationDegreeInclusions,
         educationDegreeLevel,
+        showEducationDeleteDialog,
       }
     } = this.props;
 
@@ -267,6 +269,11 @@ class EducationForm extends ProfileFormFields {
 
     return (
       <div>
+        <ConfirmDeletion
+          deleteEntry={this.deleteEducationEntry}
+          open={showEducationDeleteDialog}
+          close={this.closeConfirmDeleteDialog}
+        />
         <Dialog
           open={educationDialogVisibility}
           className="dashboard-dialog"

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -13,6 +13,7 @@ import moment from 'moment';
 import { saveProfileStep } from '../util/profile_edit';
 import { generateNewWorkHistory } from '../util/util';
 import ProfileFormFields from '../util/ProfileFormFields';
+import ConfirmDeletion from './ConfirmDeletion';
 
 class EmploymentForm extends ProfileFormFields {
   componentWillMount () {
@@ -54,10 +55,10 @@ class EmploymentForm extends ProfileFormFields {
     setWorkDialogVisibility(true);
   }
 
-  deleteWorkHistoryEntry = index => {
-    const { saveProfile, profile } = this.props;
+  deleteWorkHistoryEntry = () => {
+    const { saveProfile, profile, deletionIndex } = this.props;
     let clone = _.cloneDeep(profile);
-    clone['work_history'].splice(index, 1);
+    clone['work_history'].splice(deletionIndex, 1);
     saveProfile(clone);
   }
 
@@ -149,7 +150,7 @@ class EmploymentForm extends ProfileFormFields {
     let endDateText = () => (
       _.isEmpty(position.end_date) ? "Current" : dateFormat(position.end_date)
     );
-    let deleteEntry = () => this.deleteWorkHistoryEntry(index);
+    let deleteEntry = () => this.openWorkDeleteDialog(index);
     return (
       <Grid className="profile-tab-card-grid" key={index}>
         <Cell col={4} className="profile-row-name">
@@ -168,7 +169,13 @@ class EmploymentForm extends ProfileFormFields {
   }
 
   render () {
-    const { ui: { workHistoryEdit, workDialogVisibility } } = this.props;
+    const { 
+      ui: {
+        workHistoryEdit,
+        workDialogVisibility,
+        showWorkDeleteDialog,
+      }
+    } = this.props;
     const actions = [
       <Button
         type='button'
@@ -188,6 +195,11 @@ class EmploymentForm extends ProfileFormFields {
 
     return (
       <div>
+        <ConfirmDeletion
+          deleteEntry={this.deleteWorkHistoryEntry}
+          open={showWorkDeleteDialog}
+          close={this.closeConfirmDeleteDialog}
+        />
         <Dialog
           open={workDialogVisibility}
           className="dashboard-dialog"

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -18,6 +18,9 @@ import {
   setEducationDegreeLevel,
   setEducationDegreeInclusions,
   setUserPageDialogVisibility,
+  setShowEducationDeleteDialog,
+  setShowWorkDeleteDialog,
+  setDeletionIndex,
 } from '../actions/ui';
 
 class ProfileFormContainer extends React.Component {
@@ -56,6 +59,21 @@ class ProfileFormContainer extends React.Component {
       dispatch(startProfileEdit(username));
     }
     dispatch(updateProfile(username, profile));
+  }
+
+  setDeletionIndex = index => {
+    const { dispatch } = this.props;
+    dispatch(setDeletionIndex(index));
+  }
+
+  setShowEducationDeleteDialog = bool => {
+    const { dispatch } = this.props;
+    dispatch(setShowEducationDeleteDialog(bool));
+  }
+
+  setShowWorkDeleteDialog = bool => {
+    const { dispatch } = this.props;
+    dispatch(setShowWorkDeleteDialog(bool));
   }
 
   setUserPageDialogVisibility = bool => {
@@ -149,6 +167,9 @@ class ProfileFormContainer extends React.Component {
         setEducationDegreeInclusions: this.setEducationDegreeInclusions,
         fetchProfile: this.fetchProfile,
         setUserPageDialogVisibility: this.setUserPageDialogVisibility,
+        setShowEducationDeleteDialog: this.setShowEducationDeleteDialog,
+        setShowWorkDeleteDialog: this.setShowWorkDeleteDialog,
+        setDeletionIndex: this.setDeletionIndex,
       })
     ));
   }

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -20,6 +20,9 @@ import {
   SET_EDUCATION_DIALOG_INDEX,
   SET_EDUCATION_DIALOG_VISIBILITY,
   SET_USER_PAGE_DIALOG_VISIBILITY,
+  SET_DELETION_INDEX,
+  SET_SHOW_WORK_DELETE_DIALOG,
+  SET_SHOW_EDUCATION_DELETE_DIALOG,
 } from '../actions/ui';
 import IntegrationTestHelper from '../util/integration_test_helper';
 import * as api from '../util/api';
@@ -41,11 +44,22 @@ describe("UserPage", () => {
 
   let userActions = [RECEIVE_GET_USER_PROFILE_SUCCESS, REQUEST_GET_USER_PROFILE];
 
+  let openDialog = () => {
+    return [...document.getElementsByClassName('deletion-confirmation')].find(dialog => (
+      dialog.style["left"] === "0px"
+    ));
+  };
+
   afterEach(() => {
     helper.cleanup();
   });
 
   describe("Education History", () => {
+    let deleteButton = div => {
+      return div.getElementsByClassName('profile-tab-card')[1].
+        getElementsByClassName('delete-button')[0];
+    };
+
     it('shows the education component', done => {
       renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
         let title = div.getElementsByClassName('profile-card-title')[1];
@@ -54,7 +68,28 @@ describe("UserPage", () => {
       });
     });
 
-    it('should let you delete an education entry', done => {
+    it('should confirm deletion and let you cancel', done => {
+      renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+        let button = deleteButton(div);
+
+        listenForActions([
+          SET_DELETION_INDEX,
+          SET_SHOW_EDUCATION_DELETE_DIALOG,
+          SET_SHOW_EDUCATION_DELETE_DIALOG,
+          SET_SHOW_WORK_DELETE_DIALOG,
+          SET_DELETION_INDEX
+        ], () => {
+          TestUtils.Simulate.click(button);
+          let dialog = openDialog();
+          let cancelButton = dialog.getElementsByClassName('cancel-button')[0];
+          TestUtils.Simulate.click(cancelButton);
+        }).then(() => {
+          done();
+        });
+      });
+    });
+
+    it('should confirm deletion and let you continue', done => {
       renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
         let updatedProfile = _.cloneDeep(USER_PROFILE_RESPONSE);
         updatedProfile.education.splice(0,1);
@@ -64,17 +99,23 @@ describe("UserPage", () => {
           Promise.resolve(updatedProfile)
         );
 
-        let deleteButton = div.getElementsByClassName('profile-tab-card')[1].
-          getElementsByClassName('profile-row-icons')[0].
-          getElementsByClassName('mdl-button')[1];
+        let button = deleteButton(div);
 
         listenForActions([
+          SET_DELETION_INDEX,
+          SET_SHOW_EDUCATION_DELETE_DIALOG,
           START_PROFILE_EDIT,
           UPDATE_PROFILE_VALIDATION,
+          SET_SHOW_EDUCATION_DELETE_DIALOG,
+          SET_SHOW_WORK_DELETE_DIALOG,
+          SET_DELETION_INDEX,
           REQUEST_PATCH_USER_PROFILE,
           RECEIVE_PATCH_USER_PROFILE_SUCCESS,
         ], () => {
-          TestUtils.Simulate.click(deleteButton);
+          TestUtils.Simulate.click(button);
+          let dialog = openDialog();
+          button = dialog.getElementsByClassName('delete-button')[0];
+          TestUtils.Simulate.click(button);
         }).then(() => {
           done();
         });
@@ -121,6 +162,12 @@ describe("UserPage", () => {
   });
 
   describe("Employment History", () => {
+    let deleteButton = div => {
+      return div.getElementsByClassName('profile-tab-card')[0].
+        getElementsByClassName('profile-row-icons')[0].
+        getElementsByClassName('mdl-button')[1];
+    };
+
     it('shows the employment history component', done => {
       renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
         let title = div.getElementsByClassName('profile-card-title')[0];
@@ -129,8 +176,28 @@ describe("UserPage", () => {
       });
     });
 
-    it('should let you delete a work history entry', done => {
+    it('should confirm deletion and let you cancel', done => {
+      renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+        let button = deleteButton(div);
 
+        listenForActions([
+          SET_DELETION_INDEX,
+          SET_SHOW_WORK_DELETE_DIALOG,
+          SET_SHOW_WORK_DELETE_DIALOG,
+          SET_SHOW_EDUCATION_DELETE_DIALOG,
+          SET_DELETION_INDEX,
+        ], () => {
+          TestUtils.Simulate.click(button);
+          let dialog = openDialog();
+          let cancelButton = dialog.getElementsByClassName('cancel-button')[0];
+          TestUtils.Simulate.click(cancelButton);
+        }).then(() => {
+          done();
+        });
+      });
+    });
+
+    it('should confirm deletion and let you continue', done => {
       renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
         let updatedProfile = _.cloneDeep(USER_PROFILE_RESPONSE);
         updatedProfile.work_history.splice(0,1);
@@ -145,12 +212,20 @@ describe("UserPage", () => {
           getElementsByClassName('mdl-button')[1];
 
         listenForActions([
+          SET_DELETION_INDEX,
+          SET_SHOW_WORK_DELETE_DIALOG,
           START_PROFILE_EDIT,
           UPDATE_PROFILE_VALIDATION,
+          SET_SHOW_EDUCATION_DELETE_DIALOG,
+          SET_SHOW_WORK_DELETE_DIALOG,
+          SET_DELETION_INDEX,
           REQUEST_PATCH_USER_PROFILE,
           RECEIVE_PATCH_USER_PROFILE_SUCCESS,
         ], () => {
           TestUtils.Simulate.click(deleteButton);
+          let dialog = openDialog();
+          let button = dialog.getElementsByClassName('delete-button')[0];
+          TestUtils.Simulate.click(button);
         }).then(() => {
           done();
         });

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -16,6 +16,10 @@ import {
   SET_EDUCATION_DEGREE_INCLUSIONS,
 
   SET_USER_PAGE_DIALOG_VISIBILITY,
+
+  SET_SHOW_EDUCATION_DELETE_DIALOG,
+  SET_SHOW_WORK_DELETE_DIALOG,
+  SET_DELETION_INDEX,
 } from '../actions/ui';
 import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
 
@@ -34,6 +38,9 @@ export const INITIAL_UI_STATE = {
     [DOCTORATE]: false,
   },
   userPageDialogVisibility: false,
+  showWorkDeleteDialog: false,
+  showEducationDeleteDialog: false,
+  deletionIndex: null,
 };
 
 export const ui = (state = INITIAL_UI_STATE, action) => {
@@ -102,6 +109,21 @@ export const ui = (state = INITIAL_UI_STATE, action) => {
   case SET_USER_PAGE_DIALOG_VISIBILITY: {
     return Object.assign({}, state, {
       userPageDialogVisibility: action.payload
+    });
+  }
+  case SET_SHOW_EDUCATION_DELETE_DIALOG: {
+    return Object.assign({}, state, {
+      showEducationDeleteDialog: action.payload
+    });
+  }
+  case SET_SHOW_WORK_DELETE_DIALOG: {
+    return Object.assign({}, state, {
+      showWorkDeleteDialog: action.payload
+    });
+  }
+  case SET_DELETION_INDEX: {
+    return Object.assign({}, state, {
+      deletionIndex: action.payload
     });
   }
   default:

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -12,6 +12,9 @@ import {
   SET_EDUCATION_DEGREE_LEVEL,
   SET_EDUCATION_DEGREE_INCLUSIONS,
   SET_USER_PAGE_DIALOG_VISIBILITY,
+  SET_SHOW_EDUCATION_DELETE_DIALOG,
+  SET_SHOW_WORK_DELETE_DIALOG,
+  SET_DELETION_INDEX,
 
   clearUI,
   updateDialogText,
@@ -26,6 +29,9 @@ import {
   setEducationDegreeLevel,
   setEducationDegreeInclusions,
   setUserPageDialogVisibility,
+  setShowEducationDeleteDialog,
+  setShowWorkDeleteDialog,
+  setDeletionIndex,
 } from '../actions/ui';
 import { INITIAL_UI_STATE } from '../reducers/ui';
 import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
@@ -189,9 +195,38 @@ describe('ui reducers', () => {
   });
 
   describe('user page', () => {
-    it('should let you set the user page dialog visibility', done => {
-      dispatchThen(setUserPageDialogVisibility(true), [SET_USER_PAGE_DIALOG_VISIBILITY]).then(state => {
-        assert.deepEqual(state.userPageDialogVisibility, true);
+    [true, false].forEach(bool => {
+      it(`should let you set the user page dialog visibility to ${bool}`, done => {
+        dispatchThen(setUserPageDialogVisibility(bool), [SET_USER_PAGE_DIALOG_VISIBILITY]).then(state => {
+          assert.deepEqual(state.userPageDialogVisibility, bool);
+          done();
+        });
+      });
+    });
+  });
+
+  describe('confirm delete dialog', () => {
+    [true, false].forEach( bool => {
+      it(`should let you set to show the education delete dialog to ${bool}`, done => {
+        dispatchThen(setShowEducationDeleteDialog(bool), [SET_SHOW_EDUCATION_DELETE_DIALOG]).then(state => {
+          assert.deepEqual(state.showEducationDeleteDialog, bool);
+          done();
+        });
+      });
+    });
+
+    [true, false].forEach( bool => {
+      it(`should let you set to show the work delete dialog to ${bool}`, done => {
+        dispatchThen(setShowWorkDeleteDialog(bool), [SET_SHOW_WORK_DELETE_DIALOG]).then(state => {
+          assert.deepEqual(state.showWorkDeleteDialog, bool);
+          done();
+        });
+      });
+    });
+
+    it('should let you set a deletion index', done => {
+      dispatchThen(setDeletionIndex(3), [SET_DELETION_INDEX]).then(state => {
+        assert.deepEqual(state.deletionIndex, 3);
         done();
       });
     });

--- a/static/js/util/ProfileFormFields.js
+++ b/static/js/util/ProfileFormFields.js
@@ -66,4 +66,33 @@ export default class ProfileFormFields extends React.Component {
   static contextTypes = {
     router: React.PropTypes.object.isRequired
   };
+
+  static propTypes = {
+    setDeletionIndex:             React.PropTypes.func,
+    setShowWorkDeleteDialog:      React.PropTypes.func,
+    setShowEducationDeleteDialog: React.PropTypes.func,
+  };
+
+  closeConfirmDeleteDialog = () => {
+    const {
+      setDeletionIndex,
+      setShowEducationDeleteDialog,
+      setShowWorkDeleteDialog
+    } = this.props;
+    setShowEducationDeleteDialog(false);
+    setShowWorkDeleteDialog(false);
+    setDeletionIndex(null);
+  }
+
+  openEducationDeleteDialog  = index => {
+    const { setDeletionIndex, setShowEducationDeleteDialog } = this.props;
+    setDeletionIndex(index);
+    setShowEducationDeleteDialog(true);
+  }
+
+  openWorkDeleteDialog = index => {
+    const { setDeletionIndex, setShowWorkDeleteDialog } = this.props;
+    setDeletionIndex(index);
+    setShowWorkDeleteDialog(true);
+  }
 }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #439 

#### What's this PR do?

This adds a confirmation dialog that pops-up when clicking the 'delete'
icon for a work or education history entry. This entails some associated
reducers and actions, and a new class called `ConfirmDeletion` which
will, hopefully, be generally useful for this sort of thing.

#### Where should the reviewer start?

Most of the key stuff ends up being implemented as instance methods on
`ProfileFormFields` and `ProfileFormContainer`.

#### How should this be manually tested?

Make sure that any deletion action causes a confirmation dialog to appear, and make sure that the buttons ('yes' , 'no') do what they should.

This should work on `/users` and on `/profile`.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

![delete_education](https://cloud.githubusercontent.com/assets/6207644/15866440/9736e054-2cac-11e6-9f7f-95dcb7441d41.png)

#### What GIF best describes this PR or how it makes you feel?
