### PR TITLE
Added flow typechecking for JS

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,6 @@
   "presets": ["es2015", "react", "stage-1"],
   "ignore": [
     "node_modules/**"
-  ]
+  ],
+  "plugins": ["transform-flow-strip-types"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,10 @@
     }],
     "guard-for-in": [2],
     "prefer-template": [2],
+    "flow-vars/define-flow-type": 2,
+    "flow-vars/use-flow-type": 2,
+    "flowtype/space-after-type-colon": [2, "always"],
+    "flowtype/space-before-type-colon": [2, "never"]
   },
   "env": {
     "es6": true,
@@ -46,6 +50,8 @@
   },
   "plugins": [
     "babel",
-    "react"
+    "react",
+    "flowtype",
+    "flow-vars"
   ]
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,13 @@
+[ignore]
+.*/node_modules/fbjs/.*
+.*.git/.*
+
+[include]
+./static/js
+
+[libs]
+./static/js/flow/declarations.js
+
+[options]
+esproposal.class_static_fields=enable
+esproposal.class_instance_fields=enable

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,5 +1,7 @@
 FROM node:6.2
 MAINTAINER ODL DevOps <mitx-devops@mit.edu>
 
+RUN apt-get update && apt-get install libelf1
+
 RUN adduser --disabled-password --gecos "" mitodl
 USER mitodl

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
     },
     "abbrev": {
       "version": "1.0.7",
-      "from": "abbrev@>=1.0.0 <2.0.0",
+      "from": "abbrev@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
     },
     "accepts": {
@@ -18,9 +18,9 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz"
     },
     "acorn": {
-      "version": "3.1.0",
-      "from": "acorn@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.1.0.tgz"
+      "version": "3.2.0",
+      "from": "acorn@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz"
     },
     "acorn-globals": {
       "version": "1.0.9",
@@ -41,7 +41,7 @@
     },
     "ajaxchimp": {
       "version": "1.3.0",
-      "from": "ajaxchimp@latest",
+      "from": "ajaxchimp@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ajaxchimp/-/ajaxchimp-1.3.0.tgz"
     },
     "align-text": {
@@ -94,6 +94,11 @@
       "from": "append-transform@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.3.0.tgz"
     },
+    "archive-type": {
+      "version": "3.2.0",
+      "from": "archive-type@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz"
+    },
     "are-we-there-yet": {
       "version": "1.1.2",
       "from": "are-we-there-yet@>=1.1.2 <1.2.0",
@@ -114,6 +119,11 @@
       "from": "arr-flatten@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
     },
