### PR TITLE
Added text to JumboTron for terms of service

### DIFF
--- a/static/js/containers/TermsOfServicePage.js
+++ b/static/js/containers/TermsOfServicePage.js
@@ -7,6 +7,7 @@ import Jumbotron from '../components/Jumbotron';
 
 import { saveProfile, FETCH_SUCCESS } from '../actions';
 import { TERMS_CARD_ROW_HEIGHT } from '../constants';
+import { getPreferredName } from '../util/util';
 
 class TermsOfServicePage extends React.Component {
   static propTypes = {
@@ -35,10 +36,11 @@ class TermsOfServicePage extends React.Component {
 
   render() {
     const { userProfile: { profile } } = this.props;
-    let preferredName = profile.preferredName || SETTINGS.name;
+    let preferredName = getPreferredName(profile);
+    let text = `Welcome ${preferredName}, let's complete your enrollment to MIT MicroMasters.`;
 
     return (
-      <Jumbotron profile={profile} text={preferredName}>
+      <Jumbotron profile={profile} text={text}>
         <div className="card-copy terms-of-service-main">
           <div className="program">
             <div className="terms-card-header">

--- a/static/js/containers/TermsOfServicePage_test.js
+++ b/static/js/containers/TermsOfServicePage_test.js
@@ -10,6 +10,7 @@ import {
 import { USER_PROFILE_RESPONSE } from '../constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
 import * as api from '../util/api';
+import * as util from '../util/util';
 
 describe("TermsOfService", () => {
   let listenForActions, renderComponent, helper;
@@ -22,6 +23,20 @@ describe("TermsOfService", () => {
 
   afterEach(() => {
     helper.cleanup();
+  });
+
+  it("sees their username in the terms of service", () => {
+    const username = 'fake_username';
+    let getPreferredNameStub = helper.sandbox.stub(util, 'getPreferredName');
+    getPreferredNameStub.returns("fake_username");
+    return renderComponent("/terms_of_service").then(([, div]) => {
+      assert(getPreferredNameStub.called, "getPreferredName wasn't called");
+
+      assert(
+        div.textContent.includes(`Welcome ${username}, let's complete your enrollment to MIT MicroMasters.`),
+        "Couldn't find text"
+      );
+    });
   });
 
   it("requires terms of service if user hasn't already agreed to it", () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #633 

#### What's this PR do?
Shows the same text on the terms of service page that we show on the profile page.

#### How should this be manually tested?
Create a new user on edX, login to MicroMasters with it and view the terms of service page. It should have the 'Welcome username, let's complete...' text. Note: it's important to have a brand new user to make sure that we handle the empty preferred name case correctly.

#### Screenshots (if appropriate)
![screenshot from 2016-06-27 14-39-23](https://cloud.githubusercontent.com/assets/863262/16391402/f582556c-3c74-11e6-81c2-74ce16aa0d42.png)


