### PR TITLE
Removed routing from initial profile flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,6 +9,8 @@
 ./static/js/flow/declarations.js
 node_modules/iflow-lodash/index.js.flow
 node_modules/iflow-moment/index.js.flow
+node_modules/iflow-react-router/index.js.flow
+node_modules/iflow-redux/index.js.flow
 
 [options]
 esproposal.class_static_fields=enable

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "history": "2.1.1",
     "iflow-lodash": "^1.1.16",
     "iflow-moment": "^1.1.13",
+    "iflow-react-router": "^1.1.16",
+    "iflow-redux": "^1.0.37",
     "imports-loader": "^0.6.5",
     "iso-3166-2": "0.4.0",
     "isomorphic-fetch": "2.2.1",

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -93,3 +93,8 @@ export const SET_SHOW_EDUCATION_DELETE_ALL_DIALOG = 'SET_SHOW_EDUCATION_DELETE_A
 export const setShowEducationDeleteAllDialog = (bool: boolean): Action => (
   { type: SET_SHOW_EDUCATION_DELETE_ALL_DIALOG, payload: bool }
 );
+
+export const SET_PROFILE_STEP = 'SET_PROFILE_STEP';
+export const setProfileStep = (step: string): Action => (
+  { type: SET_PROFILE_STEP, payload: step }
+);

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -24,6 +24,7 @@ import type {
   EducationEntry,
   Profile,
   ValidationErrors,
+  BoundSaveProfile,
 } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
