### PR TITLE
Sorted employment entries in resume order

### DIFF
--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -12,6 +12,7 @@ import _ from 'lodash';
 import moment from 'moment';
 
 import { generateNewWorkHistory, userPrivilegeCheck } from '../util/util';
+import { sortWorkEntriesByDate } from '../util/sorting';
 import { employmentValidation } from '../util/validation';
 import ProfileFormFields from '../util/ProfileFormFields';
 import ConfirmDeletion from './ConfirmDeletion';
@@ -120,7 +121,8 @@ class EmploymentForm extends ProfileFormFields {
     if ( ui.workHistoryEdit === true ) {
       let workHistoryRows = [];
       if ( !_.isUndefined(work_history) ) {
-        workHistoryRows = Object.entries(work_history).filter(([,entry]: [string, WorkHistoryEntry]) =>
+        let sorted = sortWorkEntriesByDate(work_history);
+        workHistoryRows = Object.entries(sorted).filter(([,entry]: [string, WorkHistoryEntry]) =>
           entry.id !== undefined
         ).map(([i, entry]) => this.jobRow(entry, i));
       }

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -1,3 +1,5 @@
 /* eslint-disable no-unused-vars */
 import type { Settings } from './generalTypes';
 declare var SETTINGS: Settings;
+declare var describe: Function;
+declare var it: Function;

--- a/static/js/util/sorting.js
+++ b/static/js/util/sorting.js
@@ -1,0 +1,27 @@
+// @flow
+import moment from 'moment';
+
+import type { WorkHistoryEntry, EducationEntry } from '../flow/profileTypes';
+
+type SortableEntry = WorkHistoryEntry|EducationEntry;
+export function resumeOrder(entries: SortableEntry[], dateFieldName: string): SortableEntry[] {
+  let sortFunc = (a, b) => {
+    let adate = moment(a[dateFieldName]);
+    let bdate = moment(b[dateFieldName]);
+    if ( adate.isBefore(bdate) ) {
+      return 1;
+    }
+    if ( adate.isAfter(bdate) ) {
+      return -1;
+    }
+    return 0;
+  };
+  return entries.sort(sortFunc);
+}
+
+export function sortWorkEntriesByDate(entries: Array<WorkHistoryEntry>): Array<WorkHistoryEntry> {
+  let sorted = [];
+  sorted.push(...resumeOrder(entries.filter(entry => entry.end_date === null), 'start_date'));
+  sorted.push(...resumeOrder(entries.filter(entry => entry.end_date !== null), 'end_date'));
+  return sorted;
+}

--- a/static/js/util/sorting_test.js
+++ b/static/js/util/sorting_test.js
@@ -1,0 +1,66 @@
+// @flow
+import { assert } from 'chai';
+import moment from 'moment';
+
+import { resumeOrder, sortWorkEntriesByDate } from './sorting';
+import { generateNewWorkHistory } from './util';
+
+let format = 'YYYY-MM';
+
+describe('profile sort functions', () => {
+  it('should sort by resume order', () => {
+    let entries = ['1969-01', '1997-01', '1992-01', '1934-01'].map(year => (
+      { 'date': moment(year, format).format(format) }
+    ));
+    let sorted = resumeOrder(entries, 'date');
+    let expected = [
+      '1997-01',
+      '1992-01',
+      '1969-01',
+      '1934-01',
+    ];
+    assert.deepEqual(expected, sorted.map(entry => entry.date));
+  });
+
+  it('should sort employment entries first by "current" and then by resume order', () => {
+    let entries = [
+      ['1962-12', null],
+      ['1923-12', null],
+      ['2001-01', '2012-03'],
+      ['1962-12', '1963-11'],
+      ['1961-08', '1982-01'],
+      ['2001-12', null],
+    ].map(([start, end]) => {
+      let entry = generateNewWorkHistory();
+      entry.start_date = moment(start, format);
+      entry.end_date = end ? moment(end, format) : null;
+      return entry;
+    });
+    let sorted = sortWorkEntriesByDate(entries);
+
+    // null end date (current position) jobs come first
+    sorted.slice(0, 3).forEach(entry => (
+      assert.isNull(entry.end_date)
+    ));
+
+    // finished (non-current) jobs at the end
+    sorted.slice(3,6).forEach(entry => (
+      assert.isNotNull(entry.end_date)
+    ));
+
+    // check overall date order
+    let expectedDateOrder = [
+      ['2001-12', null],
+      ['1962-12', null],
+      ['1923-12', null],
+      ['2001-01', '2012-03'],
+      ['1961-08', '1982-01'],
+      ['1962-12', '1963-11'],
+    ];
+    let actualDateOrder = sorted.map(entry => ([
+      entry.start_date.format(format), 
+      entry.end_date === null ? null : entry.end_date.format(format)
+    ]));
+    assert.deepEqual(expectedDateOrder, actualDateOrder);
+  });
+});


### PR DESCRIPTION
#### What are the relevant tickets?

closes #584 

#### What's this PR do?

This adds a function to `util.js` that takes an `Array<EmploymentEntry>` and returns a sorted array (in resume order). Then we can just call this on `profile.work_history` before we draw the UI to get things in the right order.

#### Where should the reviewer start?

Check out the changes to `util/util.js` and make sure the tests all look legit.

#### How should this be manually tested?

Add a variety of employment entries, with and without end dates, and check that the following sort order is displayed on `/users` and on `/profile/professional`:

- 'current' entries (w/out an end date) should be displayed first, as a group
- 'current' entries should be ordered by start date
- 'non-current' entries should appear after all 'current' entries
- 'non-current' entries should be ordered by end date

#### Any background context you want to provide?

#### Screenshots (if appropriate)

![current](https://cloud.githubusercontent.com/assets/6207644/16241836/8402662c-37bd-11e6-9be2-0474271be9d2.png)


#### What GIF best describes this PR or how it makes you feel?

