### PR TITLE
Made enroll and upgrade buttons accessible

### DIFF
--- a/static/js/components/CourseList.js
+++ b/static/js/components/CourseList.js
@@ -62,9 +62,13 @@ class CourseList extends React.Component {
           };
           expanderSpan = <span
             onClick={toggleExpander}
-            className={`glyphicon glyphicon-chevron-${expander[course.id] ? 'up' : 'down'}`}
+            className={`glyphicon glyphicon-menu-${expander[course.id] ? 'up' : 'down'}`}
             style={{cursor: "pointer"}}
-          />;
+          >
+            <span className="sr-only">
+              Click here to show or hide course runs
+            </span>
+          </span>;
         }
 
         let height = DASHBOARD_COURSE_HEIGHT + courseRuns.length * DASHBOARD_RUN_HEIGHT;

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -98,106 +98,224 @@ export const DASHBOARD_RESPONSE = [
             "position": 1,
             "title": "Gio Test Course #15",
             "course_id": "course-v1:odl+GIO101+CR-FALL15",
-            "status": "not-passed",
-            "id": 199
+            "status": STATUS_NOT_PASSED,
+            "id": 1
           },
           {
             "position": 2,
             "title": "Gio Test Course #14",
             "course_id": "course-v1:odl+GIO101+FALL14",
-            "status": "not-passed",
-            "id": 399
+            "status": STATUS_NOT_PASSED,
+            "id": 2
           },
           {
             "certificate_url": "www.google.com",
             "title": "Gio Test Course #13",
-            "status": "passed",
+            "status": STATUS_PASSED,
             "position": 3,
             "grade": "0.66",
             "course_id": "course-v1:odl+GIO101+FALL13",
-            "id": 299
+            "id": 3
           }
         ],
         "position_in_program": 0,
-        "title": "Gio Course",
-        "status": "not-offered",
+        "title": "Gio Course - failed, no status text",
+        "status": STATUS_NOT_OFFERED,
         "description": "",
-        "id": 199
+        "id": 1
       },
       {
         "prerequisites": "",
         "runs": [],
         "position_in_program": 1,
         "title": "8.MechCx Advanced Introductory Classical Mechanics",
-        "status": "not-offered",
+        "status": STATUS_NOT_OFFERED,
         "description": "",
-        "id": 299
+        "id": 2
       },
       {
         "prerequisites": "",
         "runs": [],
         "position_in_program": 2,
         "title": "EDX Demo course",
-        "status": "not-offered",
+        "status": STATUS_NOT_OFFERED,
         "description": "",
-        "id": 399
+        "id": 3
       },
       {
         "prerequisites": "",
         "runs": [],
         "position_in_program": 3,
         "title": "Peter Course",
-        "status": "not-offered",
+        "status": STATUS_NOT_OFFERED,
         "description": "",
-        "id": 499
+        "id": 4
       }
     ],
