### PR TITLE
Flipped CourseList arrow

### DIFF
--- a/static/js/components/CourseList.js
+++ b/static/js/components/CourseList.js
@@ -62,7 +62,7 @@ class CourseList extends React.Component {
           };
           expanderSpan = <span
             onClick={toggleExpander}
-            className={`glyphicon glyphicon-chevron-${expander[course.id] ? 'up' : 'down'}`}
+            className={`glyphicon glyphicon-chevron-${expander[course.id] ? 'down' : 'up'}`}
             style={{cursor: "pointer"}}
           />;
         }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #536 

#### What's this PR do?
Flips the arrows so they're consistent with most people's use of expander elements on web sites.

#### How should this be manually tested?
View the dashboard with a course with at least one run. The chevron should point up by default. When you click it it should point down and you should see the run appear below the course.
