### PR TITLE
Removed popover from EducationDisplay on /users

### DIFF
--- a/static/js/components/EducationDialog.js
+++ b/static/js/components/EducationDialog.js
@@ -2,8 +2,9 @@ import React from 'react';
 import Button from 'react-mdl/lib/Button';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Dialog from 'material-ui/Dialog';
+import _ from 'lodash';
 
-import { HIGH_SCHOOL } from '../constants';
+import { HIGH_SCHOOL, BACHELORS, EDUCATION_LEVELS } from '../constants';
 import ProfileFormFields from '../util/ProfileFormFields';
 import { educationValidation } from '../util/validation';
 
@@ -17,9 +18,10 @@ export default class EducationDialog extends ProfileFormFields {
   }
 
   static propTypes = {
-    open:     React.PropTypes.bool,
-    onClose:  React.PropTypes.func,
-    onSave:   React.PropTypes.func,
+    open:           React.PropTypes.bool,
+    onClose:        React.PropTypes.func,
+    onSave:         React.PropTypes.func,
+    showLevelForm:  React.PropTypes.bool,
   };
 
   clearEducationEdit = () => {
@@ -42,29 +44,42 @@ export default class EducationDialog extends ProfileFormFields {
     });
   };
 
-  editEducationForm = level => {
-    const { ui: { educationDialogIndex } } = this.props;
+  editEducationForm = () => {
+    const {
+      ui: { educationDialogIndex},
+      showLevelForm,
+      profile: { education },
+    } = this.props;
 
+    let educationDegreeLevel = _.get(education, [educationDialogIndex, "degree_name"]) || BACHELORS;
     let keySet = (key) => ['education', educationDialogIndex, key];
 
-    let fieldOfStudy, highSchoolPadding;
-    if (level !== HIGH_SCHOOL) {
-      fieldOfStudy = <Cell col={6}>
-        {this.boundTextField(keySet('field_of_study'), 'Field of Study')}
-      </Cell>;
-    } else {
-      highSchoolPadding = <Cell col={6} />;
-    }
+    let fieldOfStudy = () => {
+      if (educationDegreeLevel !== HIGH_SCHOOL) { 
+        return <Cell col={6}>{this.boundTextField(keySet('field_of_study'), 'Field of Study')}</Cell>;
+      }
+    };
+    let highSchoolPadding = () => (
+      educationDegreeLevel === HIGH_SCHOOL ? <Cell col={6} /> : undefined
+    );
+    let levelForm = () => {
+      if ( showLevelForm ) {
+        return <Cell col={12}>
+          {this.boundSelectField(keySet('degree_name'), 'Degree Type', EDUCATION_LEVELS)}
+        </Cell>;
+      }
+    };
 
     return <Grid className="profile-tab-grid">
       <Cell col={12} className="profile-form-title">
-        {this.educationLevelLabels[level]}
+        {this.educationLevelLabels[educationDegreeLevel]}
       </Cell>
-      {fieldOfStudy}
+      { levelForm() }
+      { fieldOfStudy() }
       <Cell col={6}>
         {this.boundDateField(keySet('graduation_date'), 'Graduation Date', true)}
       </Cell>
-      {highSchoolPadding}
+      { highSchoolPadding() }
       <Cell col={6}>
         {this.boundTextField(keySet('school_name'), 'School Name')}
       </Cell>
@@ -91,12 +106,7 @@ export default class EducationDialog extends ProfileFormFields {
   };
 
   render () {
-    const {
-      ui: {
-        educationDialogVisibility,
-        educationDegreeLevel,
-      }
-    } = this.props;
+    const { ui: {educationDialogVisibility } } = this.props;
 
     let actions = [
       <Button
@@ -123,7 +133,7 @@ export default class EducationDialog extends ProfileFormFields {
         actions={actions}
         autoScrollBodyContent={true}
       >
-        {this.editEducationForm(educationDegreeLevel)}
+        {this.editEducationForm()}
       </Dialog>
     );
   }

--- a/static/js/components/EducationDisplay.js
+++ b/static/js/components/EducationDisplay.js
@@ -5,8 +5,6 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 import FABButton from 'react-mdl/lib/FABButton';
 import Icon from 'react-mdl/lib/Icon';
 import { Card } from 'react-mdl/lib/Card';
-import Menu from 'react-mdl/lib/Menu';
-import { MenuItem } from 'react-mdl/lib/Menu';
 import _ from 'lodash';
 import moment from 'moment';
 
@@ -19,6 +17,7 @@ import {
   deleteEducationEntry,
 } from '../util/editEducation';
 import { userPrivilegeCheck } from '../util/util';
+import { HIGH_SCHOOL } from '../constants';
 
 export default class EducationDisplay extends ProfileFormFields {
   openEditEducationForm = index => {
@@ -72,26 +71,6 @@ export default class EducationDisplay extends ProfileFormFields {
     );
   };
 
-  addEducationMenu = () => {
-    let menuItems = this.educationLevelOptions.map(educationLevel => (
-      <MenuItem 
-        key={educationLevel.label}
-        onClick={() => this.openNewEducationForm(educationLevel.value, null)}>
-        { educationLevel.label }
-      </MenuItem>
-    ));
-    return (
-      <Menu
-        target="add-education-button"
-        valign="top"
-        align="right"
-        className="add-education-menu"
-      >
-        { menuItems }
-      </Menu>
-    );
-  };
-
   renderEducationEntries = () => {
     const { profile, profile: { education }} = this.props;
     let rows = [];
@@ -105,6 +84,7 @@ export default class EducationDisplay extends ProfileFormFields {
           id="add-education-button"
           className="profile-add-button"
           key="I'm unique!"
+          onClick={() => this.openNewEducationForm(HIGH_SCHOOL, null)}
         >
           <Icon name="add" />
         </FABButton>
@@ -114,10 +94,7 @@ export default class EducationDisplay extends ProfileFormFields {
   }
 
   render() {
-    const {
-      profile,
-      ui: { showEducationDeleteDialog }
-    } = this.props;
+    const { ui: { showEducationDeleteDialog } } = this.props;
     return (
       <div>
         <ConfirmDeletion
@@ -125,7 +102,7 @@ export default class EducationDisplay extends ProfileFormFields {
           open={showEducationDeleteDialog}
           close={this.closeConfirmDeleteDialog}
         />
-        <EducationDialog {...this.props} />
+        <EducationDialog {...this.props} showLevelForm={true} />
         <Card shadow={1} className="profile-tab-card" id="education-card">
           <Grid className="profile-tab-card-grid">
             <Cell col={4} className="profile-card-title">
@@ -134,7 +111,6 @@ export default class EducationDisplay extends ProfileFormFields {
             <Cell col={8} />
           </Grid>
           { this.renderEducationEntries() }
-          { userPrivilegeCheck(profile, this.addEducationMenu(), undefined) }
         </Card>
       </div>
     );

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -160,7 +160,7 @@ class EducationForm extends ProfileFormFields {
           open={showEducationDeleteDialog}
           close={this.closeConfirmDeleteDialog}
         />
-        <EducationDialog {...this.props} />
+        <EducationDialog {...this.props} showLevelForm={false} />
         {levelsGrid}
       </div>
     );

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -153,9 +153,6 @@ describe("UserPage", () => {
             SET_EDUCATION_DEGREE_LEVEL,
           ], () => {
             TestUtils.Simulate.click(addButton);
-            addButton = div.getElementsByClassName('add-education-menu')[0].
-              getElementsByTagName('li')[0];
-            TestUtils.Simulate.click(addButton);
           });
         });
       });


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #527 

#### What's this PR do?

This removes the little popover menu for adding education entries on the `/users` page. Instead, now we can pass a prop (`showLevelForm`) in to the `EducationDialog` component. When that's `true`, we should a menu that lets the user pick the degree level (high school and so on). When false, we hide it.

#### Where should the reviewer start?

Look over the changes to `EducationDisplay` and `EducationDialog`.

#### How should this be manually tested?

Make sure you can add any kind of degree type on `/users`. Make sure you can add all degree types (and they don't show the degree type dropdown) on `/profile/education`.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

