### PR TITLE
Swapped courses and faq in program page

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -79,8 +79,8 @@ class ProgramPage(Page):
         FieldPanel('background_image'),
         FieldPanel('contact_us'),
         FieldPanel('title_over_image'),
+        InlinePanel('courses', label='Program Courses'),
         InlinePanel('faqs', label='Frequently Asked Questions'),
-        InlinePanel('courses', label='Program Courses')
     ]
 
     def get_context(self, request):

--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -65,11 +65,11 @@
               <a href="#home" aria-controls="home" role="tab" data-toggle="tab">Program Home</a>
             </li>
             <li role="presentation">
-              <a href="#faqs" aria-controls="faqs" role="tab" data-toggle="tab">Frequently Asked
-                Questions</a>
+              <a href="#courses" aria-controls="courses" role="tab" data-toggle="tab">Courses</a>
             </li>
             <li role="presentation">
-              <a href="#courses" aria-controls="courses" role="tab" data-toggle="tab">Courses</a>
+              <a href="#faqs" aria-controls="faqs" role="tab" data-toggle="tab">Frequently Asked
+                Questions</a>
             </li>
           </ul>
 
@@ -109,42 +109,7 @@
 
 
             </div>
-            <div role="tabpanel" class="tab-pane fade in" id="faqs">
 
-              <div class="panel-body">
-                <div class="row">
-                  <div class="col-md-10">
-                    <h3>You have questions and we have answers</h3>
-                    <div class="panel-group panel-group-continuous" id="exampleAccordionContinuous"
-                         aria-multiselectable="true" role="tablist">
-                      {% for faq in page.faqs.all %}
-                        <div class="panel">
-                          <div class="panel-heading" id="exampleHeadingContinuousOne"
-                               role="tab">
-                            <a class="panel-title"
-                               data-parent="#exampleAccordionContinuous"
-                               data-toggle="collapse"
-                               href="#faqs-{{ forloop.counter }}"
-                               aria-controls="exampleCollapseContinuousOne"
-                               aria-expanded="true">
-                              {{ faq.question }}
-                            </a>
-                          </div>
-                          <div class="panel-collapse collapse in"
-                               id="faqs-{{ forloop.counter }}"
-                               aria-labelledby="exampleHeadingContinuousOne"
-                               role="tabpanel">
-                            <div class="panel-body">
-                              {{ faq.answer }}
-                            </div>
-                          </div>
-                        </div>
-                      {% endfor %}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
             <div role="tabpanel" class="tab-pane fade in" id="courses">
               <div class="panel-body">
                 <div class="row">
@@ -179,6 +144,43 @@
                 </div>
               </div>
             </div>
+
+            <div role="tabpanel" class="tab-pane fade in" id="faqs">
+              <div class="panel-body">
+                <div class="row">
+                  <div class="col-md-10">
+                    <h3>You have questions and we have answers</h3>
+                    <div class="panel-group panel-group-continuous" id="exampleAccordionContinuous"
+                         aria-multiselectable="true" role="tablist">
+                      {% for faq in page.faqs.all %}
+                        <div class="panel">
+                          <div class="panel-heading" id="exampleHeadingContinuousOne"
+                               role="tab">
+                            <a class="panel-title"
+                               data-parent="#exampleAccordionContinuous"
+                               data-toggle="collapse"
+                               href="#faqs-{{ forloop.counter }}"
+                               aria-controls="exampleCollapseContinuousOne"
+                               aria-expanded="true">
+                              {{ faq.question }}
+                            </a>
+                          </div>
+                          <div class="panel-collapse collapse in"
+                               id="faqs-{{ forloop.counter }}"
+                               aria-labelledby="exampleHeadingContinuousOne"
+                               role="tabpanel">
+                            <div class="panel-body">
+                              {{ faq.answer }}
+                            </div>
+                          </div>
+                        </div>
+                      {% endfor %}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
           </div>
         </div>
       </section>


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #528 

#### What's this PR do?
Puts the courses tab before the FAQ one in the program page

#### Where should the reviewer start?
`program_page.html`

#### How should this be manually tested?
Create a program page in the CMS and verify that the tabs are in the right order

#### Any background context you want to provide?
To fix the issue was enough to change the order of the Nav tabs. I changed the order of the rest just to be consistent and to avoid confusion in the future.

#### Screenshots (if appropriate)
<img width="1329" alt="screen shot 2016-06-21 at 11 50 12 am" src="https://cloud.githubusercontent.com/assets/1005204/16236431/5ff207d6-37a6-11e6-9a4a-e5e7509cc63e.png">
