### PR TITLE
Added spinner for dashboard

### DIFF
--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -8,8 +8,6 @@ import _ from 'lodash';
 import {
   CLEAR_DASHBOARD,
   CLEAR_PROFILE,
-  RECEIVE_DASHBOARD_FAILURE,
-  RECEIVE_GET_USER_PROFILE_SUCCESS,
   START_PROFILE_EDIT,
   UPDATE_PROFILE_VALIDATION,
 } from '../actions';
@@ -17,8 +15,6 @@ import {
   CLEAR_UI,
 } from '../actions/ui';
 import {
-  DASHBOARD_RESPONSE,
-  DASHBOARD_RESPONSE_ERROR,
   USER_PROFILE_RESPONSE
 } from '../constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
@@ -26,7 +22,6 @@ import IntegrationTestHelper from '../util/integration_test_helper';
 describe('App', () => {
   let listenForActions, renderComponent, helper;
   let editProfileActions;
-  let dashboardErrorActions;
 
   beforeEach(() => {
     helper = new IntegrationTestHelper();
@@ -35,10 +30,6 @@ describe('App', () => {
     editProfileActions = [
       START_PROFILE_EDIT,
       UPDATE_PROFILE_VALIDATION
-    ];
-    dashboardErrorActions = [
-      RECEIVE_DASHBOARD_FAILURE,
-      RECEIVE_GET_USER_PROFILE_SUCCESS
     ];
   });
 
@@ -50,59 +41,6 @@ describe('App', () => {
     return renderComponent("/dashboard").then(([, div]) => {
       return listenForActions([CLEAR_DASHBOARD, CLEAR_PROFILE, CLEAR_UI], () => {
         ReactDOM.unmountComponentAtNode(div);
-      });
-    });
-  });
-
-  describe('dashboard errors', () => {
-    let errorString = `Sorry, we were unable to load the data necessary
-      to process your request. Please reload the page.`;
-    errorString = errorString.replace(/\s\s+/g, ' ');
-
-    it('error from the backend triggers error message in dashboard', () => {
-      helper.dashboardStub.returns(Promise.reject(DASHBOARD_RESPONSE_ERROR));
-
-      return renderComponent("/dashboard", dashboardErrorActions, false).then(([, div]) => {
-        let message = div.getElementsByClassName('alert-message')[0];
-        assert(message.textContent.indexOf(errorString) > -1);
-        assert(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.error_code) > -1);
-        assert(message.textContent.indexOf("Additional info:") > -1);
-        assert(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.user_message) > -1);
-      });
-    });
-
-    it('the error from the backend does not need to be complete', () => {
-      let response = _.cloneDeep(DASHBOARD_RESPONSE_ERROR);
-      delete response.user_message;
-      helper.dashboardStub.returns(Promise.reject(response));
-
-      return renderComponent("/dashboard", dashboardErrorActions, false).then(([, div]) => {
-        let message = div.getElementsByClassName('alert-message')[0];
-        assert(message.textContent.indexOf(errorString) > -1);
-        assert(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.error_code) > -1);
-        assert.equal(message.textContent.indexOf("Additional info:"), -1);
-        assert.equal(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.user_message), -1);
-      });
-    });
-
-    it('the error from the backend does not need to exist at all as long as there is an http error', () => {
-      helper.dashboardStub.returns(Promise.reject({}));
-
-      return renderComponent("/dashboard", dashboardErrorActions, false).then(([, div]) => {
-        let message = div.getElementsByClassName('alert-message')[0];
-        assert(message.textContent.indexOf(errorString) > -1);
-        assert.equal(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.error_code), -1);
-        assert.equal(message.textContent.indexOf("Additional info:"), -1);
-        assert.equal(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.user_message), -1);
-      });
-    });
-
-    it('a regular response does not show the error', () => {
-      helper.dashboardStub.returns(Promise.resolve(DASHBOARD_RESPONSE));
-
-      return renderComponent("/dashboard").then(([, div]) => {
-        let message = div.getElementsByClassName('alert-message')[0];
-        assert.equal(message, undefined);
       });
     });
   });

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -2,9 +2,13 @@
 /* global SETTINGS: false */
 import React from 'react';
 import { connect } from 'react-redux';
+import Loader from 'react-loader';
+
+import { FETCH_PROCESSING } from '../actions';
 import Jumbotron from '../components/Jumbotron';
 import CourseList from '../components/CourseList';
 import ErrorMessage from '../components/ErrorMessage';
