### PR TITLE
Fixed style regression

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -9,6 +9,7 @@ import { makeDashboardRoutes } from './dashboard_routes';
 
 // requirements for react-mdl which uses a modified version of material-design-lite
 import 'react-mdl/extra/material.js';
+import 'style!css!react-mdl/extra/material.css';
 
 // Object.entries polyfill
 import entries from 'object.entries';

--- a/static/js/style.js
+++ b/static/js/style.js
@@ -1,3 +1,2 @@
 __webpack_public_path__ = `http://${SETTINGS.host}:8078/`;  // eslint-disable-line no-undef, camelcase
 import '../scss/layout.scss';
-import 'style!css!react-mdl/extra/material.css';


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #620 

#### What's this PR do?
Moves the react-mdl CSS back into dashboard.js. It overrides many common style rules which is why we're seeing different styles with it included. We're only using bootstrap CSS on the 404 page currently so this shouldn't cause any problems.

#### How should this be manually tested?
First, turn on DEBUG mode so we can view the 404 page. You can do this by setting `DEBUG=False` in `settings.py` and adding your host name to the `ALLOWED_HOSTS` list.

Then run `NODE_ENV=production ./webpack_if_prod.sh` in your terminal to generate static assets. Next, run `docker-compose run web ./manage.py collectstatic` to copy static assets into `staticfiles/`.

After that, look at the two screenshots for the program page in #620. Go to a program page and verify that it looks like it did before, more or less. Go to `/xyz/` and verify the 404 page still works as expected, and also click the dropdown and click 'logout' to make sure that works.
