### PR TITLE
Hide switch on user page

### DIFF
--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -183,6 +183,7 @@ class EmploymentForm extends ProfileFormFields {
         showWorkDeleteDialog,
       },
       errors,
+      showSwitch,
     } = this.props;
     const actions = [
       <Button
@@ -200,6 +201,20 @@ class EmploymentForm extends ProfileFormFields {
         Save
       </Button>,
     ];
+    let workSwitch = () => {
+      if ( showSwitch ) {
+        return (
+          <div>
+            <Switch
+              ripple
+              id="profile-tab-professional-switch"
+              onChange={this.toggleWorkHistoryEdit}
+              checked={workHistoryEdit}>
+            </Switch>
+          </div>
+        );
+      }
+    };
 
     return (
       <div>
@@ -224,14 +239,7 @@ class EmploymentForm extends ProfileFormFields {
             </Cell>
             <Cell col={7}></Cell>
             <Cell col={1}>
-              <div>
-                <Switch
-                  ripple
-                  id="profile-tab-professional-switch"
-                  onChange={this.toggleWorkHistoryEdit}
-                  checked={workHistoryEdit}>
-                </Switch>
-              </div>
+              { workSwitch() }
             </Cell>
           </Grid>
           {this.renderWorkHistory()}

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -29,7 +29,7 @@ class EmploymentTab extends React.Component {
         <Grid className="profile-tab-grid">
           <Cell col={1}></Cell>
           <Cell col={10}>
-            <EmploymentForm {...this.props} />
+            <EmploymentForm {...this.props} showSwitch={true} />
           </Cell>
           <Cell col={1}></Cell>
           <Cell col={1}></Cell>

--- a/static/js/components/User.js
+++ b/static/js/components/User.js
@@ -70,7 +70,7 @@ export default class User extends React.Component {
 
       <Grid className="user-cards-grid">
         <Cell col={6}>
-          <EmploymentForm {...this.props} />
+          <EmploymentForm {...this.props} showSwitch={false} />
         </Cell>
         <Cell col={6}>
           <EducationDisplay {...this.props} />

--- a/static/js/util/ProfileFormFields.js
+++ b/static/js/util/ProfileFormFields.js
@@ -81,6 +81,7 @@ export default class ProfileFormFields extends React.Component {
     setDeletionIndex:             React.PropTypes.func,
     setShowWorkDeleteDialog:      React.PropTypes.func,
     setShowEducationDeleteDialog: React.PropTypes.func,
+    showSwitch:                   React.PropTypes.bool,
   };
 
   closeConfirmDeleteDialog: Function = (): void => {


### PR DESCRIPTION
this closes #533 

This removes the switch from the user page, by adding a boolean prop to `EmploymentForm` which we can set to `false` whenever we want to hide the switch.

Make sure there no regressions in adding items and so on (on `/profile/professional`, the user page will not be usable until #540 is merged).