### PR TITLE
Added resumeOrder to education entries

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,6 +7,8 @@
 
 [libs]
 ./static/js/flow/declarations.js
+node_modules/iflow-lodash/index.js.flow
+node_modules/iflow-moment/index.js.flow
 
 [options]
 esproposal.class_static_fields=enable

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "file-loader": "0.8.5",
     "flow-bin": "^0.27.0",
     "history": "2.1.1",
+    "iflow-lodash": "^1.1.16",
+    "iflow-moment": "^1.1.13",
     "imports-loader": "^0.6.5",
     "iso-3166-2": "0.4.0",
     "isomorphic-fetch": "2.2.1",

--- a/static/js/components/EducationDisplay.js
+++ b/static/js/components/EducationDisplay.js
@@ -19,6 +19,7 @@ import {
 } from '../util/editEducation';
 import { userPrivilegeCheck } from '../util/util';
 import { HIGH_SCHOOL } from '../constants';
+import { educationEntriesByDate } from '../util/sorting';
 import type { EducationEntry } from '../flow/profileTypes';
 
 export default class EducationDisplay extends ProfileFormFields {
@@ -44,7 +45,7 @@ export default class EducationDisplay extends ProfileFormFields {
     let deleteEntry = () => this.openEducationDeleteDialog(index);
     let editEntry = () => this.openEditEducationForm(index);
     let validationAlert = () => {
-      if (_.get(errors, ['education', index])) {
+      if (_.get(errors, ['education', String(index)])) {
         return <IconButton name="error" onClick={editEntry} />;
       }
     };
@@ -77,7 +78,8 @@ export default class EducationDisplay extends ProfileFormFields {
     const { profile, profile: { education }} = this.props;
     let rows = [];
     if (education !== undefined) {
-      rows = education.map( (entry, index) => this.educationRow(entry, index));
+      let sorted = educationEntriesByDate(education);
+      rows = sorted.map( ([index, entry]) => this.educationRow(entry, index));
     }
     userPrivilegeCheck(profile, () => {
       rows.push(

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -18,6 +18,7 @@ import {
   deleteEducationEntry,
 } from '../util/editEducation';
 import { educationValidation } from '../util/validation';
+import { educationEntriesByDate } from '../util/sorting';
 import type { Option } from '../flow/generalTypes';
 import type {
   EducationEntry,
@@ -61,9 +62,10 @@ class EducationForm extends ProfileFormFields {
     if (educationDegreeInclusions[level.value]) {
       let rows: Array<React$Element|void> = [];
       if (education !== undefined) {
-        rows = education.map((entry, index) => (
-          entry.degree_name === level.value ? this.educationRow(entry, index) : undefined
-        ));
+        let sorted = educationEntriesByDate(education);
+        rows = sorted.filter(([,entry]) => (
+          entry.degree_name === level.value
+        )).map(([index, entry]) => this.educationRow(entry, index));
       }
       rows.push(
         <FABButton
@@ -89,7 +91,7 @@ class EducationForm extends ProfileFormFields {
     let deleteEntry = () => this.openEducationDeleteDialog(index);
     let editEntry = () => this.openEditEducationForm(index);
     let validationAlert = () => {
-      if (_.get(errors, ['education', index])) {
+      if (_.get(errors, ['education', String(index)])) {
         return <IconButton name="error" onClick={editEntry} />;
       }
     };

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -12,7 +12,7 @@ import _ from 'lodash';
 import moment from 'moment';
 
 import { generateNewWorkHistory, userPrivilegeCheck } from '../util/util';
-import { sortWorkEntriesByDate } from '../util/sorting';
+import { workEntriesByDate } from '../util/sorting';
 import { employmentValidation } from '../util/validation';
 import ProfileFormFields from '../util/ProfileFormFields';
 import ConfirmDeletion from './ConfirmDeletion';
@@ -138,8 +138,8 @@ class EmploymentForm extends ProfileFormFields {
     if ( ui.workHistoryEdit === true ) {
       let workHistoryRows = [];
       if ( !_.isUndefined(work_history) ) {
-        let sorted = sortWorkEntriesByDate(work_history);
-        workHistoryRows = sorted.map((entry, index) => (
+        let sorted = workEntriesByDate(work_history);
+        workHistoryRows = sorted.map(([index, entry]) => (
           entry.id === undefined ? undefined : this.jobRow(entry, index)
         ));
       }
@@ -170,7 +170,7 @@ class EmploymentForm extends ProfileFormFields {
       setWorkDialogVisibility(true);
     };
     let validationAlert = () => {
-      if (_.get(errors, ['work_history', index])) {
+      if (_.get(errors, ['work_history', String(index)])) {
         return <IconButton name="error" onClick={editCallback} />;
       }
     };

--- a/static/js/util/sorting.js
+++ b/static/js/util/sorting.js
@@ -1,26 +1,35 @@
 // @flow
 import moment from 'moment';
+import _ from 'lodash';
 
-import type { WorkHistoryEntry } from '../flow/profileTypes';
+import type { WorkHistoryEntry, EducationEntry } from '../flow/profileTypes';
 
-export function resumeOrder(entries: WorkHistoryEntry[], dateFieldName: string): WorkHistoryEntry[] {
-  let sortFunc = (a, b) => {
-    let adate = moment(a[dateFieldName]);
-    let bdate = moment(b[dateFieldName]);
-    if ( adate.isBefore(bdate) ) {
-      return 1;
-    }
-    if ( adate.isAfter(bdate) ) {
-      return -1;
-    }
-    return 0;
-  };
-  return entries.sort(sortFunc);
+export function momentCompareDesc(a: moment$Moment, b: moment$Moment): number {
+  if ( a.isBefore(b) ) {
+    return 1;
+  }
+  if ( a.isAfter(b) ) {
+    return -1;
+  }
+  return 0;
 }
 
-export function sortWorkEntriesByDate(entries: Array<WorkHistoryEntry>): Array<WorkHistoryEntry> {
-  let sorted = [];
-  sorted.push(...resumeOrder(entries.filter(entry => entry.end_date === null), 'start_date'));
-  sorted.push(...resumeOrder(entries.filter(entry => entry.end_date !== null), 'end_date'));
-  return sorted;
+export function dateOrderDesc(entries: [number, Object][], dateFieldName: string): any {
+  let clone = _.clone(entries);
+  let sortFunc = ([, a], [, b]) => {
+    return momentCompareDesc(moment(a[dateFieldName]), moment(b[dateFieldName]));
+  };
+  return clone.sort(sortFunc);
+}
+
+export function workEntriesByDate(entries: Array<WorkHistoryEntry>): Array<WorkHistoryEntry> {
+  let tuples = entries.map((entry, index) => [index, entry]);
+  let out = [];
+  out.push(...dateOrderDesc(tuples.filter(([,entry]) => entry.end_date === null), 'start_date'));
+  out.push(...dateOrderDesc(tuples.filter(([,entry]) => entry.end_date !== null), 'end_date'));
+  return out;
+}
+
+export function educationEntriesByDate(entries: Array<EducationEntry>): Array<EducationEntry> {
+  return dateOrderDesc(entries.map((entry, index) => [index, entry]), 'graduation_date');
 }

--- a/static/js/util/sorting_test.js
+++ b/static/js/util/sorting_test.js
@@ -2,27 +2,71 @@
 import { assert } from 'chai';
 import moment from 'moment';
 
-import { resumeOrder, sortWorkEntriesByDate } from './sorting';
-import { generateNewWorkHistory } from './util';
+import {
+  dateOrderDesc,
+  workEntriesByDate,
+  educationEntriesByDate,
+  momentCompareDesc,
+} from './sorting';
+import { generateNewWorkHistory, generateNewEducation } from './util';
+import { HIGH_SCHOOL } from '../constants';
 
 let format = 'YYYY-MM';
 
-describe('profile sort functions', () => {
-  it('should sort by resume order', () => {
+describe('sorting functions', () => {
+  describe('momentCompareDesc', () => {
+    it('should sort arrays of moment objects in descending order', () => {
+      let moments = [
+        moment('1987-12', 'YYYY-MM'),
+        moment('1986-12', 'YYYY-MM'),
+        moment('1987-09', 'YYYY-MM'),
+        moment('1901-03', 'YYYY-MM'),
+        moment('2001-04', 'YYYY-MM'),
+        moment('2016-12', 'YYYY-MM'),
+      ];
+      moments.sort(momentCompareDesc);
+      let expected = [
+        '2016-12',
+        '2001-04',
+        '1987-12',
+        '1987-09',
+        '1986-12',
+        '1901-03',
+      ];
+      assert.deepEqual(expected, moments.map(m => m.format('YYYY-MM')));
+    });
+  });
+
+  describe('dateOrderDesc', () => {
     let entries = ['1969-01', '1997-01', '1992-01', '1934-01'].map(year => (
       { 'end_date': moment(year, format).format(format) }
     ));
-    let sorted = resumeOrder(entries, 'end_date');
+    let sorted = dateOrderDesc(entries.map((entry, index) => (
+      [index, entry]
+    )), 'end_date');
     let expected = [
       '1997-01',
       '1992-01',
       '1969-01',
       '1934-01',
     ];
-    assert.deepEqual(expected, sorted.map(entry => entry.end_date));
+
+    it('should sort by date, descending', () => {
+      assert.deepEqual(expected, sorted.map(([,entry]) => entry.end_date));
+    });
+
+    it('should not modify the original array', () => {
+      assert.notDeepEqual(entries, sorted);
+    });
+
+    it('should return the indices of the objects in the original array', () => {
+      sorted.forEach(([index, entry]) => {
+        assert.deepEqual(entries[index], entry);
+      });
+    });
   });
 
-  it('should sort employment entries first by "current" and then by resume order', () => {
+  describe('workEntriesByDate', () => {
     let entries = [
       ['1962-12', null],
       ['1923-12', null],
@@ -36,31 +80,74 @@ describe('profile sort functions', () => {
       entry.end_date = end ? moment(end, format).format(format) : null;
       return entry;
     });
-    let sorted = sortWorkEntriesByDate(entries);
+    let sorted = workEntriesByDate(entries);
 
-    // null end date (current position) jobs come first
-    sorted.slice(0, 3).forEach(entry => (
-      assert.isNull(entry.end_date)
-    ));
+    it('should sort employment entries first by "current" and then by date descending (resume order)', () => {
+      // null end date (current position) jobs come first
+      sorted.slice(0, 3).forEach(([,entry]) => (
+        assert.isNull(entry.end_date)
+      ));
 
-    // finished (non-current) jobs at the end
-    sorted.slice(3,6).forEach(entry => (
-      assert.isNotNull(entry.end_date)
-    ));
+      // finished (non-current) jobs at the end
+      sorted.slice(3,6).forEach(([,entry]) => (
+        assert.isNotNull(entry.end_date)
+      ));
 
-    // check overall date order
-    let expectedDateOrder = [
-      ['2001-12', null],
-      ['1962-12', null],
-      ['1923-12', null],
-      ['2001-01', '2012-03'],
-      ['1961-08', '1982-01'],
-      ['1962-12', '1963-11'],
+      // check overall date order
+      let expectedDateOrder = [
+        ['2001-12', null],
+        ['1962-12', null],
+        ['1923-12', null],
+        ['2001-01', '2012-03'],
+        ['1961-08', '1982-01'],
+        ['1962-12', '1963-11'],
+      ];
+      let actualDateOrder = sorted.map(([,entry]) => ([
+        entry.start_date,
+        entry.end_date
+      ]));
+      assert.deepEqual(expectedDateOrder, actualDateOrder);
+    });
+
+    it('should return the indices of the sorted entries in the original array', () => {
+      sorted.forEach(([index, entry]) => {
+        assert.deepEqual(entry, entries[index]);
+      });
+    });
+  });
+
+  describe('educationEntriesByDate', () => {
+    let entries = [
+      '1979-12',
+      '1923-12',
+      '2001-01',
+      '1962-12',
+      '1961-08',
+      '2001-12',
+    ].map(date => {
+      let entry = generateNewEducation(HIGH_SCHOOL);
+      entry.graduation_date = moment(date, format).format(format);
+      return entry;
+    });
+    let sorted = educationEntriesByDate(entries);
+
+    let expectation = [
+      '2001-12',
+      '2001-01',
+      '1979-12',
+      '1962-12',
+      '1961-08',
+      '1923-12',
     ];
-    let actualDateOrder = sorted.map(entry => ([
-      entry.start_date,
-      entry.end_date
-    ]));
-    assert.deepEqual(expectedDateOrder, actualDateOrder);
+
+    it('should sort education entries by date descending', () => {
+      assert.deepEqual(expectation, sorted.map(([,e]) => e.graduation_date));
+    });
+
+    it('should return the indices of the sorted entries in the original array', () => {
+      sorted.forEach(([index, entry]) => {
+        assert.deepEqual(entry, entries[index]);
+      });
+    });
   });
 });

--- a/static/js/util/validation.js
+++ b/static/js/util/validation.js
@@ -154,7 +154,7 @@ export function employmentValidation(profile: Profile): ValidationErrors {
     profile.work_history.forEach((workHistory, index) => {
       if (!isNilOrEmptyString(workHistory.end_date) && workHistory.end_date !== undefined &&
         moment(workHistory.end_date).isBefore(workHistory.start_date, 'month')) {
-        _.set(errors, ['work_history', index, 'end_date'], "End date cannot be before start date");
+        _.set(errors, ['work_history', String(index), 'end_date'], "End date cannot be before start date");
       }
       let editIsEmpty = _.isEmpty(workHistory.end_date_edit) || (
         workHistory.end_date_edit !== undefined &&
@@ -162,7 +162,7 @@ export function employmentValidation(profile: Profile): ValidationErrors {
           isNilOrEmptyString(workHistory.end_date_edit.month)
       );
       if (isNilOrEmptyString(workHistory.end_date) && !editIsEmpty) {
-        _.set(errors, ['work_history', index, 'end_date'], "Please enter a valid end date or leave it blank");
+        _.set(errors, ['work_history', String(index), 'end_date'], "Please enter a valid end date or leave it blank");
       }
     });
 


### PR DESCRIPTION
#### What are the relevant tickets?

closes #583 

#### What's this PR do?

Adds a little function to sort education entries by `graduation_date` in resume order, which we can use in `EducationDisplay` and `EducationForm`.

#### Where should the reviewer start?

#### How should this be manually tested?

Make sure that:

- on the user page all education entries are presented in a single list in resume order, and you can add/delete/edit entries as usual.
- on `/profile/education` make that that, for each degree level, the degree entries within that level are sorted by resume order, and, again, that you can do all the normal actions on entries.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

