### PR TITLE
Removed UI validators from PrivacyTab validator callback

### DIFF
--- a/static/js/components/PrivacyTab.js
+++ b/static/js/components/PrivacyTab.js
@@ -8,9 +8,7 @@ import {
   combineValidators,
   personalValidation,
   educationValidation,
-  educationUiValidation,
   employmentValidation,
-  employmentUiValidation,
   privacyValidation,
 } from '../util/validation';
 import type { Profile } from '../flow/profileTypes';
@@ -50,9 +48,7 @@ class PrivacyTab extends ProfileFormFields {
                 combineValidators(
                   personalValidation,
                   educationValidation,
-                  educationUiValidation,
                   employmentValidation,
-                  employmentUiValidation,
                   privacyValidation
                 )
               }

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -387,7 +387,7 @@ describe("ProfilePage", function() {
     });
   });
 
-  it(`validates education and employment switches when saving the ${lastPage}`, () => {
+  it('does not validate education and employment switches when saving the privacy page', () => {
     return renderComponent(lastPage).then(([, div]) => {
       // close all switches and remove all education so we don't get validation errors
       let receivedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
@@ -408,10 +408,7 @@ describe("ProfilePage", function() {
       });
 
       return confirmSaveButtonBehavior(updatedProfile, {button: button}, true).then(state => {
-        assert.deepEqual(state.profiles[SETTINGS.username].edit.errors, {
-          [`education_${HIGH_SCHOOL}_required`]: `High school is required if switch is set`,
-          work_history_required: "Work history is required if switch is set"
-        });
+        assert.deepEqual(state.profiles[SETTINGS.username].edit.errors, {});
       });
     });
   });


### PR DESCRIPTION
#### What are the relevant tickets?

closes #576 

#### What's this PR do?

removes validation of the education and work history UI state when saving on the `PrivacyTab`.

#### Where should the reviewer start?

#### How should this be manually tested?

Follow the description of the repro for the problem on the issue: #576, and confirm that you can successfully save on `/profile/privacy`.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