+import { getPreferredName } from '../util/util';
 
 class DashboardPage extends React.Component {
   static propTypes = {
@@ -21,7 +25,8 @@ class DashboardPage extends React.Component {
       dispatch,
       profile: { profile },
     } = this.props;
-    let preferredName = profile.preferredName || SETTINGS.name;
+    const loaded = dashboard.fetchStatus !== FETCH_PROCESSING;
+    let preferredName = getPreferredName(profile);
     let errorMessage;
     let dashboardContent;
     // if there are no errors coming from the backend, simply show the dashboard
@@ -39,10 +44,10 @@ class DashboardPage extends React.Component {
     }
     return (
       <Jumbotron profile={profile} text={preferredName}>
-        <div>
+        <Loader loaded={loaded}>
           {errorMessage}
           {dashboardContent}
-        </div>
+        </Loader>
       </Jumbotron>
     );
   }

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -1,0 +1,96 @@
+/* global document: false, window: false */
+import '../global_init';
+
+import { assert } from 'chai';
+import _ from 'lodash';
+
+import {
+  REQUEST_DASHBOARD,
+  RECEIVE_DASHBOARD_FAILURE,
+  RECEIVE_GET_USER_PROFILE_SUCCESS,
+} from '../actions';
+import {
+  DASHBOARD_RESPONSE,
+  DASHBOARD_RESPONSE_ERROR,
+} from '../constants';
+import IntegrationTestHelper from '../util/integration_test_helper';
+
+describe('DashboardPage', () => {
+  let renderComponent, helper;
+  let dashboardErrorActions;
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper();
+    renderComponent = helper.renderComponent.bind(helper);
+    dashboardErrorActions = [
+      RECEIVE_DASHBOARD_FAILURE,
+      RECEIVE_GET_USER_PROFILE_SUCCESS
+    ];
+  });
+
+  afterEach(() => {
+    helper.cleanup();
+  });
+
+  it('shows a spinner when dashboard get is processing', () => {
+    return renderComponent('/dashboard').then(([, div]) => {
+      assert.notOk(div.querySelector(".spinner"), "Found spinner but no fetch in progress");
+      helper.store.dispatch({ type: REQUEST_DASHBOARD });
+
+      assert(div.querySelector(".spinner"), "Unable to find spinner");
+    });
+  });
+
+  describe('dashboard errors', () => {
+    let errorString = `Sorry, we were unable to load the data necessary
+      to process your request. Please reload the page.`;
+    errorString = errorString.replace(/\s\s+/g, ' ');
+
+    it('error from the backend triggers error message in dashboard', () => {
+      helper.dashboardStub.returns(Promise.reject(DASHBOARD_RESPONSE_ERROR));
+
+      return renderComponent("/dashboard", dashboardErrorActions, false).then(([, div]) => {
+        let message = div.getElementsByClassName('alert-message')[0];
+        assert(message.textContent.indexOf(errorString) > -1);
+        assert(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.error_code) > -1);
+        assert(message.textContent.indexOf("Additional info:") > -1);
+        assert(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.user_message) > -1);
+      });
+    });
+
+    it('the error from the backend does not need to be complete', () => {
+      let response = _.cloneDeep(DASHBOARD_RESPONSE_ERROR);
+      delete response.user_message;
+      helper.dashboardStub.returns(Promise.reject(response));
+
+      return renderComponent("/dashboard", dashboardErrorActions, false).then(([, div]) => {
+        let message = div.getElementsByClassName('alert-message')[0];
+        assert(message.textContent.indexOf(errorString) > -1);
+        assert(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.error_code) > -1);
+        assert.equal(message.textContent.indexOf("Additional info:"), -1);
+        assert.equal(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.user_message), -1);
+      });
+    });
+
+    it('the error from the backend does not need to exist at all as long as there is an http error', () => {
+      helper.dashboardStub.returns(Promise.reject({}));
+
+      return renderComponent("/dashboard", dashboardErrorActions, false).then(([, div]) => {
+        let message = div.getElementsByClassName('alert-message')[0];
+        assert(message.textContent.indexOf(errorString) > -1);
+        assert.equal(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.error_code), -1);
+        assert.equal(message.textContent.indexOf("Additional info:"), -1);
+        assert.equal(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.user_message), -1);
+      });
+    });
+
+    it('a regular response does not show the error', () => {
+      helper.dashboardStub.returns(Promise.resolve(DASHBOARD_RESPONSE));
+
+      return renderComponent("/dashboard").then(([, div]) => {
+        let message = div.getElementsByClassName('alert-message')[0];
+        assert.equal(message, undefined);
+      });
+    });
+  });
+});


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #587 

#### What's this PR do?
Adds a spinner to the dashboard page when it is loading, and moved some dashboard tests from `App_test.js` into new `DashboardPage_test.js`

#### Where should the reviewer start?

#### How should this be manually tested?
View the dashboard over a slow connection. To simulate a slow connection replace the function in `api.js` with this:

    export function getDashboard() {
      return new Promise(resolve => {
        setTimeout(() => {
          resolve(mockableFetchJSONWithCSRF('/api/v0/dashboard/', {}, true));
        }, 3000);
      });
    }


#### Screenshots (if appropriate)

![screenshot from 2016-06-27 15-23-09](https://cloud.githubusercontent.com/assets/863262/16392668/12ea69a4-3c7b-11e6-9786-748cb6d87b98.png)

