### PR TITLE
Added validation for employment and education switches

### DIFF
--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -1,7 +1,4 @@
-import _ from 'lodash';
-
 import * as api from '../util/api';
-import * as validation from '../util/validation';
 
 // user profile actions
 export const REQUEST_GET_USER_PROFILE = 'REQUEST_GET_USER_PROFILE';
@@ -87,18 +84,6 @@ export const updateProfileValidation = (username, errors) => ({
   type: UPDATE_PROFILE_VALIDATION,
   payload: { errors, username }
 });
-
-export const validateProfile = (username, profile) => {
-  return dispatch => {
-    let errors = validation.validateProfile(profile);
-    dispatch(updateProfileValidation(username, errors));
-    if (_.isEmpty(errors)) {
-      return Promise.resolve();
-    } else {
-      return Promise.reject();
-    }
-  };
-};
 
 export function fetchUserProfile(username) {
   return dispatch => {

--- a/static/js/components/EducationDialog.js
+++ b/static/js/components/EducationDialog.js
@@ -5,7 +5,7 @@ import Dialog from 'material-ui/Dialog';
 
 import { HIGH_SCHOOL } from '../constants';
 import ProfileFormFields from '../util/ProfileFormFields';
-import { saveProfileStep } from '../util/profile_edit';
+import { educationValidation } from '../util/validation';
 
 export default class EducationDialog extends ProfileFormFields {
   constructor(props) {
@@ -36,7 +36,8 @@ export default class EducationDialog extends ProfileFormFields {
   };
 
   saveEducationForm = () => {
-    saveProfileStep.call(this).then(() => {
+    const { saveProfile, profile, ui } = this.props;
+    saveProfile(educationValidation, profile, ui).then(() => {
       this.clearEducationEdit();
     });
   };

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -111,6 +111,7 @@ class EducationForm extends ProfileFormFields {
   render() {
     let {
       profile,
+      errors,
       ui: {
         educationDegreeInclusions,
         showEducationDeleteDialog,
@@ -143,6 +144,13 @@ class EducationForm extends ProfileFormFields {
           </Cell>
         </Grid>
         {this.renderEducationLevel(level)}
+        <Grid className="profile-tab-grid">
+          <Cell col={12}>
+            <span className="validation-error-text-large">
+              {errors[`education_${level.value}_required`]}
+            </span>
+          </Cell>
+        </Grid>
       </Card>
     ));
     return (

--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -3,15 +3,21 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 
 import ProfileProgressControls from './ProfileProgressControls';
 import EducationForm from './EducationForm';
+import {
+  educationUiValidation,
+  educationValidation,
+  combineValidators,
+} from '../util/validation';
 
 class EducationTab extends React.Component {
   static propTypes = {
     saveProfile: React.PropTypes.func,
-    profile: React.PropTypes.object
+    profile: React.PropTypes.object,
+    ui: React.PropTypes.object
   };
   
   render() {
-    const { saveProfile, profile } = this.props;
+    const { saveProfile, profile, ui } = this.props;
     return <div>
       <Grid className="profile-splash">
         <Cell col={12}>
@@ -31,6 +37,8 @@ class EducationTab extends React.Component {
             nextUrl="/profile/professional"
             saveProfile={saveProfile}
             profile={profile}
+            ui={ui}
+            validator={combineValidators(educationValidation, educationUiValidation)}
           />
         </Cell>
         <Cell col={1} />

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -10,8 +10,8 @@ import IconButton from 'react-mdl/lib/IconButton';
 import _ from 'lodash';
 import moment from 'moment';
 
-import { saveProfileStep } from '../util/profile_edit';
 import { generateNewWorkHistory, userPrivilegeCheck } from '../util/util';
+import { employmentValidation } from '../util/validation';
 import ProfileFormFields from '../util/ProfileFormFields';
 import ConfirmDeletion from './ConfirmDeletion';
 
@@ -24,7 +24,8 @@ class EmploymentForm extends ProfileFormFields {
   }
 
   saveWorkHistoryEntry = () => {
-    saveProfileStep.call(this).then(() => {
+    const { saveProfile, profile, ui } = this.props;
+    saveProfile(employmentValidation, profile, ui).then(() => {
       this.closeWorkDialog();
     });
   }
@@ -56,10 +57,10 @@ class EmploymentForm extends ProfileFormFields {
   }
 
   deleteWorkHistoryEntry = () => {
-    const { saveProfile, profile, deletionIndex } = this.props;
+    const { saveProfile, profile, ui, deletionIndex } = this.props;
     let clone = _.cloneDeep(profile);
     clone['work_history'].splice(deletionIndex, 1);
-    saveProfile(clone);
+    saveProfile(employmentValidation, clone, ui);
   }
 
   editWorkHistoryForm () {
@@ -180,12 +181,13 @@ class EmploymentForm extends ProfileFormFields {
   }
 
   render () {
-    const { 
+    const {
       ui: {
         workHistoryEdit,
         workDialogVisibility,
         showWorkDeleteDialog,
-      }
+      },
+      errors,
     } = this.props;
     const actions = [
       <Button
@@ -238,6 +240,13 @@ class EmploymentForm extends ProfileFormFields {
             </Cell>
           </Grid>
           {this.renderWorkHistory()}
+          <Grid className="profile-tab-grid">
+            <Cell col={12}>
+              <span className="validation-error-text-large">
+                {errors.work_history_required}
+              </span>
+            </Cell>
+          </Grid>
         </Card>
       </div>
     );

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -3,15 +3,21 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 
 import EmploymentForm from './EmploymentForm';
 import ProfileProgressControls from './ProfileProgressControls';
+import {
+  employmentValidation,
+  employmentUiValidation,
+  combineValidators,
+} from '../util/validation';
 
 class EmploymentTab extends React.Component {
   static propTypes = {
     saveProfile: React.PropTypes.func,
-    profile: React.PropTypes.object
+    profile: React.PropTypes.object,
+    ui: React.PropTypes.object
   };
 
   render () {
-    const { saveProfile, profile } = this.props;
+    const { saveProfile, profile, ui } = this.props;
     return (
       <div>
         <Grid className="profile-splash">
@@ -32,6 +38,8 @@ class EmploymentTab extends React.Component {
               nextUrl="/profile/privacy"
               saveProfile={saveProfile}
               profile={profile}
+              ui={ui}
+              validator={combineValidators(employmentValidation, employmentUiValidation)}
             />
           </Cell>
           <Cell col={1}></Cell>

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -3,6 +3,7 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 
 import PersonalForm from './PersonalForm';
 import ProfileProgressControls from './ProfileProgressControls';
+import { personalValidation } from '../util/validation';
 
 class PersonalTab extends React.Component {
   static propTypes = {
@@ -10,10 +11,11 @@ class PersonalTab extends React.Component {
     errors:         React.PropTypes.object,
     saveProfile:    React.PropTypes.func,
     updateProfile:  React.PropTypes.func,
+    ui:             React.PropTypes.object
   };
 
   render() {
-    const { saveProfile, profile } = this.props;
+    const { saveProfile, profile, ui } = this.props;
     return <div>
       <Grid className="profile-splash">
         <Cell col={12}>
@@ -33,6 +35,8 @@ class PersonalTab extends React.Component {
             nextUrl="/profile/education"
             profile={profile}
             saveProfile={saveProfile}
+            ui={ui}
+            validator={personalValidation}
           />
         </Cell>
         <Cell col={1} />

--- a/static/js/components/PrivacyTab.js
+++ b/static/js/components/PrivacyTab.js
@@ -3,16 +3,26 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 
 import ProfileProgressControls from './ProfileProgressControls';
 import ProfileFormFields from '../util/ProfileFormFields';
+import {
+  combineValidators,
+  personalValidation,
+  educationValidation,
+  educationUiValidation,
+  employmentValidation,
+  employmentUiValidation,
+  privacyValidation,
+} from '../util/validation';
 
 class PrivacyTab extends ProfileFormFields {
   static propTypes = {
     profile:        React.PropTypes.object,
     saveProfile:    React.PropTypes.func,
-    updateProfile:  React.PropTypes.func
+    updateProfile:  React.PropTypes.func,
+    ui:             React.PropTypes.object
   };
 
   render() {
-    const { saveProfile, profile } = this.props;
+    const { saveProfile, profile, ui } = this.props;
     return (
       <div>
         <Grid className="profile-splash">
@@ -32,6 +42,17 @@ class PrivacyTab extends ProfileFormFields {
               isLastTab={true}
               saveProfile={saveProfile}
               profile={profile}
+              ui={ui}
+              validator={
+                combineValidators(
+                  personalValidation,
+                  educationValidation,
+                  educationUiValidation,
+                  employmentValidation,
+                  employmentUiValidation,
+                  privacyValidation
+                )
+              }
             />
           </Cell>
         </Grid>

--- a/static/js/components/ProfileProgressControls.js
+++ b/static/js/components/ProfileProgressControls.js
@@ -9,7 +9,9 @@ export default class ProfileProgressControls extends React.Component {
     prevUrl: React.PropTypes.string,
     isLastTab: React.PropTypes.bool,
     saveProfile: React.PropTypes.func.isRequired,
-    profile: React.PropTypes.object.isRequired
+    profile: React.PropTypes.object.isRequired,
+    ui: React.PropTypes.object.isRequired,
+    validator: React.PropTypes.func.isRequired
   };
 
   stepBack = () => {
@@ -18,8 +20,8 @@ export default class ProfileProgressControls extends React.Component {
   };
 
   saveAndContinue = () => {
-    const { nextUrl, isLastTab } = this.props;
-    saveProfileStep.call(this, isLastTab).then(() => {
+    const { nextUrl, isLastTab, validator } = this.props;
+    saveProfileStep.call(this, validator, isLastTab).then(() => {
       this.context.router.push(nextUrl);
     });
   };

--- a/static/js/components/UserPagePersonalDialog.js
+++ b/static/js/components/UserPagePersonalDialog.js
@@ -2,13 +2,15 @@ import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import Button from 'react-mdl/lib/Button';
 
-import { saveProfileStep } from '../util/profile_edit';
+import { personalValidation } from '../util/validation';
 import PersonalForm from './PersonalForm';
 
 export default class UserPagePersonalDialog extends React.Component {
   static propTypes = {
     setUserPageDialogVisibility:  React.PropTypes.func,
     ui:                           React.PropTypes.object,
+    profile:                      React.PropTypes.object,
+    saveProfile:                  React.PropTypes.func,
     clearProfileEdit:             React.PropTypes.func,
   };
 
@@ -19,7 +21,8 @@ export default class UserPagePersonalDialog extends React.Component {
   };
 
   savePersonalInfo = () => {
-    saveProfileStep.call(this).then(() => {
+    const { profile, ui, saveProfile } = this.props;
+    saveProfile(personalValidation, profile, ui).then(() => {
       this.closePersonalDialog();
     });
   };

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -1,10 +1,11 @@
 /* global SETTINGS: false */
 import React from 'react';
+import _ from 'lodash';
 
 import {
   startProfileEdit,
   updateProfile,
-  validateProfile,
+  updateProfileValidation,
   clearProfileEdit,
   fetchUserProfile,
   saveProfile,
@@ -121,7 +122,7 @@ class ProfileFormContainer extends React.Component {
     dispatch(setEducationDegreeInclusions(inclusions));
   }
 
-  saveProfile(isEdit, profile) {
+  saveProfile(isEdit, validator, profile, ui) {
     const { dispatch } = this.props;
     const username = SETTINGS.username;
 
@@ -129,11 +130,15 @@ class ProfileFormContainer extends React.Component {
       // Validation errors will only show up if we start the edit
       dispatch(startProfileEdit(username));
     }
-    return dispatch(validateProfile(username, profile)).then(() => {
+    let errors = validator(profile, ui);
+    dispatch(updateProfileValidation(username, errors));
+    if (_.isEmpty(errors)) {
       return dispatch(saveProfile(username, profile)).then(() => {
         dispatch(clearProfileEdit(username));
       });
-    });
+    } else {
+      return Promise.reject(errors);
+    }
   }
 
   childrenWithProps = profileFromStore => {

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -1,5 +1,4 @@
 /* global SETTINGS: false */
-import '../global_init';
 import TestUtils from 'react-addons-test-utils';
 import assert from 'assert';
 
@@ -7,11 +6,18 @@ import {
   REQUEST_PATCH_USER_PROFILE,
   RECEIVE_PATCH_USER_PROFILE_SUCCESS,
   START_PROFILE_EDIT,
-  UPDATE_PROFILE_VALIDATION
+  UPDATE_PROFILE_VALIDATION,
+
+  receiveGetUserProfileSuccess,
 } from '../actions';
-import { USER_PROFILE_RESPONSE } from '../constants';
+import {
+  setEducationDegreeInclusions,
+  setWorkHistoryEdit,
+} from '../actions/ui';
+import { USER_PROFILE_RESPONSE, EDUCATION_LEVELS } from '../constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
 import * as api from '../util/api';
+import { HIGH_SCHOOL } from '../constants';
 
 describe("ProfilePage", function() {
   this.timeout(5000);  // eslint-disable-line no-invalid-this
@@ -26,6 +32,10 @@ describe("ProfilePage", function() {
   let lastPage = pageUrlStubs[pageUrlStubs.length - 1];
   let prevButtonSelector = '.progress-button.previous';
   let nextButtonSelector = '.progress-button.next';
+  let noInclusions = {};
+  for (const { value } of EDUCATION_LEVELS) {
+    noInclusions[value] = false;
+  }
 
   beforeEach(() => {
     helper = new IntegrationTestHelper();
@@ -38,17 +48,24 @@ describe("ProfilePage", function() {
     helper.cleanup();
   });
 
-  let confirmSaveButtonBehavior = (updatedProfile, pageElements) => {
+  let confirmSaveButtonBehavior = (updatedProfile, pageElements, validationFailure=false) => {
     let { div, button } = pageElements;
     button = button || div.querySelector(nextButtonSelector);
     patchUserProfileStub.throws("Invalid arguments");
     patchUserProfileStub.withArgs(SETTINGS.username, updatedProfile).returns(Promise.resolve(updatedProfile));
-    return listenForActions([
-      REQUEST_PATCH_USER_PROFILE,
-      RECEIVE_PATCH_USER_PROFILE_SUCCESS,
+
+    let actions = [];
+    if (!validationFailure) {
+      actions.push(
+        REQUEST_PATCH_USER_PROFILE,
+        RECEIVE_PATCH_USER_PROFILE_SUCCESS,
+      );
+    }
+    actions.push(
       START_PROFILE_EDIT,
       UPDATE_PROFILE_VALIDATION
-    ], () => {
+    );
+    return listenForActions(actions, () => {
       TestUtils.Simulate.click(button);
     });
   };
@@ -66,13 +83,106 @@ describe("ProfilePage", function() {
 
   it(`marks email_optin and filled_out when saving ${lastPage}`, done => {
     renderComponent(lastPage).then(([, div]) => {
+      // close all switches and remove all education so we don't get validation errors
+      let receivedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+        education: []
+      });
+      helper.store.dispatch(receiveGetUserProfileSuccess(SETTINGS.username, receivedProfile));
+      helper.store.dispatch(setEducationDegreeInclusions(noInclusions));
+
       let button = div.querySelector(nextButtonSelector);
       assert(button.innerHTML.includes("I'm Done!"));
-      let updatedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+      let updatedProfile = Object.assign({}, receivedProfile, {
         email_optin: true,
         filled_out: true
       });
+
       confirmSaveButtonBehavior(updatedProfile, {button: button}).then(() => {
+        done();
+      });
+    });
+  });
+
+  it("validates education switches on the education page", done => {
+    renderComponent('/profile/education').then(([, div]) => {
+      // close all switches and remove all education so we don't get validation errors
+      let receivedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+        education: []
+      });
+      helper.store.dispatch(receiveGetUserProfileSuccess(SETTINGS.username, receivedProfile));
+      helper.store.dispatch(setEducationDegreeInclusions(
+        Object.assign({}, noInclusions, {
+          [HIGH_SCHOOL]: true
+        })
+      ));
+      helper.store.dispatch(setWorkHistoryEdit(true));
+
+      let button = div.querySelector(nextButtonSelector);
+      assert(button.innerHTML.includes("Save and Continue"));
+      let updatedProfile = Object.assign({}, receivedProfile, {
+        email_optin: true,
+        filled_out: true
+      });
+
+      confirmSaveButtonBehavior(updatedProfile, {button: button}, true).then(state => {
+        assert.deepEqual(state.profiles[SETTINGS.username].edit.errors, {
+          [`education_${HIGH_SCHOOL}_required`]: `High school is required if switch is set`
+        });
+        done();
+      });
+    });
+  });
+
+  it(`validates employment switches when saving the employment page`, done => {
+    renderComponent('/profile/professional').then(([, div]) => {
+      // close all switches and remove all education so we don't get validation errors
+      let receivedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+        work_history: []
+      });
+      helper.store.dispatch(receiveGetUserProfileSuccess(SETTINGS.username, receivedProfile));
+      helper.store.dispatch(setWorkHistoryEdit(true));
+
+      let button = div.querySelector(nextButtonSelector);
+      assert(button.innerHTML.includes("Save and Continue"));
+      let updatedProfile = Object.assign({}, receivedProfile, {
+        email_optin: true,
+        filled_out: true
+      });
+
+      confirmSaveButtonBehavior(updatedProfile, {button: button}, true).then(state => {
+        assert.deepEqual(state.profiles[SETTINGS.username].edit.errors, {
+          work_history_required: "Work history is required if switch is set"
+        });
+        done();
+      });
+    });
+  });
+
+  it(`validates education and employment switches when saving the ${lastPage}`, done => {
+    renderComponent(lastPage).then(([, div]) => {
+      // close all switches and remove all education so we don't get validation errors
+      let receivedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+        education: [],
+        work_history: []
+      });
+      helper.store.dispatch(receiveGetUserProfileSuccess(SETTINGS.username, receivedProfile));
+      helper.store.dispatch(setEducationDegreeInclusions({
+        [HIGH_SCHOOL]: true
+      }));
+      helper.store.dispatch(setWorkHistoryEdit(true));
+
+      let button = div.querySelector(nextButtonSelector);
+      assert(button.innerHTML.includes("I'm Done!"));
+      let updatedProfile = Object.assign({}, receivedProfile, {
+        email_optin: true,
+        filled_out: true
+      });
+
+      confirmSaveButtonBehavior(updatedProfile, {button: button}, true).then(state => {
+        assert.deepEqual(state.profiles[SETTINGS.username].edit.errors, {
+          [`education_${HIGH_SCHOOL}_required`]: `High school is required if switch is set`,
+          work_history_required: "Work history is required if switch is set"
+        });
         done();
       });
     });
@@ -81,9 +191,14 @@ describe("ProfilePage", function() {
   for (let pageUrlStub of pageUrlStubs.slice(0,3)) {
     for (let filledOutValue of [true, false]) {
       it(`respects the current value (${filledOutValue}) when saving on ${pageUrlStub}`, done => {
-        let updatedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {filled_out: filledOutValue});
+        let updatedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+          filled_out: filledOutValue,
+          education: []
+        });
         helper.profileGetStub.returns(Promise.resolve(updatedProfile));
         renderComponent(pageUrlStub).then(([, div]) => {
+          // close all switches
+          helper.store.dispatch(setEducationDegreeInclusions(noInclusions));
           confirmSaveButtonBehavior(updatedProfile, {div: div}).then(() => {
             done();
           });

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -1,6 +1,4 @@
 /* global SETTINGS: false */
-import _ from 'lodash';
-
 import {
   fetchUserProfile,
   receiveGetUserProfileSuccess,
@@ -8,7 +6,6 @@ import {
   saveProfile,
   updateProfile,
   updateProfileValidation,
-  validateProfile,
   startProfileEdit,
   clearProfileEdit,
   REQUEST_GET_USER_PROFILE,
@@ -192,62 +189,50 @@ describe('reducers', () => {
       store.dispatch(startProfileEdit('jane'));
 
       dispatchThen(
-        validateProfile('jane', USER_PROFILE_RESPONSE),
+        updateProfileValidation('jane', {}),
         [UPDATE_PROFILE_VALIDATION]
       ).then(profileState => {
         assert.deepEqual(profileState['jane'].edit.errors, {});
-
-        // also assert that it returns a resolved promise
-        store.dispatch(validateProfile('jane', USER_PROFILE_RESPONSE)).then(() => {
-          done();
-        });
+        done();
       });
     });
 
     it('should validate an existing profile with validation errors', done => {
-      let profileWithError = Object.assign({}, USER_PROFILE_RESPONSE, {
-        first_name: ''
-      });
-
       // populate a profile
       store.dispatch(receiveGetUserProfileSuccess('jane', USER_PROFILE_RESPONSE));
       store.dispatch(startProfileEdit('jane'));
+      let errors = {
+        first_name: "Given name is required"
+      };
       dispatchThen(
-        validateProfile('jane',profileWithError),
+        updateProfileValidation('jane', errors),
         [UPDATE_PROFILE_VALIDATION]
       ).then(profileState => {
-        assert.deepEqual(profileState['jane'].edit.errors, {
-          first_name: 'Given name is required'
-        });
+        assert.deepEqual(profileState['jane'].edit.errors, errors);
 
-        // also assert that it returns a rejected promise
-        store.dispatch(validateProfile('jane', profileWithError)).catch(() => {
-          done();
-        });
+        done();
       });
     });
 
     it('should validate a profile with nested objects and errors', done => {
-      let profileWithError = _.cloneDeep(USER_PROFILE_RESPONSE);
-      profileWithError.work_history[0].position = undefined;
+      let errors = {
+        work_history: [
+          {
+            position: 'Position is required'
+          }
+        ]
+      };
 
       // populate a profile
       store.dispatch(receiveGetUserProfileSuccess('jane', USER_PROFILE_RESPONSE));
       store.dispatch(startProfileEdit('jane'));
       dispatchThen(
-        validateProfile('jane', profileWithError),
+        updateProfileValidation('jane', errors),
         [UPDATE_PROFILE_VALIDATION]
       ).then(profileState => {
-        assert.deepEqual(profileState['jane'].edit.errors, {
-          work_history: [
-            {position: 'Position is required'}
-          ]
-        });
+        assert.deepEqual(profileState['jane'].edit.errors, errors);
 
-        // also assert that it returns a rejected promise
-        store.dispatch(validateProfile('jane', profileWithError)).catch(() => {
-          done();
-        });
+        done();
       });
     });
 

--- a/static/js/util/editEducation.js
+++ b/static/js/util/editEducation.js
@@ -1,5 +1,7 @@
 import _ from 'lodash';
+
 import { generateNewEducation } from "../util/util";
+import { educationValidation } from '../util/validation';
 
 export function openEditEducationForm(index) {
   const {
@@ -37,10 +39,10 @@ export function openNewEducationForm(level, index) {
 }
 
 export function deleteEducationEntry () {
-  const { saveProfile, profile, deletionIndex } = this.props;
+  const { saveProfile, profile, ui, deletionIndex } = this.props;
   let clone = _.cloneDeep(profile);
   clone['education'].splice(deletionIndex, 1);
-  saveProfile(clone);
+  saveProfile(educationValidation, clone, ui);
 }
 
 

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -439,13 +439,15 @@ export function boundDateField(keySet, label, omitDay) {
 }
 
 /**
- * Saves the profile and returns a promise, taking an optional function
- * to retrieve keys for validation of nested fields (e.g. profile.work_history)
+ * Validates the profile then PATCHes the profile if validation succeeded.
  *
+ * @param validator {func} The function used to validate profile
  * @param isLastStep {bool} If true, this is the last tab in the profile
+ * @returns {Promise} A promise which resolves with the new profile if validation and PATCH succeeded,
+ * or rejects if either failed
  */
-export function saveProfileStep(isLastStep=false) {
-  const { saveProfile, profile } = this.props;
+export function saveProfileStep(validator, isLastStep=false) {
+  const { saveProfile, profile, ui } = this.props;
   let clone = Object.assign({}, profile, {
     filled_out: profile.filled_out || isLastStep
   });
@@ -453,5 +455,5 @@ export function saveProfileStep(isLastStep=false) {
     // user has also seen email consent message at this point
     clone.email_optin = true;
   }
-  return saveProfile(clone);
+  return saveProfile(validator, clone, ui);
 }

--- a/static/js/util/profile_edit_test.js
+++ b/static/js/util/profile_edit_test.js
@@ -38,7 +38,8 @@ describe('Profile Editing utility functions', () => {
           "date_field": "Date field is required",
           "account_privacy": "Account privacy is required"
         },
-        updateProfile: change
+        updateProfile: change,
+        ui: {}
       }
     };
     sandbox = sinon.sandbox.create();
@@ -673,7 +674,8 @@ describe('Profile Editing utility functions', () => {
     });
 
     it('saves with finalStep as true', () => {
-      let ret = saveProfileStep.call(that, true);
+      let func = () => null;
+      let ret = saveProfileStep.call(that, func, true);
 
       let clone = Object.assign({}, that.props.profile, {
         filled_out: true,
@@ -681,7 +683,9 @@ describe('Profile Editing utility functions', () => {
       });
 
       assert.ok(that.props.saveProfile.calledWith(
+        func,
         clone,
+        that.props.ui,
       ));
       assert.equal(ret, saveProfileReturnValue);
     });

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -1,6 +1,10 @@
 c.validation-wrapper {
   padding-bottom: 10px;
 }
+.validation-error-text-large {
+  color: #DA0000;
+  font-size: large;
+}
 .validation-error-text {
   color: #DA0000;
   font-size: smaller;


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #433 
Rebased on #508 

#### What's this PR do?
Adds validation for switches for education and employment, so that a validation error will be produced if:
 - the switch is on but there is nothing in the card
 - the switch is off but there's something in the card

#### Where should the reviewer start?
static/js/util/validation.js

#### How should this be manually tested?
In the profile pages, start at personal and go forward to the education tab. You should not get a validation error on the personal page. In the education page leave some cards blank and go forward. For all cards which are blank you should see a red validation error which has the label of the card within it. If you turn off a card or add an item to another card and continue, the validation error should go away.

Go back to the education page and add an item to one of the cards if necessary. Close the tab and click 'Save and Continue'. You should see a validation error.

For the employment tab, make it blank but have the switch turned on. When you proceed you should see a validation error. Add an item, turn the switch off, and click 'Save and Continue'. You should see a different validation error.

Also check that the user page functions exactly as it did before.

