### PR TITLE
Collapse education on `/users/`

### DIFF
--- a/static/js/components/EducationDialog.js
+++ b/static/js/components/EducationDialog.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import Button from 'react-mdl/lib/Button';
+import Grid, { Cell } from 'react-mdl/lib/Grid';
+import Dialog from 'material-ui/Dialog';
+
+import { HIGH_SCHOOL } from '../constants';
+import ProfileFormFields from '../util/ProfileFormFields';
+import { saveProfileStep } from '../util/profile_edit';
+
+export default class EducationDialog extends ProfileFormFields {
+  constructor(props) {
+    super(props);
+    this.educationLevelLabels = {};
+    this.educationLevelOptions.forEach(level => {
+      this.educationLevelLabels[level.value] = level.label;
+    });
+  }
+
+  static propTypes = {
+    open:     React.PropTypes.bool,
+    onClose:  React.PropTypes.func,
+    onSave:   React.PropTypes.func,
+  };
+
+  clearEducationEdit = () => {
+    const {
+      setEducationDialogVisibility,
+      setEducationDegreeLevel,
+      setEducationDialogIndex,
+      clearProfileEdit,
+    } = this.props;
+    setEducationDialogVisibility(false);
+    setEducationDegreeLevel('');
+    setEducationDialogIndex(null);
+    clearProfileEdit();
+  };
+
+  saveEducationForm = () => {
+    saveProfileStep.call(this).then(() => {
+      this.clearEducationEdit();
+    });
+  };
+
+  editEducationForm = level => {
+    const { ui: { educationDialogIndex } } = this.props;
+
+    let keySet = (key) => ['education', educationDialogIndex, key];
+
+    let fieldOfStudy, highSchoolPadding;
+    if (level !== HIGH_SCHOOL) {
+      fieldOfStudy = <Cell col={6}>
+        {this.boundTextField(keySet('field_of_study'), 'Field of Study')}
+      </Cell>;
+    } else {
+      highSchoolPadding = <Cell col={6} />;
+    }
+
+    return <Grid className="profile-tab-grid">
+      <Cell col={12} className="profile-form-title">
+        {this.educationLevelLabels[level]}
+      </Cell>
+      {fieldOfStudy}
+      <Cell col={6}>
+        {this.boundDateField(keySet('graduation_date'), 'Graduation Date', true)}
+      </Cell>
+      {highSchoolPadding}
+      <Cell col={6}>
+        {this.boundTextField(keySet('school_name'), 'School Name')}
+      </Cell>
+      <Cell col={6}>
+      </Cell>
+      <Cell col={4}>
+        {this.boundCountrySelectField(
+          keySet('school_state_or_territory'),
+          keySet('school_country'),
+          'Country'
+        )}
+      </Cell>
+      <Cell col={4}>
+        {this.boundStateSelectField(
+          keySet('school_state_or_territory'),
+          keySet('school_country'),
+          'State'
+        )}
+      </Cell>
+      <Cell col={4} key="school_city">
+        {this.boundTextField(keySet('school_city'), 'City')}
+      </Cell>
+    </Grid>;
+  };
+
+  render () {
+    const {
+      ui: {
+        educationDialogVisibility,
+        educationDegreeLevel,
+      }
+    } = this.props;
+
+    let actions = [
+      <Button
+        type='button'
+        key='cancel'
+        className="cancel-button"
+        onClick={this.clearEducationEdit}>
+        Cancel
+      </Button>,
+      <Button
+        key='save'
+        type='button'
+        className="save-button"
+        onClick={this.saveEducationForm}>
+        Save
+      </Button>,
+    ];
+
+    return (
+      <Dialog
+        open={educationDialogVisibility}
+        className="dashboard-dialog"
+        onRequestClose={this.clearEducationEdit}
+        actions={actions}
+        autoScrollBodyContent={true}
+      >
+        {this.editEducationForm(educationDegreeLevel)}
+      </Dialog>
+    );
+  }
+}
+

