### PR TITLE
Set work history switch to be on by default

### DIFF
--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -16,13 +16,6 @@ import ProfileFormFields from '../util/ProfileFormFields';
 import ConfirmDeletion from './ConfirmDeletion';
 
 class EmploymentForm extends ProfileFormFields {
-  componentWillMount () {
-    const { profile, setWorkHistoryEdit } = this.props;
-    if ( _.isArray(profile.work_history) && _.isEmpty(profile.work_history) ) {
-      setWorkHistoryEdit(false);
-    }
-  }
-
   saveWorkHistoryEntry = () => {
     const { saveProfile, profile, ui } = this.props;
     saveProfile(employmentValidation, profile, ui).then(() => {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #516 

#### What's this PR do?

Removes a `componentWillMount` lifecycle callback on `EmploymentForm` which was setting the switch to default to 'off' (in the case that a user has not yet entered any work history).

Now the switch should always initially have the default value from the store, which is `true`.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

