### PR TITLE
Fixed bug where validation errors showed up on first login

### DIFF
--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -109,6 +109,7 @@ class App extends React.Component {
     if (
       userProfile.getStatus === FETCH_SUCCESS &&
       profile.agreed_to_terms_of_service &&
+      !TERMS_OF_SERVICE_REGEX.test(pathname) &&
       !PROFILE_REGEX.test(pathname) &&
       !complete
     ) {

--- a/static/js/flow/profileTypes.js
+++ b/static/js/flow/profileTypes.js
@@ -59,7 +59,7 @@ export type ProfileGetResult = {
   profile?: Profile,
   errorInfo?: APIErrorInfo,
   getStatus: string,
-  edit?: Object;
+  edit?: {errors: ValidationErrors, profile: Profile},
 };
 
 export type BoundSaveProfile = (validator: Validator|UIValidator, profile: Profile, ui: UIState) => Promise<Profile>;


### PR DESCRIPTION
#### What are the relevant tickets?

closes #634 

#### What's this PR do?

This adds an additional check to the `requireCompleteProfile` method on `App.js`, which ensures that we don't get a race condition relating to the terms of service page.

The race condition emerges when a user is signing in to micromasters for the first time. They get shown the terms of service page, and when they agree the following happens:

- we dispatch an asynchronous action to `PATCH` the updated user profile (with `filled_out === true`)
- the `profiles.username` object is updated (`patchStatus: FETCH_PROCESSING`)
- the store change triggers `componentDidUpdate` on `App.js`
- we call the `requireCompleteProfile` method on `App.js` from the `componentDidUpdate` method
- the pathname is still `/terms_of_service` (remember that the asynchronous `PATCH` response hasn't yet come back)
- the `!PROFILE_REGEX.test(pathname)` test returns `true`, because `pathname === /terms_of_service`
- we validate the profile, and update the profile validation
- `PATCH` response comes back, and we execute the `.then` callback, which pushes `/profile` to the location
- since we already validated the profile, validation errors show up.

We can get around this by simply checking that we're not on `/terms_of_service` before we check and update the validation in the `requireCompleteProfile` method.

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

