### PR TITLE
Removed python3-dev which points to a python 3.4 package

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -2,7 +2,6 @@
 git
 curl
 libpq-dev
-python3-dev
 libjpeg-dev
 zlib1g-dev
 net-tools


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #458 

#### What's this PR do?
When we installed python3-dev it pulled in python 3.4 dependencies. In the `python:3.5` image these are already installed so this PR gets rid of this step. Note that python2.7 is also installed but it's required by `lsb-release` which we probably don't want to get rid of

#### Where should the reviewer start?

#### How should this be manually tested?
The build should succeed

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

