### PR TITLE
Moved program link from title to entire card

### DIFF
--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -69,6 +69,9 @@
 
               {% for program in programs %}
               <li class="col-sm-6">
+                {% if program.programpage %}
+                  <a href="{{ program.programpage.url }}" class="program-link">
+                {% endif %}
                 <div class="media-item">
                   <div class="media-top">
                     <div class="image-wrap">
@@ -76,13 +79,7 @@
                     </div>
                   </div>
                   <div class="info-wrap">
-                    {% if program.programpage %}
-                    <a href="{{ program.programpage.url }}">
-                      <div class="title">{{ program }}</div>
-                    </a>
-                    {% else %}
                     <div class="title">{{ program }}</div>
-                    {% endif %}
                     <div class="description">
                       {% if program.description %}
                       {{ program.description }}
@@ -99,6 +96,9 @@
                     </div>
                   </div>
                 </div>
+                {% if program.programpage %}
+                  </a>
+                {% endif %}
               </li>
               {% endfor %}
               <li class="col-sm-6">

--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -424,6 +424,10 @@ body.app-media {
   min-height:65px;
 }
 
+.program-link:hover {
+  text-decoration: none;
+}
+
 .media-list .title-coming-soon {
   font-size: x-large;
   color:#FFFFFF;

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -61,6 +61,29 @@ class TestViews(TestCase):
             status_code=200
         )
 
+    def test_program_link(self):
+        """Verify that program links are present in home page if ProgramPage is set"""
+        program = ProgramFactory.create(live=True)
+        program_page = ProgramPage(program=program, title="Test Program")
+
+        response = self.client.get('/')
+        self.assertNotContains(
+            response,
+            program_page.url,
+            status_code=200
+        )
+
+        homepage = HomePage.objects.first()
+        homepage.add_child(instance=program_page)
+        program_page.save_revision().publish()
+
+        response = self.client.get('/')
+        self.assertContains(
+            response,
+            program_page.url,
+            status_code=200
+        )
+
     def test_login_button(self):
         """Verify that we see a login button if not logged in"""
         response = self.client.get('/')


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #453 

#### What's this PR do?
Adds a test to make sure the program link exists if ProgramPage was created for it, and moves the existing link from the program title to the program card

#### How should this be manually tested?
Go to the home page and make sure you can click the card to go to the program page
