### PR TITLE
Fixed spinner positioning

### DIFF
--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -47,3 +47,10 @@ body {
     width: 100%;
     height: 100%;
 }
+
+.loader {
+  position: relative;
+  // arbitrarily chosen height
+  height: 300px;
+  width: 100%;
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #465 

#### What's this PR do?
Sets the container div for the loader to use relative positioning so the inner spinner will be centered within that, rather than centered inside the entire page.

#### How should this be manually tested?
In `api.js` replace `getUserProfile` with this:

    export function getUserProfile(username) {
      return new Promise(resolve => {
        setTimeout(() => {
          resolve(mockableFetchJSONWithCSRF(`/api/v0/profiles/${username}/`));
        }, 100000);
      });
    }

This will delay the load of the user page for 100 seconds. Go to `/users/` and see that the spinner is where it should be. You should be able to resize the browser without affecting the position of the spinner.

#### Screenshots (if appropriate)

![screenshot from 2016-06-16 14-30-00](https://cloud.githubusercontent.com/assets/863262/16128464/d4eacea0-33ce-11e6-89e1-60e7c1037626.png)

