### PR TITLE
Fixed bug with preferred name not updating on Jumbotron

### DIFF
--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -23,7 +23,7 @@ class ProfilePage extends ProfileFormContainer {
       profile = profiles[SETTINGS.username];
     }
 
-    let text = `Welcome ${getPreferredName(profile)}, let's
+    let text = `Welcome ${getPreferredName(profile.profile)}, let's
     complete your enrollment to MIT MicroMaster’s.`;
 
     let childrenWithProps = this.childrenWithProps(profile);


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #581 

#### What's this PR do?

very little :P 

#### Where should the reviewer start?

#### How should this be manually tested?

Go to `/profile/personal`. Note that `preferred_name` in the banner up top matches the entry in the form. Update the form (append `'_test'` or something) and click 'save and continue'. The 'preferred name' displayed up to should update.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

