### PR TITLE
Added custom 500 page

### DIFF
--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -32,3 +32,4 @@ urlpatterns = [
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 handler404 = 'ui.views.page_404'
+handler500 = 'ui.views.page_500'

--- a/ui/templates/500.html
+++ b/ui/templates/500.html
@@ -1,0 +1,20 @@
+{% extends "base_error.html" %}
+{% load i18n static %}
+
+{% block title %}{% trans "MIT MicroMasters" %}{% endblock %}
+
+{% block error_header %}
+INTERNAL SERVER ERROR
+{% endblock %}
+
+{% block error_content %}
+<div id="page-not-found">
+	<p>The page you requested has problems: an engineer will be blamed for this.</p>
+
+	<p>We get emails every time you see this page, keep refreshing if you're mad or just write to
+	<a href="mailto:mitx-support@mit.edu">mitx-support@mit.edu</a></p>
+
+	<iframe width="630" height="473" src="https://www.youtube.com/embed/IAIPUGO1iko"
+		frameborder="0" allowfullscreen></iframe>
+</div>
+{% endblock %}

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -12,6 +12,7 @@ from ui.url_utils import (
 from ui.views import (
     dashboard,
     page_404,
+    page_500,
 )
 
 dashboard_urlpatterns = [
@@ -27,4 +28,5 @@ dashboard_urlpatterns = [
 urlpatterns = [
     url(r'^logout/$', 'django.contrib.auth.views.logout', {'next_page': '/'}),
     url(r'^404/$', page_404, name='ui-404'),
+    url(r'^500/$', page_500, name='ui-500'),
 ] + dashboard_urlpatterns

--- a/ui/views.py
+++ b/ui/views.py
@@ -83,3 +83,24 @@ def page_404(request):
     )
     response.status_code = 404
     return response
+
+
+def page_500(request):
+    """
+    Overridden handler for the 500 error pages.
+    """
+    name = request.user.profile.preferred_name if not request.user.is_anonymous() else ""
+
+    response = render(
+        request,
+        "500.html",
+        context={
+            "style_src": get_bundle_url(request, "style.js"),
+            "dashboard_src": get_bundle_url(request, "dashboard.js"),
+            "js_settings_json": "{}",
+            "authenticated": not request.user.is_anonymous(),
+            "name": name,
+        }
+    )
+    response.status_code = 500
+    return response

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -252,6 +252,29 @@ class TestViews(TestCase):
             assert response.context['authenticated'] is False
             assert response.context['name'] == ""
 
+    def test_500_error_context_logged_in(self):
+        """
+        Assert context values for 500 error page when logged in
+        """
+        with mute_signals(post_save):
+            profile = ProfileFactory.create()
+            self.client.force_login(profile.user)
+
+        response = self.client.get('/500/')
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.context['authenticated'] is True
+        assert response.context['name'] == profile.preferred_name
+
+    def test_500_error_context_logged_out(self):
+        """
+        Assert context values for 500 error page when logged out
+        """
+        # case with specific page
+        response = self.client.get('/500/')
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.context['authenticated'] is False
+        assert response.context['name'] == ""
+
 
 class TestProgramPage(TestCase):
     """


### PR DESCRIPTION
#### What are the relevant tickets?
closes #487 

#### What's this PR do?
Adds a custom 500 page

#### Where should the reviewer start?
`ui.views` and then '500.html'

#### How should this be manually tested?
to see the the 500 template, just go to `/500/`.
To actually test that a 500 is returned for a error, you need to:
  - set the debug to False in your `docker-compose.yml`
  - run `node node_modules/webpack/bin/webpack.js --config webpack.config.prod.js --bail` to build the static assets
  - run `docker-compose run web ./manage.py collectstatic` 
  - raise any exception in a view like `ui.views.dashboard`