--- a/static/js/components/EducationDisplay.js
+++ b/static/js/components/EducationDisplay.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import IconButton from 'react-mdl/lib/IconButton';
+
+import Grid, { Cell } from 'react-mdl/lib/Grid';
+import FABButton from 'react-mdl/lib/FABButton';
+import Icon from 'react-mdl/lib/Icon';
+import { Card } from 'react-mdl/lib/Card';
+import Menu from 'react-mdl/lib/Menu';
+import { MenuItem } from 'react-mdl/lib/Menu';
+import _ from 'lodash';
+import moment from 'moment';
+
+import ProfileFormFields from '../util/ProfileFormFields';
+import ConfirmDeletion from './ConfirmDeletion';
+import EducationDialog from './EducationDialog';
+import {
+  openEditEducationForm,
+  openNewEducationForm,
+  deleteEducationEntry,
+} from '../util/editEducation';
+import { userPrivilegeCheck } from '../util/util';
+
+export default class EducationDisplay extends ProfileFormFields {
+  openEditEducationForm = index => {
+    openEditEducationForm.call(this, index);
+  }
+
+  openNewEducationForm = (level, index) => {
+    openNewEducationForm.call(this, level, index);
+  };
+
+  deleteEducationEntry = () => {
+    deleteEducationEntry.call(this);
+  };
+
+  educationRow = (entry, index) => {
+    const { profile, errors } = this.props;
+    if (!('id' in entry)) {
+      // don't show new educations, wait until we saved on the server before showing them
+      return;
+    }
+
+    let deleteEntry = () => this.openEducationDeleteDialog(index);
+    let editEntry = () => this.openEditEducationForm(index);
+    let validationAlert = () => {
+      if (_.get(errors, ['education', index])) {
+        return <IconButton name="error" onClick={editEntry} />;
+      }
+    };
+    let dateFormat = date => moment(date).format("MM[/]YYYY");
+    let degree = this.educationLevelOptions.find(level => (
+      level.value === entry.degree_name
+    )).label;
+    let icons = () => (
+      <Cell col={2} className="profile-row-icons">
+        {validationAlert()}
+        <IconButton className="edit-button" name="edit" onClick={editEntry} />
+        <IconButton className="delete-button" name="delete" onClick={deleteEntry} />
+      </Cell>
+    );
+    return (
+      <Grid className="profile-tab-card-grid user-page" key={index}>
+        <Cell col={4} className="profile-row-name">
+          <span className="school-type">{ degree }</span><br/>
+          { entry.school_name }
+        </Cell>
+        <Cell col={6} className="profile-row-date-range">
+          {`${dateFormat(entry.graduation_date)}`}
+        </Cell>
+        { userPrivilegeCheck(profile, icons, () => <Cell col={2} />) }
+      </Grid>
+    );
+  };
+
+  addEducationMenu = () => {
+    let menuItems = this.educationLevelOptions.map(educationLevel => (
+      <MenuItem 
+        key={educationLevel.label}
+        onClick={() => this.openNewEducationForm(educationLevel.value, null)}>
+        { educationLevel.label }
+      </MenuItem>
+    ));
+    return (
+      <Menu
+        target="add-education-button"
+        valign="top"
+        align="right"
+        className="add-education-menu"
+      >
+        { menuItems }
+      </Menu>
+    );
+  };
+
+  renderEducationEntries = () => {
+    const { profile, profile: { education }} = this.props;
+    let rows = [];
+    if (education !== undefined) {
+      rows = education.map( (entry, index) => this.educationRow(entry, index));
+    }
+    userPrivilegeCheck(profile, () => {
+      rows.push(
+        <FABButton
+          colored
+          id="add-education-button"
+          className="profile-add-button"
+          key="I'm unique!"
+        >
+          <Icon name="add" />
+        </FABButton>
+      );
+    });
+    return rows;
+  }
+
+  render() {
+    const {
+      profile,
+      ui: { showEducationDeleteDialog }
+    } = this.props;
+    return (
+      <div>
+        <ConfirmDeletion
+          deleteEntry={this.deleteEducationEntry}
+          open={showEducationDeleteDialog}
+          close={this.closeConfirmDeleteDialog}
+        />
+        <EducationDialog {...this.props} />
+        <Card shadow={1} className="profile-tab-card" id="education-card">
+          <Grid className="profile-tab-card-grid">
+            <Cell col={4} className="profile-card-title">
+              Education
+            </Cell>
+            <Cell col={8} />
+          </Grid>
+          { this.renderEducationEntries() }
+          { userPrivilegeCheck(profile, this.addEducationMenu(), undefined) }
+        </Card>
+      </div>
+    );
+  }
+}

--- a/static/js/components/User.js
+++ b/static/js/components/User.js
@@ -6,7 +6,7 @@ import iso3166 from 'iso-3166-2';
 
 import { makeProfileImageUrl } from '../util/util';
 import EmploymentForm from './EmploymentForm';
