### PR TITLE
Added check to only show edit buttons for a user's own profile

### DIFF
--- a/static/js/components/User.js
+++ b/static/js/components/User.js
@@ -8,6 +8,7 @@ import { makeProfileImageUrl } from '../util/util';
 import EmploymentForm from './EmploymentForm';
 import EducationForm from './EducationForm';
 import UserPagePersonalDialog from './UserPagePersonalDialog.js';
+import { userPrivilegeCheck } from '../util/util';
 
 export default class User extends React.Component {
   static propTypes = {
@@ -62,7 +63,7 @@ export default class User extends React.Component {
           { profile.city }, { getStateName() }
         </span>
         <CardMenu>
-          <IconButton name="edit" onClick={this.toggleShowPersonalDialog}/>
+          {userPrivilegeCheck(profile, () => <IconButton name="edit" onClick={this.toggleShowPersonalDialog}/>)}
         </CardMenu>
       </Card>
 

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ga from 'react-ga';
 import striptags from 'striptags';
+import _ from 'lodash';
 
 export function sendGoogleAnalyticsEvent(category, action, label, value) {
   let event = {
@@ -16,6 +17,13 @@ export function sendGoogleAnalyticsEvent(category, action, label, value) {
   ga.event(event);
 }
 
+export function userPrivilegeCheck (profile, privileged, unPrivileged) {
+  if ( profile.username === SETTINGS.username ) {
+    return _.isFunction(privileged) ? privileged() : privileged;
+  } else {
+    return _.isFunction(unPrivileged) ? unPrivileged() : unPrivileged;
+  }
+}
 
 export function makeProfileProgressDisplay(active) {
   const width = 750, height = 100, radius = 20, paddingX = 40, paddingY = 5;

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -9,6 +9,7 @@ import {
   generateNewWorkHistory,
   getPreferredName,
   makeProfileProgressDisplay,
+  userPrivilegeCheck,
 } from '../util/util';
 
 /* eslint-disable camelcase */
@@ -124,6 +125,34 @@ describe('utility functions', () => {
           );
         }
       }
+    });
+  });
+
+  describe('User privilege check', () => {
+    it('should return the value of the first function if the profile username matches', () => {
+      let profile = { username: SETTINGS.username };
+      let privilegedCallback = () => "hi";
+      assert.equal(userPrivilegeCheck(profile, privilegedCallback), "hi");
+    });
+
+    it('should return the second argument if the profile username matches', () => {
+      let profile = { username: SETTINGS.username };
+      let privilegedString = "hi";
+      assert.equal(userPrivilegeCheck(profile, privilegedString), "hi");
+    });
+
+    it('should return the value of the second function if the profile username does not match', () => {
+      let profile = { username: "another_user" };
+      let privilegedCallback = () => "vim";
+      let unprivilegedCallback = () => "emacs";
+      assert.equal(userPrivilegeCheck(profile, privilegedCallback, unprivilegedCallback), "emacs");
+    });
+
+    it('should return the value of the second argument if the profile username does not match', () => {
+      let profile = { username: "another_user" };
+      let privilegedCallback = () => "vim";
+      let unprivilegedString = "emacs";
+      assert.equal(userPrivilegeCheck(profile, privilegedCallback, unprivilegedString), "emacs");
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?

closes #415 

#### What's this PR do?

This adds a little utility function called `userPrivilegeCheck`, which
basically just checks that the username on the profile in question is
the same as `SETTINGS.username`. We pass a callback in to
`userPrivilegeCheck`, and `userPrivilegeCheck` returns the value of
executing that callback if the usernames match, else it returns an
optional second argument or, if that isn't provided, it returns
undefined.

#### Where should the reviewer start?

#### How should this be manually tested?

Make another profile on your dev box. Check two things:

- you should see edit icons on your own profile, and be able to edit normally
- you shouldn't see any edit icons on another user's profile

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

