### PR TITLE
Removed padding from date field

### DIFF
--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -227,7 +227,7 @@ export function boundDateField(keySet: string[], label: string, omitDay: boolean
     />;
   }
 
-  return <div style={{paddingBottom: "20px"}}>
+  return <div>
     <TextField
       floatingLabelText={label}
       floatingLabelFixed={true}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #577

#### What's this PR do?
Removes padding inserted on the date field. I think I added this padding to make space for the validation text, but the text fields should already have this space

#### How should this be manually tested?
In the users page go to the graduation date in the education dialog, the start date in the employment dialog and the date of birth in the personal dialog. Cause a validation error in each case and make sure that everything still looks fine.
