### PR TITLE
Used level of attainment from edX to set default switch values

### DIFF
--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -237,3 +237,12 @@ export const ISO_8601_FORMAT = 'YYYY-MM-DD';
 export const DASHBOARD_COURSE_HEIGHT = 70;
 export const TERMS_CARD_ROW_HEIGHT = 70;
 export const DASHBOARD_RUN_HEIGHT = 40;
+
+// NOTE: this is in order of attainment
+export const EDUCATION_LEVELS = [
+  {value: HIGH_SCHOOL, label: "High school"},
+  {value: ASSOCIATE, label: 'Associate degree'},
+  {value: BACHELORS, label: "Bachelor's degree"},
+  {value: MASTERS, label: "Master's or professional degree"},
+  {value: DOCTORATE, label: "Doctorate"}
+];

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -1,3 +1,5 @@
+/* global SETTINGS: false */
+import { RECEIVE_GET_USER_PROFILE_SUCCESS } from '../actions';
 import {
   CLEAR_UI,
   UPDATE_DIALOG_TEXT,
@@ -22,6 +24,7 @@ import {
   SET_DELETION_INDEX,
 } from '../actions/ui';
 import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
+import { calculateDegreeInclusions } from '../util/util';
 
 export const INITIAL_UI_STATE = {
   workHistoryEdit:            true,
@@ -30,10 +33,10 @@ export const INITIAL_UI_STATE = {
   educationDialogVisibility:  false,
   educationDialogIndex:       null,
   educationDegreeLevel:       '',
-  educationDegreeInclusions:  {
-    [HIGH_SCHOOL]: true,
-    [ASSOCIATE]: true,
-    [BACHELORS]: true,
+  educationDegreeInclusions: {
+    [HIGH_SCHOOL]: false,
+    [ASSOCIATE]: false,
+    [BACHELORS]: false,
     [MASTERS]: false,
     [DOCTORATE]: false,
   },
@@ -125,6 +128,15 @@ export const ui = (state = INITIAL_UI_STATE, action) => {
     return Object.assign({}, state, {
       deletionIndex: action.payload
     });
+  }
+  case RECEIVE_GET_USER_PROFILE_SUCCESS: {
+    const { profile, username } = action.payload;
+    if (SETTINGS.username === username) {
+      return Object.assign({}, state, {
+        educationDegreeInclusions: calculateDegreeInclusions(profile)
+      });
+    }
+    return state;
   }
   default:
     return state;

--- a/static/js/util/ProfileFormFields.js
+++ b/static/js/util/ProfileFormFields.js
@@ -9,7 +9,7 @@ import {
   boundStateSelectField,
   boundRadioGroupField,
 } from './profile_edit';
-import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
+import { EDUCATION_LEVELS } from '../constants';
 import LANGUAGE_CODES from '../language_codes';
 import INDUSTRIES from '../industries';
 import iso3166 from 'iso-3166-2';
@@ -50,13 +50,7 @@ export default class ProfileFormFields extends React.Component {
       { value: 'private', label: 'Private', helper: `Your MicroMaster’s profile will only 
         be visible to MIT faculty and staff.` }
     ];
-    this.educationLevelOptions = [
-      {value: HIGH_SCHOOL, label: "High school"},
-      {value: ASSOCIATE, label: 'Associate degree'},
-      {value: BACHELORS, label: "Bachelor's degree"},
-      {value: MASTERS, label: "Master's or professional degree"},
-      {value: DOCTORATE, label: "Doctorate"}
-    ];
+    this.educationLevelOptions = EDUCATION_LEVELS;
     this.industryOptions = INDUSTRIES.map(industry => ({
       value: industry,
       label: industry

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -5,6 +5,8 @@ import ga from 'react-ga';
 import striptags from 'striptags';
 import _ from 'lodash';
 
+import { EDUCATION_LEVELS } from '../constants';
+
 export function sendGoogleAnalyticsEvent(category, action, label, value) {
   let event = {
     category: category,
@@ -220,4 +222,24 @@ export function makeProfileImageUrl(profile) {
  */
 export function getPreferredName(profile) {
   return profile.preferred_name || SETTINGS.name || SETTINGS.username;
+}
+
+export function calculateDegreeInclusions(profile) {
+  let highestLevelFound = false;
+  let inclusions = {};
+  for (const { value } of EDUCATION_LEVELS) {
+    inclusions[value] = highestLevelFound ? false : true;
+    if (value === profile.edx_level_of_education) {
+      // every level after this point is higher than the user has attained according to edx
+      highestLevelFound = true;
+    }
+  }
+
+  // turn on all switches where the user has data
+  for (const { value } of EDUCATION_LEVELS) {
+    if (profile.education.filter(education => education.degree_name === value).length > 0) {
+      inclusions[value] = true;
+    }
+  }
+  return inclusions;
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #507 

#### What's this PR do?
Populates switches with the level of attainment from edX. If none is found all switches are on by default.

#### Where should the reviewer start?
static/js/util/util.js

#### How should this be manually tested?
Log in, go to `/profile`, navigate to the education, then verify that the switches are:
 - always on if there is one or more education items in the card, regardless of anything else, or
 - all on if no edx_level_of_education is set in the profile, or
 - on only if the level of education is less or equal to the card's level of education

You should be able to change the level in the profile model and refresh to see the different states.

#### Any background context you want to provide?


#### Screenshots (if appropriate)


#### What GIF best describes this PR or how it makes you feel?

