### PR TITLE
Added Elasticsearch index

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,20 +168,32 @@ updates, you can run this without the ``--install`` flag: ``./webpack_dev_server
 **DEBUGGING NOTE:** If you see an error related to node-sass when you run this script, try running
 ``npm rebuild node-sass``
 
+#### 3) Build the containers
+Run this command:
 
-#### 3) Run the container
+    docker-compose build
 
-For first-time container start-up, start it with a full build:
+You will also need to run this command whenever ``requirements.txt`` or ``test_requirements.txt`` change.
 
-    docker-compose up --build
+#### 4) Create an Elasticsearch index
+To do this, run this command:
+
+    docker-compose run web ./manage.py recreate_index
+
+This is required to initialize the Elasticsearch index and mappings. This command should only need
+to be run when the Elasticsearch container is first created. It may also be run afterwards to clear and recreate
+existing indexes, and to reindex relevant documents.
+
+#### 5) Run the container
+
+Start Django, PostgreSQL, and other related services:
+
+    docker-compose up
 
 In another terminal tab, navigate the the MicroMasters directory
 and add a superuser in the now-running Docker container:
 
-    docker-compose run web python3 manage.py createsuperuser
-
-Starting the container after this can be done without the ``--build``
-param: ``docker-compose up``
+    docker-compose run web ./manage.py createsuperuser
 
 You should now be able to do the following:
 
@@ -196,7 +208,7 @@ You should now be able to do the following:
 The CMS can be found at `/cms/`. Use the CMS to manage the content of the program pages and, by extension, the home 
 page.  
 
-#### Adding a new MicroMaters program
+#### Adding a new MicroMasters program
 
 1. Login to the cms with an admin account. If you don't have one, you can use the superuser account created earlier.
 
@@ -226,7 +238,7 @@ skip to step 5.
 As shown above, manage commands can be executed on the Docker-contained
 MicroMasters app. For example, you can run a Python shell with the following command:
 
-    docker-compose run web python3 manage.py shell
+    docker-compose run web ./manage.py shell
 
 Tests should be run in the Docker container, not the host machine. They can be run with the following commands:
 

--- a/backends/pipeline_api_test.py
+++ b/backends/pipeline_api_test.py
@@ -4,7 +4,6 @@ Tests for the pipeline APIs
 
 from urllib.parse import urljoin
 
-from django.test import TestCase
 import mock
 
 from backends import pipeline_api, edxorg
@@ -13,10 +12,11 @@ from profiles.api import get_social_username
 from profiles.models import Profile
 from profiles.factories import UserFactory
 from profiles.util import split_name
+from search.base import ESTestCase
 
 
 # pylint: disable=no-self-use
-class EdxPipelineApiTest(TestCase):
+class EdxPipelineApiTest(ESTestCase):
     """
     Test class for APIs run during the Python Social Auth
     authentication pipeline.
@@ -52,6 +52,7 @@ class EdxPipelineApiTest(TestCase):
         """
         Set up class
         """
+        super(EdxPipelineApiTest, self).setUp()
         self.user = UserFactory()
         self.user.social_auth.create(
             provider='not_edx',
@@ -213,7 +214,7 @@ class EdxPipelineApiTest(TestCase):
             assert self.user_profile.edx_language_proficiencies == proficiencies
 
 
-class LinkedInPipelineTests(TestCase):
+class LinkedInPipelineTests(ESTestCase):
     """Tests for the LinkedIn pipline entry"""
 
     def test_saves_linkedin_response(self):

--- a/backends/utils_test.py
+++ b/backends/utils_test.py
@@ -8,17 +8,16 @@ from mock import (
 )
 
 import pytz
-from django.test import TestCase
 from requests.exceptions import HTTPError
 
 from backends import utils
 from backends.edxorg import EdxOrgOAuth2
 from profiles.factories import UserFactory
-
+from search.base import ESTestCase
 # pylint: disable=protected-access
 
 
-class RefreshTest(TestCase):
+class RefreshTest(ESTestCase):
     """Class to test refresh token"""
 
     @classmethod

--- a/courses/management/commands/gen_fake_data_test.py
+++ b/courses/management/commands/gen_fake_data_test.py
@@ -2,7 +2,6 @@
 gen_fake_data test
 """
 
-from django.test import TestCase
 import mock
 
 from courses.management.commands.gen_fake_data import Command
@@ -11,9 +10,10 @@ from courses.models import (
     CourseRun,
     Program,
 )
+from search.base import ESTestCase
 
 
-class GenFakeDataTest(TestCase):
+class GenFakeDataTest(ESTestCase):
     """
     gen_fake_data tests
     """

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -5,7 +5,6 @@ Model tests
 from datetime import datetime, timedelta
 
 import pytz