+    "array-differ": {
+      "version": "1.0.0",
+      "from": "array-differ@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+    },
     "array-equal": {
       "version": "1.0.0",
       "from": "array-equal@>=1.0.0 <2.0.0",
@@ -121,7 +131,7 @@
     },
     "array-find-index": {
       "version": "1.0.1",
-      "from": "array-find-index@>=1.0.0 <2.0.0",
+      "from": "array-find-index@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
     },
     "array-flatten": {
@@ -181,7 +191,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "from": "async@>=1.5.2 <2.0.0",
+      "from": "async@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
     "async-each": {
@@ -237,9 +247,9 @@
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.0.4.tgz"
     },
     "babel-generator": {
-      "version": "6.9.0",
+      "version": "6.10.0",
       "from": "babel-generator@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.9.0.tgz"
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.10.0.tgz"
     },
     "babel-helper-bindify-decorators": {
       "version": "6.8.0",
@@ -368,12 +378,12 @@
     },
     "babel-plugin-syntax-flow": {
       "version": "6.8.0",
-      "from": "babel-plugin-syntax-flow@>=6.3.13 <7.0.0",
+      "from": "babel-plugin-syntax-flow@>=6.8.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.8.0.tgz"
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.8.0",
-      "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0",
+      "from": "babel-plugin-syntax-jsx@>=6.8.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.8.0.tgz"
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -397,9 +407,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.8.0.tgz"
     },
     "babel-plugin-transform-class-properties": {
-      "version": "6.9.0",
+      "version": "6.9.1",
       "from": "babel-plugin-transform-class-properties@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.9.0.tgz"
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.9.1.tgz"
     },
     "babel-plugin-transform-decorators": {
       "version": "6.8.0",
@@ -417,9 +427,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.9.0",
+      "version": "6.10.1",
       "from": "babel-plugin-transform-es2015-block-scoping@>=6.6.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.9.0.tgz"
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.10.1.tgz"
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.9.0",
@@ -513,7 +523,7 @@
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-flow-strip-types@>=6.3.13 <7.0.0",
+      "from": "babel-plugin-transform-flow-strip-types@>=6.8.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.8.0.tgz"
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -528,7 +538,7 @@
     },
     "babel-plugin-transform-react-jsx": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-react-jsx@>=6.3.13 <7.0.0",
+      "from": "babel-plugin-transform-react-jsx@6.8.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz"
     },
     "babel-plugin-transform-react-jsx-source": {
@@ -542,9 +552,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.9.0.tgz",
       "dependencies": {
         "babel-core": {
-          "version": "6.9.0",
+          "version": "6.9.1",
           "from": "babel-core@>=6.9.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.9.0.tgz"
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.9.1.tgz"
         },
         "babel-register": {
           "version": "6.9.0",
@@ -596,9 +606,9 @@
       }
     },
     "babel-runtime": {
-      "version": "6.9.0",
+      "version": "6.9.2",
       "from": "babel-runtime@>=6.0.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.0.tgz"
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz"
     },
     "babel-template": {
       "version": "6.9.0",
@@ -611,14 +621,14 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.9.0.tgz"
     },
     "babel-types": {
-      "version": "6.9.0",
+      "version": "6.10.0",
       "from": "babel-types@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.9.0.tgz"
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.10.0.tgz"
     },
     "babylon": {
-      "version": "6.8.0",
+      "version": "6.8.1",
       "from": "babylon@>=6.7.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.0.tgz"
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.1.tgz"
     },
     "balanced-match": {
       "version": "0.4.1",
@@ -640,27 +650,52 @@
       "from": "batch@0.5.3",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
     },
+    "beeper": {
+      "version": "1.1.0",
+      "from": "beeper@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+    },
     "big.js": {
       "version": "3.1.3",
       "from": "big.js@>=3.1.3 <4.0.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
     },
+    "bin-check": {
+      "version": "2.0.0",
+      "from": "bin-check@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz"
+    },
+    "bin-version": {
+      "version": "1.0.4",
+      "from": "bin-version@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz"
+    },
+    "bin-version-check": {
+      "version": "2.1.0",
+      "from": "bin-version-check@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+      "dependencies": {
+        "semver": {
+          "version": "4.3.6",
+          "from": "semver@>=4.0.3 <5.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+        }
+      }
+    },
+    "bin-wrapper": {
+      "version": "3.0.2",
+      "from": "bin-wrapper@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz"
+    },
     "binary-extensions": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "from": "binary-extensions@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.1.tgz"
     },
     "bl": {
       "version": "1.1.2",
-      "from": "bl@>=1.1.2 <1.2.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.5 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-        }
-      }
+      "from": "bl@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz"
     },
     "block-stream": {
       "version": "0.0.9",
@@ -703,19 +738,19 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "browserslist": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "from": "browserslist@>=1.3.1 <1.4.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.2.tgz"
     },
     "buffer": {
       "version": "3.6.0",
       "from": "buffer@>=3.0.3 <4.0.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz"
     },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+    "buffer-to-vinyl": {
+      "version": "1.1.0",
+      "from": "buffer-to-vinyl@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz"
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -748,14 +783,31 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
     },
     "caniuse-db": {
-      "version": "1.0.30000469",
+      "version": "1.0.30000479",
       "from": "caniuse-db@>=1.0.30000444 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000469.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000479.tgz"
+    },
+    "capture-stack-trace": {
+      "version": "1.0.0",
+      "from": "capture-stack-trace@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
     },
     "caseless": {
       "version": "0.11.0",
       "from": "caseless@>=0.11.0 <0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+    },
+    "caw": {
+      "version": "1.2.0",
+      "from": "caw@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "from": "object-assign@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+        }
+      }
     },
     "center-align": {
       "version": "0.1.3",
@@ -764,12 +816,12 @@
     },
     "chai": {
       "version": "3.5.0",
-      "from": "chai@latest",
+      "from": "chai@>=3.5.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz"
     },
     "chai-as-promised": {
       "version": "5.3.0",
-      "from": "chai-as-promised@latest",
+      "from": "chai-as-promised@>=5.3.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz"
     },
     "chalk": {
@@ -778,9 +830,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "chokidar": {
-      "version": "1.5.1",
+      "version": "1.5.2",
       "from": "chokidar@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.5.2.tgz"
     },
     "clamp": {
       "version": "1.0.1",
@@ -808,14 +860,31 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
     },
     "cliui": {
-      "version": "3.2.0",
-      "from": "cliui@>=3.0.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
+      "version": "2.1.0",
+      "from": "cliui@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "from": "wordwrap@0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+        }
+      }
     },
     "clone": {
       "version": "1.0.2",
-      "from": "clone@>=1.0.2 <2.0.0",
+      "from": "clone@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+    },
+    "clone-stats": {
+      "version": "0.0.1",
+      "from": "clone-stats@>=0.0.1 <0.0.2",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+    },
+    "co": {
+      "version": "3.1.0",
+      "from": "co@3.1.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
     },
     "coa": {
       "version": "1.0.1",
@@ -863,9 +932,9 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "commander": {
-      "version": "2.9.0",
-      "from": "commander@>=2.9.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+      "version": "2.8.1",
+      "from": "commander@>=2.8.1 <2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
     },
     "compressible": {
       "version": "2.0.8",
@@ -885,14 +954,7 @@
     "concat-stream": {
       "version": "1.5.1",
       "from": "concat-stream@>=1.4.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
     },
     "connect-history-api-fallback": {
       "version": "1.1.0",
@@ -903,6 +965,11 @@
       "version": "1.1.0",
       "from": "console-browserify@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
+    },
+    "console-stream": {
+      "version": "0.1.1",
+      "from": "console-stream@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz"
     },
     "constants-browserify": {
       "version": "0.0.1",
@@ -944,10 +1011,22 @@
       "from": "core-util-is@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
+    "create-error-class": {
+      "version": "3.0.2",
+      "from": "create-error-class@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz"
+    },
     "cross-spawn-async": {
       "version": "2.2.4",
       "from": "cross-spawn-async@>=2.1.9 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.4.tgz"
+      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.4.tgz",
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.0.1",
+          "from": "lru-cache@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz"
+        }
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
@@ -980,9 +1059,9 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
     },
     "cssnano": {
-      "version": "3.6.2",
+      "version": "3.7.0",
       "from": "cssnano@>=2.6.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.6.2.tgz"
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.7.0.tgz"
     },
     "csso": {
       "version": "2.0.0",
@@ -995,9 +1074,14 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz"
     },
     "cssstyle": {
-      "version": "0.2.34",
+      "version": "0.2.36",
       "from": "cssstyle@>=0.2.34 <0.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.34.tgz"
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.36.tgz"
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "from": "currently-unhandled@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
     },
     "d": {
       "version": "0.1.1",
@@ -1005,9 +1089,9 @@
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
     },
     "dashdash": {
-      "version": "1.13.1",
+      "version": "1.14.0",
       "from": "dashdash@>=1.12.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1021,6 +1105,11 @@
       "from": "date-now@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
     },
+    "dateformat": {
+      "version": "1.0.12",
+      "from": "dateformat@>=1.0.11 <2.0.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz"
+    },
     "debug": {
       "version": "2.2.0",
       "from": "debug@>=2.1.1 <3.0.0",
@@ -1030,6 +1119,89 @@
       "version": "1.2.0",
       "from": "decamelize@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+    },
+    "decompress": {
+      "version": "3.0.0",
+      "from": "decompress@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz"
+    },
+    "decompress-tar": {
+      "version": "3.1.0",
+      "from": "decompress-tar@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0",
+          "from": "clone@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "from": "vinyl@>=0.4.3 <0.5.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+        }
+      }
+    },
+    "decompress-tarbz2": {
+      "version": "3.1.0",
+      "from": "decompress-tarbz2@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0",
+          "from": "clone@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "from": "vinyl@>=0.4.3 <0.5.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+        }
+      }
+    },
+    "decompress-targz": {
+      "version": "3.1.0",
+      "from": "decompress-targz@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0",
+          "from": "clone@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "from": "vinyl@>=0.4.3 <0.5.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+        }
+      }
+    },
+    "decompress-unzip": {
+      "version": "3.4.0",
+      "from": "decompress-unzip@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
+      "dependencies": {
+        "through2": {
+          "version": "2.0.1",
+          "from": "through2@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+        }
+      }
     },
     "deep-eql": {
       "version": "0.1.3",
@@ -1047,6 +1219,11 @@
       "version": "1.0.1",
       "from": "deep-equal@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+    },
+    "deep-extend": {
+      "version": "0.4.1",
+      "from": "deep-extend@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1120,6 +1297,33 @@
       "from": "domain-browser@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
+    "download": {
+      "version": "4.4.3",
+      "from": "download@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz"
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "from": "duplexer2@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
+    },
+    "duplexify": {
+      "version": "3.4.3",
+      "from": "duplexify@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz",
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.0.0",
+          "from": "end-of-stream@1.0.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz"
+        }
+      }
+    },
+    "each-async": {
+      "version": "1.1.1",
+      "from": "each-async@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz"
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "from": "ecc-jsbn@>=0.1.1 <0.2.0",
@@ -1139,6 +1343,11 @@
       "version": "0.1.12",
       "from": "encoding@>=0.1.11 <0.2.0",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
+    },
+    "end-of-stream": {
+      "version": "1.1.0",
+      "from": "end-of-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
     },
     "enhanced-resolve": {
       "version": "0.9.1",
@@ -1163,19 +1372,26 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
     },
     "es-abstract": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "from": "es-abstract@>=1.3.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.1.tgz"
     },
     "es-to-primitive": {
       "version": "1.1.1",
-      "from": "es-to-primitive@>=1.1.0 <2.0.0",
+      "from": "es-to-primitive@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz"
     },
     "es5-ext": {
       "version": "0.10.11",
-      "from": "es5-ext@>=0.10.10 <0.11.0",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+      "from": "es5-ext@>=0.10.11 <0.11.0",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
+      "dependencies": {
+        "es6-symbol": {
+          "version": "3.0.2",
+          "from": "es6-symbol@>=3.0.2 <3.1.0",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+        }
+      }
     },
     "es6-iterator": {
       "version": "2.0.0",
@@ -1183,9 +1399,9 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
     },
     "es6-map": {
-      "version": "0.1.3",
+      "version": "0.1.4",
       "from": "es6-map@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz"
     },
     "es6-set": {
       "version": "0.1.4",
@@ -1193,9 +1409,9 @@
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
     },
     "es6-symbol": {
-      "version": "3.0.2",
-      "from": "es6-symbol@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+      "version": "3.1.0",
+      "from": "es6-symbol@>=3.1.0 <3.2.0",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
     },
     "es6-weak-map": {
       "version": "2.0.1",
@@ -1240,9 +1456,9 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.9.0.tgz",
       "dependencies": {
         "globals": {
-          "version": "9.7.0",
+          "version": "9.8.0",
           "from": "globals@>=9.2.0 <10.0.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.7.0.tgz"
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.8.0.tgz"
         },
         "user-home": {
           "version": "2.0.0",
@@ -1260,6 +1476,16 @@
       "version": "3.2.0",
       "from": "eslint-plugin-babel@3.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.2.0.tgz"
+    },
+    "eslint-plugin-flow-vars": {
+      "version": "0.4.0",
+      "from": "eslint-plugin-flow-vars@latest",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flow-vars/-/eslint-plugin-flow-vars-0.4.0.tgz"
+    },
+    "eslint-plugin-flowtype": {
+      "version": "2.2.7",
+      "from": "eslint-plugin-flowtype@>=2.2.7 <3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.2.7.tgz"
     },
     "eslint-plugin-react": {
       "version": "5.0.1",
@@ -1323,6 +1549,11 @@
       "from": "eventsource@>=0.1.6 <0.2.0",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz"
     },
+    "executable": {
+      "version": "1.1.0",
+      "from": "executable@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz"
+    },
     "exit-hook": {
       "version": "1.1.1",
       "from": "exit-hook@>=1.0.0 <2.0.0",
@@ -1367,8 +1598,13 @@
     },
     "extend": {
       "version": "3.0.0",
-      "from": "extend@>=3.0.0 <3.1.0",
+      "from": "extend@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "from": "extend-shallow@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
     },
     "extglob": {
       "version": "0.3.2",
@@ -1379,6 +1615,11 @@
       "version": "1.0.2",
       "from": "extsprintf@1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+    },
+    "fancy-log": {
+      "version": "1.2.0",
+      "from": "fancy-log@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz"
     },
     "fast-levenshtein": {
       "version": "1.1.3",
@@ -1396,9 +1637,9 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz"
     },
     "fbjs": {
-      "version": "0.8.2",
+      "version": "0.8.3",
       "from": "fbjs@>=0.8.0 <0.9.0",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.3.tgz",
       "dependencies": {
         "core-js": {
           "version": "1.2.6",
@@ -1406,6 +1647,11 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
         }
       }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "from": "fd-slicer@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
     },
     "fetch-mock": {
       "version": "4.4.0",
@@ -1427,10 +1673,25 @@
       "from": "file-loader@0.8.5",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz"
     },
+    "file-type": {
+      "version": "3.8.0",
+      "from": "file-type@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.8.0.tgz"
+    },
     "filename-regex": {
       "version": "2.0.0",
       "from": "filename-regex@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+    },
+    "filename-reserved-regex": {
+      "version": "1.0.0",
+      "from": "filename-reserved-regex@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz"
+    },
+    "filenamify": {
+      "version": "1.2.1",
+      "from": "filenamify@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz"
     },
     "fileset": {
       "version": "0.2.1",
@@ -1466,6 +1727,16 @@
         }
       }
     },
+    "find-versions": {
+      "version": "1.2.1",
+      "from": "find-versions@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz"
+    },
+    "first-chunk-stream": {
+      "version": "1.0.0",
+      "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+    },
     "flat-cache": {
       "version": "1.0.10",
       "from": "flat-cache@>=1.0.9 <2.0.0",
@@ -1475,6 +1746,11 @@
       "version": "1.0.2",
       "from": "flatten@1.0.2",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
+    },
+    "flow-bin": {
+      "version": "0.27.0",
+      "from": "flow-bin@latest",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.27.0.tgz"
     },
     "for-in": {
       "version": "0.1.5",
@@ -1546,6 +1822,11 @@
       "from": "generate-object-property@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
+    "get-proxy": {
+      "version": "1.1.0",
+      "from": "get-proxy@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz"
+    },
     "get-stdin": {
       "version": "4.0.1",
       "from": "get-stdin@>=4.0.1 <5.0.0",
@@ -1577,6 +1858,18 @@
       "version": "2.0.0",
       "from": "glob-parent@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+    },
+    "glob-stream": {
+      "version": "5.3.2",
+      "from": "glob-stream@>=5.3.2 <6.0.0",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.2.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "from": "glob@>=5.0.3 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+        }
+      }
     },
     "globals": {
       "version": "8.18.0",
@@ -1617,17 +1910,22 @@
           "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
-        "lru-cache": {
-          "version": "2.7.3",
-          "from": "lru-cache@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-        },
         "minimatch": {
           "version": "0.2.14",
           "from": "minimatch@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         }
       }
+    },
+    "glogg": {
+      "version": "1.0.0",
+      "from": "glogg@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
+    },
+    "got": {
+      "version": "5.6.0",
+      "from": "got@>=5.0.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-5.6.0.tgz"
     },
     "graceful-fs": {
       "version": "4.1.4",
@@ -1644,6 +1942,55 @@
       "from": "growl@1.8.1",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
     },
+    "gulp-decompress": {
+      "version": "1.2.0",
+      "from": "gulp-decompress@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz"
+    },
+    "gulp-rename": {
+      "version": "1.2.2",
+      "from": "gulp-rename@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz"
+    },
+    "gulp-sourcemaps": {
+      "version": "1.6.0",
+      "from": "gulp-sourcemaps@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+      "dependencies": {
+        "through2": {
+          "version": "2.0.1",
+          "from": "through2@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.7",
+      "from": "gulp-util@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "from": "object-assign@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+        },
+        "through2": {
+          "version": "2.0.1",
+          "from": "through2@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+        },
+        "vinyl": {
+          "version": "0.5.3",
+          "from": "vinyl@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+        }
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "from": "gulplog@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
+    },
     "handlebars": {
       "version": "4.0.5",
       "from": "handlebars@>=4.0.3 <5.0.0",
@@ -1659,7 +2006,14 @@
     "har-validator": {
       "version": "2.0.6",
       "from": "har-validator@>=2.0.6 <2.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "from": "commander@>=2.9.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+        }
+      }
     },
     "has": {
       "version": "1.0.1",
@@ -1675,6 +2029,11 @@
       "version": "1.0.0",
       "from": "has-flag@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+    },
+    "has-gulplog": {
+      "version": "0.1.0",
+      "from": "has-gulplog@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
     },
     "has-own": {
       "version": "1.0.0",
@@ -1709,13 +2068,13 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
     "hoist-non-react-statics": {
-      "version": "1.0.6",
+      "version": "1.1.0",
       "from": "hoist-non-react-statics@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.1.0.tgz"
     },
     "home-or-tmp": {
       "version": "1.0.0",
-      "from": "home-or-tmp@^1.0.0",
+      "from": "home-or-tmp@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
     },
     "hosted-git-info": {
@@ -1773,9 +2132,14 @@
       "from": "ignore@>=3.1.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.2.tgz"
     },
+    "immutable": {
+      "version": "3.8.1",
+      "from": "immutable@>=3.7.6 <4.0.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz"
+    },
     "imports-loader": {
       "version": "0.6.5",
-      "from": "imports-loader@latest",
+      "from": "imports-loader@>=0.6.5 <0.7.0",
       "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
       "dependencies": {
         "source-map": {
@@ -1824,8 +2188,13 @@
     },
     "inherits": {
       "version": "2.0.1",
-      "from": "inherits@>=2.0.0 <3.0.0",
+      "from": "inherits@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+    },
+    "ini": {
+      "version": "1.3.4",
+      "from": "ini@>=1.3.0 <1.4.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "inline-style-prefix-all": {
       "version": "2.0.2",
@@ -1852,15 +2221,15 @@
       "from": "invariant@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "from": "invert-kv@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-    },
     "ipaddr.js": {
       "version": "1.0.5",
       "from": "ipaddr.js@1.0.5",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
+    },
+    "is-absolute": {
+      "version": "0.1.7",
+      "from": "is-absolute@>=0.1.5 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz"
     },
     "is-absolute-url": {
       "version": "2.0.0",
@@ -1887,9 +2256,14 @@
       "from": "is-builtin-module@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
+    "is-bzip2": {
+      "version": "1.0.0",
+      "from": "is-bzip2@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
+    },
     "is-callable": {
       "version": "1.1.3",
-      "from": "is-callable@>=1.1.1 <2.0.0",
+      "from": "is-callable@>=1.1.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
     },
     "is-date-object": {
@@ -1932,15 +2306,30 @@
       "from": "is-glob@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
     },
+    "is-gzip": {
+      "version": "1.0.0",
+      "from": "is-gzip@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
+    },
     "is-my-json-valid": {
       "version": "2.13.1",
-      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+      "from": "is-my-json-valid@>=2.10.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
+    },
+    "is-natural-number": {
+      "version": "2.1.1",
+      "from": "is-natural-number@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz"
     },
     "is-number": {
       "version": "2.1.0",
       "from": "is-number@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "from": "is-obj@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1977,15 +2366,30 @@
       "from": "is-property@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
+    "is-redirect": {
+      "version": "1.0.0",
+      "from": "is-redirect@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
+    },
     "is-regex": {
       "version": "1.0.3",
       "from": "is-regex@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
     },
+    "is-relative": {
+      "version": "0.1.3",
+      "from": "is-relative@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+    },
     "is-resolvable": {
       "version": "1.0.0",
       "from": "is-resolvable@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz"
+    },
+    "is-retry-allowed": {
+      "version": "1.0.0",
+      "from": "is-retry-allowed@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.0.0.tgz"
     },
     "is-stream": {
       "version": "1.1.0",
@@ -2002,15 +2406,35 @@
       "from": "is-symbol@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
     },
+    "is-tar": {
+      "version": "1.0.0",
+      "from": "is-tar@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "from": "is-typedarray@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
+    "is-url": {
+      "version": "1.2.1",
+      "from": "is-url@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.1.tgz"
+    },
     "is-utf8": {
       "version": "0.2.1",
       "from": "is-utf8@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+    },
+    "is-valid-glob": {
+      "version": "0.3.0",
+      "from": "is-valid-glob@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz"
+    },
+    "is-zip": {
+      "version": "1.0.0",
+      "from": "is-zip@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
     },
     "isarray": {
       "version": "1.0.0",
@@ -2045,14 +2469,7 @@
     "istanbul": {
       "version": "1.0.0-alpha.2",
       "from": "istanbul@1.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-1.0.0-alpha.2.tgz",
-      "dependencies": {
-        "wordwrap": {
-          "version": "1.0.0",
-          "from": "wordwrap@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-1.0.0-alpha.2.tgz"
     },
     "istanbul-api": {
       "version": "1.0.0-alpha.13",
@@ -2215,10 +2632,15 @@
       "from": "lazy-cache@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
     },
-    "lcid": {
+    "lazy-req": {
+      "version": "1.1.0",
+      "from": "lazy-req@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz"
+    },
+    "lazystream": {
       "version": "1.0.0",
-      "from": "lcid@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+      "from": "lazystream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
     },
     "levn": {
       "version": "0.3.0",
@@ -2262,6 +2684,11 @@
       "from": "lodash._baseclone@>=4.5.0 <4.6.0",
       "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-4.5.7.tgz"
     },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+    },
     "lodash._baseiteratee": {
       "version": "4.7.0",
       "from": "lodash._baseiteratee@>=4.7.0 <4.8.0",
@@ -2277,10 +2704,40 @@
       "from": "lodash._basetostring@>=4.12.0 <4.13.0",
       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz"
     },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+    },
     "lodash._createcompounder": {
       "version": "3.0.0",
       "from": "lodash._createcompounder@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz"
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+    },
+    "lodash._reescape": {
+      "version": "3.0.0",
+      "from": "lodash._reescape@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0",
+      "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
     },
     "lodash._root": {
       "version": "3.0.1",
@@ -2311,6 +2768,26 @@
       "version": "3.2.0",
       "from": "lodash.deburr@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz"
+    },
+    "lodash.escape": {
+      "version": "3.2.0",
+      "from": "lodash.escape@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
+    },
+    "lodash.isarguments": {
+      "version": "3.0.8",
+      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+    },
+    "lodash.isequal": {
+      "version": "4.2.0",
+      "from": "lodash.isequal@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.2.0.tgz"
     },
     "lodash.isplainobject": {
       "version": "4.0.4",
@@ -2357,6 +2834,33 @@
       "from": "lodash.rest@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.3.tgz"
     },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+    },
+    "lodash.template": {
+      "version": "3.6.2",
+      "from": "lodash.template@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+      "dependencies": {
+        "lodash._basetostring": {
+          "version": "3.0.1",
+          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "from": "lodash.keys@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+        }
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "3.1.1",
+      "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
+    },
     "lodash.throttle": {
       "version": "4.0.1",
       "from": "lodash.throttle@>=4.0.1 <5.0.0",
@@ -2372,6 +2876,11 @@
       "from": "lodash.words@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz"
     },
+    "logalot": {
+      "version": "2.1.0",
+      "from": "logalot@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz"
+    },
     "lolex": {
       "version": "1.3.2",
       "from": "lolex@1.3.2",
@@ -2379,7 +2888,7 @@
     },
     "longest": {
       "version": "1.0.1",
-      "from": "longest@>=1.0.1 <2.0.0",
+      "from": "longest@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "loose-envify": {
@@ -2388,14 +2897,29 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz"
     },
     "loud-rejection": {
-      "version": "1.3.0",
+      "version": "1.4.1",
       "from": "loud-rejection@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.4.1.tgz"
+    },
+    "lowercase-keys": {
+      "version": "1.0.0",
+      "from": "lowercase-keys@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+    },
+    "lpad": {
+      "version": "2.0.1",
+      "from": "lpad@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/lpad/-/lpad-2.0.1.tgz"
+    },
+    "lpad-align": {
+      "version": "1.1.0",
+      "from": "lpad-align@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.0.tgz"
     },
     "lru-cache": {
-      "version": "4.0.1",
-      "from": "lru-cache@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz"
+      "version": "2.7.3",
+      "from": "lru-cache@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
     },
     "map-obj": {
       "version": "1.0.1",
@@ -2419,13 +2943,18 @@
     },
     "meow": {
       "version": "3.7.0",
-      "from": "meow@>=3.7.0 <4.0.0",
+      "from": "meow@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
     },
     "merge-descriptors": {
       "version": "1.0.1",
       "from": "merge-descriptors@1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+    },
+    "merge-stream": {
+      "version": "1.0.0",
+      "from": "merge-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz"
     },
     "methods": {
       "version": "1.1.2",
@@ -2434,7 +2963,7 @@
     },
     "micromatch": {
       "version": "2.3.8",
-      "from": "micromatch@>=2.1.5 <3.0.0",
+      "from": "micromatch@>=2.3.7 <3.0.0",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz"
     },
     "mime": {
@@ -2499,11 +3028,6 @@
           "from": "graceful-fs@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
         },
-        "lru-cache": {
-          "version": "2.7.3",
-          "from": "lru-cache@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-        },
         "minimatch": {
           "version": "0.2.14",
           "from": "minimatch@>=0.2.11 <0.3.0",
@@ -2526,15 +3050,37 @@
       "from": "ms@0.7.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
+    "multipipe": {
+      "version": "0.1.2",
+      "from": "multipipe@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "dependencies": {
+        "duplexer2": {
+          "version": "0.0.2",
+          "from": "duplexer2@0.0.2",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.9 <1.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        }
+      }
+    },
     "mute-stream": {
       "version": "0.0.5",
       "from": "mute-stream@0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
     },
     "nan": {
-      "version": "2.3.3",
+      "version": "2.3.5",
       "from": "nan@>=2.3.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.3.tgz"
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz"
     },
     "negotiator": {
       "version": "0.6.1",
@@ -2542,9 +3088,9 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
     },
     "node-fetch": {
-      "version": "1.5.2",
-      "from": "node-fetch@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.5.2.tgz"
+      "version": "1.5.3",
+      "from": "node-fetch@>=1.3.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.5.3.tgz"
     },
     "node-gyp": {
       "version": "3.3.1",
@@ -2562,11 +3108,6 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
             }
           }
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "from": "lru-cache@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
         },
         "minimatch": {
           "version": "1.0.0",
@@ -2597,6 +3138,11 @@
       "from": "node-sass@3.7.0",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.7.0.tgz"
     },
+    "node-status-codes": {
+      "version": "1.0.0",
+      "from": "node-status-codes@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
+    },
     "node-uuid": {
       "version": "1.4.7",
       "from": "node-uuid@>=1.4.7 <1.5.0",
@@ -2604,7 +3150,7 @@
     },
     "nopt": {
       "version": "3.0.6",
-      "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+      "from": "nopt@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
     },
     "normalize-package-data": {
@@ -2623,9 +3169,9 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
     },
     "normalize-url": {
-      "version": "1.5.2",
+      "version": "1.5.3",
       "from": "normalize-url@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.5.2.tgz"
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.5.3.tgz"
     },
     "npmlog": {
       "version": "2.0.4",
@@ -2643,9 +3189,9 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
     },
     "nwmatcher": {
-      "version": "1.3.7",
+      "version": "1.3.8",
       "from": "nwmatcher@>=1.3.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.7.tgz"
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.8.tgz"
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -2694,27 +3240,30 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "from": "optimist@>=0.6.0 <0.7.0",
+      "from": "optimist@>=0.6.1 <0.7.0",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
           "from": "minimist@>=0.0.1 <0.1.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "from": "wordwrap@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
         }
       }
     },
     "optionator": {
       "version": "0.8.1",
       "from": "optionator@>=0.8.1 <0.9.0",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
-      "dependencies": {
-        "wordwrap": {
-          "version": "1.0.0",
-          "from": "wordwrap@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz"
+    },
+    "ordered-read-streams": {
+      "version": "0.3.0",
+      "from": "ordered-read-streams@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz"
     },
     "original": {
       "version": "1.0.0",
@@ -2733,15 +3282,15 @@
       "from": "os-browserify@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
     },
+    "os-filter-obj": {
+      "version": "1.0.3",
+      "from": "os-filter-obj@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz"
+    },
     "os-homedir": {
       "version": "1.0.1",
       "from": "os-homedir@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "from": "os-locale@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
     },
     "os-tmpdir": {
       "version": "1.0.1",
@@ -2823,6 +3372,11 @@
       "from": "pbkdf2-compat@2.0.1",
       "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
     },
+    "pend": {
+      "version": "1.2.0",
+      "from": "pend@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+    },
     "pify": {
       "version": "2.3.0",
       "from": "pify@>=2.0.0 <3.0.0",
@@ -2866,9 +3420,9 @@
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.0.tgz"
     },
     "postcss-convert-values": {
-      "version": "2.3.4",
+      "version": "2.4.0",
       "from": "postcss-convert-values@>=2.3.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.4.0.tgz"
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
@@ -2980,6 +3534,11 @@
       "from": "postcss-reduce-idents@>=2.2.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.3.0.tgz"
     },
+    "postcss-reduce-initial": {
+      "version": "1.0.0",
+      "from": "postcss-reduce-initial@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.0.tgz"
+    },
     "postcss-reduce-transforms": {
       "version": "1.0.3",
       "from": "postcss-reduce-transforms@>=1.0.3 <2.0.0",
@@ -3031,9 +3590,9 @@
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
     },
     "process": {
-      "version": "0.11.4",
+      "version": "0.11.5",
       "from": "process@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.4.tgz"
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.5.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -3081,9 +3640,9 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
     },
     "query-string": {
-      "version": "4.1.0",
+      "version": "4.2.2",
       "from": "query-string@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.2.2.tgz"
     },
     "querystring": {
       "version": "0.2.0",
@@ -3109,6 +3668,11 @@
       "version": "1.0.3",
       "from": "range-parser@>=1.0.3 <1.1.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+    },
+    "rc": {
+      "version": "1.1.6",
+      "from": "rc@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz"
     },
     "react": {
       "version": "15.1.0",
@@ -3248,6 +3812,11 @@
         }
       }
     },
+    "read-all-stream": {
+      "version": "3.1.0",
+      "from": "read-all-stream@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz"
+    },
     "read-json-sync": {
       "version": "1.1.1",
       "from": "read-json-sync@>=1.1.0 <2.0.0",
@@ -3264,9 +3833,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
-      "version": "2.1.4",
-      "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+      "version": "2.0.6",
+      "from": "readable-stream@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
     },
     "readdirp": {
       "version": "2.0.0",
@@ -3289,9 +3858,9 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
     },
     "reduce-css-calc": {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "from": "reduce-css-calc@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.4.tgz",
       "dependencies": {
         "balanced-match": {
           "version": "0.1.0",
@@ -3333,9 +3902,14 @@
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.0.1.tgz"
     },
     "regenerate": {
-      "version": "1.2.1",
+      "version": "1.3.1",
       "from": "regenerate@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz"
+    },
+    "regenerator-runtime": {
+      "version": "0.9.5",
+      "from": "regenerator-runtime@>=0.9.5 <0.10.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
     },
     "regex-cache": {
       "version": "0.4.3",
@@ -3372,9 +3946,14 @@
       "from": "repeating@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
     },
+    "replace-ext": {
+      "version": "0.0.1",
+      "from": "replace-ext@0.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+    },
     "request": {
       "version": "2.72.0",
-      "from": "request@>=2.61.0 <3.0.0",
+      "from": "request@>=2.55.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz"
     },
     "require-uncached": {
@@ -3404,7 +3983,7 @@
     },
     "rimraf": {
       "version": "2.5.2",
-      "from": "rimraf@>=2.0.0 <3.0.0",
+      "from": "rimraf@>=2.2.8 <3.0.0",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
     },
     "ripemd160": {
@@ -3449,10 +4028,25 @@
       "from": "sax@>=1.2.1 <1.3.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
     },
+    "seek-bzip": {
+      "version": "1.0.5",
+      "from": "seek-bzip@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz"
+    },
     "semver": {
       "version": "5.1.0",
       "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+    },
+    "semver-regex": {
+      "version": "1.0.0",
+      "from": "semver-regex@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
+    },
+    "semver-truncate": {
+      "version": "1.1.0",
+      "from": "semver-truncate@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.0.tgz"
     },
     "send": {
       "version": "0.13.1",
@@ -3484,9 +4078,26 @@
       }
     },
     "serve-static": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "from": "serve-static@>=1.10.2 <1.11.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
+      "dependencies": {
+        "mime": {
+          "version": "1.3.4",
+          "from": "mime@1.3.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+        },
+        "send": {
+          "version": "0.13.2",
+          "from": "send@0.13.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz"
+        }
+      }
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
     },
     "sha.js": {
       "version": "2.2.6",
@@ -3572,7 +4183,7 @@
     },
     "source-map-support": {
       "version": "0.2.10",
-      "from": "source-map-support@^0.2.10",
+      "from": "source-map-support@>=0.2.10 <0.3.0",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
       "dependencies": {
         "source-map": {
@@ -3581,6 +4192,11 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
         }
       }
+    },
+    "sparkles": {
+      "version": "1.0.0",
+      "from": "sparkles@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -3612,6 +4228,11 @@
       "from": "sprintf-js@>=1.0.2 <1.1.0",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
+    "squeak": {
+      "version": "1.3.0",
+      "from": "squeak@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz"
+    },
     "sshpk": {
       "version": "1.8.3",
       "from": "sshpk@>=1.7.0 <2.0.0",
@@ -3623,6 +4244,11 @@
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
+    },
+    "stat-mode": {
+      "version": "0.2.1",
+      "from": "stat-mode@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz"
     },
     "statuses": {
       "version": "1.2.1",
@@ -3641,7 +4267,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@^1.0.27-1",
+          "from": "readable-stream@>=1.0.27-1 <2.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         }
       }
@@ -3650,6 +4276,11 @@
       "version": "0.0.2",
       "from": "stream-cache@>=0.0.1 <0.1.0",
       "resolved": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz"
+    },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "from": "stream-combiner2@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -3681,6 +4312,16 @@
       "from": "strip-bom@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
     },
+    "strip-bom-stream": {
+      "version": "1.0.0",
+      "from": "strip-bom-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz"
+    },
+    "strip-dirs": {
+      "version": "1.1.1",
+      "from": "strip-dirs@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz"
+    },
     "strip-indent": {
       "version": "1.0.1",
       "from": "strip-indent@>=1.0.1 <2.0.0",
@@ -3691,6 +4332,11 @@
       "from": "strip-json-comments@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
+    "strip-outer": {
+      "version": "1.0.0",
+      "from": "strip-outer@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz"
+    },
     "striptags": {
       "version": "2.1.1",
       "from": "striptags@2.1.1",
@@ -3700,6 +4346,11 @@
       "version": "0.13.1",
       "from": "style-loader@0.13.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.1.tgz"
+    },
+    "sum-up": {
+      "version": "1.0.3",
+      "from": "sum-up@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz"
     },
     "supports-color": {
       "version": "2.0.0",
@@ -3736,6 +4387,11 @@
       "from": "tar@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
     },
+    "tar-stream": {
+      "version": "1.5.2",
+      "from": "tar-stream@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz"
+    },
     "text-table": {
       "version": "0.2.0",
       "from": "text-table@>=0.2.0 <0.3.0",
@@ -3746,10 +4402,54 @@
       "from": "through@>=2.3.6 <3.0.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
+    "through2": {
+      "version": "0.6.5",
+      "from": "through2@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        }
+      }
+    },
+    "through2-filter": {
+      "version": "2.0.0",
+      "from": "through2-filter@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+      "dependencies": {
+        "through2": {
+          "version": "2.0.1",
+          "from": "through2@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+        }
+      }
+    },
+    "time-stamp": {
+      "version": "1.0.1",
+      "from": "time-stamp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz"
+    },
+    "timed-out": {
+      "version": "2.0.0",
+      "from": "timed-out@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+    },
     "timers-browserify": {
       "version": "1.4.2",
       "from": "timers-browserify@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+    },
+    "to-absolute-glob": {
+      "version": "0.1.1",
+      "from": "to-absolute-glob@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz"
     },
     "to-fast-properties": {
       "version": "1.0.2",
@@ -3758,7 +4458,7 @@
     },
     "tough-cookie": {
       "version": "2.2.2",
-      "from": "tough-cookie@>=2.2.0 <2.3.0",
+      "from": "tough-cookie@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
     },
     "tr46": {
@@ -3770,6 +4470,11 @@
       "version": "1.0.0",
       "from": "trim-newlines@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+    },
+    "trim-repeated": {
+      "version": "1.0.0",
+      "from": "trim-repeated@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz"
     },
     "tryit": {
       "version": "1.0.2",
@@ -3783,7 +4488,7 @@
     },
     "tunnel-agent": {
       "version": "0.4.3",
-      "from": "tunnel-agent@>=0.4.1 <0.5.0",
+      "from": "tunnel-agent@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
     },
     "tv4": {
@@ -3823,38 +4528,13 @@
     },
     "uglify-js": {
       "version": "2.6.2",
-      "from": "uglify-js@>=2.6.0 <2.7.0",
+      "from": "uglify-js@>=2.6.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
           "from": "async@>=0.2.6 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "from": "camelcase@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "from": "cliui@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "from": "window-size@0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "from": "yargs@>=3.10.0 <3.11.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
         }
       }
     },
@@ -3883,10 +4563,20 @@
       "from": "uniqs@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
     },
+    "unique-stream": {
+      "version": "2.2.1",
+      "from": "unique-stream@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
+    },
     "unpipe": {
       "version": "1.0.0",
       "from": "unpipe@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+    },
+    "unzip-response": {
+      "version": "1.0.0",
+      "from": "unzip-response@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz"
     },
     "url": {
       "version": "0.10.3",
@@ -3910,14 +4600,19 @@
       "from": "url-parse@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.1.tgz"
     },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "from": "url-parse-lax@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz"
+    },
     "user-home": {
       "version": "1.1.1",
-      "from": "user-home@^1.1.1",
+      "from": "user-home@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
     },
     "util": {
       "version": "0.10.3",
-      "from": "util@>=0.10.3 <0.11.0",
+      "from": "util@>=0.10.3 <1.0.0",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
     },
     "util-deprecate": {
@@ -3932,8 +4627,13 @@
     },
     "uuid": {
       "version": "2.0.2",
-      "from": "uuid@>=2.0.2 <3.0.0",
+      "from": "uuid@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
+    },
+    "vali-date": {
+      "version": "1.0.0",
+      "from": "vali-date@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz"
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
@@ -3950,10 +4650,37 @@
       "from": "verror@1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
+    "vinyl": {
+      "version": "1.1.1",
+      "from": "vinyl@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
+    },
+    "vinyl-assign": {
+      "version": "1.2.1",
+      "from": "vinyl-assign@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz"
+    },
+    "vinyl-fs": {
+      "version": "2.4.3",
+      "from": "vinyl-fs@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
+      "dependencies": {
+        "through2": {
+          "version": "2.0.1",
+          "from": "through2@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+        }
+      }
+    },
     "vm-browserify": {
       "version": "0.0.4",
       "from": "vm-browserify@0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+    },
+    "ware": {
+      "version": "1.3.0",
+      "from": "ware@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz"
     },
     "warning": {
       "version": "2.1.0",
@@ -4051,29 +4778,29 @@
       "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
     },
     "which": {
-      "version": "1.2.9",
-      "from": "which@>=1.2.8 <2.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.9.tgz"
+      "version": "1.2.10",
+      "from": "which@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
     },
     "window-size": {
-      "version": "0.1.4",
-      "from": "window-size@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+      "version": "0.1.0",
+      "from": "window-size@0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
     },
     "wordwrap": {
-      "version": "0.0.3",
-      "from": "wordwrap@>=0.0.2 <0.1.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+      "version": "1.0.0",
+      "from": "wordwrap@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
     },
     "wowjs": {
       "version": "1.1.3",
-      "from": "wowjs@latest",
+      "from": "wowjs@>=1.1.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/wowjs/-/wowjs-1.1.3.tgz"
     },
-    "wrap-ansi": {
-      "version": "2.0.0",
-      "from": "wrap-ansi@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
+    "wrap-fn": {
+      "version": "0.1.5",
+      "from": "wrap-fn@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz"
     },
     "wrappy": {
       "version": "1.0.2",
@@ -4100,20 +4827,27 @@
       "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
-    "y18n": {
-      "version": "3.2.1",
-      "from": "y18n@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
-    },
     "yallist": {
       "version": "2.0.0",
       "from": "yallist@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
     },
     "yargs": {
-      "version": "3.32.0",
-      "from": "yargs@>=3.8.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
+      "version": "3.10.0",
+      "from": "yargs@>=3.10.0 <3.11.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "from": "camelcase@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+        }
+      }
+    },
+    "yauzl": {
+      "version": "2.5.0",
+      "from": "yauzl@>=2.2.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.5.0.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "babel-eslint": "6.0.4",
     "babel-loader": "6.2.4",
     "babel-plugin-jsx": "1.2.0",
+    "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-plugin-transform-react-jsx": "6.8.0",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
@@ -20,9 +21,12 @@
     "eslint": "2.9.0",
     "eslint-config-defaults": "9.0.0",
     "eslint-plugin-babel": "3.2.0",
+    "eslint-plugin-flow-vars": "^0.4.0",
+    "eslint-plugin-flowtype": "^2.2.7",
     "eslint-plugin-react": "5.0.1",
     "fetch-mock": "4.4.0",
     "file-loader": "0.8.5",
+    "flow-bin": "^0.27.0",
     "history": "2.1.1",
     "imports-loader": "^0.6.5",
     "iso-3166-2": "0.4.0",
@@ -67,6 +71,7 @@
     "postinstall": "./webpack_if_prod.sh",
     "lint": "node ./node_modules/eslint/bin/eslint.js ./static/js",
     "test": "./js_test.sh",
-    "coverage": "node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- --compilers js:babel-register --require static/js/global_init.js 'static/**/*/*_test.js'"
+    "coverage": "node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- --compilers js:babel-register --require static/js/global_init.js 'static/**/*/*_test.js'",
+    "flow": "flow check"
   }
 }

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -1,82 +1,85 @@
+// @flow
 // general UI actions
+import type { Action } from '../flow/generalTypes';
+
 export const CLEAR_UI = 'CLEAR_UI';
 export const clearUI = () => ({ type: CLEAR_UI });
 
 export const UPDATE_DIALOG_TEXT = 'UPDATE_DIALOG_TEXT';
-export const updateDialogText = text => (
+export const updateDialogText = (text: string): Action => (
   { type: UPDATE_DIALOG_TEXT, payload: text }
 );
 
 export const UPDATE_DIALOG_TITLE = 'UPDATE_DIALOG_TITLE';
-export const updateDialogTitle = title => (
+export const updateDialogTitle = (title: string): Action => (
   { type: UPDATE_DIALOG_TITLE, payload: title }
 );
 
 export const SET_DIALOG_VISIBILITY = 'SET_DIALOG_VISIBILITY';
-export const setDialogVisibility = bool => (
+export const setDialogVisibility = (bool: boolean): Action => (
   { type: SET_DIALOG_VISIBILITY, payload: bool }
 );
 
 // work history actions
 export const SET_WORK_HISTORY_EDIT = 'SET_WORK_HISTORY_EDIT';
-export const setWorkHistoryEdit = bool => (
+export const setWorkHistoryEdit = (bool: boolean): Action => (
   { type: SET_WORK_HISTORY_EDIT, payload: bool }
 );
 
 export const SET_WORK_DIALOG_VISIBILITY = 'SET_WORK_DIALOG_VISIBILITY';
-export const setWorkDialogVisibility = bool => (
+export const setWorkDialogVisibility = (bool: boolean): Action => (
   { type: SET_WORK_DIALOG_VISIBILITY, payload: bool }
 );
 
 export const SET_WORK_DIALOG_INDEX = 'SET_WORK_DIALOG_INDEX';
-export const setWorkDialogIndex = index => (
+export const setWorkDialogIndex = (index: number): Action => (
   { type: SET_WORK_DIALOG_INDEX, payload: index }
 );
 
 // dashboard actions
 export const TOGGLE_DASHBOARD_EXPANDER = 'TOGGLE_DASHBOARD_EXPANDER';
-export const toggleDashboardExpander = (courseId, newValue) => ({
+export const toggleDashboardExpander = (courseId: number, newValue: boolean): Action => ({
   type: TOGGLE_DASHBOARD_EXPANDER,
   payload: { courseId, newValue }
 });
 
 // education actions
 export const SET_EDUCATION_DIALOG_VISIBILITY = 'SET_EDUCATION_DIALOG_VISIBILITY';
-export const setEducationDialogVisibility = bool => (
+export const setEducationDialogVisibility = (bool: boolean): Action => (
   { type: SET_EDUCATION_DIALOG_VISIBILITY, payload: bool }
 );
 
 export const SET_EDUCATION_DIALOG_INDEX = 'SET_EDUCATION_DIALOG_INDEX';
-export const setEducationDialogIndex = index => (
+export const setEducationDialogIndex = (index: number): Action => (
   { type: SET_EDUCATION_DIALOG_INDEX, payload: index }
 );
 
 export const SET_EDUCATION_DEGREE_LEVEL = 'SET_EDUCATION_DEGREE_LEVEL';
-export const setEducationDegreeLevel = level => (
+export const setEducationDegreeLevel = (level: string): Action => (
   { type: SET_EDUCATION_DEGREE_LEVEL, payload: level }
 );
 
 export const SET_EDUCATION_DEGREE_INCLUSIONS = 'SET_EDUCATION_DEGREE_INCLUSIONS';
-export const setEducationDegreeInclusions = degreeInclusions => (
+export const setEducationDegreeInclusions = (degreeInclusions: Object): Action => (
   { type: SET_EDUCATION_DEGREE_INCLUSIONS, payload: degreeInclusions }
 );
 
 export const SET_USER_PAGE_DIALOG_VISIBILITY = 'SET_USER_PAGE_DIALOG_VISIBILITY';
-export const setUserPageDialogVisibility = bool => (
+export const setUserPageDialogVisibility = (bool: boolean): Action => (
   { type: SET_USER_PAGE_DIALOG_VISIBILITY, payload: bool }
 );
 
 export const SET_SHOW_EDUCATION_DELETE_DIALOG = 'SET_SHOW_EDUCATION_DELETE_DIALOG';
-export const setShowEducationDeleteDialog = bool => (
+export const setShowEducationDeleteDialog = (bool: boolean): Action => (
   { type: SET_SHOW_EDUCATION_DELETE_DIALOG, payload: bool }
 );
 
 export const SET_SHOW_WORK_DELETE_DIALOG = 'SET_SHOW_WORK_DELETE_DIALOG';
-export const setShowWorkDeleteDialog = bool => (
+export const setShowWorkDeleteDialog = (bool: boolean): Action => (
   { type: SET_SHOW_WORK_DELETE_DIALOG, payload: bool }
 );
 
 export const SET_DELETION_INDEX = 'SET_DELETION_INDEX';
-export const setDeletionIndex = index => (
+export const setDeletionIndex = (index: number): Action => (
   { type: SET_DELETION_INDEX, payload: index }
 );

--- a/static/js/components/EducationDialog.js
+++ b/static/js/components/EducationDialog.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import Button from 'react-mdl/lib/Button';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
@@ -9,13 +10,14 @@ import ProfileFormFields from '../util/ProfileFormFields';
 import { educationValidation } from '../util/validation';
 
 export default class EducationDialog extends ProfileFormFields {
-  constructor(props) {
+  constructor(props: Object) {
     super(props);
     this.educationLevelLabels = {};
     this.educationLevelOptions.forEach(level => {
       this.educationLevelLabels[level.value] = level.label;
     });
   }
+  educationLevelLabels: Object;
 
   static propTypes = {
     open:           React.PropTypes.bool,
@@ -24,7 +26,7 @@ export default class EducationDialog extends ProfileFormFields {
     showLevelForm:  React.PropTypes.bool,
   };
 
-  clearEducationEdit = () => {
+  clearEducationEdit: Function = (): void => {
     const {
       setEducationDialogVisibility,
       setEducationDegreeLevel,
@@ -37,14 +39,14 @@ export default class EducationDialog extends ProfileFormFields {
     clearProfileEdit();
   };
 
-  saveEducationForm = () => {
+  saveEducationForm: Function = (): void => {
     const { saveProfile, profile, ui } = this.props;
     saveProfile(educationValidation, profile, ui).then(() => {
       this.clearEducationEdit();
     });
   };
 
-  editEducationForm = () => {
+  editEducationForm: Function = (): void => {
     const {
       ui: { educationDialogIndex},
       showLevelForm,

--- a/static/js/components/EducationDisplay.js
+++ b/static/js/components/EducationDisplay.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import IconButton from 'react-mdl/lib/IconButton';
 
@@ -18,21 +19,22 @@ import {
 } from '../util/editEducation';
 import { userPrivilegeCheck } from '../util/util';
 import { HIGH_SCHOOL } from '../constants';
+import type { EducationEntry } from '../flow/profileTypes';
 
 export default class EducationDisplay extends ProfileFormFields {
-  openEditEducationForm = index => {
+  openEditEducationForm: Function = (index: number): void => {
     openEditEducationForm.call(this, index);
-  }
+  };
 
-  openNewEducationForm = (level, index) => {
+  openNewEducationForm: Function = (level: string, index: number): void => {
     openNewEducationForm.call(this, level, index);
   };
 
-  deleteEducationEntry = () => {
+  deleteEducationEntry: Function = (): void => {
     deleteEducationEntry.call(this);
   };
 
-  educationRow = (entry, index) => {
+  educationRow: Function = (entry: EducationEntry, index: number): void => {
     const { profile, errors } = this.props;
     if (!('id' in entry)) {
       // don't show new educations, wait until we saved on the server before showing them
@@ -71,7 +73,7 @@ export default class EducationDisplay extends ProfileFormFields {
     );
   };
 
-  renderEducationEntries = () => {
+  renderEducationEntries: Function = (): React$Element[] => {
     const { profile, profile: { education }} = this.props;
     let rows = [];
     if (education !== undefined) {
@@ -91,7 +93,7 @@ export default class EducationDisplay extends ProfileFormFields {
       );
     });
     return rows;
-  }
+  };
 
   render() {
     const { ui: { showEducationDeleteDialog } } = this.props;

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import Button from 'react-mdl/lib/Button';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
@@ -14,27 +15,28 @@ import { generateNewWorkHistory, userPrivilegeCheck } from '../util/util';
 import { employmentValidation } from '../util/validation';
 import ProfileFormFields from '../util/ProfileFormFields';
 import ConfirmDeletion from './ConfirmDeletion';
+import type { WorkHistoryEntry } from '../flow/profileTypes';
 
 class EmploymentForm extends ProfileFormFields {
-  saveWorkHistoryEntry = () => {
+  saveWorkHistoryEntry: Function = (): void => {
     const { saveProfile, profile, ui } = this.props;
     saveProfile(employmentValidation, profile, ui).then(() => {
       this.closeWorkDialog();
     });
-  }
+  };
 
-  toggleWorkHistoryEdit = () => {
+  toggleWorkHistoryEdit: Function = (): void => {
     const { ui, setWorkHistoryEdit } = this.props;
     setWorkHistoryEdit(!ui.workHistoryEdit);
-  }
+  };
 
-  closeWorkDialog = () => {
+  closeWorkDialog: Function = (): void => {
     const { setWorkDialogVisibility, clearProfileEdit } = this.props;
     setWorkDialogVisibility(false);
     clearProfileEdit();
-  }
+  };
 
-  addWorkHistoryEntry = () => {
+  addWorkHistoryEntry: Function = (): void => {
     const {
       updateProfile,
       profile,
@@ -47,16 +49,16 @@ class EmploymentForm extends ProfileFormFields {
     updateProfile(clone);
     setWorkDialogIndex(clone.work_history.length - 1);
     setWorkDialogVisibility(true);
-  }
+  };
 
-  deleteWorkHistoryEntry = () => {
+  deleteWorkHistoryEntry: Function = (): void => {
     const { saveProfile, profile, ui, deletionIndex } = this.props;
     let clone = _.cloneDeep(profile);
     clone['work_history'].splice(deletionIndex, 1);
     saveProfile(employmentValidation, clone, ui);
-  }
+  };
 
-  editWorkHistoryForm () {
+  editWorkHistoryForm(): React$Element {
     const { ui } = this.props;
     let keySet = (key) => ['work_history', ui.workDialogIndex, key];
     return (
@@ -95,12 +97,12 @@ class EmploymentForm extends ProfileFormFields {
     );
   }
 
-  renderWorkHistory () {
+  renderWorkHistory(): React$Element|React$Element[] {
     const { ui, profile, profile: { work_history } } = this.props;
     if ( ui.workHistoryEdit === true ) {
       let workHistoryRows = [];
       if ( !_.isUndefined(work_history) ) {
-        workHistoryRows = Object.entries(work_history).filter(([,entry]) =>
+        workHistoryRows = Object.entries(work_history).filter(([,entry]: [string, WorkHistoryEntry]) =>
           entry.id !== undefined
         ).map(([i, entry]) => this.jobRow(entry, i));
       }
@@ -127,7 +129,7 @@ class EmploymentForm extends ProfileFormFields {
     }
   }
 
-  jobRow (position, index) {
+  jobRow (position: WorkHistoryEntry, index: string) {
     const {
       setWorkDialogVisibility,
       setWorkDialogIndex,

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 

--- a/static/js/components/User.js
+++ b/static/js/components/User.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import { Card, CardMenu } from 'react-mdl/lib/Card';
@@ -17,13 +18,13 @@ export default class User extends React.Component {
     ui:                           React.PropTypes.object,
   };
 
-  toggleShowPersonalDialog = () => {
+  toggleShowPersonalDialog: Function = (): void => {
     const {
       setUserPageDialogVisibility,
       ui: { userPageDialogVisibility }
     } = this.props;
     setUserPageDialogVisibility(!userPageDialogVisibility);
-  }
+  };
 
   render() {
     const { profile } = this.props;

--- a/static/js/components/UserPagePersonalDialog.js
+++ b/static/js/components/UserPagePersonalDialog.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import Button from 'react-mdl/lib/Button';
@@ -14,13 +15,13 @@ export default class UserPagePersonalDialog extends React.Component {
     clearProfileEdit:             React.PropTypes.func,
   };
 
-  closePersonalDialog = () => {
+  closePersonalDialog: Function = (): void => {
     const { setUserPageDialogVisibility, clearProfileEdit } = this.props;
     setUserPageDialogVisibility(false);
     clearProfileEdit();
   };
 
-  savePersonalInfo = () => {
+  savePersonalInfo: Function = (): void => {
     const { profile, ui, saveProfile } = this.props;
     saveProfile(personalValidation, profile, ui).then(() => {
       this.closePersonalDialog();

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -1,0 +1,3 @@
+/* eslint-disable no-unused-vars */
+import type { Settings } from './generalTypes';
+declare var SETTINGS: Settings;

--- a/static/js/flow/generalTypes.js
+++ b/static/js/flow/generalTypes.js
@@ -1,0 +1,20 @@
+export type Option = {
+  value: string;
+  label: string;
+};
+
+export type Action = {
+  type: string;
+  payload: any
+};
+
+export type Settings = {
+  gaTrackingID: string;
+  reactGaDebug: boolean;
+  authenticated: boolean;
+  name: string;
+  username: string;
+  host: string;
+  edx_base_url: string;
+};
+

--- a/static/js/flow/profileTypes.js
+++ b/static/js/flow/profileTypes.js
@@ -1,0 +1,40 @@
+export type Profile = {
+  first_name: String;
+  education: Array<EducationEntry>;
+  work_history: Array<WorkHistoryEntry>;
+};
+
+export type EducationEntry = {
+  id: ?number;
+  degree_name: string;
+  graduation_date: ?string|DateEdit;
+  graduation_date_edit: ?string;
+  field_of_study: string;
+  online_degree: boolean;
+  school_name: string;
+  school_city: string;
+  school_state_or_territory: string;
+  school_country: string;
+};
+
+export type DateEdit = {
+  month: ?string;
+  year: ?string;
+};
+
+export type WorkHistoryEntry = {
+  id: ?number;
+  position: string;
+  industry: string;
+  company_name: string;
+  start_date: ?string|DateEdit;
+  start_date_edit: ?string;
+  end_date: ?string|DateEdit;
+  end_date_edit: ?string;
+  city: string;
+  country: string;
+  state_or_territory: string;
+};
+
+export type ValidationErrors = {
+};

--- a/static/js/industries.js
+++ b/static/js/industries.js
@@ -1,3 +1,4 @@
+// @flow
 export default [
   "Accounting",
   "Airlines/Aviation",

--- a/static/js/language_codes.js
+++ b/static/js/language_codes.js
@@ -1,3 +1,4 @@
+// @flow
 // from http://data.okfn.org/data/core/language-codes
 export default [
   {

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -1,3 +1,4 @@
+// @flow
 /* global SETTINGS: false */
 import { combineReducers } from 'redux';
 import {
@@ -23,10 +24,12 @@ import {
   FETCH_SUCCESS,
 } from '../actions';
 import { ui } from './ui';
+import type { Action } from '../flow/generalTypes';
+import type { Profile } from '../flow/profileTypes';
 
 export const INITIAL_PROFILES_STATE = {};
-
-export const profiles = (state = INITIAL_PROFILES_STATE, action) => {
+type ProfileState = {};
+export const profiles = (state: ProfileState = INITIAL_PROFILES_STATE, action: Action) => {
   let patchProfile = newProfile => {
     let clone = Object.assign({}, state);
     let username = action.payload.username;
@@ -38,7 +41,7 @@ export const profiles = (state = INITIAL_PROFILES_STATE, action) => {
     return clone;
   };
 
-  let getProfile = () => {
+  let getProfile = (): Profile => {
     if (state[action.payload.username] !== undefined) {
       return state[action.payload.username];
     }
@@ -117,11 +120,12 @@ export const profiles = (state = INITIAL_PROFILES_STATE, action) => {
   }
 };
 
-const INITIAL_DASHBOARD_STATE = {
+type DashboardState = {programs: any[]};
+const INITIAL_DASHBOARD_STATE: any = {
   programs: []
 };
 
-export const dashboard = (state = INITIAL_DASHBOARD_STATE, action) => {
+export const dashboard = (state: DashboardState = INITIAL_DASHBOARD_STATE, action: Action) => {
   switch (action.type) {
   case REQUEST_DASHBOARD:
     return Object.assign({}, state, {

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -1,3 +1,4 @@
+// @flow
 /* global SETTINGS: false */
 import { RECEIVE_GET_USER_PROFILE_SUCCESS } from '../actions';
 import {
@@ -25,8 +26,24 @@ import {
 } from '../actions/ui';
 import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
 import { calculateDegreeInclusions } from '../util/util';
+import type { Action } from '../flow/generalTypes';
 
-export const INITIAL_UI_STATE = {
+export type UIState = {
+  workHistoryEdit:            boolean;
+  workDialogVisibility:       boolean;
+  dashboardExpander:          {};
+  educationDialogVisibility:  boolean;
+  educationDialogIndex:       ?number;
+  educationDegreeLevel:       string;
+  educationDegreeInclusions: {};
+  userPageDialogVisibility: boolean;
+  showWorkDeleteDialog: boolean;
+  showEducationDeleteDialog: boolean;
+  deletionIndex: ?number;
+  dialog: {};
+};
+
+export const INITIAL_UI_STATE: UIState = {
   workHistoryEdit:            true,
   workDialogVisibility:       false,
   dashboardExpander:          {},
@@ -44,9 +61,10 @@ export const INITIAL_UI_STATE = {
   showWorkDeleteDialog: false,
   showEducationDeleteDialog: false,
   deletionIndex: null,
+  dialog: {},
 };
 
-export const ui = (state = INITIAL_UI_STATE, action) => {
+export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
   switch (action.type) {
   case UPDATE_DIALOG_TEXT:
     return Object.assign({}, state, {

--- a/static/js/store/configureStore.js
+++ b/static/js/store/configureStore.js
@@ -1,3 +1,4 @@
+// @flow
 /* global require:false, module:false */
 import { compose, createStore, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
@@ -21,7 +22,7 @@ if (process.env.NODE_ENV !== "production") {
   )(createStore);
 }
 
-export default function configureStore(initialState) {
+export default function configureStore(initialState: ?Object) {
   const store = createStoreWithMiddleware(rootReducer, initialState);
 
   if (module.hot) {

--- a/static/js/util/ProfileFormFields.js
+++ b/static/js/util/ProfileFormFields.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import _ from 'lodash';
 
@@ -13,9 +14,10 @@ import { EDUCATION_LEVELS } from '../constants';
 import LANGUAGE_CODES from '../language_codes';
 import INDUSTRIES from '../industries';
 import iso3166 from 'iso-3166-2';
+import type { Option } from '../flow/generalTypes';
 
 export default class ProfileFormFields extends React.Component {
-  constructor(props) {
+  constructor(props: Object) {
     super(props);
 
     // bind our field methods to this
@@ -56,6 +58,20 @@ export default class ProfileFormFields extends React.Component {
       label: industry
     }));
   }
+  // type declarations
+  boundTextField: Function;
+  boundSelectField: Function;
+  boundCountrySelectField: Function;
+  boundStateSelectField: Function;
+  boundDateField: Function;
+  boundRadioGroupField: Function;
+  countryOptions: Option[];
+  genderOptions: Option[];
+  languageOptions: Option[];
+  privacyOptions: Array<{value: string, label: string, helper: string}>;
+  educationLevelOptions: Option[];
+  industryOptions: Option[];
+
 
   static contextTypes = {
     router: React.PropTypes.object.isRequired
@@ -67,7 +83,7 @@ export default class ProfileFormFields extends React.Component {
     setShowEducationDeleteDialog: React.PropTypes.func,
   };
 
-  closeConfirmDeleteDialog = () => {
+  closeConfirmDeleteDialog: Function = (): void => {
     const {
       setDeletionIndex,
       setShowEducationDeleteDialog,
@@ -78,13 +94,13 @@ export default class ProfileFormFields extends React.Component {
     setDeletionIndex(null);
   }
 
-  openEducationDeleteDialog  = index => {
+  openEducationDeleteDialog: Function = (index: number): void => {
     const { setDeletionIndex, setShowEducationDeleteDialog } = this.props;
     setDeletionIndex(index);
     setShowEducationDeleteDialog(true);
   }
 
-  openWorkDeleteDialog = index => {
+  openWorkDeleteDialog:Function = (index: number): void => {
     const { setDeletionIndex, setShowWorkDeleteDialog } = this.props;
     setDeletionIndex(index);
     setShowWorkDeleteDialog(true);

--- a/static/js/util/courseList.js
+++ b/static/js/util/courseList.js
@@ -1,4 +1,5 @@
- /* global SETTINGS: false */
+// @flow
+/* global SETTINGS: false */
 import moment from 'moment';
 import React from 'react';
 import Button from 'react-bootstrap/lib/Button';
@@ -23,11 +24,8 @@ function asPercent(number) {
 
 /**
  * Determine React elements for the UI given a course status
- * @param {object} course A course coming from the dashboard
- * @param {moment} now The current time
- * @returns {ReactElement} Some React element or string to display for course status
  */
-export function makeCourseStatusDisplay(course, now = moment()) {
+export function makeCourseStatusDisplay(course: Object, now: moment = moment()): string|React$Element {
   let firstRun = {};
   if (course.runs.length > 0) {
     firstRun = course.runs[0];
@@ -100,10 +98,8 @@ export function makeCourseStatusDisplay(course, now = moment()) {
 
 /**
  * Display status for a course run
- * @param run {Object} A course run
- * @returns {ReactElement}
  */
-export function makeRunStatusDisplay(run) {
+export function makeRunStatusDisplay(run: Object): string {
   switch (run.status) {
   case STATUS_PASSED:
     return "Passed";
@@ -122,7 +118,7 @@ export function makeRunStatusDisplay(run) {
  * @param {Number} numRuns The number of course runs to draw a line past
  * @returns {ReactElement} Some React element or string to display for course status
  */
-export function makeCourseProgressDisplay(course, isFirst, isLast, numRuns) {
+export function makeCourseProgressDisplay(course: Object, isFirst: boolean, isLast: boolean, numRuns: number) {
   let outerRadius = 10, innerRadius = 8, width = 30;
   let totalHeight = DASHBOARD_COURSE_HEIGHT + numRuns * DASHBOARD_RUN_HEIGHT;
   let centerX = width/2, centerY = DASHBOARD_COURSE_HEIGHT/2;

--- a/static/js/util/editEducation.js
+++ b/static/js/util/editEducation.js
@@ -1,9 +1,10 @@
+// @flow
 import _ from 'lodash';
 
 import { generateNewEducation } from "../util/util";
 import { educationValidation } from '../util/validation';
 
-export function openEditEducationForm(index) {
+export function openEditEducationForm(index: number) {
   const {
     profile,
     setEducationDialogIndex,
@@ -17,7 +18,7 @@ export function openEditEducationForm(index) {
   setEducationDialogVisibility(true);
 }
 
-export function openNewEducationForm(level, index) {
+export function openNewEducationForm(level: string, index: number) {
   const {
     profile,
     updateProfile,

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import moment from 'moment';
 import iso3166 from 'iso-3166-2';
@@ -13,6 +14,9 @@ import {
   validateYear,
   validateDay,
 } from '../util/validation';
+import type { Validator, UIValidator } from './validation';
+import type { Profile } from '../flow/profileTypes';
+import type { Option } from '../flow/generalTypes';
 
 // utility functions for pushing changes to profile forms back to the
 // redux store.
@@ -23,13 +27,8 @@ import {
  * bind this to this.boundRadioGroupField in the constructor of a form component
  * to update radio buttons.
  * pass in the name (used as placeholder), key for profile, and the options.
- *
- * @param keySet {String[]} Path to the field
- * @param label {String} Label for the field
- * @param options {Object[]} A list of options for the select field
- * @returns {ReactElement}
  */
-export function boundRadioGroupField(keySet, label, options) {
+export function boundRadioGroupField(keySet: string[], label: string, options: Option[]): React$Element {
   const { profile, updateProfile, errors } = this.props;
   const styles = {
     labelStyle: {
@@ -93,12 +92,8 @@ export function boundRadioGroupField(keySet, label, options) {
  * we pass in a keyset looking like this:
  *
  * ["top-level-key", index, "nested_object_key"] or just ["top_level_key"]
- *
- * @param keySet {String[]} Path to the field
- * @param label {String} Label for the field
- * @returns {ReactElement}
  */
-export function boundTextField(keySet, label) {
+export function boundTextField(keySet: string[], label: string): React$Element {
   const {
     profile,
     errors,
@@ -131,15 +126,9 @@ export function boundTextField(keySet, label) {
  * bind this to this.boundSelectField in the constructor of a form component
  * to update select fields
  * pass in the name (used as placeholder), key for profile, and the options.
- *
- * @param keySet {String[]} Path to the field
- * @param label {String} Label for the field
- * @param options {Object[]} A list of options for the select field
- * @param onChange {func} Handler which is called when the state changes or is cleared.
- * Takes the updated profile as argument
- * @returns {ReactElement}
  */
-export function boundSelectField(keySet, label, options, onChange) {
+export type ChangeFunc = (p: Profile) => void | void;
+export function boundSelectField(keySet: string[], label: string, options: Option[], onChange?: ChangeFunc) {
   const {
     profile,
     errors,
@@ -179,7 +168,7 @@ export function boundSelectField(keySet, label, options, onChange) {
     _.set(clone, editKeySet, undefined);
 
     updateProfile(clone);
-    if (_.isFunction(onChange)) {
+    if (onChange !== undefined) {
       onChange(clone);
     }
   };
@@ -242,13 +231,8 @@ import { boundSelectField as mockedBoundSelectField } from './profile_edit';
 /**
  * Bind this to this.boundStateSelectField in the constructor of a form component
  * to update select fields
- *
- * @param stateKeySet {String[]} Path to the state field
- * @param countryKeySet {String[]} Path to the country field
- * @param label {String} The label of the field
- * @returns {ReactElement}
  */
-export function boundStateSelectField(stateKeySet, countryKeySet, label) {
+export function boundStateSelectField(stateKeySet: string[], countryKeySet: string[], label: string): React$Element {
   const {
     profile,
   } = this.props;
@@ -268,13 +252,8 @@ export function boundStateSelectField(stateKeySet, countryKeySet, label) {
 /**
  * Bind this to this.boundCountrySelectField in the constructor of a form component
  * to update select fields
- *
- * @param stateKeySet {String[]} Path to the state field
- * @param countryKeySet {String[]} Path to the country field
- * @param label {String} The label of the field
- * @returns {ReactElement}
  */
-export function boundCountrySelectField(stateKeySet, countryKeySet, label) {
+export function boundCountrySelectField(stateKeySet: string[], countryKeySet: string[], label: string): React$Element {
   const {
     updateProfile,
   } = this.props;
@@ -293,13 +272,8 @@ export function boundCountrySelectField(stateKeySet, countryKeySet, label) {
  * bind this to this.boundDateField in the constructor of a form component
  * to update date fields
  * pass in the name (used as placeholder), key for profile.
- *
- * @param keySet {String[]} Path to look up and set a field
- * @param label {String} Label for the field
- * @param omitDay {bool} If false, there is a date textbox in addition to month and year
- * @returns {ReactElement}
  */
-export function boundDateField(keySet, label, omitDay) {
+export function boundDateField(keySet: string[], label: string, omitDay: boolean): React$Element {
   const {
     profile,
     errors,
@@ -440,13 +414,10 @@ export function boundDateField(keySet, label, omitDay) {
 
 /**
  * Validates the profile then PATCHes the profile if validation succeeded.
- *
- * @param validator {func} The function used to validate profile
- * @param isLastStep {bool} If true, this is the last tab in the profile
- * @returns {Promise} A promise which resolves with the new profile if validation and PATCH succeeded,
+ * Returns a promise which resolves with the new profile if validation and PATCH succeeded,
  * or rejects if either failed
  */
-export function saveProfileStep(validator, isLastStep=false) {
+export function saveProfileStep(validator: Validator|UIValidator, isLastStep: boolean = false): Promise<Profile> {
   const { saveProfile, profile, ui } = this.props;
   let clone = Object.assign({}, profile, {
     filled_out: profile.filled_out || isLastStep

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -1,3 +1,4 @@
+// @flow
 /* global SETTINGS:false */
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -6,9 +7,14 @@ import striptags from 'striptags';
 import _ from 'lodash';
 
 import { EDUCATION_LEVELS } from '../constants';
+import type {
+  Profile,
+  EducationEntry,
+  WorkHistoryEntry
+} from '../flow/profileTypes';
 
-export function sendGoogleAnalyticsEvent(category, action, label, value) {
-  let event = {
+export function sendGoogleAnalyticsEvent(category: any, action: any, label: any, value: any) {
+  let event: any = {
     category: category,
     action: action,
     label: label,
@@ -19,7 +25,7 @@ export function sendGoogleAnalyticsEvent(category, action, label, value) {
   ga.event(event);
 }
 
-export function userPrivilegeCheck (profile, privileged, unPrivileged) {
+export function userPrivilegeCheck (profile: Profile, privileged: any, unPrivileged: any): any {
   if ( profile.username === SETTINGS.username ) {
     return _.isFunction(privileged) ? privileged() : privileged;
   } else {
@@ -27,7 +33,7 @@ export function userPrivilegeCheck (profile, privileged, unPrivileged) {
   }
 }
 
-export function makeProfileProgressDisplay(active) {
+export function makeProfileProgressDisplay(active: number) {
   const width = 750, height = 100, radius = 20, paddingX = 40, paddingY = 5;
   const tabNames = ["Personal", "Education", "Professional", "Profile Privacy"];
   const numCircles = tabNames.length;
@@ -141,11 +147,8 @@ export function makeProfileProgressDisplay(active) {
 /* eslint-disable camelcase */
 /**
  * Generate new education object 
- *
- * @param {String} level The select degree level
- * @returns {Object} New empty education object
  */
-export function generateNewEducation(level) {
+export function generateNewEducation(level: string): EducationEntry {
   return {
     'degree_name': level,
     'graduation_date': null,
@@ -160,10 +163,8 @@ export function generateNewEducation(level) {
 
 /**
  * Generate new work history object
- * 
- * @returns {Object} New empty work history object
  */
-export function generateNewWorkHistory() {
+export function generateNewWorkHistory(): WorkHistoryEntry {
   return {
     position: null,
     industry: null,
@@ -180,10 +181,8 @@ export function generateNewWorkHistory() {
 
 /**
  * Converts string to int using base 10. Stricter in what is accepted than parseInt
- * @param value {String} A value to be parsed
- * @returns {Number|undefined} Either an integer or undefined if parsing didn't work.
  */
-export const filterPositiveInt = value => {
+export const filterPositiveInt = (value: string): number|void => {
   if(/^[0-9]+$/.test(value)) {
     return Number(value);
   }
@@ -192,9 +191,8 @@ export const filterPositiveInt = value => {
 
 /**
  * Returns the string with any HTML rendered and then its tags stripped
- * @return {String} rendered text stripped of HTML
  */
-export function makeStrippedHtml(textOrElement) {
+export function makeStrippedHtml(textOrElement: any): string {
   if (React.isValidElement(textOrElement)) {
     let container = document.createElement("div");
     ReactDOM.render(textOrElement, container);
@@ -204,7 +202,7 @@ export function makeStrippedHtml(textOrElement) {
   }
 }
 
-export function makeProfileImageUrl(profile) {
+export function makeProfileImageUrl(profile: Profile) {
   let imageUrl = `${SETTINGS.edx_base_url}/static/images/profiles/default_120.png`.
   //replacing multiple "/" with a single forward slash, excluding the ones following the colon
     replace(/([^:]\/)\/+/g, "$1");
@@ -217,14 +215,12 @@ export function makeProfileImageUrl(profile) {
 
 /**
  * Returns the preferred name or else the username
- * @param profile {Object} The user profile
- * @returns {string}
  */
-export function getPreferredName(profile) {
+export function getPreferredName(profile: Profile): string {
   return profile.preferred_name || SETTINGS.name || SETTINGS.username;
 }
 
-export function calculateDegreeInclusions(profile) {
+export function calculateDegreeInclusions(profile: Profile) {
   let highestLevelFound = false;
   let inclusions = {};
   for (const { value } of EDUCATION_LEVELS) {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #522 (I guess?)

#### What's this PR do?

This adds the flow typechecker to our project. This comprises a few changes:

- adding the package for the typechecker itself (flow-bin)
- a babel plugin to automatically strip out flow type annotations
- two eslint plugins to handle imported types correctly
- adding a bunch of type annotations to our code

#### Where should the reviewer start?

#### How should this be manually tested?

Make sure nothing is broken! I think I only added annotations and didn't change any functionality, but it's a little hard to be sure.

You'll need to rebuild your docker containers for the typechecker to work, once you have you should be able to do:

```
docker-compose run watch npm run-script flow
```

to type-check the code.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

