### PR TITLE
Added extra validation for dates

### DIFF
--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -36,7 +36,7 @@ export const USER_PROFILE_RESPONSE = {
     "position": "Software Developer",
     "industry": "Education",
     "start_date": "1982-02-02",
-    "end_date": "7654-03-21"
+    "end_date": "1982-03-21"
   }, {
     "id": 2,
     "city": "New York",
@@ -45,8 +45,8 @@ export const USER_PROFILE_RESPONSE = {
     "company_name": "Planet Express",
     "position": "Delivery",
     "industry": "Shipping",
-    "start_date": "3000-01-01",
-    "end_date": "4000-01-01"
+    "start_date": "1999-03-28",
+    "end_date": "2013-09-04"
   }],
   "education": [{
     "id": 1,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #403 
Rebased on #504 

#### What's this PR do?
Handles the three validation cases mentioned in the issue

#### How should this be manually tested?
 - Verify that an error occurs if you change your date of birth to a date in the future and click Save
 - In a work history entry try to add a year but not a month for the end date. Verify that the error message is: "Please enter a valid end date or leave it blank". If you remove both year and month, everything should work fine since that means you are currently working there.
 - In a work history entry verify that you get an error if your end date is before your start date. Verify that the message is: "End date cannot be before start date"
 - Also in work history, remove the start date, click 'Save' and verify that the error message is "Please enter a valid start date"
 - In an education entry verify that you see this error message when the graduation date is missing or invalid: "Please enter a valid graduation date"

