### PR TITLE
Removed singleTest command

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,6 @@ Tests should be run in the Docker container, not the host machine. They can be r
     # run the JS tests without coverage report
     docker-compose run watch npm test
     # run a single JS test file
-    docker-compose run watch npm run-script singleTest /path/to/test.js
+    docker-compose run watch npm test /path/to/test.js
     # Run the JS linter
     docker-compose run watch npm run-script lint

--- a/js_test.sh
+++ b/js_test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euf -o pipefail
+
+node ./node_modules/mocha/bin/_mocha --compilers js:babel-register --require static/js/global_init.js ${1:-'static/**/*/*_test.js'}
+

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
   "scripts": {
     "postinstall": "./webpack_if_prod.sh",
     "lint": "node ./node_modules/eslint/bin/eslint.js ./static/js",
-    "test": "node ./node_modules/mocha/bin/_mocha --compilers js:babel-register --require static/js/global_init.js 'static/**/*/*_test.js'",
-    "singleTest": "node ./node_modules/mocha/bin/_mocha --compilers js:babel-register --require static/js/global_init.js $1",
+    "test": "./js_test.sh",
     "coverage": "node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- --compilers js:babel-register --require static/js/global_init.js 'static/**/*/*_test.js'"
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?

#### What's this PR do?
Removes `singleTest` script from package.json and moves the test command into a separate script `js_test.sh`. This allows the user to run `npm test` to run all JS tests or `npm test ./static/js/...` for a single file.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?
It looks like parameter substitutions like `$1` don't work in `package.json`. It ignores them and appends all parameters to the end of the line instead, so we can't do the fancy bash default parameters inside `package.json`, it has to go in a separate file.

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

