### PR TITLE
Fixed bug with MM id in Jumbotron

### DIFF
--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -28,7 +28,7 @@ class ProfilePage extends ProfileFormContainer {
 
     let childrenWithProps = this.childrenWithProps(profile);
     return <div className="card">
-      <Jumbotron profile={profile} text={text}>
+      <Jumbotron profile={profile.profile} text={text}>
         <div className="card-copy">
           <div style={{textAlign: "center"}}>
             {makeProfileProgressDisplay(this.activeTab())}

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -70,6 +70,13 @@ describe("ProfilePage", function() {
     });
   };
 
+  it('should show the pretty-printed MM id', () => {
+    return renderComponent(pageUrlStubs[0]).then(([, div]) => {
+      let id = div.querySelector('.card-student-id');
+      assert.equal(`ID: ${USER_PROFILE_RESPONSE.pretty_printed_student_id}`, id.textContent);
+    });
+  });
+
   it('navigates backward when Previous button is clicked', () => {
     let firstPage = pageUrlStubs[0];
     let secondPage = pageUrlStubs[1];


### PR DESCRIPTION
#### What are the relevant tickets?

closes #550 

#### What's this PR do?

Passes the correct profile object into the `<Jumbotron>` component from `ProfilePage`.

#### Where should the reviewer start?

#### How should this be manually tested?

Make sure that all pages with a Jumbotron (`/dashboard`, `/terms_of_service`, `/profile`) display the pretty printed ID.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