-    "id": 799
+    "id": 3
   },
   {
     "courses": [
       {
-        "id": 3,
+        "id": 5,
         "status": STATUS_OFFERED_NOT_ENROLLED,
         "position_in_program": 1,
-        "title": "Supply Chain and Logistics Fundamentals",
+        "title": "Supply Chain and Logistics Fundamentals - enroll button",
         "runs": [
           {
-            "course_id": null,
-            "id": 3,
+            "course_id": "course-v1:supply+chain",
+            "id": 4,
             "status": STATUS_OFFERED_NOT_ENROLLED,
             "fuzzy_enrollment_start_date": null,
             "title": "Supply Chain Design",
-            "enrollment_start_date": "2016-03-04T01:00:00Z"
+            "enrollment_start_date": "2016-03-04T01:00:00Z",
+            "position": 0
           }
         ],
         "description": null,
         "prerequisites": null
       },
       {
-        "id": 4,
+        "id": 6,
         "status": STATUS_PASSED,
-        "position_in_program": 0,
-        "title": "Demo course",
+        "position_in_program": 5,
+        "title": "Passed course - status text is 88%",
         "runs": [
           {
             "certificate_url": "www.google.com",
             "course_id": "course-v1:edX+DemoX+Demo_Course",
-            "id": 4,
+            "id": 5,
             "status": STATUS_PASSED,
             "title": "Demo course",
-            "grade": "0.88"
+            "grade": "0.88",
+            "position": 0
           }
         ],
         "description": "The demo course",
         "prerequisites": ""
       },
       {
-        "id": 5,
+        "id": 7,
         "status": STATUS_NOT_OFFERED,
         "position_in_program": 2,
-        "title": "Empty course",
+        "title": "Empty course - no status text",
         "runs": [
+        ],
+        "description": null,
+        "prerequisites": null
+      },
+      {
+        "id": 8,
+        "status": STATUS_ENROLLED_NOT_VERIFIED,
+        "position_in_program": 3,
+        "title": "Not verified course - upgrade to verified button",
+        "runs": [
+          {
+            "id": 7,
+            "status": STATUS_ENROLLED_NOT_VERIFIED,
+            "title": "Not verified run",
+            "verification_date": "2200-01-01T03:00:00Z",
+            "course_id": "not-verified",
+            "position": 0
+          }
+        ],
+        "description": null,
+        "prerequisites": null
+      },
+      {
+        "id": 10,
+        "status": STATUS_OFFERED_NOT_ENROLLED,
+        "position_in_program": 4,
+        "title": "Enrollment starting course - status text says Enrollment starting",
+        "runs": [
+          {
+            "course_id": "course-v1:supply+chain",
+            "id": 8,
+            "status": STATUS_OFFERED_NOT_ENROLLED,
+            "fuzzy_enrollment_start_date": null,
+            "title": "Enrollment starting run",
+            "enrollment_start_date": "2106-03-04T01:00:00Z",
+            "position": 0
+          }
+        ],
+        "description": null,
+        "prerequisites": null
+      },
+      {
+        "id": 12,
+        "status": STATUS_PASSED,
+        "title": "Passed course missing grade - no status text",
+        "position_in_program": 6,
+        "runs": [
+          {
+            "certificate_url": "www.google.com",
+            "title": "Passed run missing grade",
+            "status": STATUS_PASSED,
+            "position": 0,
+            "course_id": "course_id",
+            "id": 10
+          }
+        ]
+      },
+      {
+        "id": 13,
+        "status": STATUS_ENROLLED_NOT_VERIFIED,
+        "title": "Enrolled, no verification date - no status text",
+        "position_in_program": 7,
+        "runs": [
+          {
+            "title": "Enrolled no verification date",
+            "status": STATUS_ENROLLED_NOT_VERIFIED,
+            "position": 0,
+            "course_id": "course_id",
+            "id": 11
+          }
+        ]
+      },
+      {
+        "id": 14,
+        "position_in_program": 8,
+        "title": "enrolled not verified, verification date passed - no status text",
+        "status": STATUS_ENROLLED_NOT_VERIFIED,
+        "runs": [
+          {
+            "position": 0,
+            "id": 12,
+            "status": STATUS_ENROLLED_NOT_VERIFIED,
+            "title": "enrolled not verified, verification date passed",
+            "verification_date": "2000-01-01"
+          }
+        ]
+      },
+      {
+        "id": 15,
+        "position_in_program": 9,
+        "title": "verified not completed, course starts in future - status text is Course starting",
+        "status": STATUS_VERIFIED_NOT_COMPLETED,
+        "runs": [
+          {
+            "id": 13,
+            "status": STATUS_VERIFIED_NOT_COMPLETED,
+            "course_start_date": "8765-03-21",
+            "title": "First run",
+            "position": 0
+          }
+        ]
+      },
+      {
+        "id": 11,
+        "status": STATUS_OFFERED_NOT_ENROLLED,
+        "position_in_program": 0,
+        "title": "Fuzzy enrollment starting course - First in program, status text is soonish",
+        "runs": [
+          {
+            "course_id": "course-v1:supply+chain",
+            "id": 9,
+            "status": STATUS_OFFERED_NOT_ENROLLED,
+            "fuzzy_enrollment_start_date": "soonish",
+            "title": "Fuzzy enrollment starting run",
+            "position": 0
+          }
         ],
         "description": null,
         "prerequisites": null
@@ -205,30 +323,32 @@ export const DASHBOARD_RESPONSE = [
     ],
     "title": "Master Program",
     "description": null,
-    "id": 1
+    "id": 4
   },
   {
     "title": "Last program",
     "description": "The last program",
     "courses": [
       {
-        "id": 4,
+        "id": 9,
         "status": STATUS_VERIFIED_NOT_COMPLETED,
         "position_in_program": 0,
-        "title": "Course for last program",
+        "title": "Course for last program, no grade - in progress, status text is 0%",
         "runs": [
           {
             "course_id": "course-v1:edX+DemoX+Demo_Course",
-            "id": 4,
+            "id": 6,
             "status": STATUS_VERIFIED_NOT_COMPLETED,
-            "title": "Course run for last program"
+            "title": "Course run for last program",
+            "position": 0,
+            "course_start_date": "2016-01-01",
           }
         ],
         "description": "Course for Last program",
         "prerequisites": ""
       },
     ],
-    "id": 3
+    "id": 5
   },
 ];
 

--- a/static/js/constants_test.js
+++ b/static/js/constants_test.js
@@ -1,0 +1,40 @@
+import _ from 'lodash';
+import { assert } from 'chai';
+
+import { DASHBOARD_RESPONSE } from './constants';
+
+describe('constants', () => {
+  it("doesn't duplicate any id numbers within the same type of information", () => {
+    let programIds : Set<number> = new Set();
+    let courseIds : Set<number> = new Set();
+    let runIds : Set<number> = new Set();
+    for (let program of DASHBOARD_RESPONSE) {
+      assert(!_.isNil(program.id), 'Missing program id');
+      assert(!programIds.has(program.id), `Duplicate program id ${program.id}`);
+      programIds.add(program.id);
+
+      let positionInProgram : Set<number> = new Set();
+
+      for (let course of program.courses) {
+        assert(!_.isNil(course.id), `Missing course id for program ${program.id}`);
+        assert(!courseIds.has(course.id), `Duplicate course id ${course.id}`);
+        courseIds.add(course.id);
+
+        assert(!_.isNil(course.position_in_program), `Missing position_in_program for course ${course.id}`);
+        assert(!positionInProgram.has(course.position_in_program), `Duplicate position for course ${course.id}`);
+        positionInProgram.add(course.position_in_program);
+
+        let positionInCourse : Set<number> = new Set();
+        for (let run of course.runs) {
+          assert(!_.isNil(run.id), `Missing run id for course ${course.id}`);
+          assert(!runIds.has(run.id), `Duplicate run id ${run.id}`);
+          runIds.add(run.id);
+
+          assert(!_.isNil(run.position), `Missing position for run ${run.id}`);
+          assert(!positionInCourse.has(run.position), `Duplicate position for run ${run.id}`);
+          positionInCourse.add(run.position);
+        }
+      }
+    }
+  });
+});

--- a/static/js/util/courseList.js
+++ b/static/js/util/courseList.js
@@ -67,7 +67,10 @@ export function makeCourseStatusDisplay(course: Object, now: moment = moment()):
 
     let verificationDate = moment(firstRun.verification_date);
     if (verificationDate.isAfter(now, 'day')) {
-      return <Button bsStyle="success" href={courseUpgradeUrl} target="_blank">UPGRADE TO VERIFIED</Button>;
+      return <Button bsStyle="success" href={courseUpgradeUrl} target="_blank">
+        UPGRADE TO VERIFIED
+        <span className="sr-only"> for {firstRun.title}</span>
+      </Button>;
     } else {
       // User cannot verify anymore
       return "";
@@ -84,7 +87,10 @@ export function makeCourseStatusDisplay(course: Object, now: moment = moment()):
     } else {
       if (firstRun.course_id) {
         let courseInfoUrl = `${SETTINGS.edx_base_url}/courses/${firstRun.course_id}/about`;
-        return <Button bsStyle="success" href={courseInfoUrl} target="_blank">ENROLL</Button>;
+        return <Button bsStyle="success" href={courseInfoUrl} target="_blank">
+          ENROLL
+          <span className="sr-only"> in {firstRun.title}</span>
+        </Button>;
       } else {
         return "";
       }

--- a/static/js/util/courseList_test.js
+++ b/static/js/util/courseList_test.js
@@ -111,10 +111,11 @@ describe('courseList functions', () => {
         renderCourseStatusDisplay({
           status: STATUS_ENROLLED_NOT_VERIFIED,
           runs: [{
-            verification_date: tomorrow
-          }]
+            verification_date: tomorrow,
+            title: "Run title"
+          }],
         }, moment(today)),
-        "UPGRADE TO VERIFIED"
+        "UPGRADE TO VERIFIED for Run title"
       );
     });
 
