### PR TITLE
FAQ collapsed by default

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -166,7 +166,7 @@
                               {{ faq.question }}
                             </a>
                           </div>
-                          <div class="panel-collapse collapse in"
+                          <div class="panel-collapse collapse"
                                id="faqs-{{ forloop.counter }}"
                                aria-labelledby="exampleHeadingContinuousOne"
                                role="tabpanel">


### PR DESCRIPTION
#### What are the relevant tickets?
closes #604 

#### What's this PR do?
Makes the FAQ collapsed by default

#### Where should the reviewer start?
it is a one line change

#### How should this be manually tested?
verify that the FAQ are collapsed by default in the program page

#### Screenshots (if appropriate)
![screen shot 2016-06-30 at 2 44 53 pm](https://cloud.githubusercontent.com/assets/1005204/16500127/3eda46b2-3ed1-11e6-9757-bbaff4eeee3d.png)

