### PR TITLE
Used chai to assert Promise behavior

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -165,14 +165,19 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "assert": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "from": "assert@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
     },
     "assert-plus": {
       "version": "0.2.0",
       "from": "assert-plus@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "from": "assertion-error@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
     },
     "async": {
       "version": "1.5.2",
@@ -757,6 +762,16 @@
       "from": "center-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
     },
+    "chai": {
+      "version": "3.5.0",
+      "from": "chai@latest",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz"
+    },
+    "chai-as-promised": {
+      "version": "5.3.0",
+      "from": "chai-as-promised@latest",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz"
+    },
     "chalk": {
       "version": "1.1.3",
       "from": "chalk@>=1.1.0 <2.0.0",
@@ -1015,6 +1030,18 @@
       "version": "1.2.0",
       "from": "decamelize@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "from": "deep-eql@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "from": "type-detect@0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+        }
+      }
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -3004,9 +3031,9 @@
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
     },
     "process": {
-      "version": "0.11.3",
+      "version": "0.11.4",
       "from": "process@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.3.tgz"
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.4.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -3614,7 +3641,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@>=1.0.27-1 <2.0.0",
+          "from": "readable-stream@^1.0.27-1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         }
       }
@@ -3773,6 +3800,11 @@
       "version": "0.3.2",
       "from": "type-check@>=0.3.2 <0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "from": "type-detect@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
     },
     "type-is": {
       "version": "1.6.13",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "babel-preset-stage-1": "6.5.0",
     "babel-register": "6.8.0",
     "bootstrap": "3.3.6",
+    "chai": "^3.5.0",
+    "chai-as-promised": "^5.3.0",
     "css-loader": "0.23.1",
     "eslint": "2.9.0",
     "eslint-config-defaults": "9.0.0",

--- a/static/js/components/CourseList_test.js
+++ b/static/js/components/CourseList_test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 import sinon from 'sinon';
-import assert from 'assert';
+import { assert } from 'chai';
 import _ from 'lodash';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -2,7 +2,7 @@
 import '../global_init';
 
 import ReactDOM from 'react-dom';
-import assert from 'assert';
+import { assert } from 'chai';
 import _ from 'lodash';
 
 import {
@@ -35,72 +35,65 @@ describe('App', () => {
     helper.cleanup();
   });
 
-  it('clears profile, ui, and dashboard after unmounting', done => {
-    renderComponent("/dashboard").then(([, div]) => {
-      listenForActions([CLEAR_DASHBOARD, CLEAR_PROFILE, CLEAR_UI], () => {
+  it('clears profile, ui, and dashboard after unmounting', () => {
+    return renderComponent("/dashboard").then(([, div]) => {
+      return listenForActions([CLEAR_DASHBOARD, CLEAR_PROFILE, CLEAR_UI], () => {
         ReactDOM.unmountComponentAtNode(div);
-      }).then(() => {
-        done();
       });
     });
   });
 
   describe('profile completeness', () => {
-    it('redirects to /profile if profile is not complete', done => {
+    it('redirects to /profile if profile is not complete', () => {
       let response = Object.assign({}, USER_PROFILE_RESPONSE, {
         first_name: undefined
       });
       helper.profileGetStub.returns(Promise.resolve(response));
 
-      renderComponent("/dashboard", editProfileActions).then(() => {
+      return renderComponent("/dashboard", editProfileActions).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile/personal");
-        done();
       });
     });
 
-    it('redirects to /profile if profile is not filled out', done => {
+    it('redirects to /profile if profile is not filled out', () => {
       let response = Object.assign({}, USER_PROFILE_RESPONSE, {
         filled_out: false
       });
       helper.profileGetStub.returns(Promise.resolve(response));
 
-      renderComponent("/dashboard").then(() => {
+      return renderComponent("/dashboard").then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile/personal");
-        done();
       });
     });
 
-    it('redirects to /profile/professional if a field is missing there', done => {
+    it('redirects to /profile/professional if a field is missing there', () => {
       let profile = _.cloneDeep(USER_PROFILE_RESPONSE);
       profile.work_history[1].city = "";
 
       helper.profileGetStub.returns(Promise.resolve(profile));
-      renderComponent("/dashboard", editProfileActions).then(() => {
+      return renderComponent("/dashboard", editProfileActions).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile/professional");
-        done();
       });
     });
 
-    it('redirects to /profile/privacy if a field is missing there', done => {
+    it('redirects to /profile/privacy if a field is missing there', () => {
       let response = Object.assign({}, USER_PROFILE_RESPONSE, {
         account_privacy: ''
       });
       helper.profileGetStub.returns(Promise.resolve(response));
 
-      renderComponent("/dashboard", editProfileActions).then(() => {
+      return renderComponent("/dashboard", editProfileActions).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile/privacy");
-        done();
       });
     });
 
-    it('redirects to /profile/education if a field is missing there', done => {
+    it('redirects to /profile/education if a field is missing there', () => {
       let response = _.cloneDeep(USER_PROFILE_RESPONSE);
       response.education[0].school_name = '';
       helper.profileGetStub.returns(Promise.resolve(response));
 
-      renderComponent("/dashboard", editProfileActions).then(() => {
+      return renderComponent("/dashboard", editProfileActions).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile/education");
-        done();
       });
     });
   });

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -1,6 +1,6 @@
 /* global SETTINGS: false */
 import TestUtils from 'react-addons-test-utils';
-import assert from 'assert';
+import { assert } from 'chai';
 
 import {
   REQUEST_PATCH_USER_PROFILE,
@@ -73,7 +73,7 @@ describe("ProfilePage", function() {
   it('navigates backward when Previous button is clicked', () => {
     let firstPage = pageUrlStubs[0];
     let secondPage = pageUrlStubs[1];
-    renderComponent(secondPage).then(([, div]) => {
+    return renderComponent(secondPage).then(([, div]) => {
       let button = div.querySelector(prevButtonSelector);
       assert.equal(helper.currentLocation.pathname, secondPage);
       TestUtils.Simulate.click(button);
@@ -81,8 +81,8 @@ describe("ProfilePage", function() {
     });
   });
 
-  it(`marks email_optin and filled_out when saving ${lastPage}`, done => {
-    renderComponent(lastPage).then(([, div]) => {
+  it(`marks email_optin and filled_out when saving ${lastPage}`, () => {
+    return renderComponent(lastPage).then(([, div]) => {
       // close all switches and remove all education so we don't get validation errors
       let receivedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
         education: []
@@ -97,14 +97,12 @@ describe("ProfilePage", function() {
         filled_out: true
       });
 
-      confirmSaveButtonBehavior(updatedProfile, {button: button}).then(() => {
-        done();
-      });
+      return confirmSaveButtonBehavior(updatedProfile, {button: button});
     });
   });
 
-  it("validates education switches on the education page", done => {
-    renderComponent('/profile/education').then(([, div]) => {
+  it("validates education switches on the education page", () => {
+    return renderComponent('/profile/education').then(([, div]) => {
       // close all switches and remove all education so we don't get validation errors
       let receivedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
         education: []
@@ -124,17 +122,16 @@ describe("ProfilePage", function() {
         filled_out: true
       });
 
-      confirmSaveButtonBehavior(updatedProfile, {button: button}, true).then(state => {
+      return confirmSaveButtonBehavior(updatedProfile, {button: button}, true).then(state => {
         assert.deepEqual(state.profiles[SETTINGS.username].edit.errors, {
           [`education_${HIGH_SCHOOL}_required`]: `High school is required if switch is set`
         });
-        done();
       });
     });
   });
 
-  it(`validates employment switches when saving the employment page`, done => {
-    renderComponent('/profile/professional').then(([, div]) => {
+  it(`validates employment switches when saving the employment page`, () => {
+    return renderComponent('/profile/professional').then(([, div]) => {
       // close all switches and remove all education so we don't get validation errors
       let receivedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
         work_history: []
@@ -149,17 +146,16 @@ describe("ProfilePage", function() {
         filled_out: true
       });
 
-      confirmSaveButtonBehavior(updatedProfile, {button: button}, true).then(state => {
+      return confirmSaveButtonBehavior(updatedProfile, {button: button}, true).then(state => {
         assert.deepEqual(state.profiles[SETTINGS.username].edit.errors, {
           work_history_required: "Work history is required if switch is set"
         });
-        done();
       });
     });
   });
 
-  it(`validates education and employment switches when saving the ${lastPage}`, done => {
-    renderComponent(lastPage).then(([, div]) => {
+  it(`validates education and employment switches when saving the ${lastPage}`, () => {
+    return renderComponent(lastPage).then(([, div]) => {
       // close all switches and remove all education so we don't get validation errors
       let receivedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
         education: [],
@@ -178,30 +174,27 @@ describe("ProfilePage", function() {
         filled_out: true
       });
 
-      confirmSaveButtonBehavior(updatedProfile, {button: button}, true).then(state => {
+      return confirmSaveButtonBehavior(updatedProfile, {button: button}, true).then(state => {
         assert.deepEqual(state.profiles[SETTINGS.username].edit.errors, {
           [`education_${HIGH_SCHOOL}_required`]: `High school is required if switch is set`,
           work_history_required: "Work history is required if switch is set"
         });
-        done();
       });
     });
   });
 
   for (let pageUrlStub of pageUrlStubs.slice(0,3)) {
     for (let filledOutValue of [true, false]) {
-      it(`respects the current value (${filledOutValue}) when saving on ${pageUrlStub}`, done => {
+      it(`respects the current value (${filledOutValue}) when saving on ${pageUrlStub}`, () => {
         let updatedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
           filled_out: filledOutValue,
           education: []
         });
         helper.profileGetStub.returns(Promise.resolve(updatedProfile));
-        renderComponent(pageUrlStub).then(([, div]) => {
+        return renderComponent(pageUrlStub).then(([, div]) => {
           // close all switches
           helper.store.dispatch(setEducationDegreeInclusions(noInclusions));
-          confirmSaveButtonBehavior(updatedProfile, {div: div}).then(() => {
-            done();
-          });
+          return confirmSaveButtonBehavior(updatedProfile, {div: div});
         });
       });
     }

--- a/static/js/containers/TermsOfServicePage_test.js
+++ b/static/js/containers/TermsOfServicePage_test.js
@@ -1,7 +1,7 @@
 /* global SETTINGS: false */
 import '../global_init';
 import TestUtils from 'react-addons-test-utils';
-import assert from 'assert';
+import { assert } from 'chai';
 
 import {
   REQUEST_PATCH_USER_PROFILE,
@@ -24,34 +24,30 @@ describe("TermsOfService", () => {
     helper.cleanup();
   });
 
-  it("requires terms of service if user hasn't already agreed to it", done => {
+  it("requires terms of service if user hasn't already agreed to it", () => {
     let response = Object.assign({}, USER_PROFILE_RESPONSE, {
       agreed_to_terms_of_service: false
     });
     helper.profileGetStub.returns(Promise.resolve(response));
 
-    renderComponent("/dashboard").then(() => {
+    return renderComponent("/dashboard").then(() => {
       assert.equal(helper.currentLocation.pathname, "/terms_of_service");
-
-      done();
     });
   });
 
-  it("requires terms of service if user hasn't already agreed to it even if profile is not complete", done => {
+  it("requires terms of service if user hasn't already agreed to it even if profile is not complete", () => {
     let response = Object.assign({}, USER_PROFILE_RESPONSE, {
       agreed_to_terms_of_service: false,
       filled_out: false
     });
     helper.profileGetStub.returns(Promise.resolve(response));
 
-    renderComponent("/dashboard").then(() => {
+    return renderComponent("/dashboard").then(() => {
       assert.equal(helper.currentLocation.pathname, "/terms_of_service");
-
-      done();
     });
   });
 
-  it("agrees to terms of service", done => {
+  it("agrees to terms of service", () => {
     let profileActions = [
       REQUEST_PATCH_USER_PROFILE,
       RECEIVE_PATCH_USER_PROFILE_SUCCESS
@@ -68,27 +64,24 @@ describe("TermsOfService", () => {
     profilePatchStub.throws("Invalid arguments");
     profilePatchStub.withArgs(SETTINGS.username, updatedProfile).returns(Promise.resolve(updatedProfile));
 
-    renderComponent("/terms_of_service").then(([component]) => {
-      listenForActions(profileActions, () => {
+    return renderComponent("/terms_of_service").then(([component]) => {
+      return listenForActions(profileActions, () => {
         let button = component.querySelector(".btn-success");
 
         TestUtils.Simulate.click(button);
-      }).then(() => {
-        done();
       });
     });
   });
 
-  it("clicks Cancel on terms of service page", done => {
+  it("clicks Cancel on terms of service page", () => {
     let response = Object.assign({}, USER_PROFILE_RESPONSE, {
       agreed_to_terms_of_service: false
     });
     helper.profileGetStub.returns(Promise.resolve(response));
 
-    renderComponent("/terms_of_service").then(([component]) => {
+    return renderComponent("/terms_of_service").then(([component]) => {
       let cancelLink = component.querySelector(".btn-danger");
       assert.equal(cancelLink.href, "/logout");
-      done();
     });
   });
 });

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -1,7 +1,7 @@
 /* global SETTINGS: false */
 import '../global_init';
 import TestUtils from 'react-addons-test-utils';
-import assert from 'assert';
+import { assert } from 'chai';
 import _ from 'lodash';
 
 import { 
@@ -65,19 +65,18 @@ describe("UserPage", () => {
           getElementsByClassName('delete-button')[0];
       };
 
-      it('shows the education component', done => {
-        renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+      it('shows the education component', () => {
+        return renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
           let title = div.getElementsByClassName('profile-card-title')[1];
           assert.equal(title.textContent, 'Education');
-          done();
         });
       });
 
-      it('should confirm deletion and let you cancel', done => {
-        renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+      it('should confirm deletion and let you cancel', () => {
+        return renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
           let button = deleteButton(div);
 
-          listenForActions([
+          return listenForActions([
             SET_DELETION_INDEX,
             SET_SHOW_EDUCATION_DELETE_DIALOG,
             SET_SHOW_EDUCATION_DELETE_DIALOG,
@@ -88,14 +87,12 @@ describe("UserPage", () => {
             let dialog = openDialog();
             let cancelButton = dialog.getElementsByClassName('cancel-button')[0];
             TestUtils.Simulate.click(cancelButton);
-          }).then(() => {
-            done();
           });
         });
       });
 
-      it('should confirm deletion and let you continue', done => {
-        renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+      it('should confirm deletion and let you continue', () => {
+        return renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
           let updatedProfile = _.cloneDeep(USER_PROFILE_RESPONSE);
           updatedProfile.username = SETTINGS.username;
           updatedProfile.education.splice(0,1);
@@ -107,7 +104,7 @@ describe("UserPage", () => {
 
           let button = deleteButton(div);
 
-          listenForActions([
+          return listenForActions([
             SET_DELETION_INDEX,
             SET_SHOW_EDUCATION_DELETE_DIALOG,
             START_PROFILE_EDIT,
@@ -122,37 +119,33 @@ describe("UserPage", () => {
             let dialog = openDialog();
             button = dialog.getElementsByClassName('delete-button')[0];
             TestUtils.Simulate.click(button);
-          }).then(() => {
-            done();
           });
         });
       });
 
-      it('should let you edit an education entry', done => {
-        renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+      it('should let you edit an education entry', () => {
+        return renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
 
           let editButton = div.getElementsByClassName('profile-tab-card')[1].
             getElementsByClassName('profile-row-icons')[0].
             getElementsByClassName('mdl-button')[0];
 
-          listenForActions([
+          return listenForActions([
             SET_EDUCATION_DIALOG_INDEX,
             SET_EDUCATION_DIALOG_VISIBILITY,
             SET_EDUCATION_DEGREE_LEVEL,
           ], () => {
             TestUtils.Simulate.click(editButton);
-          }).then(() => {
-            done();
           });
         });
       });
 
-      it('should let you add an education entry', done => {
-        renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+      it('should let you add an education entry', () => {
+        return renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
           let addButton = div.getElementsByClassName('profile-tab-card')[1].
             getElementsByClassName('profile-add-button')[0];
 
-          listenForActions([
+          return listenForActions([
             START_PROFILE_EDIT,
             UPDATE_PROFILE,
             SET_EDUCATION_DIALOG_INDEX,
@@ -163,8 +156,6 @@ describe("UserPage", () => {
             addButton = div.getElementsByClassName('add-education-menu')[0].
               getElementsByTagName('li')[0];
             TestUtils.Simulate.click(addButton);
-          }).then(() => {
-            done();
           });
         });
       });
@@ -177,19 +168,18 @@ describe("UserPage", () => {
           getElementsByClassName('mdl-button')[1];
       };
 
-      it('shows the employment history component', done => {
-        renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+      it('shows the employment history component', () => {
+        return renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
           let title = div.getElementsByClassName('profile-card-title')[0];
           assert.equal(title.textContent, 'Employment');
-          done();
         });
       });
 
-      it('should confirm deletion and let you cancel', done => {
-        renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+      it('should confirm deletion and let you cancel', () => {
+        return renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
           let button = deleteButton(div);
 
-          listenForActions([
+          return listenForActions([
             SET_DELETION_INDEX,
             SET_SHOW_WORK_DELETE_DIALOG,
             SET_SHOW_WORK_DELETE_DIALOG,
@@ -200,14 +190,12 @@ describe("UserPage", () => {
             let dialog = openDialog();
             let cancelButton = dialog.getElementsByClassName('cancel-button')[0];
             TestUtils.Simulate.click(cancelButton);
-          }).then(() => {
-            done();
           });
         });
       });
 
-      it('should confirm deletion and let you continue', done => {
-        renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+      it('should confirm deletion and let you continue', () => {
+        return renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
           let updatedProfile = _.cloneDeep(USER_PROFILE_RESPONSE);
           updatedProfile.username = SETTINGS.username;
           updatedProfile.work_history.splice(0,1);
@@ -221,7 +209,7 @@ describe("UserPage", () => {
             getElementsByClassName('profile-row-icons')[0].
             getElementsByClassName('mdl-button')[1];
 
-          listenForActions([
+          return listenForActions([
             SET_DELETION_INDEX,
             SET_SHOW_WORK_DELETE_DIALOG,
             START_PROFILE_EDIT,
@@ -236,70 +224,61 @@ describe("UserPage", () => {
             let dialog = openDialog();
             let button = dialog.getElementsByClassName('delete-button')[0];
             TestUtils.Simulate.click(button);
-          }).then(() => {
-            done();
           });
         });
       });
 
-      it('should let you edit a work history entry', done => {
-        renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+      it('should let you edit a work history entry', () => {
+        return renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
 
           let editButton = div.getElementsByClassName('profile-tab-card')[0].
             getElementsByClassName('profile-row-icons')[0].
             getElementsByClassName('mdl-button')[0];
 
-          listenForActions([
+          return listenForActions([
             SET_WORK_DIALOG_INDEX,
             SET_WORK_DIALOG_VISIBILITY
           ], () => {
             TestUtils.Simulate.click(editButton);
-          }).then(() => {
-            done();
           });
         });
       });
 
-      it('should let you add a work history entry', done => {
+      it('should let you add a work history entry', () => {
         renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
           let editButton = div.getElementsByClassName('profile-tab-card')[0].
             getElementsByClassName('profile-add-button')[0];
 
-          listenForActions([
+          return listenForActions([
             START_PROFILE_EDIT,
             UPDATE_PROFILE,
             SET_WORK_DIALOG_INDEX,
             SET_WORK_DIALOG_VISIBILITY
           ], () => {
             TestUtils.Simulate.click(editButton);
-          }).then(() => {
-            done();
           });
         });
       });
     });
 
     describe('Personal Info', () => {
-      it('should show name and location', done => {
-        renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+      it('should show name and location', () => {
+        return renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
           let name = div.getElementsByClassName('users-name')[0].textContent;
           assert.deepEqual(name, USER_PROFILE_RESPONSE.preferred_name);
 
           let location = div.getElementsByClassName('users-location')[0].textContent;
 
           assert.deepEqual(location, `${USER_PROFILE_RESPONSE.city}, `);
-          done();
         });
       });
 
-      it('should let you edit personal info', done => {
-        renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
+      it('should let you edit personal info', () => {
+        return renderComponent(`/users/${SETTINGS.username}`, userActions).then(([, div]) => {
           let personalButton = div.getElementsByClassName('material-icons')[0];
 
-          listenForActions([SET_USER_PAGE_DIALOG_VISIBILITY], () => {
+          return listenForActions([SET_USER_PAGE_DIALOG_VISIBILITY], () => {
             TestUtils.Simulate.click(personalButton);
-          }).then(() => {
-            done();
           });
         });
       });
@@ -324,7 +303,7 @@ describe("UserPage", () => {
     });
 
     it('should hide all edit, delete icons', () => {
-      renderComponent(`/users/${SETTINGS.username}`, userActions).then(() => {
+      return renderComponent(`/users/${SETTINGS.username}`, userActions).then(() => {
         let icons = [...document.getElementsByClassName('mdl-button--icons')];
         assert.deepEqual(icons, []);
       });

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -22,3 +22,8 @@ require('react-mdl/extra/material.js');
 process.on('unhandledRejection', reason => {
   throw reason;
 });
+
+// enable chai-as-promised
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -48,7 +48,7 @@ import rootReducer from '../reducers';
 import * as util from '../util/util';
 
 import configureTestStore from 'redux-asserts';
-import assert from 'assert';
+import { assert } from 'chai';
 import sinon from 'sinon';
 
 describe('ui reducers', () => {
@@ -67,92 +67,84 @@ describe('ui reducers', () => {
     dispatchThen = null;
   });
 
-  it('should clear the ui', done => {
-    dispatchThen(clearUI(), [CLEAR_UI]).then(state => {
-      assert.deepEqual(state, INITIAL_UI_STATE);
-      done();
-    });
+  it('should clear the ui', () => {
+    return assert.eventually.deepEqual(
+      dispatchThen(clearUI(), [CLEAR_UI]),
+      INITIAL_UI_STATE
+    );
   });
 
   describe('dialog reducers', () => {
-    it('should set a dialog title', done => {
-      dispatchThen(updateDialogTitle('A title'), [UPDATE_DIALOG_TITLE]).then(state => {
+    it('should set a dialog title', () => {
+      return dispatchThen(updateDialogTitle('A title'), [UPDATE_DIALOG_TITLE]).then(state => {
         assert.equal(state.dialog.title, 'A title');
-        done();
       });
     });
 
-    it('should set dialog text', done => {
-      dispatchThen(updateDialogText('Some Text'), [UPDATE_DIALOG_TEXT]).then(state => {
+    it('should set dialog text', () => {
+      return dispatchThen(updateDialogText('Some Text'), [UPDATE_DIALOG_TEXT]).then(state => {
         assert.equal(state.dialog.text, 'Some Text');
-        done();
       });
     });
 
-    it('should set dialog visibility', done => {
-      dispatchThen(setDialogVisibility(true), [SET_DIALOG_VISIBILITY]).then(state => {
+    it('should set dialog visibility', () => {
+      return dispatchThen(setDialogVisibility(true), [SET_DIALOG_VISIBILITY]).then(state => {
         assert.equal(state.dialog.visible, true);
-        done();
       });
     });
   });
 
   describe('work_history reducers', () => {
-    it('should set the work history dialog visibility', done => {
-      dispatchThen(setWorkDialogVisibility(true), [SET_WORK_DIALOG_VISIBILITY]).then(state => {
+    it('should set the work history dialog visibility', () => {
+      return dispatchThen(setWorkDialogVisibility(true), [SET_WORK_DIALOG_VISIBILITY]).then(state => {
         assert.equal(state.workDialogVisibility, true);
 
-        dispatchThen(setWorkDialogVisibility(false), [SET_WORK_DIALOG_VISIBILITY]).then(state => {
+        return dispatchThen(setWorkDialogVisibility(false), [SET_WORK_DIALOG_VISIBILITY]).then(state => {
           assert.equal(state.workDialogVisibility, false);
-          done();
         });
       });
     });
 
-    it('should set work history edit', done => {
-      dispatchThen(setWorkHistoryEdit(true), [SET_WORK_HISTORY_EDIT]).then(state => {
+    it('should set work history edit', () => {
+      return dispatchThen(setWorkHistoryEdit(true), [SET_WORK_HISTORY_EDIT]).then(state => {
         assert.equal(state.workHistoryEdit, true);
 
-        dispatchThen(setWorkHistoryEdit(false), [SET_WORK_HISTORY_EDIT]).then(state => {
+        return dispatchThen(setWorkHistoryEdit(false), [SET_WORK_HISTORY_EDIT]).then(state => {
           assert.equal(state.workHistoryEdit, false);
-          done();
         });
       });
     });
 
-    it('should set a work history dialog index', done => {
-      dispatchThen(setWorkDialogIndex(2), [SET_WORK_DIALOG_INDEX]).then(state => {
+    it('should set a work history dialog index', () => {
+      return dispatchThen(setWorkDialogIndex(2), [SET_WORK_DIALOG_INDEX]).then(state => {
         assert.equal(state.workDialogIndex, 2);
 
-        dispatchThen(setWorkDialogIndex(5), [SET_WORK_DIALOG_INDEX]).then(state => {
+        return dispatchThen(setWorkDialogIndex(5), [SET_WORK_DIALOG_INDEX]).then(state => {
           assert.equal(state.workDialogIndex, 5);
-          done();
         });
       });
     });
   });
 
   describe('dashboard expander', () => {
-    it('has an empty default state', done => {
-      dispatchThen({type: "undefined"}, []).then(state => {
+    it('has an empty default state', () => {
+      return dispatchThen({type: "undefined"}, []).then(state => {
         assert.deepEqual(state.dashboardExpander, {});
-        done();
       });
     });
 
-    it('toggles a course expander', done => {
-      dispatchThen(toggleDashboardExpander(3, true), [TOGGLE_DASHBOARD_EXPANDER]).then(state => {
+    it('toggles a course expander', () => {
+      return dispatchThen(toggleDashboardExpander(3, true), [TOGGLE_DASHBOARD_EXPANDER]).then(state => {
         assert.deepEqual(state.dashboardExpander, {
           3: true
         });
-        done();
       });
     });
   });
 
   describe('education reducers', () => {
-    it('has a default state', done => {
-      dispatchThen({type: "undefined"}, []).then(state => {
+    it('has a default state', () => {
+      return dispatchThen({type: "undefined"}, []).then(state => {
         assert.deepEqual(state.educationDialogVisibility, false);
         assert.deepEqual(state.educationDialogIndex, null);
         assert.deepEqual(state.educationDegreeLevel, '');
@@ -164,7 +156,6 @@ describe('ui reducers', () => {
             [MASTERS]: false,
             [DOCTORATE]: false,
           });
-        done();
       });
     });
 
@@ -194,28 +185,25 @@ describe('ui reducers', () => {
       assert(!calculateDegreeInclusionsStub.called);
     });
 
-    it('should let you set education dialog visibility', done => {
-      dispatchThen(setEducationDialogVisibility(true), [SET_EDUCATION_DIALOG_VISIBILITY]).then(state => {
+    it('should let you set education dialog visibility', () => {
+      return dispatchThen(setEducationDialogVisibility(true), [SET_EDUCATION_DIALOG_VISIBILITY]).then(state => {
         assert.deepEqual(state.educationDialogVisibility, true);
-        done();
       });
     });
 
-    it('should let you set education degree level', done => {
-      dispatchThen(setEducationDegreeLevel('foobar'), [SET_EDUCATION_DEGREE_LEVEL]).then(state => {
+    it('should let you set education degree level', () => {
+      return dispatchThen(setEducationDegreeLevel('foobar'), [SET_EDUCATION_DEGREE_LEVEL]).then(state => {
         assert.deepEqual(state.educationDegreeLevel, 'foobar');
-        done();
       });
     });
 
-    it('should let you set education dialog index', done => {
-      dispatchThen(setEducationDialogIndex(3), [SET_EDUCATION_DIALOG_INDEX]).then(state => {
+    it('should let you set education dialog index', () => {
+      return dispatchThen(setEducationDialogIndex(3), [SET_EDUCATION_DIALOG_INDEX]).then(state => {
         assert.deepEqual(state.educationDialogIndex, 3);
-        done();
       });
     });
 
-    it('should let you set degree inclusions', done => {
+    it('should let you set degree inclusions', () => {
       let newInclusions = {
         [HIGH_SCHOOL]: true,
         [ASSOCIATE]: false,
@@ -223,19 +211,20 @@ describe('ui reducers', () => {
         [MASTERS]: true,
         [DOCTORATE]: true,
       };
-      dispatchThen(setEducationDegreeInclusions(newInclusions), [SET_EDUCATION_DEGREE_INCLUSIONS]).then(state => {
+      return dispatchThen(
+        setEducationDegreeInclusions(newInclusions),
+        [SET_EDUCATION_DEGREE_INCLUSIONS]
+      ).then(state => {
         assert.deepEqual(state.educationDegreeInclusions, newInclusions);
-        done();
       });
     });
   });
 
   describe('user page', () => {
     [true, false].forEach(bool => {
-      it(`should let you set the user page dialog visibility to ${bool}`, done => {
-        dispatchThen(setUserPageDialogVisibility(bool), [SET_USER_PAGE_DIALOG_VISIBILITY]).then(state => {
+      it(`should let you set the user page dialog visibility to ${bool}`, () => {
+        return dispatchThen(setUserPageDialogVisibility(bool), [SET_USER_PAGE_DIALOG_VISIBILITY]).then(state => {
           assert.deepEqual(state.userPageDialogVisibility, bool);
-          done();
         });
       });
     });
@@ -243,27 +232,24 @@ describe('ui reducers', () => {
 
   describe('confirm delete dialog', () => {
     [true, false].forEach( bool => {
-      it(`should let you set to show the education delete dialog to ${bool}`, done => {
-        dispatchThen(setShowEducationDeleteDialog(bool), [SET_SHOW_EDUCATION_DELETE_DIALOG]).then(state => {
+      it(`should let you set to show the education delete dialog to ${bool}`, () => {
+        return dispatchThen(setShowEducationDeleteDialog(bool), [SET_SHOW_EDUCATION_DELETE_DIALOG]).then(state => {
           assert.deepEqual(state.showEducationDeleteDialog, bool);
-          done();
         });
       });
     });
 
     [true, false].forEach( bool => {
-      it(`should let you set to show the work delete dialog to ${bool}`, done => {
-        dispatchThen(setShowWorkDeleteDialog(bool), [SET_SHOW_WORK_DELETE_DIALOG]).then(state => {
+      it(`should let you set to show the work delete dialog to ${bool}`, () => {
+        return dispatchThen(setShowWorkDeleteDialog(bool), [SET_SHOW_WORK_DELETE_DIALOG]).then(state => {
           assert.deepEqual(state.showWorkDeleteDialog, bool);
-          done();
         });
       });
     });
 
-    it('should let you set a deletion index', done => {
-      dispatchThen(setDeletionIndex(3), [SET_DELETION_INDEX]).then(state => {
+    it('should let you set a deletion index', () => {
+      return dispatchThen(setDeletionIndex(3), [SET_DELETION_INDEX]).then(state => {
         assert.deepEqual(state.deletionIndex, 3);
-        done();
       });
     });
   });

--- a/static/js/util/courseList_test.js
+++ b/static/js/util/courseList_test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { assert } from 'chai';
 import moment from 'moment';
 import React from 'react';
 

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -46,27 +46,25 @@ class IntegrationTestHelper {
   }
 
   renderComponent(url = "/", extraTypesToAssert = []) {
-    return new Promise(resolve => {
-      let expectedTypes = [
-        REQUEST_DASHBOARD,
-        RECEIVE_DASHBOARD_SUCCESS,
-        REQUEST_GET_USER_PROFILE,
-        RECEIVE_GET_USER_PROFILE_SUCCESS
-      ];
+    let expectedTypes = [
+      REQUEST_DASHBOARD,
+      RECEIVE_DASHBOARD_SUCCESS,
+      REQUEST_GET_USER_PROFILE,
+      RECEIVE_GET_USER_PROFILE_SUCCESS
+    ];
 
-      expectedTypes.push(...extraTypesToAssert);
-      let component, div;
+    expectedTypes.push(...extraTypesToAssert);
+    let component, div;
 
-      this.listenForActions(expectedTypes, () => {
-        this.browserHistory.push(url);
-        div = document.createElement("div");
-        component = ReactDOM.render(
-          makeDashboardRoutes(this.browserHistory, this.store, () => null),
-          div
-        );
-      }).then(() => {
-        resolve([component, div]);
-      });
+    return this.listenForActions(expectedTypes, () => {
+      this.browserHistory.push(url);
+      div = document.createElement("div");
+      component = ReactDOM.render(
+        makeDashboardRoutes(this.browserHistory, this.store, () => null),
+        div
+      );
+    }).then(() => {
+      return Promise.resolve([component, div]);
     });
   }
 }

--- a/static/js/util/profile_edit_test.js
+++ b/static/js/util/profile_edit_test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import assert from 'assert';
+import { assert } from 'chai';
 import iso3166 from 'iso-3166-2';
 import _ from 'lodash';
 import MenuItem from 'material-ui/MenuItem';
@@ -572,9 +572,9 @@ describe('Profile Editing utility functions', () => {
 
       assert.deepEqual(that.props.profile.date_of_birth, null);
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
-        day: "28",
+        day: 28,
         month: "13",
-        year: "2066"
+        year: 2066
       });
     });
 
@@ -635,8 +635,8 @@ describe('Profile Editing utility functions', () => {
       assert.deepEqual(that.props.profile.date_of_birth, null);
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
         day: "",
-        month: "2",
-        year: "2066"
+        month: 2,
+        year: 2066
       });
     });
 
@@ -646,9 +646,9 @@ describe('Profile Editing utility functions', () => {
       monthTextField.props.onChange({target: {value: ""}});
       assert.deepEqual(that.props.profile.date_of_birth, null);
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
-        day: "28",
+        day: 28,
         month: "",
-        year: "2066"
+        year: 2066
       });
     });
 
@@ -658,8 +658,8 @@ describe('Profile Editing utility functions', () => {
       yearTextField.props.onChange({target: {value: ""}});
       assert.deepEqual(that.props.profile.date_of_birth, null);
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
-        day: "28",
-        month: "2",
+        day: 28,
+        month: 2,
         year: ""
       });
     });

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -1,5 +1,5 @@
 /* global SETTINGS: false */
-import assert from 'assert';
+import { assert } from 'chai';
 import React from 'react';
 
 import {

--- a/static/js/util/validation_test.js
+++ b/static/js/util/validation_test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { assert } from 'chai';
 import _ from 'lodash';
 import sinon from 'sinon';
 import moment from 'moment';
@@ -190,11 +190,11 @@ describe('Profile validation functions', () => {
 
     it('should reject end date before start date', () => {
       let errors = {
-        work_history: {
-          1: {
+        work_history: [, // eslint-disable-line no-sparse-arrays
+          {
             end_date: "End date cannot be before start date"
           }
-        }
+        ]
       };
       let profile = _.cloneDeep(USER_PROFILE_RESPONSE);
       profile.work_history[1].end_date = moment(profile.work_history[1].start_date).subtract(1, 'months');
@@ -210,11 +210,11 @@ describe('Profile validation functions', () => {
 
     for (let field of ['year', 'month']) {
       let errors = {
-        work_history: {
-          1: {
+        work_history: [, // eslint-disable-line no-sparse-arrays
+          {
             end_date: "Please enter a valid end date or leave it blank"
           }
-        }
+        ]
       };
 
       it(`should error if end_date has an edit value in ${field}`, () => {
@@ -232,11 +232,11 @@ describe('Profile validation functions', () => {
 
     it(`should error if end_date has a number in year`, () => {
       let errors = {
-        work_history: {
-          1: {
+        work_history: [, // eslint-disable-line no-sparse-arrays
+          {
             end_date: "Please enter a valid end date or leave it blank"
           }
-        }
+        ]
       };
       let profile = _.cloneDeep(USER_PROFILE_RESPONSE);
       profile.work_history[1].end_date = null;


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #475 

#### What's this PR do?
Replaces `assert` with `chai` and `chai-as-promised`. Tests are changed to always return a promise. Tests that have a rejected promise will use `assert.isRejected` instead.

#### How should this be manually tested?
Just check that the tests pass

