### PR TITLE
prevented non-numbers from being entered in date fields

### DIFF
--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -425,7 +425,7 @@ describe("UserPage", function() {
             end_date: "2002-01-01",
             end_date_edit: {
               year: "2002",
-              month: "01",
+              month: "1",
               day: undefined
             },
             city: "FoobarVille",

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -147,6 +147,7 @@ export function boundDateField(keySet: string[], label: string, omitDay: boolean
 
   // Get an object { day, month, year } which contains the values being edited in the textbox
   // values may be strings or numbers. Otherwise return empty object.
+  let pad = (toPad, length) => _.padStart(String(toPad), length, '0');
   let getEditObject = () => {
     let edit = _.get(profile, editKeySet, {});
 
@@ -154,9 +155,9 @@ export function boundDateField(keySet: string[], label: string, omitDay: boolean
       let date = getDate();
       if (date !== null && date.isValid()) {
         return {
-          month: date.month() + 1,
+          month: pad(date.month() + 1, 2),
           year: date.year(),
-          day: date.date()
+          day: pad(date.date(), 2),
         };
       }
     }
@@ -179,15 +180,20 @@ export function boundDateField(keySet: string[], label: string, omitDay: boolean
       month: month !== undefined ? month : edit.month,
       day: day !== undefined ? day : edit.day
     });
-    
+
     // these functions return undefined if a month, day, or year is invalid, and converts the value to a number
     // except if the input value is an empty string, in which case an empty string is returned
     let validatedDay = 1;
     if (!omitDay) {
       validatedDay = validateDay(newEdit.day);
+      newEdit.day = validatedDay === undefined ? '' : String(validatedDay);
     }
+
     let validatedMonth = validateMonth(newEdit.month);
+    newEdit.month = validatedMonth === undefined ? '' : String(validatedMonth);
+
     let validatedYear = validateYear(newEdit.year);
+    newEdit.year = validatedYear === undefined ? '' : String(validatedYear);
 
     // keep text up to date
     _.set(clone, editKeySet, newEdit);
@@ -196,8 +202,9 @@ export function boundDateField(keySet: string[], label: string, omitDay: boolean
       // store the edit value and make the formatted date undefined so it doesn't pass validation
       _.set(clone, keySet, null);
     } else {
-      let momentDate = moment(`${validatedYear}-${validatedMonth}-${validatedDay}`, ISO_8601_FORMAT);
-      if (!momentDate.isValid()) {
+      let formattedYear = _.padStart(String(validatedYear), 4, '0');
+      let momentDate = moment(`${formattedYear}-${validatedMonth}-${validatedDay}`, ISO_8601_FORMAT);
+      if (!momentDate.isValid() || momentDate.isBefore(moment("1800", "YYYY"))) {
         // date is invalid according to moment.js so make the formatted date undefined so it
         // doesn't pass validation
         _.set(clone, keySet, null);

--- a/static/js/util/profile_edit_test.js
+++ b/static/js/util/profile_edit_test.js
@@ -195,84 +195,174 @@ describe('Profile Editing utility functions', () => {
       assert.equal(yearTextField.props.value, 1985);
     });
 
+    it('left pads month and day values when not editing', () => {
+      that.props.profile.date_of_birth = "1917-01-07";
+      rerender(false);
+      assert.equal(monthTextField.props.value, '01');
+      assert.equal(dayTextField.props.value, '07');
+    });
+
+    it('does not left pad month and day values when editing is in progress', () => {
+      that.props.profile.date_of_birth = "1917-01-07";
+      rerender(false);
+      monthTextField.props.onChange({target: {value: "2"}});
+      assert.deepEqual(that.props.profile.date_of_birth_edit, {
+        month: '2',
+        year: '1917',
+        day: '7'
+      });
+    });
+
+    it('rejects non-numerical input for the month field', () => {
+      that.props.profile.date_of_birth = "1917-11-07";
+      rerender(false);
+      monthTextField.props.onChange({target: {value: "text"}});
+      assert.deepEqual(that.props.profile.date_of_birth, null);
+      assert.deepEqual(that.props.profile.date_of_birth_edit, {
+        day: "7",
+        month: "",
+        year: "1917",
+      });
+    });
+
+    it('accepts numerical input for the month field', () => {
+      that.props.profile.date_of_birth = "1917-11-07";
+      rerender(false);
+      monthTextField.props.onChange({target: {value: "08"}});
+      assert.deepEqual(that.props.profile.date_of_birth, "1917-08-07");
+    });
+
+    it('rejects non-numerical input for the year field', () => {
+      that.props.profile.date_of_birth = "1917-11-07";
+      rerender(false);
+      yearTextField.props.onChange({target: {value: "text"}});
+      assert.deepEqual(that.props.profile.date_of_birth, null);
+      assert.deepEqual(that.props.profile.date_of_birth_edit, {
+        day: "7",
+        month: "11",
+        year: "",
+      });
+    });
+
+    it('accepts numerical input for the year field', () => {
+      that.props.profile.date_of_birth = "1917-11-07";
+      rerender(false);
+      yearTextField.props.onChange({target: {value: "1918"}});
+      assert.deepEqual(that.props.profile.date_of_birth, "1918-11-07");
+    });
+
+    it('only accepts inputs that are valid months, converting when necessary', () => {
+      that.props.profile.date_of_birth = "1917-11-07";
+      rerender(false);
+      monthTextField.props.onChange({target: {value: "233"}});
+      assert.deepEqual(that.props.profile.date_of_birth, "1917-12-07");
+      assert.deepEqual(that.props.profile.date_of_birth_edit, {
+        day: "7",
+        month: "12",
+        year: "1917",
+      });
+    });
+
+    it('only accepts years in the range 1800-2100, correcting up or down', () => {
+      that.props.profile.date_of_birth = "1917-11-07";
+      rerender(false);
+      yearTextField.props.onChange({target: {value: "1233"}});
+      assert.deepEqual(that.props.profile.date_of_birth, "1800-11-07");
+      assert.deepEqual(that.props.profile.date_of_birth_edit, {
+        day: "7",
+        month: "11",
+        year: "1800",
+      });
+
+      that.props.profile.date_of_birth = "1917-11-07";
+      rerender(false);
+      yearTextField.props.onChange({target: {value: "3000"}});
+      assert.deepEqual(that.props.profile.date_of_birth, "2100-11-07");
+      assert.deepEqual(that.props.profile.date_of_birth_edit, {
+        day: "7",
+        month: "11",
+        year: "2100",
+      });
+    });
+
     it("updates the day edit value when the day TextField onChange is used", () => {
       rerender(false);
-      dayTextField.props.onChange({target: {value: "text"}});
+      dayTextField.props.onChange({target: {value: "12"}});
 
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
-        day: "text",
-        month: undefined,
-        year: undefined
+        day: "12",
+        month: "",
+        year: "",
       });
     });
 
     it("updates the month edit value when the month TextField onChange is used", () => {
       rerender(false);
-      monthTextField.props.onChange({target: {value: "text"}});
+      monthTextField.props.onChange({target: {value: "12"}});
 
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
-        day: undefined,
-        month: "text",
-        year: undefined
+        day: "",
+        month: "12",
+        year: ""
       });
     });
 
     it("updates the year edit value when the year TextField onChange is used", () => {
       rerender(false);
-      yearTextField.props.onChange({target: {value: "text"}});
+      yearTextField.props.onChange({target: {value: "1992"}});
 
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
-        day: undefined,
-        month: undefined,
-        year: "text"
+        day: "",
+        month: "",
+        year: "1992"
       });
     });
 
     it("updates the day correctly when edit value already exists", () => {
       that.props.profile.date_of_birth_edit = {
-        day: "day",
-        month: "month",
-        year: "year"
+        day: "15",
+        month: "8",
+        year: "1991"
       };
       rerender(false);
-      dayTextField.props.onChange({target: {value: "changed"}});
+      dayTextField.props.onChange({target: {value: "11"}});
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
-        day: "changed",
-        month: "month",
-        year: "year"
+        day: "11",
+        month: "8",
+        year: "1991"
       });
     });
 
     it("updates the month correctly when edit value already exists", () => {
       that.props.profile.date_of_birth_edit = {
-        day: "day",
-        month: "month",
-        year: "year"
+        day: "09",
+        month: "11",
+        year: "1965"
       };
       rerender(false);
-      monthTextField.props.onChange({target: {value: "changed"}});
+      monthTextField.props.onChange({target: {value: "8"}});
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
-        day: "day",
-        month: "changed",
-        year: "year"
+        day: "9",
+        month: "8",
+        year: "1965"
       });
     });
 
     it("updates the year correctly when edit value already exists", () => {
       that.props.profile.date_of_birth_edit = {
-        day: "day",
-        month: "month",
-        year: "year"
+        day: "09",
+        month: "11",
+        year: "1965"
       };
       rerender(false);
-      yearTextField.props.onChange({target: {value: "changed"}});
+      yearTextField.props.onChange({target: {value: "1991"}});
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
-        day: "day",
-        month: "month",
-        year: "changed"
+        day: "9",
+        month: "11",
+        year: "1991"
       });
     });
