### PR TITLE
Updated validation state when editing fields

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -1,6 +1,6 @@
 // @flow
 // general UI actions
-import type { Action } from '../flow/generalTypes';
+import type { Action, Dispatcher } from '../flow/generalTypes';
 
 export const CLEAR_UI = 'CLEAR_UI';
 export const clearUI = () => ({ type: CLEAR_UI });
@@ -22,9 +22,12 @@ export const setDialogVisibility = (bool: boolean): Action => (
 
 // work history actions
 export const SET_WORK_HISTORY_EDIT = 'SET_WORK_HISTORY_EDIT';
-export const setWorkHistoryEdit = (bool: boolean): Action => (
-  { type: SET_WORK_HISTORY_EDIT, payload: bool }
-);
+export const setWorkHistoryEdit = (bool: boolean): Dispatcher => {
+  return dispatch => {
+    dispatch({ type: SET_WORK_HISTORY_EDIT, payload: bool});
+    return Promise.resolve();
+  };
+};
 
 export const SET_WORK_DIALOG_VISIBILITY = 'SET_WORK_DIALOG_VISIBILITY';
 export const setWorkDialogVisibility = (bool: boolean): Action => (
@@ -60,9 +63,12 @@ export const setEducationDegreeLevel = (level: string): Action => (
 );
 
 export const SET_EDUCATION_DEGREE_INCLUSIONS = 'SET_EDUCATION_DEGREE_INCLUSIONS';
-export const setEducationDegreeInclusions = (degreeInclusions: Object): Action => (
-  { type: SET_EDUCATION_DEGREE_INCLUSIONS, payload: degreeInclusions }
-);
+export const setEducationDegreeInclusions = (degreeInclusions: Object): Dispatcher => {
+  return dispatch => {
+    dispatch({ type: SET_EDUCATION_DEGREE_INCLUSIONS, payload: degreeInclusions });
+    return Promise.resolve();
+  };
+};
 
 export const SET_USER_PAGE_DIALOG_VISIBILITY = 'SET_USER_PAGE_DIALOG_VISIBILITY';
 export const setUserPageDialogVisibility = (bool: boolean): Action => (

--- a/static/js/components/EducationDialog.js
+++ b/static/js/components/EducationDialog.js
@@ -12,6 +12,9 @@ import SelectField from './inputs/SelectField';
 import CountrySelectField from './inputs/CountrySelectField';
 import StateSelectField from './inputs/StateSelectField';
 import FieldsOfStudySelectField from './inputs/FieldsOfStudySelectField';
+import type { UIState } from '../reducers/ui';
+import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
+import type { Validator, UIValidator } from '../util/validation';
 
 export default class EducationDialog extends ProfileFormFields {
   constructor(props: Object) {
@@ -23,11 +26,16 @@ export default class EducationDialog extends ProfileFormFields {
   }
   educationLevelLabels: Object;
 
-  static propTypes = {
-    open:           React.PropTypes.bool,
-    onClose:        React.PropTypes.func,
-    onSave:         React.PropTypes.func,
-    showLevelForm:  React.PropTypes.bool,
+  props: {
+    ui:                           UIState,
+    setEducationDialogVisibility: () => void,
+    setEducationDegreeLevel:      () => void,
+    setEducationDialogIndex:      () => void,
+    clearProfileEdit:             () => void,
+    saveProfile:                  SaveProfileFunc,
+    profile:                      Profile,
+    showLevelForm:                boolean,
+    validator:                    Validator|UIValidator,
   };
 
   clearEducationEdit: Function = (): void => {
@@ -57,7 +65,7 @@ export default class EducationDialog extends ProfileFormFields {
       profile: { education },
     } = this.props;
 
-    let educationDegreeLevel = _.get(education, [educationDialogIndex, "degree_name"]) || BACHELORS;
+    let educationDegreeLevel = _.get(education[educationDialogIndex], "degree_name") || BACHELORS;
     let keySet = (key) => ['education', educationDialogIndex, key];
 
     let fieldOfStudy = () => {

--- a/static/js/components/EducationDisplay.js
+++ b/static/js/components/EducationDisplay.js
@@ -21,6 +21,7 @@ import { userPrivilegeCheck } from '../util/util';
 import { HIGH_SCHOOL } from '../constants';
 import { educationEntriesByDate } from '../util/sorting';
 import type { EducationEntry } from '../flow/profileTypes';
+import { educationValidation } from '../util/validation';
 
 export default class EducationDisplay extends ProfileFormFields {
   openEditEducationForm: Function = (index: number): void => {
@@ -107,7 +108,11 @@ export default class EducationDisplay extends ProfileFormFields {
           close={this.closeConfirmDeleteDialog}
           confirmText="Delete this entry?"
         />
-        <EducationDialog {...this.props} showLevelForm={true} />
+        <EducationDialog
+          {...this.props}
+          showLevelForm={true}
+          validator={educationValidation}
+        />
         <Card shadow={1} className="profile-tab-card" id="education-card">
           <Grid className="profile-tab-card-grid">
             <Cell col={4} className="profile-card-title">

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -24,23 +24,27 @@ import type {
   EducationEntry,
   Profile,
   ValidationErrors,
-  BoundSaveProfile,
+  SaveProfileFunc,
+  UpdateProfileFunc,
 } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
+import type { Validator, UIValidator } from '../util/validation';
+import type { AsyncActionHelper } from '../flow/generalTypes';
 
 class EducationForm extends ProfileFormFields {
   props: {
     profile:                          Profile,
     ui:                               UIState;
-    updateProfile:                    () => void,
-    saveProfile:                      BoundSaveProfile,
+    updateProfile:                    UpdateProfileFunc,
+    saveProfile:                      SaveProfileFunc,
     clearProfileEdit:                 () => void,
     errors:                           ValidationErrors,
     setEducationDialogVisibility:     () => void,
     setEducationDialogIndex:          () => void,
     setEducationDegreeLevel:          () => void,
-    setEducationDegreeInclusions:     () => void,
+    setEducationDegreeInclusions:     AsyncActionHelper,
     setShowEducationDeleteAllDialog:  (bool: boolean) => void,
+    validator:                        Validator|UIValidator,
   };
 
   openEditEducationForm: Function = (index: number): void => {
@@ -147,12 +151,18 @@ class EducationForm extends ProfileFormFields {
       setEducationDegreeLevel,
       setShowEducationDeleteAllDialog,
       profile: { education },
+      profile,
+      validator,
+      updateProfile,
     } = this.props;
     if ( !education.find(entry => entry.degree_name === level) ) {
       let newState = Object.assign({}, educationDegreeInclusions, {
         [level]: !educationDegreeInclusions[level]
       });
-      setEducationDegreeInclusions(newState);
+      setEducationDegreeInclusions(newState).then(() => {
+        let clone = _.cloneDeep(profile);
+        updateProfile(clone, validator);
+      });
     } else {
       setEducationDegreeLevel(level);
       setShowEducationDeleteAllDialog(true);

--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -9,7 +9,7 @@ import {
   educationValidation,
   combineValidators,
 } from '../util/validation';
-import type { Profile, BoundSaveProfile } from '../flow/profileTypes';
+import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
 class EducationTab extends React.Component {
@@ -18,10 +18,11 @@ class EducationTab extends React.Component {
     prevStep:     () => void,
     profile:      Profile,
     ui:           UIState,
-    saveProfile:  BoundSaveProfile,
+    saveProfile:  SaveProfileFunc,
   };
 
   render() {
+    let validator = combineValidators(educationValidation, educationUiValidation);
     return <div>
       <Grid className="profile-splash">
         <Cell col={12}>
@@ -31,7 +32,7 @@ class EducationTab extends React.Component {
       <Grid className="profile-tab-grid">
         <Cell col={1}></Cell>
         <Cell col={10}>
-          <EducationForm {...this.props} />
+          <EducationForm {...this.props} validator={validator} />
         </Cell>
         <Cell col={1}></Cell>
         <Cell col={1} />
@@ -40,7 +41,7 @@ class EducationTab extends React.Component {
             {...this.props}
             nextBtnLabel="Save and Continue"
             isLastTab={false}
-            validator={combineValidators(educationValidation, educationUiValidation)}
+            validator={validator}
           />
         </Cell>
         <Cell col={1} />

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -20,8 +20,35 @@ import SelectField from './inputs/SelectField';
 import CountrySelectField from './inputs/CountrySelectField';
 import StateSelectField from './inputs/StateSelectField';
 import type { WorkHistoryEntry } from '../flow/profileTypes';
+import type { Validator, UIValidator } from '../util/validation';
+import type {
+  Profile,
+  SaveProfileFunc,
+  ValidationErrors,
+  UpdateProfileFunc,
+} from '../flow/profileTypes';
+import type { UIState } from '../reducers/ui';
+import type { AsyncActionHelper } from '../flow/generalTypes';
 
 class EmploymentForm extends ProfileFormFields {
+  props: {
+    profile:                          Profile,
+    ui:                               UIState;
+    updateProfile:                    UpdateProfileFunc,
+    saveProfile:                      SaveProfileFunc,
+    clearProfileEdit:                 () => void,
+    errors:                           ValidationErrors,
+    setWorkDialogVisibility:          () => void,
+    setWorkDialogIndex:               () => void,
+    setWorkDegreeLevel:               () => void,
+    setWorkDegreeInclusions:          () => void,
+    setWorkHistoryEdit:               AsyncActionHelper,
+    deletionIndex:                    number,
+    setShowWorkDeleteAllDialog:       (foo: boolean) => void,
+    showSwitch:                       boolean,
+    validator:                        Validator|UIValidator,
+  };
+
   saveWorkHistoryEntry: Function = (): void => {
     const { saveProfile, profile, ui } = this.props;
     saveProfile(employmentValidation, profile, ui).then(() => {
@@ -30,9 +57,19 @@ class EmploymentForm extends ProfileFormFields {
   };
 
   changeSwitchState: Function = (): void => {
-    const { ui, setWorkHistoryEdit, profile, setShowWorkDeleteAllDialog } = this.props;
+    const {
+      ui,
+      setWorkHistoryEdit,
+      profile,
+      setShowWorkDeleteAllDialog,
+      validator,
+      updateProfile,
+    } = this.props;
     if ( _.isEmpty(profile.work_history) ) {
-      setWorkHistoryEdit(!ui.workHistoryEdit);
+      setWorkHistoryEdit(!ui.workHistoryEdit).then(() => {
+        let clone = _.cloneDeep(profile);
+        updateProfile(clone, validator);
+      });
     } else {
       setShowWorkDeleteAllDialog(true);
     }
@@ -50,11 +87,12 @@ class EmploymentForm extends ProfileFormFields {
       profile,
       setWorkDialogIndex,
       setWorkDialogVisibility,
+      validator,
     } = this.props;
     let clone = Object.assign({}, profile, {
       work_history: profile.work_history.concat(generateNewWorkHistory())
     });
-    updateProfile(clone);
+    updateProfile(clone, validator);
     setWorkDialogIndex(clone.work_history.length - 1);
     setWorkDialogVisibility(true);
   };

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -9,12 +9,12 @@ import {
   employmentUiValidation,
   combineValidators,
 } from '../util/validation';
-import type { Profile, BoundSaveProfile } from '../flow/profileTypes';
+import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
 class EmploymentTab extends React.Component {
   props: {
-    saveProfile:  BoundSaveProfile,
+    saveProfile:  SaveProfileFunc,
     profile:      Profile,
     ui:           UIState,
     nextStep:     () => void,
@@ -22,6 +22,7 @@ class EmploymentTab extends React.Component {
   };
 
   render () {
+    const validator = combineValidators(employmentValidation, employmentUiValidation);
     return (
       <div>
         <Grid className="profile-splash">
@@ -32,7 +33,7 @@ class EmploymentTab extends React.Component {
         <Grid className="profile-tab-grid">
           <Cell col={1}></Cell>
           <Cell col={10}>
-            <EmploymentForm {...this.props} showSwitch={true} />
+            <EmploymentForm {...this.props} showSwitch={true} validator={validator} />
           </Cell>
           <Cell col={1}></Cell>
           <Cell col={1}></Cell>
@@ -41,7 +42,7 @@ class EmploymentTab extends React.Component {
               {...this.props}
               nextBtnLabel="Save and Continue"
               isLastTab={false}
-              validator={combineValidators(employmentValidation, employmentUiValidation)}
+              validator={validator}
             />
           </Cell>
           <Cell col={1}></Cell>

--- a/static/js/components/PersonalForm.js
+++ b/static/js/components/PersonalForm.js
@@ -8,16 +8,19 @@ import StateSelectField from './inputs/StateSelectField';
 import ProfileFormFields from '../util/ProfileFormFields';
 import type {
   Profile,
-  BoundSaveProfile,
-  ValidationErrors
+  SaveProfileFunc,
+  ValidationErrors,
+  UpdateProfileFunc,
 } from '../flow/profileTypes';
+import type { Validator, UIValidator } from '../util/validation';
 
 export default class PersonalForm extends ProfileFormFields {
   props: {
     profile:        Profile,
     errors:         ValidationErrors,
-    saveProfile:    BoundSaveProfile,
-    updateProfile:  () => void,
+    saveProfile:    SaveProfileFunc,
+    updateProfile:  UpdateProfileFunc,
+    validator:      Validator|UIValidator,
   };
 
   render() {

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -5,15 +5,20 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 import PersonalForm from './PersonalForm';
 import ProfileProgressControls from './ProfileProgressControls';
 import { personalValidation } from '../util/validation';
-import type { Profile, BoundSaveProfile, ValidationErrors } from '../flow/profileTypes';
+import type {
+  Profile,
+  SaveProfileFunc,
+  ValidationErrors,
+  UpdateProfileFunc,
+} from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
 class PersonalTab extends React.Component {
   props: {
     profile:        Profile,
     errors:         ValidationErrors,
-    saveProfile:    BoundSaveProfile,
-    updateProfile:  () => void,
+    saveProfile:    SaveProfileFunc,
+    updateProfile:  UpdateProfileFunc,
     ui:             UIState,
     nextStep:       () => void,
     prevStep:       () => void,
@@ -30,7 +35,7 @@ class PersonalTab extends React.Component {
       <Grid className="profile-tab-grid">
         <Cell col={1} />
         <Cell col={10}>
-          <PersonalForm {...this.props} />
+          <PersonalForm {...this.props} validator={personalValidation} />
         </Cell>
         <Cell col={1} />
         <Cell col={1} />

--- a/static/js/components/PrivacyForm.js
+++ b/static/js/components/PrivacyForm.js
@@ -3,14 +3,14 @@
 import React from 'react';
 
 import ProfileFormFields from '../util/ProfileFormFields';
-import type { Profile, ValidationErrors } from '../flow/profileTypes';
+import type { Profile, ValidationErrors, UpdateProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
 class PrivacyForm extends ProfileFormFields {
   props: {
     profile:        Profile,
     ui:             UIState,
-    updateProfile:  Function,
+    updateProfile:  UpdateProfileFunc,
     errors:         ValidationErrors,
   };
 

--- a/static/js/components/PrivacyTab.js
+++ b/static/js/components/PrivacyTab.js
@@ -12,14 +12,14 @@ import {
   employmentValidation,
   privacyValidation,
 } from '../util/validation';
-import type { Profile, BoundSaveProfile } from '../flow/profileTypes';
+import type { Profile, SaveProfileFunc, UpdateProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
 class PrivacyTab extends ProfileFormFields {
   props: {
     profile:        Profile,
-    saveProfile:    BoundSaveProfile,
-    updateProfile:  () => void,
+    saveProfile:    SaveProfileFunc,
+    updateProfile:  UpdateProfileFunc,
     ui:             UIState,
     nextStep:       () => void,
     prevStep:       () => void,

--- a/static/js/components/ProfileProgressControls.js
+++ b/static/js/components/ProfileProgressControls.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Button from 'react-mdl/lib/Button';
 
 import { saveProfileStep } from '../util/profile_edit';
-import type { Profile, BoundSaveProfile } from '../flow/profileTypes';
+import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
 export default class ProfileProgressControls extends React.Component {
@@ -15,7 +15,7 @@ export default class ProfileProgressControls extends React.Component {
     validator:    Function,
     profile:      Profile,
     ui:           UIState,
-    saveProfile:  BoundSaveProfile,
+    saveProfile:  SaveProfileFunc,
   };
 
   saveAndContinue: Function = (): void => {

--- a/static/js/components/User.js
+++ b/static/js/components/User.js
@@ -10,7 +10,8 @@ import EmploymentForm from './EmploymentForm';
 import EducationDisplay from './EducationDisplay';
 import UserPagePersonalDialog from './UserPagePersonalDialog.js';
 import { userPrivilegeCheck } from '../util/util';
-import type { Profile, BoundSaveProfile } from '../flow/profileTypes';
+import { employmentValidation } from '../util/validation';
+import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
 export default class User extends React.Component {
@@ -19,7 +20,7 @@ export default class User extends React.Component {
     setUserPageDialogVisibility:  () => void,
     ui:                           UIState,
     clearProfileEdit:             () => void,
-    saveProfile:                  BoundSaveProfile,
+    saveProfile:                  SaveProfileFunc,
   };
 
   toggleShowPersonalDialog: Function = (): void => {
@@ -74,7 +75,7 @@ export default class User extends React.Component {
 
       <Grid className="user-cards-grid">
         <Cell col={6}>
-          <EmploymentForm {...this.props} showSwitch={false} />
+          <EmploymentForm {...this.props} showSwitch={false} validator={employmentValidation} />
         </Cell>
         <Cell col={6}>
           <EducationDisplay {...this.props} />

--- a/static/js/components/UserPagePersonalDialog.js
+++ b/static/js/components/UserPagePersonalDialog.js
@@ -5,7 +5,7 @@ import Button from 'react-mdl/lib/Button';
 
 import { personalValidation } from '../util/validation';
 import PersonalForm from './PersonalForm';
-import type { Profile, BoundSaveProfile } from '../flow/profileTypes';
+import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
 export default class UserPagePersonalDialog extends React.Component {
@@ -13,7 +13,7 @@ export default class UserPagePersonalDialog extends React.Component {
     setUserPageDialogVisibility:  () => void,
     ui:                           UIState,
     profile:                      Profile,
-    saveProfile:                  BoundSaveProfile,
+    saveProfile:                  SaveProfileFunc,
     clearProfileEdit:             () => void,
   };
 
@@ -56,7 +56,7 @@ export default class UserPagePersonalDialog extends React.Component {
         onRequestClose={this.closePersonalDialog}
         actions={actions}
         autoScrollBodyContent={true}>
-        <PersonalForm {...this.props} />
+        <PersonalForm {...this.props} validator={personalValidation} />
       </Dialog>
     );
   }

--- a/static/js/components/inputs/CountrySelectField.js
+++ b/static/js/components/inputs/CountrySelectField.js
@@ -3,7 +3,9 @@ import React from 'react';
 import _ from 'lodash';
 import iso3166 from 'iso-3166-2';
 import SelectField from './SelectField';
-import type { Profile } from '../../flow/profileTypes';
+import type { Profile, UpdateProfileFunc, ValidationErrors } from '../../flow/profileTypes';
+import type { Validator, UIValidator } from '../../util/validation';
+import type { Option } from '../../flow/generalTypes';
 
 let countryOptions = _(iso3166.data)
   .map((countryInfoObj, countryCode) => ({
@@ -13,18 +15,25 @@ let countryOptions = _(iso3166.data)
   .sortBy('label').value();
 
 export default class CountrySelectField extends React.Component {
-  static propTypes = {
-    updateProfile:            React.PropTypes.func,
-    stateKeySet:              React.PropTypes.array,
-    countryKeySet:            React.PropTypes.array
+  props: {
+    updateProfile:            UpdateProfileFunc,
+    stateKeySet:              Array<string>,
+    countryKeySet:            Array<string>,
+    errors:                   ValidationErrors,
+    label:                    Node,
+    maxSearchResults:         number,
+    keySet:                   Array<string>,
+    options:                  Array<Option>,
+    validator:                Validator|UIValidator,
+    profile:                  Profile,
   };
 
   onChange: Function = (newProfile: Profile): void => {
-    const { stateKeySet, updateProfile } = this.props;
+    const { stateKeySet, updateProfile, validator } = this.props;
     // clear state field when country field changes
     let clone = _.cloneDeep(newProfile);
     _.set(clone, stateKeySet, null);
-    updateProfile(clone);
+    updateProfile(clone, validator);
   };
 
   render() {

--- a/static/js/components/inputs/SelectField.js
+++ b/static/js/components/inputs/SelectField.js
@@ -5,6 +5,12 @@ import AutoComplete from '../AutoComplete';
 import { defaultFilter, showAllOptions } from '../utils/AutoCompleteSettings';
 import { callFunctionArray } from '../../util/util';
 import type { Option } from '../../flow/generalTypes';
+import type { Validator, UIValidator } from '../../util/validation';
+import type {
+  Profile,
+  ValidationErrors,
+  UpdateProfileFunc,
+} from '../../flow/profileTypes';
 
 class SelectField extends React.Component {
   constructor(props: Object) {
@@ -15,17 +21,18 @@ class SelectField extends React.Component {
   // type declarations
   editKeySet: string[];
 
-  static propTypes = {
-    profile:                  React.PropTypes.object.isRequired,
-    autocompleteStyleProps:   React.PropTypes.object,
-    autocompleteBehaviors:    React.PropTypes.array,
-    errors:                   React.PropTypes.object,
-    label:                    React.PropTypes.node,
-    onChange:                 React.PropTypes.func,
-    updateProfile:            React.PropTypes.func,
-    maxSearchResults:         React.PropTypes.number,
-    keySet:                   React.PropTypes.array,
-    options:                  React.PropTypes.array
+  props: {
+    profile:                  Profile,
+    autocompleteStyleProps:   Object,
+    autocompleteBehaviors:    Array<any>,
+    errors:                   ValidationErrors,
+    label:                    Node,
+    onChange:                 Function,
+    updateProfile:            UpdateProfileFunc,
+    maxSearchResults:         number,
+    keySet:                   Array<string>,
+    options:                  Array<Option>,
+    validator:                Validator|UIValidator,
   };
 
   static defaultProps = {
@@ -48,21 +55,22 @@ class SelectField extends React.Component {
     const {
       profile,
       updateProfile,
-      keySet
+      keySet,
+      validator,
     } = this.props;
     let clone = _.cloneDeep(profile);
     _.set(clone, this.editKeySet, searchText);
     _.set(clone, keySet, null);
-    updateProfile(clone);
+    updateProfile(clone, validator);
   };
 
   onBlur: Function = (): void => {
     // clear the edit value when we lose focus. In its place we will display
     // the selected option label if one is selected, or an empty string
-    const { profile, updateProfile } = this.props;
+    const { profile, updateProfile, validator } = this.props;
     let clone = _.cloneDeep(profile);
     _.set(clone, this.editKeySet, undefined);
-    updateProfile(clone);
+    updateProfile(clone, validator);
   };
 
   onNewRequest: Function = (optionOrString: Option|string, index: number): void => {
@@ -71,7 +79,8 @@ class SelectField extends React.Component {
       updateProfile,
       keySet,
       options,
-      onChange
+      onChange,
+      validator,
     } = this.props;
     let clone = _.cloneDeep(profile);
     let toStore;
@@ -98,7 +107,7 @@ class SelectField extends React.Component {
     } // else we couldn't figure out what the user wanted to select, so leave it as is
     _.set(clone, this.editKeySet, undefined);
 
-    updateProfile(clone);
+    updateProfile(clone, validator);
     if (_.isFunction(onChange)) {
       onChange(clone);
     }

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -31,6 +31,9 @@ import {
 import type { Validator, UIValidator } from '../util/validation';
 import type { Profile, Profiles, ProfileGetResult } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
+import type { AsyncActionHelper } from '../flow/generalTypes';
+
+type UpdateProfile = (isEdit: boolean, profile: Profile, validator: Validator|UIValidator) => void;
 
 class ProfileFormContainer extends React.Component {
   props: {
@@ -58,9 +61,18 @@ class ProfileFormContainer extends React.Component {
     if (profiles[username] === undefined || profiles[username].getStatus === undefined) {
       dispatch(fetchUserProfile(username));
     }
+  };
+
+  updateProfileValidation(props: Object, profile: Profile, validator: Validator|UIValidator): void {
+    const username = SETTINGS.username;
+    const { dispatch, profiles, ui } = props;
+    if ( profiles[username].edit && !_.isEmpty(profiles[username].edit.errors) ) {
+      let errors = validator(profile, ui);
+      dispatch(updateProfileValidation(username, errors));
+    }
   }
 
-  updateProfile: Function = (isEdit: boolean, profile: Profile): void => {
+  updateProfile: UpdateProfile = (isEdit, profile, validator) => {
     const { dispatch } = this.props;
     const username = SETTINGS.username;
 
@@ -68,6 +80,7 @@ class ProfileFormContainer extends React.Component {
       dispatch(startProfileEdit(username));
     }
     dispatch(updateProfile(username, profile));
+    this.updateProfileValidation(this.props, profile, validator);
   }
 
   setProfileStep: Function = (step: string): void => {
@@ -103,11 +116,11 @@ class ProfileFormContainer extends React.Component {
   setUserPageDialogVisibility: Function = (bool: boolean): void => {
     const { dispatch } = this.props;
     dispatch(setUserPageDialogVisibility(bool));
-  }
+  };
 
-  setWorkHistoryEdit: Function = (bool: boolean): void => {
+  setWorkHistoryEdit: AsyncActionHelper = (bool: boolean) => {
     const { dispatch } = this.props;
-    dispatch(setWorkHistoryEdit(bool));
+    return dispatch(setWorkHistoryEdit(bool));
   }
 
   setWorkDialogVisibility: Function = (bool: boolean): void => {
@@ -140,9 +153,9 @@ class ProfileFormContainer extends React.Component {
     dispatch(setEducationDegreeLevel(level));
   };
 
-  setEducationDegreeInclusions: Function = (inclusions: Object): void => {
+  setEducationDegreeInclusions: AsyncActionHelper = (inclusions: Object) => {
     const { dispatch } = this.props;
-    dispatch(setEducationDegreeInclusions(inclusions));
+    return dispatch(setEducationDegreeInclusions(inclusions));
   };
 
   saveProfile(isEdit: boolean, validator: Validator|UIValidator, profile: Profile, ui: UIState) {

--- a/static/js/flow/generalTypes.js
+++ b/static/js/flow/generalTypes.js
@@ -1,4 +1,6 @@
 // @flow
+import type { Dispatch } from 'redux';
+
 export type Option = {
   value: string;
   label: string;
@@ -8,6 +10,10 @@ export type Action = {
   type: string;
   payload: any
 };
+
+export type Dispatcher = (d: Dispatch) => Promise;
+export type AsyncActionHelper = (...a: any) => Promise;
+
 
 export type Settings = {
   gaTrackingID: string;

--- a/static/js/flow/profileTypes.js
+++ b/static/js/flow/profileTypes.js
@@ -35,7 +35,8 @@ export type WorkHistoryEntry = {
 };
 
 export type ValidationErrors = {
-  date_of_birth?: string;
+  date_of_birth?:         string;
+  work_history_required?: string;
 };
 
 export type Profile = {
@@ -62,7 +63,8 @@ export type ProfileGetResult = {
   edit?: {errors: ValidationErrors, profile: Profile},
 };
 
-export type BoundSaveProfile = (validator: Validator|UIValidator, profile: Profile, ui: UIState) => Promise<Profile>;
+export type SaveProfileFunc = (validator: Validator|UIValidator, profile: Profile, ui: UIState) => Promise<Profile>;
+export type UpdateProfileFunc = (profile: Profile, validator: Validator|UIValidator) => void;
 
 export type APIErrorInfo = {
   error_code?: string,

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -40,21 +40,22 @@ import { calculateDegreeInclusions } from '../util/util';
 import type { Action } from '../flow/generalTypes';
 
 export type UIState = {
-  workHistoryEdit:            boolean;
-  workDialogVisibility:       boolean;
-  dashboardExpander:          {};
-  educationDialogVisibility:  boolean;
-  educationDialogIndex:       ?number;
-  educationDegreeLevel:       string;
-  educationDegreeInclusions: {[key: string]: boolean};
-  userPageDialogVisibility: boolean;
-  showWorkDeleteDialog: boolean;
-  showEducationDeleteDialog: boolean;
-  deletionIndex: ?number;
-  dialog: {};
-  showWorkDeleteAllDialog: boolean;
+  workHistoryEdit:              boolean;
+  workDialogVisibility:         boolean;
+  dashboardExpander:            {};
+  educationDialogVisibility:    boolean;
+  educationDialogIndex:         number;
+  educationDegreeLevel:         string;
+  educationDegreeInclusions:    {[key: string]: boolean};
+  userPageDialogVisibility:     boolean;
+  showWorkDeleteDialog:         boolean;
+  showEducationDeleteDialog:    boolean;
+  deletionIndex:                ?number;
+  dialog:                       {};
+  showWorkDeleteAllDialog:      boolean;
   showEducationDeleteAllDialog: boolean;
-  profileStep: string;
+  profileStep:                  string;
+  workDialogIndex:              ?number;
 };
 
 export const INITIAL_UI_STATE: UIState = {
@@ -62,7 +63,7 @@ export const INITIAL_UI_STATE: UIState = {
   workDialogVisibility:       false,
   dashboardExpander:          {},
   educationDialogVisibility:  false,
-  educationDialogIndex:       null,
+  educationDialogIndex:       -1,
   educationDegreeLevel:       '',
   educationDegreeInclusions: {
     [HIGH_SCHOOL]: false,
@@ -79,6 +80,7 @@ export const INITIAL_UI_STATE: UIState = {
   showWorkDeleteAllDialog: false,
   showEducationDeleteAllDialog: false,
   profileStep: PERSONAL_STEP,
+  workDialogIndex:  null,
 };
 
 export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -153,7 +153,7 @@ describe('ui reducers', () => {
     it('has a default state', () => {
       return dispatchThen({type: "undefined"}, []).then(state => {
         assert.deepEqual(state.educationDialogVisibility, false);
-        assert.deepEqual(state.educationDialogIndex, null);
+        assert.deepEqual(state.educationDialogIndex, -1);
         assert.deepEqual(state.educationDegreeLevel, '');
         assert.deepEqual(
           state.educationDegreeInclusions, {

--- a/static/js/util/ProfileFormFields.js
+++ b/static/js/util/ProfileFormFields.js
@@ -62,7 +62,8 @@ export default class ProfileFormFields extends React.Component {
       profile: this.props.profile,
       updateProfile: this.props.updateProfile,
       saveProfile: this.props.saveProfile,
-      errors: this.props.errors
+      errors: this.props.errors,
+      validator: this.props.validator,
     };
   };
 
@@ -78,7 +79,8 @@ export default class ProfileFormFields extends React.Component {
     setDeletionIndex:             React.PropTypes.func,
     setShowWorkDeleteDialog:      React.PropTypes.func,
     setShowEducationDeleteDialog: React.PropTypes.func,
-    showSwitch:                   React.PropTypes.bool
+    showSwitch:                   React.PropTypes.bool,
+    validator:                    React.PropTypes.func,
   };
 
   closeConfirmDeleteDialog: Function = (): void => {

--- a/static/js/util/editEducation.js
+++ b/static/js/util/editEducation.js
@@ -25,6 +25,7 @@ export function openNewEducationForm(level: string, index: number) {
     setEducationDialogIndex,
     setEducationDegreeLevel,
     setEducationDialogVisibility,
+    validator,
   } = this.props;
   let newIndex = index;
   if (index === null){
@@ -33,7 +34,7 @@ export function openNewEducationForm(level: string, index: number) {
   /* add empty education */
   let clone = Object.assign({}, profile);
   clone['education'] = clone['education'].concat(generateNewEducation(level));
-  updateProfile(clone);
+  updateProfile(clone, validator);
   setEducationDialogIndex(newIndex);
   setEducationDegreeLevel(level);
   setEducationDialogVisibility(true);

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -26,7 +26,7 @@ import type { Option } from '../flow/generalTypes';
  * pass in the name (used as placeholder), key for profile, and the options.
  */
 export function boundRadioGroupField(keySet: string[], label: string, options: Option[]): React$Element {
-  const { profile, updateProfile, errors } = this.props;
+  const { profile, updateProfile, errors, validator } = this.props;
   const styles = {
     labelStyle: {
       left: -10,
@@ -36,7 +36,7 @@ export function boundRadioGroupField(keySet: string[], label: string, options: O
   let onChange = e => {
     let clone = _.cloneDeep(profile);
     _.set(clone, keySet, e.target.value);
-    updateProfile(clone);
+    updateProfile(clone, validator);
   };
 
   const radioButtons = options.map(obj => {
@@ -94,12 +94,13 @@ export function boundTextField(keySet: string[], label: string): React$Element {
   const {
     profile,
     errors,
-    updateProfile
+    updateProfile,
+    validator,
   } = this.props;
   let onChange = e => {
     let clone = _.cloneDeep(profile);
     _.set(clone, keySet, e.target.value);
-    updateProfile(clone);
+    updateProfile(clone, validator);
   };
   let getValue = () => {
     let value = _.get(profile, keySet, "");
@@ -129,6 +130,7 @@ export function boundDateField(keySet: string[], label: string, omitDay: boolean
     profile,
     errors,
     updateProfile,
+    validator,
   } = this.props;
 
   // make a copy of keySet with a slightly different key for temporary storage of the textfields being edited
@@ -213,7 +215,7 @@ export function boundDateField(keySet: string[], label: string, omitDay: boolean
         _.set(clone, keySet, momentDate.format(ISO_8601_FORMAT));
       }
     }
-    updateProfile(clone);
+    updateProfile(clone, validator);
   };
 
   let edit = getEditObject();


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #549 

#### What's this PR do?

This changes the validation setup so that when the user fixes a validation error (fills out a required field, enters a valid date, etc) the error will be removed automatically. Really, we're just re-validating the profile.

#### Where should the reviewer start?

Review the changes to `actions/ui.js` and the changes to `setWorkHistoryEdit` on `EmploymentForm.js`, and the changes to `setEducationDegreeInclusions` on `EducationForm.js`.

There are also some changes comprising adding types (esp `props` declarations) to files or classes which didn't previously have them.

#### How should this be manually tested?

Visit `/users` and `/profile`. For every input on those pages (and in all stages of filling out the profile) the following should hold:

- make an invalid input (empty text field, invalid selection for 'preferred language', etc)
- click save
- validation errors should appear
- correct the invalid input
- validation errors should disappear, without the user having to click on 'save' again

additionally, correcting validation errors involving the switches on the education and work history profile steps should immediately remove the messages as well.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