@@ -160,10 +161,11 @@ describe('courseList functions', () => {
           status: STATUS_OFFERED_NOT_ENROLLED,
           runs: [{
             course_id: edxCourseKey,
-            enrollment_start_date: today
+            enrollment_start_date: today,
+            title: "Run title"
           }]
         }, moment(today)),
-        "ENROLL"
+        "ENROLL in Run title"
       );
     });
 
@@ -173,10 +175,11 @@ describe('courseList functions', () => {
           status: STATUS_OFFERED_NOT_ENROLLED,
           runs: [{
             course_id: edxCourseKey,
-            enrollment_start_date: yesterday
+            enrollment_start_date: yesterday,
+            title: "Run title"
           }]
         }, moment(today)),
-        "ENROLL"
+        "ENROLL in Run title"
       );
     });
     it("is an offered course with valid enrollment date and no edx_course_key", () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #473

#### What's this PR do?
Uses the `sr-only` CSS class to show some text only for screen readers, specifically which run the button applies to. Also refactored the `DASHBOARD_RESPONSE` constant to have all possible course status cases so we can see them at a glance.

Also switches the bootstrap chevron icon with the menu one

#### Where should the reviewer start?
static/js/util/courseList.js

#### How should this be manually tested?
Stub in `DASHBOARD_RESPONSE` in the `getDashboard()` function in `api.js`. View the dashboard. You should see `ENROLL` and `UPGRADE TO VERIFIED` buttons, one of each. If you inspect each button and look at the text inside the element there should also be the run title.

#### Any background context you want to provide?
http://stackoverflow.com/questions/19758598/what-is-sr-only-in-bootstrap-3