-    
+
     it("updates the formatted date if month and year are valid and omitDay is true", () => {
       rerender(true);
       monthTextField.props.onChange({target: {value: "12"}});
@@ -306,14 +396,14 @@ describe('Profile Editing utility functions', () => {
     it("stores text in date_of_birth_edit if it's not a valid date", () => {
       that.props.profile.date_of_birth = "2066-02-28";
       rerender(false);
-      monthTextField.props.onChange({target: {value: "13"}});
+      monthTextField.props.onChange({target: {value: "MONTH"}});
       rerender(false);
 
       assert.deepEqual(that.props.profile.date_of_birth, null);
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
-        day: 28,
-        month: "13",
-        year: 2066
+        day: "28",
+        month: "",
+        year: "2066"
       });
     });
 
@@ -328,8 +418,8 @@ describe('Profile Editing utility functions', () => {
       // day is 28 here but it's discarded in the timestamp above, resulting in 01
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
         month: "1",
-        year: 2066,
-        day: 28
+        year: "2066",
+        day: "28"
       });
     });
 
@@ -362,8 +452,8 @@ describe('Profile Editing utility functions', () => {
       assert.deepEqual(that.props.profile.date_of_birth, null);
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
         day: "31",
-        month: 2,
-        year: 2066
+        month: "2",
+        year: "2066"
       });
     });
 
