### PR TITLE
Fixed filtering text to remain if textbox clicked

### DIFF
--- a/static/js/components/AutoComplete.js
+++ b/static/js/components/AutoComplete.js
@@ -370,9 +370,16 @@ class AutoComplete extends Component {
       });
     }
 
+    let skipFilter = this.props.showOptionsWhenBlank;
+    // We want to open the popup with all results if available, else
+    // if the popup is already open we want to filter as usual
+    if (this.state.searchText !== '' && this.state.searchText !== undefined && this.state.open) {
+      skipFilter = false;
+    }
+
     this.setState({
       focusTextField: true,
-      skipFilter: this.props.showOptionsWhenBlank
+      skipFilter: skipFilter
     });
 
     if (this.props.onFocus) {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #547 

#### What's this PR do?
When the user clicks an autocomplete field, it should show all options. If the user types text it filtered based on that text, but when they click again it shows all options. This PR changes the behavior to continue to show filtered results in this case.

#### How should this be manually tested?
Go to the /users/ page and find an AutoComplete field. Then look for these scenarios:
 - Clear the select field, focus away from field. Click on field again and make sure you see all entries. Type text and verify that it shows only entries whose prefix matches the text. Click on the text field and verify that the options you see haven't changed.
 - Select an option and focus away from field. Click on the text field and verify that you see all options. Click again and you should see only the filtered fields.
 - Select an option and focus away from the field. Click on the text field and delete all text, verify that you see all options. Click on the text field again and verify that you still see all options.