### PR TITLE
Redirected to 404 if user goes to a missing user page

### DIFF
--- a/static/js/containers/LoginButton.js
+++ b/static/js/containers/LoginButton.js
@@ -24,25 +24,32 @@ class LoginButton extends React.Component {
       {getPreferredName(profile)}
     </span>;
 
-    return (
-      <LinkContainer to={{ pathname: '/dashboard' }} active={false}>
-        <SplitButton
-          title={title}
-          bsStyle="danger"
-          id="logout-button">
-          <LinkContainer to={{ pathname: '/settings' }} active={false}>
-            <MenuItem>
-              Settings
+    if (SETTINGS.authenticated) {
+      return (
+        <LinkContainer to={{ pathname: '/dashboard' }} active={false}>
+          <SplitButton
+            title={title}
+            bsStyle="danger"
+            id="logout-button">
+            <LinkContainer to={{ pathname: '/settings' }} active={false}>
+              <MenuItem>
+                Settings
+              </MenuItem>
+            </LinkContainer>
+            <MenuItem
+              href="/logout"
+              eventKey="logout">
+              Logout
             </MenuItem>
-          </LinkContainer>
-          <MenuItem
-            href="/logout"
-            eventKey="logout">
-            Logout
-          </MenuItem>
-        </SplitButton>
-      </LinkContainer>
-    );
+          </SplitButton>
+        </LinkContainer>
+      );
+    } else {
+      return <div className="pull-right">
+        <span>Get Started Today!</span>
+        <a className="btn btn-danger" href="/login/edxorg/">Sign in with edX.org</a>
+      </div>;
+    }
   }
 }
 

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -1,6 +1,6 @@
 // Define globals we would usually get from Django
 global.SETTINGS = {
-  isAuthenticated: true,
+  authenticated: true,
   name: "full name",
   username: "jane",
   edx_base_url: "/edx/"

--- a/ui/url_utils.py
+++ b/ui/url_utils.py
@@ -5,5 +5,4 @@ Utils for URLs (to avoid circular imports)
 DASHBOARD_URL = '/dashboard/'
 PROFILE_URL = '/profile/'
 TERMS_OF_SERVICE_URL = '/terms_of_service/'
-USERS_URL = '/users/'
 SETTINGS_URL = "/settings/"

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -7,22 +7,21 @@ from ui.url_utils import (
     DASHBOARD_URL,
     PROFILE_URL,
     TERMS_OF_SERVICE_URL,
-    USERS_URL,
     SETTINGS_URL,
 )
 from ui.views import (
-    dashboard,
+    DashboardView,
+    UsersView,
     page_404,
     page_500,
 )
 
 dashboard_urlpatterns = [
-    url(r'^{}'.format(dashboard_url.lstrip("/")), dashboard, name='ui-dashboard')
+    url(r'^{}'.format(dashboard_url.lstrip("/")), DashboardView.as_view(), name='ui-dashboard')
     for dashboard_url in [
         DASHBOARD_URL,
         PROFILE_URL,
         TERMS_OF_SERVICE_URL,
-        USERS_URL,
         SETTINGS_URL,
     ]
 ]
@@ -31,4 +30,5 @@ urlpatterns = [
     url(r'^logout/$', 'django.contrib.auth.views.logout', {'next_page': '/'}),
     url(r'^404/$', page_404, name='ui-404'),
     url(r'^500/$', page_500, name='ui-500'),
+    url(r'^users/(?P<user>[-\w]+)?/?', UsersView.as_view(), name='ui-users'),
 ] + dashboard_urlpatterns

--- a/ui/views.py
+++ b/ui/views.py
@@ -7,12 +7,16 @@ import logging
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.views.generic import View
 from django.shortcuts import (
     render,
+    Http404,
 )
+from django.utils.decorators import method_decorator
 
 from backends.edxorg import EdxOrgOAuth2
 from micromasters.utils import webpack_dev_server_host, webpack_dev_server_url
+from profiles.permissions import CanSeeIfNotPrivate
 from ui.decorators import (
     require_mandatory_urls,
 )
@@ -33,35 +37,70 @@ def get_bundle_url(request, bundle_name):
         return static("bundles/{bundle}".format(bundle=bundle_name))
 
 
-@require_mandatory_urls
-@login_required()
-def dashboard(request, *args):  # pylint: disable=unused-argument
+class ReactView(View):  # pylint: disable=unused-argument
     """
-    The app dashboard view
+    Abstract view for templates using React
     """
-    name = ""
-    if not request.user.is_anonymous():
-        name = request.user.profile.preferred_name
+    def get(self, request, *args, **kwargs):
+        """
+        Handle GET requests to templates using React
+        """
+        username = None
+        name = ""
+        if not request.user.is_anonymous():
+            name = request.user.profile.preferred_name
+            social_auths = request.user.social_auth.filter(
+                provider=EdxOrgOAuth2.name)
+            if social_auths.exists():
+                username = social_auths.first().uid
 
-    js_settings = {
-        "gaTrackingID": settings.GA_TRACKING_ID,
-        "reactGaDebug": settings.REACT_GA_DEBUG,
-        "authenticated": not request.user.is_anonymous(),
-        "name": name,
-        "username": request.user.social_auth.get(provider=EdxOrgOAuth2.name).uid,
-        "host": webpack_dev_server_host(request),
-        "edx_base_url": settings.EDXORG_BASE_URL
-    }
-
-    return render(
-        request,
-        "dashboard.html",
-        context={
-            "style_src": get_bundle_url(request, "style.js"),
-            "dashboard_src": get_bundle_url(request, "dashboard.js"),
-            "js_settings_json": json.dumps(js_settings),
+        js_settings = {
+            "gaTrackingID": settings.GA_TRACKING_ID,
+            "reactGaDebug": settings.REACT_GA_DEBUG,
+            "authenticated": not request.user.is_anonymous(),
+            "name": name,
+            "username": username,
+            "host": webpack_dev_server_host(request),
+            "edx_base_url": settings.EDXORG_BASE_URL
         }
-    )
+
+        return render(
+            request,
+            "dashboard.html",
+            context={
+                "style_src": get_bundle_url(request, "style.js"),
+                "dashboard_src": get_bundle_url(request, "dashboard.js"),
+                "js_settings_json": json.dumps(js_settings),
+            }
+        )
+
+
+@method_decorator(require_mandatory_urls, name='dispatch')
+@method_decorator(login_required, name='dispatch')
+class DashboardView(ReactView):
+    """
+    Wrapper for dashboard view which asserts certain logged in requirements
+    """
+
+
+class UsersView(ReactView):
+    """
+    View for users pages. This gets handled by the dashboard view like all other
+    React handled views, but we also want to return a 404 if the user does not exist.
+    """
+    def get(self, request, *args, **kwargs):
+        """
+        Handle GET requests
+        """
+        user = kwargs.pop('user')
+        if user is not None:
+            if not CanSeeIfNotPrivate().has_permission(request, self):
+                raise Http404
+        elif request.user.is_anonymous():
+            # /users/ redirects to logged in user's page, but user is not logged in here
+            raise Http404
+
+        return super(UsersView, self).get(request, *args, **kwargs)
 
 
 def page_404(request):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #481
Fixes #630 

#### What's this PR do?
Fixes two problems:
 - If a user goes to `/user/missing` (or some user who is invisible due to permissions), they will get a 404 page
 - Anonymous users may now look at the users page for a particular user

#### Where should the reviewer start?
ProfileFormContainer.js

#### How should this be manually tested?
 - Go to `/users/<name>` with a name that doesn't match an account on the server, and verify that it shows the 404 page
 - Log out, then view that users page again. You should see a users page with a sign in button, with no ability to edit fields.
