### PR TITLE
Added spinner and error message for profile page

### DIFF
--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -29,9 +29,9 @@ export const receiveGetUserProfileSuccess = (username, profile) => ({
   payload: { profile, username }
 });
 
-const receiveGetUserProfileFailure = username => ({
+const receiveGetUserProfileFailure = (username, errorInfo) => ({
   type: RECEIVE_GET_USER_PROFILE_FAILURE,
-  payload: { username }
+  payload: { username, errorInfo }
 });
 
 export const clearProfile = username => ({
@@ -89,8 +89,8 @@ export function fetchUserProfile(username) {
     dispatch(requestGetUserProfile(username));
     return api.getUserProfile(username).
       then(json => dispatch(receiveGetUserProfileSuccess(username, json))).
-      catch(() => {
-        dispatch(receiveGetUserProfileFailure(username));
+      catch(error => {
+        dispatch(receiveGetUserProfileFailure(username, error));
         // the exception is assumed handled and will not be propagated
       });
   };

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -352,7 +352,7 @@ export const DASHBOARD_RESPONSE = [
   },
 ];
 
-export const DASHBOARD_RESPONSE_ERROR = {
+export const ERROR_RESPONSE = {
   "errorStatusCode": 500,
   "error_code": "AB123",
   "user_message": "custom error message for the user."

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -11,7 +11,7 @@ import {
 } from '../actions';
 import {
   DASHBOARD_RESPONSE,
-  DASHBOARD_RESPONSE_ERROR,
+  ERROR_RESPONSE,
 } from '../constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
 
@@ -47,28 +47,28 @@ describe('DashboardPage', () => {
     errorString = errorString.replace(/\s\s+/g, ' ');
 
     it('error from the backend triggers error message in dashboard', () => {
-      helper.dashboardStub.returns(Promise.reject(DASHBOARD_RESPONSE_ERROR));
+      helper.dashboardStub.returns(Promise.reject(ERROR_RESPONSE));
 
       return renderComponent("/dashboard", dashboardErrorActions, false).then(([, div]) => {
         let message = div.getElementsByClassName('alert-message')[0];
         assert(message.textContent.indexOf(errorString) > -1);
-        assert(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.error_code) > -1);
+        assert(message.textContent.indexOf(ERROR_RESPONSE.error_code) > -1);
         assert(message.textContent.indexOf("Additional info:") > -1);
-        assert(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.user_message) > -1);
+        assert(message.textContent.indexOf(ERROR_RESPONSE.user_message) > -1);
       });
     });
 
     it('the error from the backend does not need to be complete', () => {
-      let response = _.cloneDeep(DASHBOARD_RESPONSE_ERROR);
+      let response = _.cloneDeep(ERROR_RESPONSE);
       delete response.user_message;
       helper.dashboardStub.returns(Promise.reject(response));
 
       return renderComponent("/dashboard", dashboardErrorActions, false).then(([, div]) => {
         let message = div.getElementsByClassName('alert-message')[0];
         assert(message.textContent.indexOf(errorString) > -1);
-        assert(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.error_code) > -1);
+        assert(message.textContent.indexOf(ERROR_RESPONSE.error_code) > -1);
         assert.equal(message.textContent.indexOf("Additional info:"), -1);
-        assert.equal(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.user_message), -1);
+        assert.equal(message.textContent.indexOf(ERROR_RESPONSE.user_message), -1);
       });
     });
 
@@ -78,9 +78,9 @@ describe('DashboardPage', () => {
       return renderComponent("/dashboard", dashboardErrorActions, false).then(([, div]) => {
         let message = div.getElementsByClassName('alert-message')[0];
         assert(message.textContent.indexOf(errorString) > -1);
-        assert.equal(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.error_code), -1);
+        assert.equal(message.textContent.indexOf(ERROR_RESPONSE.error_code), -1);
         assert.equal(message.textContent.indexOf("Additional info:"), -1);
-        assert.equal(message.textContent.indexOf(DASHBOARD_RESPONSE_ERROR.user_message), -1);
+        assert.equal(message.textContent.indexOf(ERROR_RESPONSE.user_message), -1);
       });
     });
 

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -4,8 +4,11 @@ import { assert } from 'chai';
 import _ from 'lodash';
 
 import {
+  REQUEST_GET_USER_PROFILE,
+  RECEIVE_GET_USER_PROFILE_FAILURE,
   REQUEST_PATCH_USER_PROFILE,
   RECEIVE_PATCH_USER_PROFILE_SUCCESS,
+  RECEIVE_DASHBOARD_SUCCESS,
   START_PROFILE_EDIT,
   UPDATE_PROFILE_VALIDATION,
   CLEAR_PROFILE_EDIT,
@@ -25,6 +28,7 @@ import {
 } from '../actions/ui';
 import {
   USER_PROFILE_RESPONSE,
+  ERROR_RESPONSE,
   EDUCATION_LEVELS,
   ASSOCIATE,
   DOCTORATE,
@@ -447,4 +451,41 @@ describe("ProfilePage", function() {
       });
     }
   }
+
+  it('shows a spinner when profile get is processing', () => {
+    return renderComponent('/profile').then(([, div]) => {
+      assert.notOk(div.querySelector(".spinner"), "Found spinner but no fetch in progress");
+      helper.store.dispatch({
+        type: REQUEST_GET_USER_PROFILE,
+        payload: {
+          username: SETTINGS.username
+        }
+      });
+
+      assert(div.querySelector(".spinner"), "Unable to find spinner");
+    });
+  });
+
+  it('shows an error when profile get has errored', () => {
+    return renderComponent('/profile').then(([, div]) => {
+      assert.notOk(div.querySelector(".spinner"), "Found spinner but no fetch in progress");
+      helper.store.dispatch({
+        type: REQUEST_GET_USER_PROFILE,
+        payload: {
+          username: SETTINGS.username
+        }
+      });
+
+      assert(div.querySelector(".spinner"), "Unable to find spinner");
+    });
+  });
+
+  it('renders errors when there is an error receiving the profile', () => {
+    helper.profileGetStub.returns(Promise.reject(ERROR_RESPONSE));
+
+    const types = [RECEIVE_DASHBOARD_SUCCESS, RECEIVE_GET_USER_PROFILE_FAILURE];
+    return renderComponent("/profile", types, false).then(([, div]) => {
+      assert(div.getElementsByClassName('alert-message').length > 0, 'no alert message found');
+    });
+  });
 });

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -61,7 +61,8 @@ export const profiles = (state: ProfileState = INITIAL_PROFILES_STATE, action: A
     });
   case RECEIVE_GET_USER_PROFILE_FAILURE:
     return patchProfile({
-      getStatus: FETCH_FAILURE
+      getStatus: FETCH_FAILURE,
+      errorInfo: action.payload.errorInfo
     });
   case CLEAR_PROFILE: {
     let clone = Object.assign({}, state);


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #588 

#### What's this PR do?
If the profile page is loading it should show a spinner while it loads. If the page is errored you should see an error alert box with the appropriate text.

#### Where should the reviewer start?
static/js/containers/ProfilePage.js

#### How should this be manually tested?
To test the spinner, replace the function in `api.js` with this function:

    export function getUserProfile(username: string) {
      return new Promise(resolve => {
        setTimeout(() => {
          resolve(mockableFetchJSONWithCSRF(`/api/v0/profiles/${username}/`));
        }, 3000);
      });
    }

This will cause a 3 second delay before any loading is done giving you time to see the spinner.

To test the error page, replace the same function with this code:

    import { ERROR_RESPONSE } from '../constants';
    export function getUserProfile(username: string) {
      return Promise.reject(ERROR_RESPONSE);
    }

This will cause the page to always fail loading.

#### Screenshots (if appropriate)
![screenshot from 2016-06-30 09-53-54](https://cloud.githubusercontent.com/assets/863262/16490643/961c46ba-3ea8-11e6-88b8-bbe6783467a4.png)
![screenshot from 2016-06-30 09-55-37](https://cloud.githubusercontent.com/assets/863262/16490707/d3e438f4-3ea8-11e6-85d3-71719b01bdc2.png)