@@ -374,8 +464,8 @@ describe('Profile Editing utility functions', () => {
       assert.deepEqual(that.props.profile.date_of_birth, null);
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
         day: "",
-        month: 2,
-        year: 2066
+        month: "2",
+        year: "2066"
       });
     });
 
@@ -385,9 +475,9 @@ describe('Profile Editing utility functions', () => {
       monthTextField.props.onChange({target: {value: ""}});
       assert.deepEqual(that.props.profile.date_of_birth, null);
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
-        day: 28,
+        day: "28",
         month: "",
-        year: 2066
+        year: "2066"
       });
     });
 
@@ -397,8 +487,8 @@ describe('Profile Editing utility functions', () => {
       yearTextField.props.onChange({target: {value: ""}});
       assert.deepEqual(that.props.profile.date_of_birth, null);
       assert.deepEqual(that.props.profile.date_of_birth_edit, {
-        day: 28,
-        month: 2,
+        day: "28",
+        month: "2",
         year: ""
       });
     });

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -185,9 +185,12 @@ export function generateNewWorkHistory(): WorkHistoryEntry {
 /**
  * Converts string to int using base 10. Stricter in what is accepted than parseInt
  */
-export const filterPositiveInt = (value: ?string): number|void => {
+export const filterPositiveInt = (value: ?string|number): number|void => {
   if (value === null || value === undefined) {
     return undefined;
+  }
+  if ( typeof value === 'number') {
+    return value;
   }
   if(/^[0-9]+$/.test(value)) {
     return Number(value);
@@ -249,6 +252,6 @@ export function calculateDegreeInclusions(profile: Profile) {
 /**
  * Calls an array of functions in series with a given argument and returns an array of the results
  */
-export function callFunctionArray(functionArray, arg) {
+export function callFunctionArray(functionArray: Function[], arg: any): any[] {
   return functionArray.map((func) => func(arg));
 }

--- a/static/js/util/validation.js
+++ b/static/js/util/validation.js
@@ -246,28 +246,49 @@ export function validateProfileComplete(profile: Profile): ProfileComplete {
 /**
  * Validate a day of month
  */
-export function validateDay(string: string): ?number {
-  let date = filterPositiveInt(string);
+export function validateDay(input: string): ?number {
+  let sanitized = sanitizeDate(input, 2);
+  let date = filterPositiveInt(sanitized);
   if (date === undefined) {
     return undefined;
   }
   // More complicated cases like Feb 29 are handled in moment.js isValid
-  if (date < 1 || date > 31) {
-    return undefined;
+  if (date > 31) {
+    return 31;
   }
   return date;
 }
 
 /**
+ * Removes non-numeric characters and truncates output string
+ */
+export function sanitizeDate(input: string|number, length: number): string {
+  if ( typeof input === 'string' ) {
+    let out = input.replace(/[^\d]+/g, '');
+    if ( out.match(/^0+/) ) {
+      if ( out.length <= length ) {
+        return out.slice(0, length);
+      } else {
+        return out.replace(/^0+/, "").slice(0, length);
+      }
+    } else {
+      return out.slice(0, length);
+    }
+  } else {
+    return String(input).slice(0, length);
+  }
+}
+/**
  * Validate a month number
  */
-export function validateMonth(string: ?string): ?number {
-  let month = filterPositiveInt(string);
+export function validateMonth(input: string|number): number|void {
+  let sanitized = sanitizeDate(input, 2);
+  let month = filterPositiveInt(sanitized);
   if (month === undefined) {
     return undefined;
   }
-  if (month < 1 || month > 12) {
-    return undefined;
+  if (month > 12) {
+    return 12;
   }
   return month;
 }
@@ -275,14 +296,23 @@ export function validateMonth(string: ?string): ?number {
 /**
  * Validate a year string is an integer and fits into YYYY
  */
-export function validateYear(string: string): ?number {
-  let year = filterPositiveInt(string);
+export function validateYear(input: string|number|null): ?number {
+  if ( input === null ) {
+    return undefined;
+  }
+  let sanitized = sanitizeDate(input, 4);
+  let year = filterPositiveInt(sanitized);
   if (year === undefined) {
     return undefined;
   }
-  if (year < 1800 || year >= 2100) {
-    // fit into YYYY format
-    return undefined;
+  if ( year < 1800 ) {
+    if ( String(year).length < 4 ) {
+      return year;
+    }
+    return 1800;
+  }
+  if ( year >= 2100) {
+    return 2100;
   }
   return year;
 }

--- a/static/js/util/validation_test.js
+++ b/static/js/util/validation_test.js
@@ -15,6 +15,7 @@ import {
   validateMonth,
   validateYear,
   combineValidators,
+  sanitizeDate,
 } from './validation';
 import {
   USER_PROFILE_RESPONSE,
@@ -320,29 +321,92 @@ describe('Profile validation functions', () => {
     });
   });
 
+  describe('sanitizeDate', () => {
+    describe('string input', () => {
+      it('should remove any non-numerical characters', () => {
+        [
+          ['-', 2, ''],
+          ['-32', 2, '32'],
+          ['asdf', 19, ''],
+          ['A(*@$%!@#$100', 2, '10'],
+          ['eggplant 1X00 hey', 10, '100']
+        ].forEach(([input, length, expectation]) => {
+          assert.deepEqual(sanitizeDate(input, length), expectation);
+        });
+      });
+
+      it('should trim the input down to the desired length', () => {
+        [
+          ['1999', 2, '19'],
+          ['1x9', 2, '19'],
+          ['1', 4, '1'],
+          ['', 18318, ''],
+          ['TESTS', 25, ''],
+          ['1991', 0, '']
+        ].forEach(([input, length, expectation]) => {
+          assert.deepEqual(sanitizeDate(input, length), expectation);
+        });
+      });
+
+      it('should leave leading zeros when under the length', () => {
+        assert.equal(sanitizeDate('09', 2), '09');
+      });
+
+      it('should remove leading zeros when over the length', () => {
+        assert.equal(sanitizeDate('01999', 4), '1999');
+      });
+    });
+
+    describe('numerical input', () => {
+      it('should return a string', () => {
+        assert.deepEqual(sanitizeDate(3, 1), '3');
+      });
+
+      it('should trim a number down to the correct number of places', () => {
+        [
+          [1999, 4, '1999'],
+          [1999, 2, '19'],
+          [112341234, 1, '1']
+        ].forEach(([input, length, expectation]) => {
+          assert.deepEqual(sanitizeDate(input, length), expectation);
+        });
+      });
+    });
+  });
+
   describe('validateMonth', () => {
     it('handles months starting with 0 without treating as octal', () => {
       assert.equal(9, validateMonth("09"));
     });
+
     it('converts strings to numbers', () => {
-      assert.equal(3, validateMonth("3"));
+      for (let i = 1; i < 13; i++) {
+        assert.equal(i, validateMonth(String(i)));
+      }
     });
-    it('returns undefined for invalid months', () => {
-      assert.equal(undefined, validateMonth("-3"));
-      assert.equal(undefined, validateMonth("0"));
-      assert.equal(1, validateMonth("1"));
-      assert.equal(12, validateMonth("12"));
-      assert.equal(undefined, validateMonth("13"));
+
+    it('strips out any non-numerical characters', () => {
+      assert.equal(12, validateMonth("1e2"));
+      assert.equal(4, validateMonth("0-4"));
+      assert.equal(3, validateMonth("-3"));
     });
+
+    it('returns 12 for any number >= 12', () => {
+      assert.equal(12, validateMonth("3.4"));
+      assert.equal(12, validateMonth("13"));
+    });
+
+    it('will let a user input a leading zero', () => {
+      assert.equal(0, validateMonth("0"));
+      assert.equal(8, validateMonth("08"));
+    });
+
     it('returns undefined if the text is not an integer number', () => {
       assert.equal(undefined, validateMonth(""));
       assert.equal(undefined, validateMonth("two"));
       assert.equal(undefined, validateMonth(null));
       assert.equal(undefined, validateMonth({}));
       assert.equal(undefined, validateMonth(undefined));
-      assert.equal(undefined, validateMonth("2e0"));
-      assert.equal(undefined, validateMonth("3-4"));
-      assert.equal(undefined, validateMonth("3.4"));
     });
   });
 
@@ -353,37 +417,59 @@ describe('Profile validation functions', () => {
     it('converts strings to numbers', () => {
       assert.equal(1943, validateYear("1943"));
     });
-    it('returns undefined for invalid years', () => {
-      assert.equal(undefined, validateYear("-3"));
-      assert.equal(undefined, validateYear("0"));
-      assert.equal(undefined, validateYear("1799"));
-      assert.equal(undefined, validateYear("2100"));
+
+    it('strips non-numerical characters', () => {
+      assert.equal(2004, validateYear("2e004"));
+      assert.equal(2034, validateYear("203-4"));
+    });
+    it('returns values for years less than 1800 if they are less than 4 character', () => {
+      assert.equal(3, validateYear("3"));
+      assert.equal(703, validateYear("703"));
+      assert.equal(0, validateYear("0"));
+      assert.equal(20, validateYear("-20"));
+    });
+    it('returns 1800 for 4-character years less than 1800', () => {
+      assert.equal(1800, validateYear("1799"));
+      assert.equal(1800, validateYear("1099"));
+    });
+    it('returns 2100 for years >= 2100', () => {
+      assert.equal(2100, validateYear("2100"));
+      assert.equal(2100, validateYear("2300"));
+      assert.equal(2100, validateYear("52300"));
     });
     it('returns undefined if the text is not an integer number', () => {
       assert.equal(undefined, validateYear(""));
       assert.equal(undefined, validateYear("two"));
       assert.equal(undefined, validateYear(null));
+      assert.equal(undefined, validateYear("@#"));
       assert.equal(undefined, validateYear({}));
       assert.equal(undefined, validateYear(undefined));
-      assert.equal(undefined, validateYear("2e0"));
-      assert.equal(undefined, validateYear("3-4"));
-      assert.equal(undefined, validateYear("3.4"));
     });
   });
 
-  describe('validateDate', () => {
+  describe('validateDay', () => {
     it('handles dates starting with 0 without treating as octal', () => {
       assert.equal(1, validateDay("01"));
     });
     it('converts strings to numbers', () => {
       assert.equal(3, validateDay("3"));
     });
-    it('returns undefined for invalid dates', () => {
-      assert.equal(undefined, validateDay("-3"));
-      assert.equal(undefined, validateDay("0"));
-      assert.equal(1, validateDay("1"));
-      assert.equal(31, validateDay("31"));
-      assert.equal(undefined, validateDay("32"));
+    it("allows leading zeros", () => {
+      assert.equal(0, validateDay("0"));
+      assert.equal(1, validateDay("01"));
+    });
+    it('disallows non-numerical input', () => {
+      assert.equal(3, validateDay("-3"));
+      assert.equal(20, validateDay("2e0"));
+      assert.equal(21, validateDay("2-1"));
+      assert.equal(22, validateDay("2.2"));
+    });
+    it('returns 31 for dates greater than 31', () => {
+      assert.equal(31, validateDay("32"));
+      assert.equal(31, validateDay("71"));
+    });
+    it('truncates to the first 2 characters of input', () => {
+      assert.equal(22, validateDay("220"));
     });
     it('returns undefined if the text is not an integer number', () => {
       assert.equal(undefined, validateDay(""));
@@ -391,9 +477,6 @@ describe('Profile validation functions', () => {
       assert.equal(undefined, validateDay(null));
       assert.equal(undefined, validateDay({}));
       assert.equal(undefined, validateDay(undefined));
-      assert.equal(undefined, validateDay("2e0"));
-      assert.equal(undefined, validateDay("3-4"));
-      assert.equal(undefined, validateDay("3.4"));
     });
   });
 


### PR DESCRIPTION
#### What are the relevant tickets?

closes #585 and closes #586 

#### What's this PR do?

This changes the text fields in `boundDateField` so that they only accept characters that can comprise valid inputs. So, no non-numerical characters, no characters beyond the number required for the field in question, etc.

#### Where should the reviewer start?

Review the changes to `profile_edit.js` and `validation.js`. 

#### How should this be manually tested?

Make sure you can edit and save valid dates for all date fields we have.

Also, check for the following behavior, which this PR implements:

month field:

- should accept only 2 characters
- should not accept non-numerical characters
- should only allow input of 1-12
- input of numbers larger than 12 should correct to 12

day field:

- should accept only 2 characters
- should not accept non-numerical characters
- should only allow input of 1-31
- input of numbers larger than 31 should correct to 31

year field:

- should accept 4 characters max
- should not accept non-numerical characters
- should accept numbers below 1800 as input, but they should be marked invalid on save
- should accept any number `x | 1800 <= x <= 2100` as valid input
- input of numbers larger than 2100 should correct to 2100

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