-import EducationForm from './EducationForm';
+import EducationDisplay from './EducationDisplay';
 import UserPagePersonalDialog from './UserPagePersonalDialog.js';
 import { userPrivilegeCheck } from '../util/util';
 
@@ -72,7 +72,7 @@ export default class User extends React.Component {
           <EmploymentForm {...this.props} />
         </Cell>
         <Cell col={6}>
-          <EducationForm {...this.props} />
+          <EducationDisplay {...this.props} />
         </Cell>
       </Grid>
     </div>;

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -68,7 +68,7 @@ describe("UserPage", () => {
       it('shows the education component', done => {
         renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
           let title = div.getElementsByClassName('profile-card-title')[1];
-          assert.equal(title.textContent, 'High school');
+          assert.equal(title.textContent, 'Education');
           done();
         });
       });
@@ -149,7 +149,7 @@ describe("UserPage", () => {
 
       it('should let you add an education entry', done => {
         renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
-          let editButton = div.getElementsByClassName('profile-tab-card')[1].
+          let addButton = div.getElementsByClassName('profile-tab-card')[1].
             getElementsByClassName('profile-add-button')[0];
 
           listenForActions([
@@ -159,7 +159,10 @@ describe("UserPage", () => {
             SET_EDUCATION_DIALOG_VISIBILITY,
             SET_EDUCATION_DEGREE_LEVEL,
           ], () => {
-            TestUtils.Simulate.click(editButton);
+            TestUtils.Simulate.click(addButton);
+            addButton = div.getElementsByClassName('add-education-menu')[0].
+              getElementsByTagName('li')[0];
+            TestUtils.Simulate.click(addButton);
           }).then(() => {
             done();
           });

--- a/static/js/util/editEducation.js
+++ b/static/js/util/editEducation.js
@@ -1,0 +1,46 @@
+import _ from 'lodash';
+import { generateNewEducation } from "../util/util";
+
+export function openEditEducationForm(index) {
+  const {
+    profile,
+    setEducationDialogIndex,
+    setEducationDegreeLevel,
+    setEducationDialogVisibility,
+  } = this.props;
+
+  let education = profile['education'][index];
+  setEducationDialogIndex(index);
+  setEducationDegreeLevel(education.degree_name);
+  setEducationDialogVisibility(true);
+}
+
+export function openNewEducationForm(level, index) {
+  const {
+    profile,
+    updateProfile,
+    setEducationDialogIndex,
+    setEducationDegreeLevel,
+    setEducationDialogVisibility,
+  } = this.props;
+  let newIndex = index;
+  if (index === null){
+    newIndex = profile['education'].length;
+  }
+  /* add empty education */
+  let clone = Object.assign({}, profile);
+  clone['education'] = clone['education'].concat(generateNewEducation(level));
+  updateProfile(clone);
+  setEducationDialogIndex(newIndex);
+  setEducationDegreeLevel(level);
+  setEducationDialogVisibility(true);
+}
+
+export function deleteEducationEntry () {
+  const { saveProfile, profile, deletionIndex } = this.props;
+  let clone = _.cloneDeep(profile);
+  clone['education'].splice(deletionIndex, 1);
+  saveProfile(clone);
+}
+
+

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -177,9 +177,23 @@ c.validation-wrapper {
     overflow: visible;
     margin-bottom: 35px;
     padding-bottom: 50px;
-
+    .education-add-menu {
+      position: absolute;
+      top: 5%;
+      left: 75%;
+    }
     .profile-tab-card-grid:first-child {
       padding-top: 15px;
+    }
+    .profile-tab-card-grid.user-page {
+      .school-type {
+        font-size: 12px;
+        font-weight: 400;
+        text-transform: lowercase;
+      }
+      .mdl-cell {
+        margin: auto;
+      }
     }
     .profile-tab-card-grid {
       margin: 0;


### PR DESCRIPTION
#### What are the relevant tickets?

closes #498 

#### What's this PR do?

This adds a different display component for the education history which we can use on the `/users` page.

#### Where should the reviewer start?

Review the new components (`EducationDisplay` and `EducationDialog`) and the changes to `EducationForm`.

#### How should this be manually tested?

Visit `/users`. You should see your education history, and be able to delete and add new entries. On a different user's page, the edit, add, and delete buttons should be hidden. There should be no regressions on the education profile step.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
