### PR TITLE
Changed preferred name display

### DIFF
--- a/static/js/containers/UserMenu.js
+++ b/static/js/containers/UserMenu.js
@@ -21,7 +21,7 @@ class UserMenu extends React.Component {
     // and React 15. React 15 removed span tags but react-bootstrap still expects
     // them.
     let title = <span>
-      {getPreferredName(profile)}
+      {getPreferredName(profile, false)}
     </span>;
 
     if (SETTINGS.authenticated) {

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -225,8 +225,12 @@ export function makeProfileImageUrl(profile: Profile): string {
 /**
  * Returns the preferred name or else the username
  */
-export function getPreferredName(profile: Profile): string {
-  return profile.preferred_name || SETTINGS.name || SETTINGS.username;
+export function getPreferredName(profile: Profile, last: boolean = true): string {
+  let first = profile.preferred_name || SETTINGS.name || SETTINGS.username;
+  if ( last ) {
+    return profile.last_name ? `${first} ${profile.last_name}` : first;
+  }
+  return first;
 }
 
 export function calculateDegreeInclusions(profile: Profile) {

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -104,6 +104,26 @@ describe('utility functions', () => {
       SETTINGS.name = '';
       assert.equal(SETTINGS.username, getPreferredName({}));
     });
+
+    it('shows the last name by default', () => {
+      assert.equal('First Last', getPreferredName({
+        preferred_name: 'First',
+        last_name: 'Last'
+      }));
+    });
+
+    it('does not show the last name if `last === false`', () => {
+      assert.equal('First', getPreferredName({
+        preferred_name: 'First',
+        last_name: 'Last',
+      }, false));
+    });
+
+    [true, false].forEach(bool => {
+      it(`shows just the first name if 'last === ${bool}' and 'profile.last_name === undefined'`, () => {
+        assert.equal('First', getPreferredName({preferred_name: 'First'}, bool));
+      });
+    });
   });
 
   describe('makeProfileProgressDisplay', () => {


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #529 

#### What's this PR do?

This changes the `getPreferredName` function from `util.js` so that it accepts a second positional argument (a boolean) that, if true, causes it to return the first and last name (provided the profile passed in has a last name on it).

#### Where should the reviewer start?

#### How should this be manually tested?

Make sure you get first and last name on `/dashboard`, `/terms_of_service`, `/settings`, and `/profile`. If you set `last_name` to be `None` on your profile you should still see your first name in those places.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