@@ -32,7 +33,7 @@ class EducationForm extends ProfileFormFields {
     profile:                          Profile,
     ui:                               UIState;
     updateProfile:                    () => void,
-    saveProfile:                      () => void,
+    saveProfile:                      BoundSaveProfile,
     clearProfileEdit:                 () => void,
     errors:                           ValidationErrors,
     setEducationDialogVisibility:     () => void,

--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -9,16 +9,19 @@ import {
   educationValidation,
   combineValidators,
 } from '../util/validation';
+import type { Profile, BoundSaveProfile } from '../flow/profileTypes';
+import type { UIState } from '../reducers/ui';
 
 class EducationTab extends React.Component {
-  static propTypes = {
-    saveProfile: React.PropTypes.func,
-    profile: React.PropTypes.object,
-    ui: React.PropTypes.object
+  props: {
+    nextStep:     () => void,
+    prevStep:     () => void,
+    profile:      Profile,
+    ui:           UIState,
+    saveProfile:  BoundSaveProfile,
   };
-  
+
   render() {
-    const { saveProfile, profile, ui } = this.props;
     return <div>
       <Grid className="profile-splash">
         <Cell col={12}>
@@ -34,12 +37,9 @@ class EducationTab extends React.Component {
         <Cell col={1} />
         <Cell col={10}>
           <ProfileProgressControls
+            {...this.props}
             nextBtnLabel="Save and Continue"
-            prevUrl="/profile/personal"
-            nextUrl="/profile/professional"
-            saveProfile={saveProfile}
-            profile={profile}
-            ui={ui}
+            isLastTab={false}
             validator={combineValidators(educationValidation, educationUiValidation)}
           />
         </Cell>

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -9,18 +9,19 @@ import {
   employmentUiValidation,
   combineValidators,
 } from '../util/validation';
-import type { Profile } from '../flow/profileTypes';
+import type { Profile, BoundSaveProfile } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
 class EmploymentTab extends React.Component {
   props: {
-    saveProfile:  Function,
+    saveProfile:  BoundSaveProfile,
     profile:      Profile,
     ui:           UIState,
+    nextStep:     () => void,
+    prevStep:     () => void,
   };
 
   render () {
-    const { saveProfile, profile, ui } = this.props;
     return (
       <div>
         <Grid className="profile-splash">
@@ -37,12 +38,9 @@ class EmploymentTab extends React.Component {
           <Cell col={1}></Cell>
           <Cell col={10}>
             <ProfileProgressControls
+              {...this.props}
               nextBtnLabel="Save and Continue"
-              prevUrl="/profile/education"
-              nextUrl="/profile/privacy"
-              saveProfile={saveProfile}
-              profile={profile}
-              ui={ui}
+              isLastTab={false}
               validator={combineValidators(employmentValidation, employmentUiValidation)}
             />
           </Cell>

--- a/static/js/components/Jumbotron.js
+++ b/static/js/components/Jumbotron.js
@@ -10,7 +10,7 @@ class Jumbotron extends React.Component {
   props: {
     profile:      Profile,
     text:         string,
-    children?:     React$Element[],
+    children?:    React$Element[],
   };
 
   render() {

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -5,20 +5,21 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 import PersonalForm from './PersonalForm';
 import ProfileProgressControls from './ProfileProgressControls';
 import { personalValidation } from '../util/validation';
-import type { Profile, ValidationErrors } from '../flow/profileTypes';
+import type { Profile, BoundSaveProfile, ValidationErrors } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
 class PersonalTab extends React.Component {
   props: {
     profile:        Profile,
     errors:         ValidationErrors,
-    saveProfile:    () => void,
+    saveProfile:    BoundSaveProfile,
     updateProfile:  () => void,
     ui:             UIState,
+    nextStep:       () => void,
+    prevStep:       () => void,
   };
 
   render() {
-    const { saveProfile, profile, ui } = this.props;
     return <div>
       <Grid className="profile-splash">
         <Cell col={12}>
@@ -35,11 +36,9 @@ class PersonalTab extends React.Component {
         <Cell col={1} />
         <Cell col={10}>
           <ProfileProgressControls
+            {...this.props}
             nextBtnLabel="Save and Continue"
-            nextUrl="/profile/education"
-            profile={profile}
-            saveProfile={saveProfile}
-            ui={ui}
+            isLastTab={false}
             validator={personalValidation}
           />
         </Cell>

--- a/static/js/components/PrivacyForm.js
+++ b/static/js/components/PrivacyForm.js
@@ -3,7 +3,7 @@
 import React from 'react';
 
 import ProfileFormFields from '../util/ProfileFormFields';
-import type { Profile } from '../flow/profileTypes';
+import type { Profile, ValidationErrors } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
 class PrivacyForm extends ProfileFormFields {
@@ -11,6 +11,7 @@ class PrivacyForm extends ProfileFormFields {
     profile:        Profile,
     ui:             UIState,
     updateProfile:  Function,
+    errors:         ValidationErrors,
   };
 
   render() {

--- a/static/js/components/PrivacyTab.js
+++ b/static/js/components/PrivacyTab.js
@@ -12,19 +12,20 @@ import {
   employmentValidation,
   privacyValidation,
 } from '../util/validation';
-import type { Profile } from '../flow/profileTypes';
+import type { Profile, BoundSaveProfile } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
 class PrivacyTab extends ProfileFormFields {
   props: {
     profile:        Profile,
-    saveProfile:    () => void,
+    saveProfile:    BoundSaveProfile,
     updateProfile:  () => void,
     ui:             UIState,
+    nextStep:       () => void,
+    prevStep:       () => void,
   };
 
   render() {
-    const { saveProfile, profile, ui } = this.props;
     return (
       <div>
         <Grid className="profile-splash">
@@ -38,13 +39,9 @@ class PrivacyTab extends ProfileFormFields {
           </Cell>
           <Cell col={12}>
             <ProfileProgressControls
+              {...this.props}
               nextBtnLabel="I'm Done!"
-              prevUrl="/profile/professional"
-              nextUrl="/dashboard"
               isLastTab={true}
-              saveProfile={saveProfile}
-              profile={profile}
-              ui={ui}
               validator={
                 combineValidators(
                   personalValidation,

--- a/static/js/components/ProfileProgressControls.js
+++ b/static/js/components/ProfileProgressControls.js
@@ -3,44 +3,41 @@ import React from 'react';
 import Button from 'react-mdl/lib/Button';
 
 import { saveProfileStep } from '../util/profile_edit';
+import type { Profile, BoundSaveProfile } from '../flow/profileTypes';
+import type { UIState } from '../reducers/ui';
 
 export default class ProfileProgressControls extends React.Component {
-  static propTypes = {
-    nextBtnLabel: React.PropTypes.string,
-    nextUrl: React.PropTypes.string,
-    prevUrl: React.PropTypes.string,
-    isLastTab: React.PropTypes.bool,
-    saveProfile: React.PropTypes.func.isRequired,
-    profile: React.PropTypes.object,
-    ui: React.PropTypes.object.isRequired,
-    validator: React.PropTypes.func.isRequired
-  };
-
-  stepBack: Function = (): void => {
-    const { prevUrl } = this.props;
-    this.context.router.push(prevUrl);
+  props: {
+    nextStep:     () => void,
+    prevStep:     () => void,
+    nextBtnLabel: string,
+    isLastTab:    boolean,
+    validator:    Function,
+    profile:      Profile,
+    ui:           UIState,
+    saveProfile:  BoundSaveProfile,
   };
 
   saveAndContinue: Function = (): void => {
-    const { nextUrl, isLastTab, validator } = this.props;
+    const { nextStep, isLastTab, validator } = this.props;
     saveProfileStep.call(this, validator, isLastTab).then(() => {
-      this.context.router.push(nextUrl);
+      nextStep();
     });
   };
 
   render() {
-    const { prevUrl, nextUrl, nextBtnLabel } = this.props;
+    const { nextStep, prevStep, nextBtnLabel } = this.props;
 
     let prevButton, nextButton;
-    if(prevUrl) {
+    if(prevStep) {
       prevButton = <Button
         raised
         className="progress-button previous"
-        onClick={this.stepBack}>
+        onClick={prevStep}>
         <span>Previous</span>
       </Button>;
     }
-    if(nextUrl) {
+    if(nextStep) {
       nextButton = <Button
         raised
         colored

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -372,3 +372,15 @@ export const EDUCATION_LEVELS = [
   {value: MASTERS, label: "Master's or professional degree"},
   {value: DOCTORATE, label: "Doctorate"}
 ];
+
+export const PERSONAL_STEP = 'personal';
+export const EMPLOYMENT_STEP = 'employment';
+export const EDUCATION_STEP = 'education';
+export const PRIVACY_STEP = 'privacy';
+
+export const PROFILE_STEP_LABELS = new Map([
+  [PERSONAL_STEP, "Personal"],
+  [EDUCATION_STEP, "Education"],
+  [EMPLOYMENT_STEP, "Professional"],
+  [PRIVACY_STEP, "Profile Privacy"],
+]);

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -2,6 +2,7 @@
 /* global SETTINGS: false */
 import React from 'react';
 import { connect } from 'react-redux';
+import type { Dispatch } from 'redux';
 
 import Header from '../components/Header';
 import Footer from '../components/Footer';
@@ -14,20 +15,23 @@ import {
   startProfileEdit,
   updateProfileValidation,
 } from '../actions/index';
-import { clearUI } from '../actions/ui';
+import { clearUI, setProfileStep } from '../actions/ui';
 import { validateProfileComplete } from '../util/validation';
+import type { Profile } from '../flow/profileTypes';
+import type { UIState } from '../reducers/ui';
 
 const TERMS_OF_SERVICE_REGEX = /\/terms_of_service\/?/;
 const PROFILE_REGEX = /^\/profile\/?[a-z]?/;
 
 class App extends React.Component {
-  static propTypes = {
-    children:     React.PropTypes.object.isRequired,
-    userProfile:  React.PropTypes.object.isRequired,
-    dashboard:    React.PropTypes.object.isRequired,
-    dispatch:     React.PropTypes.func.isRequired,
-    history:      React.PropTypes.object.isRequired,
-    ui:           React.PropTypes.object.isRequired,
+  props: {
+    children:     React$Element[],
+    userProfile:  {profile: Profile, getStatus: string},
+    location:     Object,
+    dispatch:     Dispatch,
+    dashboard:    Object,
+    history:      Object,
+    ui:           UIState,
   };
 
   static contextTypes = {
@@ -101,7 +105,7 @@ class App extends React.Component {
       location: { pathname },
       dispatch,
     } = this.props;
-    const [ complete, url, errors] = validateProfileComplete(profile);
+    const [ complete, step, errors] = validateProfileComplete(profile);
     if (
       userProfile.getStatus === FETCH_SUCCESS &&
       profile.agreed_to_terms_of_service &&
@@ -110,10 +114,13 @@ class App extends React.Component {
     ) {
       dispatch(startProfileEdit(SETTINGS.username));
       dispatch(updateProfileValidation(SETTINGS.username, errors));
-      this.context.router.push(url);
+      if ( step !== null ) {
+        dispatch(setProfileStep(step));
+      }
+      this.context.router.push('/profile');
     }
   }
-  
+
   render() {
     const { children, location: { pathname } } = this.props;
 

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -13,9 +13,14 @@ import {
 } from '../actions';
 import {
   CLEAR_UI,
+  SET_PROFILE_STEP,
 } from '../actions/ui';
 import {
-  USER_PROFILE_RESPONSE
+  USER_PROFILE_RESPONSE,
+  PERSONAL_STEP,
+  EDUCATION_STEP,
+  EMPLOYMENT_STEP,
+  PRIVACY_STEP,
 } from '../constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
 
@@ -29,7 +34,8 @@ describe('App', () => {
     renderComponent = helper.renderComponent.bind(helper);
     editProfileActions = [
       START_PROFILE_EDIT,
-      UPDATE_PROFILE_VALIDATION
+      UPDATE_PROFILE_VALIDATION,
+      SET_PROFILE_STEP,
     ];
   });
 
@@ -46,6 +52,8 @@ describe('App', () => {
   });
 
   describe('profile completeness', () => {
+    let checkStep = () => helper.store.getState().ui.profileStep;
+
     it('redirects to /profile if profile is not complete', () => {
       let response = Object.assign({}, USER_PROFILE_RESPONSE, {
         first_name: undefined
@@ -53,7 +61,8 @@ describe('App', () => {
       helper.profileGetStub.returns(Promise.resolve(response));
 
       return renderComponent("/dashboard", editProfileActions).then(() => {
-        assert.equal(helper.currentLocation.pathname, "/profile/personal");
+        assert.equal(helper.currentLocation.pathname, "/profile");
+        assert.equal(checkStep(), PERSONAL_STEP);
       });
     });
 
@@ -64,38 +73,42 @@ describe('App', () => {
       helper.profileGetStub.returns(Promise.resolve(response));
 
       return renderComponent("/dashboard").then(() => {
-        assert.equal(helper.currentLocation.pathname, "/profile/personal");
+        assert.equal(helper.currentLocation.pathname, "/profile");
+        assert.equal(checkStep(), PERSONAL_STEP);
       });
     });
 
-    it('redirects to /profile/professional if a field is missing there', () => {
+    it('redirects to /profile and goes to the employment step if a field is missing there', () => {
       let profile = _.cloneDeep(USER_PROFILE_RESPONSE);
       profile.work_history[1].city = "";
 
       helper.profileGetStub.returns(Promise.resolve(profile));
       return renderComponent("/dashboard", editProfileActions).then(() => {
-        assert.equal(helper.currentLocation.pathname, "/profile/professional");
+        assert.equal(helper.currentLocation.pathname, "/profile");
+        assert.equal(checkStep(), EMPLOYMENT_STEP);
       });
     });
 
-    it('redirects to /profile/privacy if a field is missing there', () => {
+    it('redirects to /profile and goes to the privacy step if a field is missing there', () => {
       let response = Object.assign({}, USER_PROFILE_RESPONSE, {
         account_privacy: ''
       });
       helper.profileGetStub.returns(Promise.resolve(response));
 
       return renderComponent("/dashboard", editProfileActions).then(() => {
-        assert.equal(helper.currentLocation.pathname, "/profile/privacy");
+        assert.equal(helper.currentLocation.pathname, "/profile");
+        assert.equal(checkStep(), PRIVACY_STEP);
       });
     });
 
-    it('redirects to /profile/education if a field is missing there', () => {
+    it('redirects to /profile and goes to the education step if a field is missing there', () => {
       let response = _.cloneDeep(USER_PROFILE_RESPONSE);
       response.education[0].school_name = '';
       helper.profileGetStub.returns(Promise.resolve(response));
 
       return renderComponent("/dashboard", editProfileActions).then(() => {
-        assert.equal(helper.currentLocation.pathname, "/profile/education");
+        assert.equal(helper.currentLocation.pathname, "/profile");
+        assert.equal(checkStep(), EDUCATION_STEP);
       });
     });
   });

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -5,17 +5,20 @@ import { connect } from 'react-redux';
 import Loader from 'react-loader';
 
 import { FETCH_PROCESSING } from '../actions';
+import type { Dispatch } from 'redux';
+
 import Jumbotron from '../components/Jumbotron';
 import CourseList from '../components/CourseList';
 import ErrorMessage from '../components/ErrorMessage';
 import { getPreferredName } from '../util/util';
+import type { Profile } from '../flow/profileTypes';
 
 class DashboardPage extends React.Component {
-  static propTypes = {
-    profile:    React.PropTypes.object.isRequired,
-    dashboard:  React.PropTypes.object.isRequired,
-    dispatch:   React.PropTypes.func.isRequired,
-    expander: React.PropTypes.object.isRequired,
+  props: {
+    profile:    {profile: Profile},
+    dashboard:  Object,
+    dispatch:   Dispatch,
+    expander:   Object,
   };
 
   render() {

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -1,3 +1,4 @@
+// @flow
 /* global SETTINGS */
 import React from 'react';
 import { connect } from 'react-redux';
@@ -6,35 +7,73 @@ import { getPreferredName } from '../util/util';
 import Jumbotron from '../components/Jumbotron';
 import { makeProfileProgressDisplay } from '../util/util';
 import ProfileFormContainer from './ProfileFormContainer';
+import PersonalTab from '../components/PersonalTab';
+import EmploymentTab from '../components/EmploymentTab';
+import PrivacyTab from '../components/PrivacyTab';
+import EducationTab from '../components/EducationTab';
+import {
+  PERSONAL_STEP,
+  EDUCATION_STEP,
+  EMPLOYMENT_STEP,
+  PRIVACY_STEP
+} from '../constants';
 
 class ProfilePage extends ProfileFormContainer {
-  activeTab () {
-    return this.props.route.childRoutes.findIndex( (route) => (
-      route.path === this.props.location.pathname.split("/")[2]
-    ));
+  currentStep: Function = (): string => {
+    const { ui: { profileStep } } = this.props;
+    return profileStep;
   }
+
+  stepTransitions: Function = (): [void|() => void, () => void] => {
+    let setStep = step => () => this.setProfileStep(step);
+    switch ( this.currentStep() ) {
+    case EDUCATION_STEP:
+      return [setStep(PERSONAL_STEP), setStep(EMPLOYMENT_STEP)];
+    case EMPLOYMENT_STEP:
+      return [setStep(EDUCATION_STEP), setStep(PRIVACY_STEP)];
+    case PRIVACY_STEP:
+      return [
+        setStep(EMPLOYMENT_STEP),
+        () => this.context.router.push('/dashboard')
+      ];
+    default:
+      return [undefined, setStep(EDUCATION_STEP)];
+    }
+  };
+
+  currentComponent: Function = (props): React$Element => {
+    switch ( this.currentStep() ) {
+    case EDUCATION_STEP:
+      return <EducationTab {...props} />;
+    case EMPLOYMENT_STEP:
+      return <EmploymentTab {...props} />;
+    case PRIVACY_STEP:
+      return <PrivacyTab {...props} />;
+    default:
+      return <PersonalTab {...props} />;
+    }
+  };
 
   render() {
     const { profiles } = this.props;
-    let profile = {
-      profile: {}
-    };
-    if (profiles[SETTINGS.username] !== undefined) {
-      profile = profiles[SETTINGS.username];
-    }
+    let props, text, profile;
+    let [prev, next] = this.stepTransitions();
+    props = Object.assign({}, this.profileProps(profiles[SETTINGS.username]), {
+      prevStep: prev,
+      nextStep: next
+    });
+    profile = props.profile;
+    text = `Welcome ${getPreferredName(profile)}, let's
+      complete your enrollment to MIT MicroMasters.`;
 
-    let text = `Welcome ${getPreferredName(profile.profile)}, let's
-    complete your enrollment to MIT MicroMasters.`;
-
-    let childrenWithProps = this.childrenWithProps(profile);
     return <div className="card">
-      <Jumbotron profile={profile.profile} text={text}>
+      <Jumbotron profile={profile} text={text}>
         <div className="card-copy">
           <div style={{textAlign: "center"}}>
-            {makeProfileProgressDisplay(this.activeTab())}
+            {makeProfileProgressDisplay(this.currentStep())}
           </div>
           <section>
-            { childrenWithProps }
+            {this.currentComponent(props)}
           </section>
         </div>
       </Jumbotron>

--- a/static/js/containers/SettingsPage.js
+++ b/static/js/containers/SettingsPage.js
@@ -18,16 +18,8 @@ import {
     privacyValidation,
 } from '../util/validation';
 import { getPreferredName } from '../util/util';
-import type { Profile } from '../flow/profileTypes';
-import type { UIState } from '../reducers/ui';
 
 class SettingsPage extends ProfileFormContainer {
-  props: {
-    profiles: {[key: string]: Profile},
-    dispatch: Function,
-    ui:       UIState,
-  };
-
   componentWillMount() {
     this.startSettingsEdit();
   }
@@ -38,49 +30,33 @@ class SettingsPage extends ProfileFormContainer {
   }
 
   render() {
-    const { profiles, ui } = this.props;
-    let profile;
-    let errors;
-    let isEdit = true;
+    const { profiles } = this.props;
+    let props = Object.assign({}, this.profileProps(profiles[SETTINGS.username]), {
+      nextStep: () => this.context.router.push('/dashboard'),
+      prevStep: undefined
+    });
     let loaded = false;
     let username = SETTINGS.username;
-    let preferredName = SETTINGS.name;
-    
+    let preferredName = getPreferredName(props.profile);
+
     if (profiles[username] !== undefined) {
       let profileFromStore = profiles[username];
       loaded = profileFromStore.getStatus !== FETCH_PROCESSING;
-      if (profileFromStore.edit !== undefined) {
-        errors = profileFromStore.edit.errors;
-        profile = profileFromStore.edit.profile;
-      } else {
-        profile = profileFromStore.profile;
-        errors = {};
-        isEdit = false;
-      }
-      preferredName = getPreferredName(profile);
     }
 
     return (
       <Loader loaded={loaded}>
-        <Jumbotron profile={profile} text={preferredName}>
+        <Jumbotron {...props} text={preferredName}>
           <div className="card-copy">
             <Grid className="profile-tab-grid privacy-form">
               <Cell col={12}>
-                <PrivacyForm
-                  {...this.props}
-                  errors={errors}
-                  profile={profile}
-                  updateProfile={this.updateProfile.bind(this, isEdit)}
-                />
+                <PrivacyForm {...props} />
               </Cell>
               <Cell col={12}>
                 <ProfileProgressControls
                   nextBtnLabel="Save"
-                  nextUrl="/dashboard"
+                  {...props}
                   isLastTab={true}
-                  saveProfile={this.saveProfile.bind(this, isEdit)}
-                  profile={profile}
-                  ui={ui}
                   validator={
                     combineValidators(privacyValidation)
                   }

--- a/static/js/dashboard_routes.js
+++ b/static/js/dashboard_routes.js
@@ -10,10 +10,6 @@ import App from './containers/App';
 import DashboardPage from './containers/DashboardPage';
 import SettingsPage from './containers/SettingsPage';
 import ProfilePage from './containers/ProfilePage';
-import PersonalTab from './components/PersonalTab';
-import EmploymentTab from './components/EmploymentTab';
-import PrivacyTab from './components/PrivacyTab';
-import EducationTab from './components/EducationTab';
 import TermsOfServicePage from './containers/TermsOfServicePage';
 import UserPage from './containers/UserPage';
 import User from './components/User';
@@ -33,13 +29,7 @@ export function makeDashboardRoutes(browserHistory: Object, store: Object, onRou
         <Router history={browserHistory} onUpdate={onRouteUpdate}>
           <Route path="/" component={App}>
             <Route path="dashboard" component={DashboardPage} />
-            <Route path="profile" component={ProfilePage}>
-              <IndexRedirect to="personal" />
-              <Route path="personal" component={PersonalTab} />
-              <Route path="education" component={EducationTab}/>
-              <Route path="professional" component={EmploymentTab} />
-              <Route path="privacy" component={PrivacyTab} />
-            </Route>
+            <Route path="profile" component={ProfilePage} />
             <Route path="/terms_of_service" component={TermsOfServicePage} />
             <Route path="/settings" component={SettingsPage}  />
             <Route path="/users" component={UserPage} >

--- a/static/js/flow/profileTypes.js
+++ b/static/js/flow/profileTypes.js
@@ -1,4 +1,7 @@
 // @flow
+import type { Validator, UIValidator } from '../util/validation';
+import type { UIState } from '../reducers/ui';
+
 export type EducationEntry = {
   id?: ?number;
   degree_name: string;
@@ -48,3 +51,5 @@ export type Profile = {
   pretty_printed_student_id: string;
   city: string;
 };
+
+export type BoundSaveProfile = (validator: Validator|UIValidator, profile: Profile, ui: UIState) => Promise<Profile>;

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -25,8 +25,17 @@ import {
   SET_DELETION_INDEX,
   SET_SHOW_WORK_DELETE_ALL_DIALOG,
   SET_SHOW_EDUCATION_DELETE_ALL_DIALOG,
+
+  SET_PROFILE_STEP,
 } from '../actions/ui';
-import { HIGH_SCHOOL, ASSOCIATE, BACHELORS, MASTERS, DOCTORATE } from '../constants';
+import {
+  HIGH_SCHOOL,
+  ASSOCIATE,
+  BACHELORS,
+  MASTERS,
+  DOCTORATE,
+  PERSONAL_STEP,
+} from '../constants';
 import { calculateDegreeInclusions } from '../util/util';
 import type { Action } from '../flow/generalTypes';
 
@@ -45,6 +54,7 @@ export type UIState = {
   dialog: {};
   showWorkDeleteAllDialog: boolean;
   showEducationDeleteAllDialog: boolean;
+  profileStep: string;
 };
 
 export const INITIAL_UI_STATE: UIState = {
@@ -68,6 +78,7 @@ export const INITIAL_UI_STATE: UIState = {
   dialog: {},
   showWorkDeleteAllDialog: false,
   showEducationDeleteAllDialog: false,
+  profileStep: PERSONAL_STEP,
 };
 
 export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
@@ -170,6 +181,11 @@ export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
   case SET_SHOW_EDUCATION_DELETE_ALL_DIALOG: {
     return Object.assign({}, state, {
       showEducationDeleteAllDialog: action.payload
+    });
+  }
+  case SET_PROFILE_STEP: {
+    return Object.assign({}, state, {
+      profileStep: action.payload
     });
   }
   default:

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -18,6 +18,7 @@ import {
   SET_DELETION_INDEX,
   SET_SHOW_WORK_DELETE_ALL_DIALOG,
   SET_SHOW_EDUCATION_DELETE_ALL_DIALOG,
+  SET_PROFILE_STEP,
 
   clearUI,
   updateDialogText,
@@ -37,6 +38,7 @@ import {
   setDeletionIndex,
   setShowWorkDeleteAllDialog,
   setShowEducationDeleteAllDialog,
+  setProfileStep,
 } from '../actions/ui';
 import { receiveGetUserProfileSuccess } from '../actions';
 import { INITIAL_UI_STATE } from '../reducers/ui';
@@ -47,6 +49,7 @@ import {
   MASTERS,
   DOCTORATE,
   USER_PROFILE_RESPONSE,
+  PROFILE_STEP_LABELS,
 } from '../constants';
 import rootReducer from '../reducers';
 import * as util from '../util/util';
@@ -268,6 +271,16 @@ describe('ui reducers', () => {
           return dispatchThen(actionCreator(bool), [action]).then(state => {
             assert.deepEqual(accessor(state), bool);
           });
+        });
+      });
+    });
+  });
+
+  describe("profile step", () => {
+    PROFILE_STEP_LABELS.forEach((label, step) =>{
+      it(`should let you set the profile step to ${label}`, () => {
+        return dispatchThen(setProfileStep(step), [SET_PROFILE_STEP]).then(state => {
+          assert.deepEqual(state.profileStep, step);
         });
       });
     });

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -6,7 +6,10 @@ import ga from 'react-ga';
 import striptags from 'striptags';
 import _ from 'lodash';
 
-import { EDUCATION_LEVELS } from '../constants';
+import {
+  EDUCATION_LEVELS,
+  PROFILE_STEP_LABELS
+} from '../constants';
 import type {
   Profile,
   EducationEntry,
@@ -33,10 +36,9 @@ export function userPrivilegeCheck (profile: Profile, privileged: any, unPrivile
   }
 }
 
-export function makeProfileProgressDisplay(active: number) {
+export function makeProfileProgressDisplay(active: string) {
   const width = 750, height = 100, radius = 20, paddingX = 40, paddingY = 5;
-  const tabNames = ["Personal", "Education", "Professional", "Profile Privacy"];
-  const numCircles = tabNames.length;
+  const numCircles = PROFILE_STEP_LABELS.size;
 
   // width from first circle edge left to the last circle edge right
   const circlesWidth = width - (paddingX * 2 + radius * 2);
@@ -74,11 +76,12 @@ export function makeProfileProgressDisplay(active: number) {
 
   const elements = [];
 
-  for (let i = 0; i < numCircles; ++i) {
+  let activeTab = [...PROFILE_STEP_LABELS.keys()].findIndex(k => k === active);
+  [...PROFILE_STEP_LABELS.entries()].forEach(([, label], i) => {
     let colorScheme;
-    if (i < active) {
+    if (i < activeTab) {
       colorScheme = colors.completed;
-    } else if (i === active) {
+    } else if (i === activeTab) {
       colorScheme = colors.current;
     } else {
       colorScheme = colors.future;
@@ -106,7 +109,7 @@ export function makeProfileProgressDisplay(active: number) {
           fontSize: "12pt"
         }}
       >
-        {tabNames[i]}
+        {label}
       </text>,
       <text
         key={`circletext_${i}`}
@@ -136,10 +139,10 @@ export function makeProfileProgressDisplay(active: number) {
         />
       );
     }
-  }
+  });
 
   return <svg style={{width: width, height: height}}>
-    <desc>Profile progress: {tabNames[active]}</desc>
+    <desc>Profile progress: {PROFILE_STEP_LABELS.get(active)}</desc>
     {elements}
   </svg>;
 }
@@ -205,11 +208,11 @@ export function makeStrippedHtml(textOrElement: any): string {
   }
 }
 
-export function makeProfileImageUrl(profile: Profile) {
+export function makeProfileImageUrl(profile: Profile): string {
   let imageUrl = `${SETTINGS.edx_base_url}/static/images/profiles/default_120.png`.
   //replacing multiple "/" with a single forward slash, excluding the ones following the colon
     replace(/([^:]\/)\/+/g, "$1");
-  if (profile.profile_url_large) {
+  if (profile !== undefined && profile.profile_url_large) {
     imageUrl = profile.profile_url_large;
   }
 

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -20,6 +20,7 @@ import {
   BACHELORS,
   DOCTORATE,
   MASTERS,
+  PROFILE_STEP_LABELS,
 } from '../constants';
 
 /* eslint-disable camelcase */
@@ -106,12 +107,13 @@ describe('utility functions', () => {
 
   describe('makeProfileProgressDisplay', () => {
     it('renders the right active display', () => {
-      let expected = ["Personal", "Education", "Professional", "Profile Privacy"];
+      let keys = [...PROFILE_STEP_LABELS.keys()];
+      PROFILE_STEP_LABELS.forEach((label, step) => {
+        let i = keys.findIndex(k => k === step);
 
-      for (let i = 0; i < expected.length; ++i) {
-        let svg = makeProfileProgressDisplay(i);
+        let svg = makeProfileProgressDisplay(step);
         let desc = svg.props.children[0];
-        assert.equal(desc.props.children.join(""), `Profile progress: ${expected[i]}`);
+        assert.equal(desc.props.children.join(""), `Profile progress: ${label}`);
 
         let foundCircle = false, foundCircleText = false, foundText = false;
         for (let child of svg.props.children[1]) {
@@ -125,7 +127,7 @@ describe('utility functions', () => {
             foundCircleText = true;
           }
           if (child.key === `text_${i}`) {
-            assert.equal(child.props.children, expected[i]);
+            assert.equal(child.props.children, label);
             foundText = true;
           }
         }
@@ -134,7 +136,7 @@ describe('utility functions', () => {
             `Unable to find one of circle: ${foundCircle} circleText: ${foundCircleText} text: ${foundText}`
           );
         }
-      }
+      });
     });
   });
 

--- a/static/js/util/validation.js
+++ b/static/js/util/validation.js
@@ -9,7 +9,14 @@ import type {
 } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 import { filterPositiveInt } from './util';
-import { HIGH_SCHOOL, EDUCATION_LEVELS } from '../constants';
+import {
+  HIGH_SCHOOL,
+  EDUCATION_LEVELS,
+  PERSONAL_STEP,
+  EDUCATION_STEP,
+  EMPLOYMENT_STEP,
+  PRIVACY_STEP,
+} from '../constants';
 
 let handleNestedValidation = (profile: Profile, keys, nestedKey: string) => {
   let nestedFields = index => (
@@ -201,21 +208,21 @@ complete profile consists of:
   - one or more work items if the user has marked any work history
   - a valid privacy level
 */
-export type ProfileComplete = [boolean, ?string, ?ValidationErrors];
+export type ProfileComplete = [boolean, string|null, ?ValidationErrors];
 export function validateProfileComplete(profile: Profile): ProfileComplete {
   let errors = {};
 
   // check personal tab
   errors = personalValidation(profile);
   if (!_.isEqual(errors, {})) {
-    return [false, '/profile/personal', errors];
+    return [false, PERSONAL_STEP, errors];
   }
 
   // check professional tab
   if (_.isArray(profile.work_history) && !_.isEmpty(profile.work_history)) {
     errors = employmentValidation(profile);
     if (!_.isEqual(errors, {})) {
-      return [false, '/profile/professional', errors];
+      return [false, EMPLOYMENT_STEP, errors];
     }
   }
 
@@ -223,14 +230,14 @@ export function validateProfileComplete(profile: Profile): ProfileComplete {
   if (_.isArray(profile.education) && !_.isEmpty(profile.education)) {
     errors = educationValidation(profile);
     if (!_.isEqual(errors, {})) {
-      return [false, '/profile/education', errors];
+      return [false, EDUCATION_STEP, errors];
     }
   }
 
   // check privacy tab
   errors = privacyValidation(profile);
   if (!_.isEqual(errors, {})) {
-    return [false, '/profile/privacy', errors];
+    return [false, PRIVACY_STEP, errors];
   }
 
   return [true, null, null];

--- a/static/js/util/validation_test.js
+++ b/static/js/util/validation_test.js
@@ -21,6 +21,9 @@ import {
   EDUCATION_LEVELS,
   BACHELORS,
   HIGH_SCHOOL,
+  PERSONAL_STEP,
+  EMPLOYMENT_STEP,
+  PRIVACY_STEP,
 } from '../constants';
 import { INITIAL_UI_STATE } from '../reducers/ui';
 
@@ -290,14 +293,14 @@ describe('Profile validation functions', () => {
         'birth_country': "Country",
       }).map(([k,v]) => ({[k]: `${v} is required`})));
       errors.date_of_birth = "Please enter a valid date of birth";
-      const expectation = [false, "/profile/personal", errors];
+      const expectation = [false, PERSONAL_STEP, errors];
       assert.deepEqual(validateProfileComplete(profile), expectation);
     });
 
     it('should return appropriate fields when a field is missing', () => {
       profile = _.cloneDeep(USER_PROFILE_RESPONSE);
       profile['account_privacy'] = '';
-      let expectation = [false, "/profile/privacy", {
+      let expectation = [false, PRIVACY_STEP, {
         account_privacy: 'Privacy level is required'
       }];
       assert.deepEqual(validateProfileComplete(profile), expectation);
@@ -310,7 +313,7 @@ describe('Profile validation functions', () => {
     it('should return fields for dialog when a nested field is missing', () => {
       profile = _.cloneDeep(USER_PROFILE_RESPONSE);
       _.set(profile, ['work_history', 0, 'country'], '');
-      let expectation = [false, "/profile/professional", {
+      let expectation = [false, EMPLOYMENT_STEP, {
         work_history: [{country: "Country is required"}]
       }];
       assert.deepEqual(validateProfileComplete(profile), expectation);

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -17,7 +17,7 @@ from ui.views import (
 )
 
 dashboard_urlpatterns = [
-    url(r'^{}'.format(dashboard_url.lstrip("/")), DashboardView.as_view(), name='ui-dashboard')
+    url(r'^{}$'.format(dashboard_url.lstrip("/")), DashboardView.as_view(), name='ui-dashboard')
     for dashboard_url in [
         DASHBOARD_URL,
         PROFILE_URL,


### PR DESCRIPTION
#### What are the relevant tickets?

closes #627 

#### What's this PR do?

This changes the way we progress through the initial profile form sequence. Currently, there's a separate url for each component (`/profile/personal -> PersonalTab`, etc), with the `/profile` route rendering the `ProfilePage` component and the tab component routes nested inside. This changes things so that:

- there's a redux action added to the ui reducer to keep track of what step the user is on (`profileStep`)
- `ProfilePage` pays attention to this bit of state and selectively renders the right tab component
- `ProfilePage` also passes in `nextStep` and `prevStep` callbacks (which either update the store or cause a react-router route transition) which the tab components can pass to `ProfileProgressControls`
- generating props for child components on `ProfileFormContainer` is pulled out into a separate method, which means we can use it either in the case of setting props on cloned children or on rendering a form component without sub-routes
- `SettingsPage` also adopts some of this pattern (using the `profileProps` method from `ProfileFormContainer`) and is, I think, a bit simpler

I think that's it...a lot of changes were necessary to our existing tests for `ProfilePage` and `App` as well.

#### Where should the reviewer start?

Review the changes to `ProfilePage` and `ProfileFormContainer` first, I think, and then look over the changes to existing tests and so on.

#### How should this be manually tested?

There should be no regressions in functionality on the profile, so:

- should be able to edit stuff
- backward / forwards buttons should work
- button labels should change on the privacy tab
- there shouldn't be any appearance changes
- additionally the settings page shouldn't have any regressions

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
