### PR TITLE
Removed logic for "upgrade" from the front end code

### DIFF
--- a/static/js/util/courseList.js
+++ b/static/js/util/courseList.js
@@ -70,23 +70,11 @@ export function makeCourseStatusDisplay(course: Course, now: moment = moment()):
     </span>;
   }
   case STATUS_ENROLLED_NOT_VERIFIED: {
-    if (!firstRun.verification_date) {
-      // Invalid case, API should always send a valid verification date
-      return "";
-    }
-
     let courseUpgradeUrl = `${SETTINGS.edx_base_url}/course_modes/choose/${firstRun.course_id}/`;
-
-    let verificationDate = moment(firstRun.verification_date);
-    if (verificationDate.isAfter(now, 'day')) {
-      return <Button bsStyle="success" href={courseUpgradeUrl} target="_blank">
-        UPGRADE TO VERIFIED
-        <span className="sr-only"> for {firstRun.title}</span>
-      </Button>;
-    } else {
-      // User cannot verify anymore
-      return "";
-    }
+    return <Button bsStyle="success" href={courseUpgradeUrl} target="_blank">
+      UPGRADE TO VERIFIED
+      <span className="sr-only"> for {firstRun.title}</span>
+    </Button>;
   }
   case STATUS_OFFERED_NOT_ENROLLED: {
     if (!firstRun.enrollment_start_date && firstRun.fuzzy_enrollment_start_date !== undefined ) {

--- a/static/js/util/courseList_test.js
+++ b/static/js/util/courseList_test.js
@@ -99,42 +99,16 @@ describe('courseList functions', () => {
       }, moment(today)), "33%");
     });
 
-    it("is an enrolled course with no verification date", () => {
-      assert.equal(renderCourseStatusDisplay({
-        status: STATUS_ENROLLED_NOT_VERIFIED,
-        runs: []
-      }, moment(today)), "");
-    });
-
-    it("is an enrolled course with a verification date of tomorrow", () => {
+    it("is an enrolled course but not verified", () => {
       assert.equal(
         renderCourseStatusDisplay({
           status: STATUS_ENROLLED_NOT_VERIFIED,
           runs: [{
-            verification_date: tomorrow,
             title: "Run title"
           }],
         }, moment(today)),
         "UPGRADE TO VERIFIED for Run title"
       );
-    });
-
-    it("is an enrolled course with a verification date of today", () => {
-      assert.equal(renderCourseStatusDisplay({
-        status: STATUS_ENROLLED_NOT_VERIFIED,
-        runs: [{
-          verification_date: today
-        }]
-      }, moment(today)), "");
-    });
-
-    it("is an enrolled course with a verification date of yesterday", () => {
-      assert.equal(renderCourseStatusDisplay({
-        status: STATUS_ENROLLED_NOT_VERIFIED,
-        runs: [{
-          verification_date: yesterday
-        }]
-      }, moment(today)), "");
     });
 
     it("is an offered course with no enrollment start date", () => {
@@ -224,7 +198,7 @@ describe('courseList functions', () => {
 
   describe("makeRunStatusDisplay", () => {
     it('shows Course passed when a course is passed', () => {
-      assert.equal("Passed", makeRunStatusDisplay({ 
+      assert.equal("Passed", makeRunStatusDisplay({
         status: STATUS_PASSED,
         runs: []
       }));


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #648 

#### What's this PR do?
Removes the logic of the upgrade to verified button from the JS code. This logic was based on a field never supplied by the backend. We will implement the correct logic in the backend with #654 

#### Where should the reviewer start?
`static/js/util/courseList.js`

#### How should this be manually tested?
if the dashboard rest API returns a `enrolled-not-verified` code, now the dashboard should show the UPGRADE button
