### PR TITLE
Added 'confirm delete all entries' when closing switches

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -83,3 +83,13 @@ export const SET_DELETION_INDEX = 'SET_DELETION_INDEX';
 export const setDeletionIndex = (index: number): Action => (
   { type: SET_DELETION_INDEX, payload: index }
 );
+
+export const SET_SHOW_WORK_DELETE_ALL_DIALOG = 'SET_SHOW_WORK_DELETE_ALL_DIALOG';
+export const setShowWorkDeleteAllDialog = (bool: boolean): Action => (
+  { type: SET_SHOW_WORK_DELETE_ALL_DIALOG, payload: bool }
+);
+
+export const SET_SHOW_EDUCATION_DELETE_ALL_DIALOG = 'SET_SHOW_EDUCATION_DELETE_ALL_DIALOG';
+export const setShowEducationDeleteAllDialog = (bool: boolean): Action => (
+  { type: SET_SHOW_EDUCATION_DELETE_ALL_DIALOG, payload: bool }
+);

--- a/static/js/components/ConfirmDeletion.js
+++ b/static/js/components/ConfirmDeletion.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import Button from 'react-mdl/lib/Button';
@@ -5,18 +6,19 @@ import Button from 'react-mdl/lib/Button';
 export default class ConfirmDeletion extends React.Component {
   static propTypes = {
     close:        React.PropTypes.func,
-    deleteEntry:  React.PropTypes.func,
+    deleteFunc:   React.PropTypes.func,
     open:         React.PropTypes.bool,
+    confirmText:  React.PropTypes.string,
   };
 
-  deleteAndClose = () => {
-    const { close, deleteEntry } = this.props;
-    deleteEntry();
+  deleteAndClose: Function = (): void => {
+    const { close, deleteFunc } = this.props;
+    deleteFunc();
     close();
   };
 
   render () {
-    const { close, open } = this.props;
+    const { close, open, confirmText } = this.props;
     let actions = [
       <Button
         type='button'
@@ -41,7 +43,7 @@ export default class ConfirmDeletion extends React.Component {
         actions={actions}
         autoScrollBodyContent={true}
       >
-        Delete this entry?
+        { confirmText }
       </Dialog>
     );
   }

--- a/static/js/components/EducationDisplay.js
+++ b/static/js/components/EducationDisplay.js
@@ -100,9 +100,10 @@ export default class EducationDisplay extends ProfileFormFields {
     return (
       <div>
         <ConfirmDeletion
-          deleteEntry={this.deleteEducationEntry}
+          deleteFunc={this.deleteEducationEntry}
           open={showEducationDeleteDialog}
           close={this.closeConfirmDeleteDialog}
+          confirmText="Delete this entry?"
         />
         <EducationDialog {...this.props} showLevelForm={true} />
         <Card shadow={1} className="profile-tab-card" id="education-card">

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -29,9 +29,13 @@ class EmploymentForm extends ProfileFormFields {
     });
   };
 
-  toggleWorkHistoryEdit: Function = (): void => {
-    const { ui, setWorkHistoryEdit } = this.props;
-    setWorkHistoryEdit(!ui.workHistoryEdit);
+  changeSwitchState: Function = (): void => {
+    const { ui, setWorkHistoryEdit, profile, setShowWorkDeleteAllDialog } = this.props;
+    if ( _.isEmpty(profile.work_history) ) {
+      setWorkHistoryEdit(!ui.workHistoryEdit);
+    } else {
+      setShowWorkDeleteAllDialog(true);
+    }
   };
 
   closeWorkDialog: Function = (): void => {
@@ -60,6 +64,19 @@ class EmploymentForm extends ProfileFormFields {
     let clone = _.cloneDeep(profile);
     clone['work_history'].splice(deletionIndex, 1);
     saveProfile(employmentValidation, clone, ui);
+  };
+
+  deleteAllWorkHistoryEntries: Function = (): void => {
+    const { saveProfile, profile, ui, setWorkHistoryEdit } = this.props;
+    let clone = _.cloneDeep(profile);
+    clone['work_history'] = [];
+    saveProfile(employmentValidation, clone, ui);
+    setWorkHistoryEdit(false);
+  };
+
+  closeConfirmDeleteAllDialog: Function = (): void => {
+    const { setShowWorkDeleteAllDialog } = this.props;
+    setShowWorkDeleteAllDialog(false);
   };
 
   editWorkHistoryForm(): React$Element {
@@ -193,6 +210,7 @@ class EmploymentForm extends ProfileFormFields {
         workHistoryEdit,
         workDialogVisibility,
         showWorkDeleteDialog,
+        showWorkDeleteAllDialog,
       },
       errors,
       showSwitch,
@@ -220,7 +238,7 @@ class EmploymentForm extends ProfileFormFields {
             <Switch
               ripple
               id="profile-tab-professional-switch"
-              onChange={this.toggleWorkHistoryEdit}
+              onChange={this.changeSwitchState}
               checked={workHistoryEdit}>
             </Switch>
           </div>
@@ -234,9 +252,16 @@ class EmploymentForm extends ProfileFormFields {
     return (
       <div>
         <ConfirmDeletion
-          deleteEntry={this.deleteWorkHistoryEntry}
+          deleteFunc={this.deleteWorkHistoryEntry}
           open={showWorkDeleteDialog}
           close={this.closeConfirmDeleteDialog}
+          confirmText="Delete this entry?"
+        />
+        <ConfirmDeletion
+          deleteFunc={this.deleteAllWorkHistoryEntries}
+          open={showWorkDeleteAllDialog}
+          close={this.closeConfirmDeleteAllDialog}
+          confirmText="Delete all work history entries?"
         />
         <Dialog
           open={workDialogVisibility}

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -22,6 +22,8 @@ import {
   setShowEducationDeleteDialog,
   setShowWorkDeleteDialog,
   setDeletionIndex,
+  setShowWorkDeleteAllDialog,
+  setShowEducationDeleteAllDialog,
 } from '../actions/ui';
 
 class ProfileFormContainer extends React.Component {
@@ -76,6 +78,16 @@ class ProfileFormContainer extends React.Component {
     const { dispatch } = this.props;
     dispatch(setShowWorkDeleteDialog(bool));
   }
+
+  setShowWorkDeleteAllDialog: Function = (bool: boolean): void => {
+    const { dispatch } = this.props;
+    dispatch(setShowWorkDeleteAllDialog(bool));
+  };
+
+  setShowEducationDeleteAllDialog: Function = (bool: boolean): void => {
+    const { dispatch } = this.props;
+    dispatch(setShowEducationDeleteAllDialog(bool));
+  };
 
   setUserPageDialogVisibility = bool => {
     const { dispatch } = this.props;
@@ -175,6 +187,8 @@ class ProfileFormContainer extends React.Component {
         setShowEducationDeleteDialog: this.setShowEducationDeleteDialog,
         setShowWorkDeleteDialog: this.setShowWorkDeleteDialog,
         setDeletionIndex: this.setDeletionIndex,
+        setShowWorkDeleteAllDialog: this.setShowWorkDeleteAllDialog,
+        setShowEducationDeleteAllDialog: this.setShowEducationDeleteAllDialog
       })
     ));
   }

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -23,6 +23,8 @@ import {
   SET_SHOW_EDUCATION_DELETE_DIALOG,
   SET_SHOW_WORK_DELETE_DIALOG,
   SET_DELETION_INDEX,
+  SET_SHOW_WORK_DELETE_ALL_DIALOG,
+  SET_SHOW_EDUCATION_DELETE_ALL_DIALOG,
 } from '../actions/ui';
 import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
 import { calculateDegreeInclusions } from '../util/util';
@@ -41,6 +43,8 @@ export type UIState = {
   showEducationDeleteDialog: boolean;
   deletionIndex: ?number;
   dialog: {};
+  showWorkDeleteAllDialog: boolean;
+  showEducationDeleteAllDialog: boolean;
 };
 
 export const INITIAL_UI_STATE: UIState = {
@@ -62,6 +66,8 @@ export const INITIAL_UI_STATE: UIState = {
   showEducationDeleteDialog: false,
   deletionIndex: null,
   dialog: {},
+  showWorkDeleteAllDialog: false,
+  showEducationDeleteAllDialog: false,
 };
 
 export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
@@ -155,6 +161,16 @@ export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
       });
     }
     return state;
+  }
+  case SET_SHOW_WORK_DELETE_ALL_DIALOG: {
+    return Object.assign({}, state, {
+      showWorkDeleteAllDialog: action.payload
+    });
+  }
+  case SET_SHOW_EDUCATION_DELETE_ALL_DIALOG: {
+    return Object.assign({}, state, {
+      showEducationDeleteAllDialog: action.payload
+    });
   }
   default:
     return state;

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -16,6 +16,8 @@ import {
   SET_SHOW_EDUCATION_DELETE_DIALOG,
   SET_SHOW_WORK_DELETE_DIALOG,
   SET_DELETION_INDEX,
+  SET_SHOW_WORK_DELETE_ALL_DIALOG,
+  SET_SHOW_EDUCATION_DELETE_ALL_DIALOG,
 
   clearUI,
   updateDialogText,
@@ -33,6 +35,8 @@ import {
   setShowEducationDeleteDialog,
   setShowWorkDeleteDialog,
   setDeletionIndex,
+  setShowWorkDeleteAllDialog,
+  setShowEducationDeleteAllDialog,
 } from '../actions/ui';
 import { receiveGetUserProfileSuccess } from '../actions';
 import { INITIAL_UI_STATE } from '../reducers/ui';
@@ -250,6 +254,21 @@ describe('ui reducers', () => {
     it('should let you set a deletion index', () => {
       return dispatchThen(setDeletionIndex(3), [SET_DELETION_INDEX]).then(state => {
         assert.deepEqual(state.deletionIndex, 3);
+      });
+    });
+  });
+
+  describe('confirm delete all dialog', () => {
+    [
+      [setShowEducationDeleteAllDialog, SET_SHOW_EDUCATION_DELETE_ALL_DIALOG, s => s.showEducationDeleteAllDialog],
+      [setShowWorkDeleteAllDialog, SET_SHOW_WORK_DELETE_ALL_DIALOG, s => s.showWorkDeleteAllDialog],
+    ].forEach( ([actionCreator, action, accessor]) => {
+      [true, false].forEach( bool => {
+        it(`should let you ${action} to ${bool}`, () => {
+          return dispatchThen(actionCreator(bool), [action]).then(state => {
+            assert.deepEqual(accessor(state), bool);
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
#### What are the relevant tickets?

closes #482 

#### What's this PR do?

This adds a pop-up dialog that asks you to confirm deleting entries when toggling switches on the work history and education forms. Basically, this means that if you have entries saved and you try to turn the switch off you have to either affirm your intention to delete all the entries, or cancel turning off the switch. It shouldn't be possible get into a state where there are invisible history entries which will be saved upon clicking 'save and continue'.

#### Where should the reviewer start?

I guess start with the changes to `EmploymentForm`, `EducationForm`, and `ConfirmDeletion`.

#### How should this be manually tested?

Visit `/profile/professional` and `/profile/education`. On the former

- confirm that you can freely toggle the switch when no work history is entered
- confirm that entering a work history entry causes the pop-up to appear upon clicking the switch
- confirm that cancelling the popup is non-destructive
- confirm that confirming the popup deletes all education entries

on the latter:

- confirm that you can freely toggle the switch for a degree level when no history is entered *for that particular level*
- confirm that entering a degree causes the popup to appear for that particular level, but not for any other.
- confirm that cancelling the popup is non-destructive
- confirm that confirming the popup deletes all education entries for a particular degree level

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