-from django.test import TestCase
 
 from courses.factories import (
     ProgramFactory,
@@ -13,9 +12,10 @@ from courses.factories import (
     CourseRunFactory,
 )
 from courses.models import CourseRun
+from search.base import ESTestCase
 
 
-class ProgramTests(TestCase):
+class ProgramTests(ESTestCase):
     """Tests for Program model"""
 
     def test_to_string(self):
@@ -24,16 +24,16 @@ class ProgramTests(TestCase):
         assert "{}".format(prog) == "Title"
 
 
-class CourseModelsMixin(TestCase):
+class CourseModelTests(ESTestCase):
     """Mixin for Course models"""
 
     @classmethod
     def setUpTestData(cls):
-        super(CourseModelsMixin, cls).setUpTestData()
+        super(CourseModelTests, cls).setUpTestData()
         cls.course = CourseFactory.create(title="Title")
 
     def setUp(self):
-        super(CourseModelsMixin, self).setUp()
+        super(CourseModelTests, self).setUp()
         self.now = datetime.now(pytz.utc)
 
     def create_run(self, course=None, start=None, end=None,
@@ -51,7 +51,7 @@ class CourseModelsMixin(TestCase):
         )
 
 
-class CourseTests(CourseModelsMixin):
+class CourseTests(CourseModelTests):
     """Tests for Course model"""
 
     def test_to_string(self):
@@ -244,7 +244,7 @@ class CourseTests(CourseModelsMixin):
         assert next_run.pk == course_run.pk
 
 
-class CourseRunTests(CourseModelsMixin):
+class CourseRunTests(CourseModelTests):
     """Tests for Course Run model"""
 
     def test_to_string(self):

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -2,13 +2,12 @@
 Tests for serializers
 """
 
-from django.test import TestCase
-
 from courses.factories import CourseRunFactory
 from courses.serializers import CourseRunSerializer
+from search.base import ESTestCase
 
 
-class CourseRunSerializerTests(TestCase):
+class CourseRunSerializerTests(ESTestCase):
     """
     Tests for CourseRunSerializer
     """

--- a/courses/views_tests.py
+++ b/courses/views_tests.py
@@ -1,12 +1,12 @@
 """Tests for the API"""
 # pylint: disable=no-self-use
 from django.core.urlresolvers import reverse
-from django.test import TestCase
 
 from .factories import ProgramFactory, CourseFactory
+from search.base import ESTestCase
 
 
-class ProgramTests(TestCase):
+class ProgramTests(ESTestCase):
     """Tests for the Program API"""
     def test_lists_live_programs(self):
         """Live programs should show up"""
@@ -26,7 +26,7 @@ class ProgramTests(TestCase):
         assert len(resp.json) == 0
 
 
-class CourseTests(TestCase):
+class CourseTests(ESTestCase):
     """Tests for the Course API"""
     def test_list_course_if_program_live(self):
         """

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -8,7 +8,6 @@ from mock import patch, MagicMock
 
 import pytz
 from django.core.exceptions import ImproperlyConfigured
-from django.test import TestCase
 
 from edx_api.certificates.models import Certificate, Certificates
 from edx_api.enrollments.models import Enrollments
@@ -20,9 +19,10 @@ from courses.factories import (
 )
 from dashboard import api
 from profiles.factories import UserFactory
+from search.base import ESTestCase
 
 
-class StatusTest(TestCase):
+class StatusTest(ESTestCase):
     """
     Tests for the different status classes
     """
@@ -93,12 +93,12 @@ class StatusTest(TestCase):
         assert len(api.CourseFormatConditionalFields.get_assoc_field(api.CourseStatus.OFFERED)) == 2
 
 
-class CourseMixin(TestCase):
+class CourseTests(ESTestCase):
     """Base class for APIs tests"""
 
     @classmethod
     def setUpTestData(cls):
-        super(CourseMixin, cls).setUpTestData()
+        super(CourseTests, cls).setUpTestData()
         cls.course = CourseFactory.create(title="Title")
 
         with open(os.path.join(os.path.dirname(__file__),
@@ -109,7 +109,7 @@ class CourseMixin(TestCase):
             [Certificate(cert_json) for cert_json in cls.certificates_json])
 
     def setUp(self):
-        super(CourseMixin, self).setUp()
+        super(CourseTests, self).setUp()
         self.now = datetime.now(pytz.utc)
 
     def create_run(self, course=None, start=None, end=None,
@@ -132,7 +132,7 @@ class CourseMixin(TestCase):
         return run
 
 
-class FormatRunTest(CourseMixin):
+class FormatRunTest(CourseTests):
     """Tests for the format_courserun_for_dashboard function"""
 
     def test_format_run_no_run(self):
@@ -244,7 +244,7 @@ class FormatRunTest(CourseMixin):
         )
 
 
-class CourseRunTest(CourseMixin):
+class CourseRunTest(CourseTests):
     """Tests for get_status_for_courserun"""
 
     @classmethod
@@ -392,7 +392,7 @@ class CourseRunTest(CourseMixin):
                 self.enrollments.get_enrollment_for_course("course-v1:MITx+8.MechCX+2014_T1"))
 
 
-class InfoCourseTest(CourseMixin):
+class InfoCourseTest(CourseTests):
     """Tests for get_info_for_course"""
 
     @classmethod
@@ -749,7 +749,7 @@ class InfoCourseTest(CourseMixin):
         mock_format.assert_called_once_with(run1, api.CourseStatus.OFFERED, position=1)
 
 
-class InfoProgramTest(TestCase):
+class InfoProgramTest(ESTestCase):
     """Tests for get_info_for_program"""
     @classmethod
     def setUpTestData(cls):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,11 +32,13 @@ web:
     MICROMASTERS_USE_WEBPACK_DEV_SERVER: 'True'
     MICROMASTERS_SECURE_SSL_REDIRECT: 'False'
     MICROMASTERS_DB_DISABLE_SSL: 'True'
+    ELASTICSEARCH_URL: elastic:9200
   env_file: .env
   ports:
     - "8079:8079"
   links:
     - db
+    - elastic
 
 watch:
   build: .
@@ -68,6 +70,7 @@ celery:
     DATABASE_URL: postgres://postgres@db:5432/postgres
     BROKER_URL: redis://redis:6379/4
     CELERY_RESULT_BACKEND: redis://redis:6379/4
+    ELASTICSEARCH_URL: elastic:9200
   links:
     - db
     - elastic

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -107,6 +107,7 @@ INSTALLED_APPS = (
     'backends',
     'profiles',
     'dashboard',
+    'search',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -409,3 +410,7 @@ CELERY_RESULT_BACKEND = get_var(
 CELERY_ALWAYS_EAGER = get_var("CELERY_ALWAYS_EAGER", True)
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = get_var(
     "CELERY_EAGER_PROPAGATES_EXCEPTIONS", True)
+
+# Elasticsearch
+ELASTICSEARCH_URL = get_var("ELASTICSEARCH_URL", None)
+ELASTICSEARCH_INDEX = get_var('ELASTICSEARCH_INDEX', 'micromasters')

--- a/micromasters/tests/test_settings.py
+++ b/micromasters/tests/test_settings.py
@@ -10,15 +10,15 @@ import tempfile
 from django.conf import settings
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
-from django.test import TestCase
 import mock
 import semantic_version
 import yaml
 
 from micromasters.settings import load_fallback, get_var
+from search.base import ESTestCase
 
 
-class TestSettings(TestCase):
+class TestSettings(ESTestCase):
     """Validate that settings work as expected."""
 
     def reload_settings(self):

--- a/profiles/api_test.py
+++ b/profiles/api_test.py
@@ -5,16 +5,16 @@ Tests for profile functions
 from mock import Mock
 
 from django.db.models.signals import post_save
-from django.test import TestCase
 from factory.django import mute_signals
 from testfixtures import LogCapture
 
 from backends.edxorg import EdxOrgOAuth2
 from profiles.api import get_social_username
 from profiles.factories import ProfileFactory
+from search.base import ESTestCase
 
 
-class SocialTests(TestCase):
+class SocialTests(ESTestCase):
     """
     Tests for profile functions
     """
@@ -23,6 +23,7 @@ class SocialTests(TestCase):
         """
         Create a user with a default social auth
         """
+        super(SocialTests, self).setUp()
 
         with mute_signals(post_save):
             profile = ProfileFactory.create(

--- a/profiles/models_test.py
+++ b/profiles/models_test.py
@@ -2,14 +2,14 @@
 Model tests
 """
 # pylint: disable=no-self-use
-from django.test import TestCase
 from django.db.models.signals import post_save
 from factory.django import mute_signals
 from profiles.factories import ProfileFactory, UserFactory
 from profiles.models import Profile
+from search.base import ESTestCase
 
 
-class ProfileTests(TestCase):
+class ProfileTests(ESTestCase):
     """tests for the profile model"""
 
     def test_student_id_on_save(self):

--- a/profiles/permissions_test.py
+++ b/profiles/permissions_test.py
@@ -4,7 +4,6 @@ Tests for profile permissions
 from mock import Mock
 from django.http import Http404
 from django.db.models.signals import post_save
-from django.test import TestCase
 from factory.django import mute_signals
 
 from backends.edxorg import EdxOrgOAuth2
@@ -17,10 +16,11 @@ from profiles.permissions import (
     CanEditIfOwner,
     CanSeeIfNotPrivate,
 )
+from search.base import ESTestCase
 
 
 # pylint: disable=no-self-use
-class CanEditIfOwnerTests(TestCase):
+class CanEditIfOwnerTests(ESTestCase):
     """
     Tests for CanEditIfOwner permissions
     """
@@ -62,7 +62,7 @@ class CanEditIfOwnerTests(TestCase):
 
 
 # pylint: disable=no-self-use
-class CanSeeIfNotPrivateTests(TestCase):
+class CanSeeIfNotPrivateTests(ESTestCase):
     """
     Tests for CanSeeIfNotPrivate permissions
     """

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -2,7 +2,6 @@
 Tests for profile serializers
 """
 
-from django.test import TestCase
 from django.db.models.signals import post_save
 from factory.django import mute_signals
 from rest_framework.fields import DateTimeField
@@ -30,10 +29,11 @@ from profiles.util import (
     GravatarImgSize,
     format_gravatar_url,
 )
+from search.base import ESTestCase
 
 
 # pylint: disable=no-self-use
-class ProfileTests(TestCase):
+class ProfileTests(ESTestCase):
     """
     Tests for profile serializers
     """

--- a/profiles/signals.py
+++ b/profiles/signals.py
@@ -1,6 +1,6 @@
-'''
+"""
 Signals for user profiles
-'''
+"""
 
 import logging
 

--- a/profiles/signals_test.py
+++ b/profiles/signals_test.py
@@ -3,13 +3,13 @@ Tests for signals
 """
 
 from django.contrib.auth.models import User
-from django.test import TestCase
 
 from profiles.models import Profile
+from search.base import ESTestCase
 
 
 # pylint: disable=no-self-use
-class SignalProfilesTest(TestCase):
+class SignalProfilesTest(ESTestCase):
     """
     Test class for signals that creates a profile whenever a user is created
     """

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -7,7 +7,6 @@ from mock import patch
 from dateutil.parser import parse
 from django.core.urlresolvers import resolve, reverse
 from django.db.models.signals import post_save
-from django.test import TestCase
 from factory.django import mute_signals
 from rest_framework.status import (
     HTTP_405_METHOD_NOT_ALLOWED,
@@ -23,9 +22,10 @@ from profiles.serializers import (
     ProfileSerializer,
 )
 from profiles.views import ProfileViewSet
+from search.base import ESTestCase
 
 
-class ProfileTests(TestCase):
+class ProfileTests(ESTestCase):
     """
     Tests for GET on profile view
     """

--- a/search/__init__.py
+++ b/search/__init__.py
@@ -1,0 +1,2 @@
+# pylint: disable=missing-docstring,invalid-name
+default_app_config = 'search.apps.SearchConfig'

--- a/search/api.py
+++ b/search/api.py
@@ -1,0 +1,259 @@
+"""
+Functions for search
+"""
+from itertools import islice
+import logging
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from elasticsearch.helpers import bulk
+from elasticsearch.exceptions import NotFoundError
+from elasticsearch_dsl import Mapping
+from elasticsearch_dsl.connections import connections
+
+from profiles.models import Profile
+from profiles.serializers import ProfileSerializer
+from search.exceptions import ReindexException
+
+log = logging.getLogger(__name__)
+
+USER_DOC_TYPE = 'user'
+DOC_TYPES = (USER_DOC_TYPE, )
+_CONN = None
+# When we create the connection, check to make sure all appropriate mappings exist
+_CONN_VERIFIED = False
+# A string which must be indexed exactly as is and not stemmed for full text search (the default)
+NOT_ANALYZED_STRING_TYPE = {
+    'type': 'string',
+    'index': 'not_analyzed',
+}
+BOOL_TYPE = {'type': 'boolean'}
+DATE_TYPE = {'type': 'date', 'format': 'date'}
+LONG_TYPE = {'type': 'long'}
+
+
+def get_conn(verify=True):
+    """
+    Lazily create the connection.
+    """
+    # pylint: disable=global-statement
+    global _CONN
+    global _CONN_VERIFIED
+
+    do_verify = False
+    if _CONN is None:
+        _CONN = connections.create_connection(hosts=[settings.ELASTICSEARCH_URL])
+        # Verify connection on first connect if verify=True.
+        do_verify = verify
+
+    if verify and not _CONN_VERIFIED:
+        # If we have a connection but haven't verified before, do it now.
+        do_verify = True
+
+    if not do_verify:
+        if not verify:
+            # We only skip verification if we're reindexing or
+            # deleting the index. Make sure we verify next time we connect.
+            _CONN_VERIFIED = False
+        return _CONN
+
+    # Make sure everything exists.
+    index_name = settings.ELASTICSEARCH_INDEX
+    if not _CONN.indices.exists(index_name):
+        raise ReindexException("Unable to find index {index_name}".format(
+            index_name=index_name
+        ))
+
+    mappings = _CONN.indices.get_mapping()[index_name]["mappings"]
+    for doc_type in DOC_TYPES:
+        if doc_type not in mappings.keys():
+            raise ReindexException("Mapping {doc_type} not found".format(
+                doc_type=doc_type
+            ))
+
+    _CONN_VERIFIED = True
+    return _CONN
+
+
+def _index_users_chunk(users):
+    """
+    Add/update a small number of user records in Elasticsearch
+
+    Args:
+        users (list of User):
+            List of users
+
+    Returns:
+        int: Number of items inserted into Elasticsearch
+    """
+
+    conn = get_conn()
+    insert_count, errors = bulk(
+        conn,
+        (serialize_user(user) for user in users),
+        index=settings.ELASTICSEARCH_INDEX,
+        doc_type=USER_DOC_TYPE,
+    )
+
+    if len(errors) > 0:
+        raise ReindexException("Error during bulk insert: {errors}".format(
+            errors=errors
+        ))
+    refresh_index()
+
+    return insert_count
+
+
+def index_users(users, chunk_size=100):
+    """
+    Add/update profile records in Elasticsearch.
+
+    Args:
+        users (iterable of User):
+            Iterable of users
+        chunk_size (int):
+            How many users to index at once.
+
+    Returns:
+        int: Number of indexed items
+    """
+    # Use an iterator so we can keep track of what's been indexed already
+    users = iter(users)
+
+    count = 0
+    chunk = list(islice(users, chunk_size))
+    while len(chunk) > 0:
+        count += _index_users_chunk(chunk)
+        chunk = list(islice(users, chunk_size))
+
+    refresh_index()
+
+    return count
+
+
+def remove_user(user):
+    """
+    Remove a user from Elasticsearch.
+    """
+    conn = get_conn()
+    try:
+        conn.delete(index=settings.ELASTICSEARCH_INDEX, doc_type=USER_DOC_TYPE, id=user.id)
+    except NotFoundError:
+        # Item is already gone
+        pass
+
+
+def serialize_user(user):
+    """
+    Serializes user for use with Elasticsearch.
+
+    Args:
+        user (User): A user to serialize
+    Returns:
+        dict: The data to be sent to Elasticsearch
+    """
+    serialized = {
+        'id': user.id,
+        '_id': user.id,
+    }
+    try:
+        serialized['profile'] = ProfileSerializer().to_representation(user.profile)
+    except Profile.DoesNotExist:
+        # Just in case
+        pass
+    return serialized
+
+
+def refresh_index():
+    """
+    Refresh the Elasticsearch index
+    """
+    get_conn().indices.refresh(index=settings.ELASTICSEARCH_INDEX)
+
+
+def create_user_mapping():
+    """
+    Create a mapping for profiles. If one already exists, delete it first.
+    """
+    conn = get_conn(verify=False)
+
+    index_name = settings.ELASTICSEARCH_INDEX
+    if conn.indices.exists_type(index=index_name, doc_type=USER_DOC_TYPE):
+        conn.indices.delete_mapping(index=index_name, doc_type=USER_DOC_TYPE)
+
+    mapping = Mapping(USER_DOC_TYPE)
+    mapping.field("id", "long")
+    mapping.field("profile", "nested", properties={
+        'account_privacy': NOT_ANALYZED_STRING_TYPE,
+        'agreed_to_terms_of_service': BOOL_TYPE,
+        'birth_city': NOT_ANALYZED_STRING_TYPE,
+        'birth_country': NOT_ANALYZED_STRING_TYPE,
+        'birth_state_or_territory': NOT_ANALYZED_STRING_TYPE,
+        'city': NOT_ANALYZED_STRING_TYPE,
+        'country': NOT_ANALYZED_STRING_TYPE,
+        'date_of_birth': DATE_TYPE,
+        'education': {'type': 'nested', 'properties': {
+            'degree_name': NOT_ANALYZED_STRING_TYPE,
+            'field_of_study': NOT_ANALYZED_STRING_TYPE,
+            'graduation_date': DATE_TYPE,
+            'id': LONG_TYPE,
+            'online_degree': BOOL_TYPE,
+            'school_city': NOT_ANALYZED_STRING_TYPE,
+            'school_country': NOT_ANALYZED_STRING_TYPE,
+            'school_name': NOT_ANALYZED_STRING_TYPE,
+            'school_state_or_territory': NOT_ANALYZED_STRING_TYPE,
+        }},
+        'email_optin': BOOL_TYPE,
+        'filled_out': BOOL_TYPE,
+        'first_name': NOT_ANALYZED_STRING_TYPE,
+        'gender': NOT_ANALYZED_STRING_TYPE,
+        'has_profile_image': BOOL_TYPE,
+        'last_name': NOT_ANALYZED_STRING_TYPE,
+        'preferred_language': NOT_ANALYZED_STRING_TYPE,
+        'preferred_name': NOT_ANALYZED_STRING_TYPE,
+        'pretty_printed_student_id': NOT_ANALYZED_STRING_TYPE,
+        'profile_url_full': NOT_ANALYZED_STRING_TYPE,
+        'profile_url_large': NOT_ANALYZED_STRING_TYPE,
+        'profile_url_medium': NOT_ANALYZED_STRING_TYPE,
+        'profile_url_small': NOT_ANALYZED_STRING_TYPE,
+        'username': NOT_ANALYZED_STRING_TYPE,
+        'work_history': {'type': 'nested', 'properties': {
+            'city': NOT_ANALYZED_STRING_TYPE,
+            'company_name': NOT_ANALYZED_STRING_TYPE,
+            'country': NOT_ANALYZED_STRING_TYPE,
+            'id': LONG_TYPE,
+            'industry': NOT_ANALYZED_STRING_TYPE,
+            'position': NOT_ANALYZED_STRING_TYPE,
+            'start_date': DATE_TYPE,
+            'state_or_territory': NOT_ANALYZED_STRING_TYPE,
+        }},
+    })
+    mapping.save(index_name)
+
+
+def create_mappings():
+    """
+    Create all mappings, deleting existing mappings if they exist.
+    """
+    create_user_mapping()
+
+
+def clear_index():
+    """
+    Wipe and recreate index and mapping. No indexing is done.
+    """
+    conn = get_conn(verify=False)
+    index_name = settings.ELASTICSEARCH_INDEX
+    if conn.indices.exists(index_name):
+        conn.indices.delete(index_name)
+    conn.indices.create(index_name)
+    conn.indices.refresh()
+    create_mappings()
+
+
+def recreate_index():
+    """
+    Wipe and recreate index and mapping, and index all items.
+    """
+    clear_index()
+    index_users(User.objects.iterator())

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -1,0 +1,284 @@
+"""
+Tests for search API functions.
+"""
+
+from urllib.parse import urljoin
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.db.models.signals import post_save
+from factory.django import mute_signals
+from rest_framework.fields import DateTimeField
+from requests import get
+
+from profiles.api import get_social_username
+from profiles.factories import (
+    EducationFactory,
+    EmploymentFactory,
+    ProfileFactory,
+    UserFactory,
+)
+from profiles.serializers import (
+    EducationSerializer,
+    EmploymentSerializer,
+)
+from profiles.util import (
+    GravatarImgSize,
+    format_gravatar_url,
+)
+from search.api import (
+    get_conn,
+    index_users,
+    refresh_index,
+    remove_user,
+    serialize_user,
+)
+from search.base import ESTestCase
+from search.exceptions import ReindexException
+
+
+def remove_key(dictionary, key):
+    """Helper method to remove a key from a dict and return the dict"""
+    del dictionary[key]
+    return dictionary
+
+
+def search():
+    """
+    Execute a search and get results
+    """
+    # Refresh the index so we can read current data
+    refresh_index()
+
+    elasticsearch_url = settings.ELASTICSEARCH_URL
+    if not elasticsearch_url.startswith("http"):
+        elasticsearch_url = "http://{}".format(elasticsearch_url)
+    url = urljoin(
+        elasticsearch_url,
+        "{}/{}".format(settings.ELASTICSEARCH_INDEX, "_search")
+    )
+    return get(url).json()['hits']
+
+
+def assert_search(results, users):
+    """
+    Assert that search results match users
+    """
+    assert results['total'] == len(users)
+    sources = sorted([hit['_source'] for hit in results['hits']], key=lambda hit: hit['id'])
+    sorted_users = sorted(users, key=lambda user: user.id)
+    serialized = [remove_key(serialize_user(user), "_id") for user in sorted_users]
+    assert serialized == sources
+
+
+# pylint: disable=no-self-use
+class IndexTests(ESTestCase):
+    """
+    Tests for indexing
+    """
+
+    def test_user_add(self):
+        """
+        Test that a newly created User is indexed properly
+        """
+        assert search()['total'] == 0
+        user = UserFactory.create()
+        assert_search(search(), [user])
+
+    def test_user_update(self):
+        """
+        Test that User is reindexed after being updated
+        """
+        user = UserFactory.create()
+        assert search()['total'] == 1
+        profile = user.profile
+        profile.first_name = 'updated'
+        profile.save()
+        assert_search(search(), [user])
+
+    def test_user_delete(self):
+        """
+        Test that User is removed from index after being updated
+        """
+        user = UserFactory.create()
+        assert search()['total'] == 1
+        user.profile.delete()
+        assert search()['total'] == 0
+
+    def test_education_add(self):
+        """
+        Test that Education is indexed after being added
+        """
+        user = UserFactory.create()
+        assert search()['total'] == 1
+        EducationFactory.create(profile=user.profile)
+        assert_search(search(), [user])
+
+    def test_education_update(self):
+        """
+        Test that Education is reindexed after being updated
+        """
+        user = UserFactory.create()
+        assert search()['total'] == 1
+        education = EducationFactory.create(profile=user.profile)
+        education.school_city = 'city'
+        education.save()
+        assert_search(search(), [user])
+
+    def test_education_delete(self):
+        """
+        Test that Education is removed from index after being deleted
+        """
+        user = UserFactory.create()
+        education = EducationFactory.create(profile=user.profile)
+        assert_search(search(), [user])
+        education.delete()
+        assert_search(search(), [user])
+
+    def test_employment_add(self):
+        """
+        Test that Employment is indexed after being added
+        """
+        user = UserFactory.create()
+        assert search()['total'] == 1
+        EmploymentFactory.create(profile=user.profile)
+        assert_search(search(), [user])
+
+    def test_employment_update(self):
+        """
+        Test that Employment is reindexed after being updated
+        """
+        user = UserFactory.create()
+        assert search()['total'] == 1
+        employment = EmploymentFactory.create(profile=user.profile)
+        employment.city = 'city'
+        employment.save()
+        assert_search(search(), [user])
+
+    def test_employment_delete(self):
+        """
+        Test that Employment is removed from index after being deleted
+        """
+        user = UserFactory.create()
+        employment = EmploymentFactory.create(profile=user.profile)
+        assert_search(search(), [user])
+        employment.delete()
+        assert_search(search(), [user])
+
+    def test_remove_profile(self):
+        """
+        Test that remove_profile removes the profile from the index
+        """
+        user = UserFactory.create()
+        assert_search(search(), [user])
+        remove_user(user)
+        assert_search(search(), [])
+
+    def test_index_users(self):
+        """
+        Test that index_profiles indexes an iterable of profiles
+        """
+        for _ in range(10):
+            with mute_signals(post_save):
+                # using ProfileFactory instead of UserFactory here since UserFactory will not fill in any
+                # fields on Profile
+                profile = ProfileFactory.create()
+            # Not strictly necessary, the muted post_save will prevent indexing
+            remove_user(profile.user)
+
+        # Confirm nothing in index
+        assert_search(search(), [])
+        index_users(User.objects.iterator(), chunk_size=4)
+        assert_search(search(), list(User.objects.all()))
+
+
+class SerializerTests(ESTestCase):
+    """
+    Tests for profile serializer
+    """
+
+    def test_profile_serializer(self):  # pylint: disable=no-self-use
+        """
+        Asserts the output of the profile serializer
+        """
+        with mute_signals(post_save):
+            profile = ProfileFactory.create()
+        EducationFactory.create(profile=profile)
+        EmploymentFactory.create(profile=profile)
+
+        assert serialize_user(profile.user) == {
+            '_id': profile.user.id,
+            'id': profile.user.id,
+            'profile': {
+                'username': get_social_username(profile.user),
+                'first_name': profile.first_name,
+                'filled_out': profile.filled_out,
+                'agreed_to_terms_of_service': profile.agreed_to_terms_of_service,
+                'last_name': profile.last_name,
+                'preferred_name': profile.preferred_name,
+                'email_optin': profile.email_optin,
+                'gender': profile.gender,
+                'date_of_birth': DateTimeField().to_representation(profile.date_of_birth),
+                'account_privacy': profile.account_privacy,
+                'has_profile_image': profile.has_profile_image,
+                'profile_url_full': format_gravatar_url(profile.user.email, GravatarImgSize.FULL),
+                'profile_url_large': format_gravatar_url(profile.user.email, GravatarImgSize.LARGE),
+                'profile_url_medium': format_gravatar_url(profile.user.email, GravatarImgSize.MEDIUM),
+                'profile_url_small': format_gravatar_url(profile.user.email, GravatarImgSize.SMALL),
+                'country': profile.country,
+                'state_or_territory': profile.state_or_territory,
+                'city': profile.city,
+                'birth_country': profile.birth_country,
+                'birth_state_or_territory': profile.birth_state_or_territory,
+                'birth_city': profile.birth_city,
+                'preferred_language': profile.preferred_language,
+                'pretty_printed_student_id': profile.pretty_printed_student_id,
+                'edx_level_of_education': profile.edx_level_of_education,
+                'education': [
+                    EducationSerializer().to_representation(education) for education in profile.education.all()
+                ],
+                'work_history': [
+                    EmploymentSerializer().to_representation(work_history) for work_history in
+                    profile.work_history.all()
+                ]
+            }
+        }
+
+
+class GetConnTests(ESTestCase):
+    """
+    Tests for get_conn
+    """
+    def setUp(self):
+        """
+        Start without any index
+        """
+        super(GetConnTests, self).setUp()
+
+        conn = get_conn(verify=False)
+        index_name = settings.ELASTICSEARCH_INDEX
+        conn.indices.delete(index_name)
+
+        # Clear globals
+        from search import api
+        api._CONN = None  # pylint: disable=protected-access
+        api._CONN_VERIFIED = False  # pylint: disable=protected-access
+
+    def test_no_index(self):
+        """
+        Test that an error is raised if we don't have an index
+        """
+        with self.assertRaises(ReindexException) as ex:
+            get_conn()
+        assert str(ex.exception) == "Unable to find index {}".format(settings.ELASTICSEARCH_INDEX)
+
+    def test_no_mapping(self):
+        """
+        Test that error is raised if we don't have a mapping
+        """
+        conn = get_conn(verify=False)
+        conn.indices.create(settings.ELASTICSEARCH_INDEX)
+
+        with self.assertRaises(ReindexException) as ex:
+            get_conn()
+        assert str(ex.exception) == "Mapping user not found"

--- a/search/apps.py
+++ b/search/apps.py
@@ -1,0 +1,17 @@
+"""
+AppConfig
+"""
+from django.apps import AppConfig
+
+
+class SearchConfig(AppConfig):
+    """
+    App config for this app
+    """
+    name = "search"
+
+    def ready(self):
+        """
+        Ready handler. Import signals.
+        """
+        import search.signals

--- a/search/base.py
+++ b/search/base.py
@@ -1,0 +1,16 @@
+"""
+Base test classes for search
+"""
+from django.test import TestCase
+
+from search.api import clear_index
+
+
+class ESTestCase(TestCase):
+    """
+    Set up ES index on setup
+    """
+
+    def setUp(self):
+        super(ESTestCase, self).setUp()
+        clear_index()

--- a/search/commands_test.py
+++ b/search/commands_test.py
@@ -1,0 +1,54 @@
+"""
+Test search management commands
+"""
+
+from django.conf import settings
+
+from profiles.factories import UserFactory
+from search.api import (
+    get_conn,
+    recreate_index,
+    remove_user,
+)
+from search.api_test import (
+    assert_search,
+    search,
+)
+from search.base import ESTestCase
+
+
+class RecreateIndexTests(ESTestCase):
+    """
+    Tests for management commands
+    """
+    def setUp(self):
+        """
+        Start without any index
+        """
+        super(RecreateIndexTests, self).setUp()
+        conn = get_conn(verify=False)
+        index_name = settings.ELASTICSEARCH_INDEX
+        if conn.indices.exists(index_name):
+            conn.indices.delete(index_name)
+
+    def test_create_index(self):  # pylint: disable=no-self-use
+        """
+        Test that recreate_index will create an index and let search successfully
+        """
+        recreate_index()
+        assert search()['total'] == 0
+
+    def test_update_index(self):  # pylint: disable=no-self-use
+        """
+        Test that recreate_index will clear old data and index all profiles
+        """
+        recreate_index()
+        user = UserFactory.create()
+        assert_search(search(), [user])
+        remove_user(user)
+        # No profiles in Elasticsearch
+        assert_search(search(), [])
+
+        # recreate_index will index the profile
+        recreate_index()
+        assert_search(search(), [user])

--- a/search/exceptions.py
+++ b/search/exceptions.py
@@ -1,0 +1,9 @@
+"""
+Exceptions related to search
+"""
+
+
+class ReindexException(Exception):
+    """
+    Exception raised when a user needs to reindex Elasticsearch
+    """

--- a/search/management/commands/recreate_index.py
+++ b/search/management/commands/recreate_index.py
@@ -1,0 +1,22 @@
+"""
+Management command to recreate the Elasticsearch index
+"""
+
+from django.core.management.base import BaseCommand
+
+from search.api import (
+    recreate_index,
+)
+
+
+class Command(BaseCommand):
+    """
+    Command for recreate_index
+    """
+    help = "Clears existing Elasticsearch indices and creates a new index and mapping."
+
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
+        """
+        Recreates the index
+        """
+        recreate_index()

--- a/search/signals.py
+++ b/search/signals.py
@@ -1,0 +1,37 @@
+"""
+Signals used for indexing
+"""
+
+import logging
+
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from profiles.models import (
+    Education,
+    Employment,
+    Profile,
+)
+from search.tasks import index_users, remove_user
+
+log = logging.getLogger(__name__)
+
+
+@receiver(post_save)
+def handle_profile_update(sender, **kwargs):  # pylint: disable=unused-argument
+    """Update index when a Profile, Education, or Employment is updated."""
+    instance = kwargs["instance"]
+    if isinstance(instance, Profile):
+        index_users.delay([instance.user])
+    elif isinstance(instance, (Education, Employment)):
+        index_users.delay([instance.profile.user])
+
+
+@receiver(post_delete)
+def handle_profile_delete(sender, **kwargs):  # pylint: disable=unused-argument
+    """Update index when a Profile, Education, or Employment is deleted."""
+    instance = kwargs['instance']
+    if isinstance(instance, Profile):
+        remove_user.delay(instance.user)
+    elif isinstance(instance, (Education, Employment)):
+        index_users.delay([instance.profile.user])

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -1,0 +1,33 @@
+"""
+Celery tasks for search
+"""
+
+from micromasters.celery import async
+from search.api import (
+    index_users as _index_users,
+    remove_user as _remove_user
+)
+
+
+@async.task
+def index_users(users):
+    """
+    Index profiles
+
+    Args:
+        users (iterable of User):
+            Iterable of Users
+    """
+    _index_users(users)
+
+
+@async.task
+def remove_user(user):
+    """
+    Remove profile from index
+
+    Args:
+        user (User):
+            A user to remove from index
+    """
+    _remove_user(user)

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,5 @@ commands =
     py.test {posargs}
 
 passenv = *
+setenv =
+    ELASTICSEARCH_INDEX=testindex

--- a/travis-docker-compose.yml
+++ b/travis-docker-compose.yml
@@ -17,10 +17,12 @@ web:
     DATABASE_URL: postgres://postgres@db:5432/postgres
     MICROMASTERS_SECURE_SSL_REDIRECT: 'False'
     MICROMASTERS_DB_DISABLE_SSL: 'True'
+    ELASTICSEARCH_URL: elastic:9200
   ports:
     - "8079:8079"
   links:
     - db
+    - elastic
 
 watch:
   image: node:6.2
@@ -33,3 +35,10 @@ watch:
     - .:/src
   environment:
     NODE_ENV: 'production'
+
+elastic:
+  image: elasticsearch
+  command: elasticsearch -Des.network.host=0.0.0.0
+  ports:
+    - "9200"
+

--- a/ui/decorators_test.py
+++ b/ui/decorators_test.py
@@ -3,11 +3,11 @@ Decorator tests
 """
 
 from django.db.models.signals import post_save
-from django.test import TestCase
 from factory.django import mute_signals
 
 from backends.edxorg import EdxOrgOAuth2
 from profiles.factories import ProfileFactory
+from search.base import ESTestCase
 from ui.url_utils import (
     DASHBOARD_URL,
     PROFILE_URL,
@@ -15,7 +15,7 @@ from ui.url_utils import (
 )
 
 
-class DecoratorTests(TestCase):
+class DecoratorTests(ESTestCase):
     """
     Decorator tests for UI views
     """

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -4,7 +4,6 @@ Test end to end django views.
 import json
 
 from django.db.models.signals import post_save
-from django.test import TestCase
 from django.core.urlresolvers import reverse
 from factory.django import mute_signals
 from factory.fuzzy import FuzzyText
@@ -19,10 +18,11 @@ from courses.factories import ProgramFactory
 from backends.edxorg import EdxOrgOAuth2
 from profiles.api import get_social_username
 from profiles.factories import ProfileFactory
+from search.base import ESTestCase
 from ui.urls import DASHBOARD_URL
 
 
-class ViewsTests(TestCase):
+class ViewsTests(ESTestCase):
     """
     Test that the views work as expected.
     """
@@ -276,6 +276,7 @@ class TestProgramPage(ViewsTests):
     Test that the ProgramPage view work as expected.
     """
     def setUp(self):
+        super(TestProgramPage, self).setUp()
         homepage = HomePage.objects.first()
         program = Program(title="Test Program Title", live=True)
         program.save()


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #699 
Fixes #670 

#### What's this PR do?
Sets up Elasticsearch indexing to happen:
 - when the `recreate_index` management command is run.
 - when a `Profile`, `Education`, or `Employment` are updated or created. In this case a celery task is executed

#### Where should the reviewer start?
search/api.py

#### How should this be manually tested?
There are changes to `docker-compose.yml` so you'll need to restart your containers, no rebuilding should be necessary though.

First, run `docker-compose run web ./manage.py recreate_index`. Then run this command: `docker-compose run web curl http://elastic:9200/micromasters/_search | python -m json.tool`. Verify that you see profile data in the search results.

Go into the users page and make an update to the profile. Run the curl command again and verify that you see the updated value in the profile.

#### Background context
From now on, people creating new instances of this app will need to create an Elasticsearch index and mapping via management command: `./manage.py recreate_index`. This command may also be run at any time to delete the existing index and reindex all relevant data (this may take a while).