### PR TITLE
Refactored ProfileFormContainer to remove boilerplate

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -1,6 +1,6 @@
 // @flow
 // general UI actions
-import type { Action, Dispatcher } from '../flow/generalTypes';
+import type { Action, Dispatcher } from '../flow/reduxTypes';
 
 export const CLEAR_UI = 'CLEAR_UI';
 export const clearUI = () => ({ type: CLEAR_UI });

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -29,7 +29,7 @@ import type {
 } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 import type { Validator, UIValidator } from '../util/validation';
-import type { AsyncActionHelper } from '../flow/generalTypes';
+import type { AsyncActionHelper } from '../flow/reduxTypes';
 
 class EducationForm extends ProfileFormFields {
   props: {

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -28,7 +28,7 @@ import type {
   UpdateProfileFunc,
 } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
-import type { AsyncActionHelper } from '../flow/generalTypes';
+import type { AsyncActionHelper } from '../flow/reduxTypes';
 
 class EmploymentForm extends ProfileFormFields {
   props: {

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -26,12 +26,12 @@ import {
   setDeletionIndex,
   setShowWorkDeleteAllDialog,
   setShowEducationDeleteAllDialog,
-  setProfileStep,
 } from '../actions/ui';
+import { createSimpleActionHelpers, createAsyncActionHelpers } from '../util/redux';
+import type { ActionHelpers, AsyncActionHelpers } from '../util/redux';
 import type { Validator, UIValidator } from '../util/validation';
 import type { Profile, Profiles, ProfileGetResult } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
-import type { AsyncActionHelper } from '../flow/generalTypes';
 
 type UpdateProfile = (isEdit: boolean, profile: Profile, validator: Validator|UIValidator) => void;
 
@@ -81,81 +81,6 @@ class ProfileFormContainer extends React.Component {
     }
     dispatch(updateProfile(username, profile));
     this.updateProfileValidation(this.props, profile, validator);
-  }
-
-  setProfileStep: Function = (step: string): void => {
-    const { dispatch } = this.props;
-    dispatch(setProfileStep(step));
-  };
-
-  setDeletionIndex: Function = (index: number): void => {
-    const { dispatch } = this.props;
-    dispatch(setDeletionIndex(index));
-  }
-
-  setShowEducationDeleteDialog: Function = (bool: boolean): void => {
-    const { dispatch } = this.props;
-    dispatch(setShowEducationDeleteDialog(bool));
-  }
-
-  setShowWorkDeleteDialog: Function = (bool: boolean): void => {
-    const { dispatch } = this.props;
-    dispatch(setShowWorkDeleteDialog(bool));
-  }
-
-  setShowWorkDeleteAllDialog: Function = (bool: boolean): void => {
-    const { dispatch } = this.props;
-    dispatch(setShowWorkDeleteAllDialog(bool));
-  };
-
-  setShowEducationDeleteAllDialog: Function = (bool: boolean): void => {
-    const { dispatch } = this.props;
-    dispatch(setShowEducationDeleteAllDialog(bool));
-  };
-
-  setUserPageDialogVisibility: Function = (bool: boolean): void => {
-    const { dispatch } = this.props;
-    dispatch(setUserPageDialogVisibility(bool));
-  };
-
-  setWorkHistoryEdit: AsyncActionHelper = (bool: boolean) => {
-    const { dispatch } = this.props;
-    return dispatch(setWorkHistoryEdit(bool));
-  }
-
-  setWorkDialogVisibility: Function = (bool: boolean): void => {
-    const { dispatch } = this.props;
-    dispatch(setWorkDialogVisibility(bool));
-  }
-
-  setWorkDialogIndex: Function = (index: number): void => {
-    const { dispatch } = this.props;
-    dispatch(setWorkDialogIndex(index));
-  }
-
-  clearProfileEdit: Function = (): void => {
-    const { dispatch } = this.props;
-    dispatch(clearProfileEdit(SETTINGS.username));
-  }
-
-  setEducationDialogVisibility: Function = (bool: boolean): void => {
-    const { dispatch } = this.props;
-    dispatch(setEducationDialogVisibility(bool));
-  }
-
-  setEducationDialogIndex: Function = (index: number): void => {
-    const { dispatch } = this.props;
-    dispatch(setEducationDialogIndex(index));
-  }
-
-  setEducationDegreeLevel: Function = (level: string): void => {
-    const { dispatch } = this.props;
-    dispatch(setEducationDegreeLevel(level));
-  };
-
-  setEducationDegreeInclusions: AsyncActionHelper = (inclusions: Object) => {
-    const { dispatch } = this.props;
-    return dispatch(setEducationDegreeInclusions(inclusions));
   };
 
   saveProfile(isEdit: boolean, validator: Validator|UIValidator, profile: Profile, ui: UIState) {
@@ -176,6 +101,32 @@ class ProfileFormContainer extends React.Component {
       return Promise.reject(errors);
     }
   }
+
+  simpleActionHelpers: Function = (): ActionHelpers => {
+    const { dispatch } = this.props;
+    return createSimpleActionHelpers(dispatch, [
+      setWorkDialogVisibility,
+      setWorkDialogIndex,
+      clearProfileEdit,
+      setEducationDialogVisibility,
+      setEducationDialogIndex,
+      setEducationDegreeLevel,
+      setUserPageDialogVisibility,
+      setShowEducationDeleteDialog,
+      setShowWorkDeleteDialog,
+      setDeletionIndex,
+      setShowWorkDeleteAllDialog,
+      setShowEducationDeleteAllDialog,
+    ]);
+  };
+
+  asyncActionHelpers: Function = (): AsyncActionHelpers => {
+    const { dispatch } = this.props;
+    return createAsyncActionHelpers(dispatch, [
+      setEducationDegreeInclusions,
+      setWorkHistoryEdit
+    ]);
+  };
 
   profileProps: Function = (profileFromStore: ProfileGetResult) => {
     let { ui } = this.props;
@@ -203,22 +154,9 @@ class ProfileFormContainer extends React.Component {
       ui: ui,
       updateProfile: this.updateProfile.bind(this, isEdit),
       saveProfile: this.saveProfile.bind(this, isEdit),
-      setWorkHistoryEdit: this.setWorkHistoryEdit,
-      setWorkDialogVisibility: this.setWorkDialogVisibility,
-      setWorkDialogIndex: this.setWorkDialogIndex,
-      clearProfileEdit: this.clearProfileEdit,
-      setEducationDialogVisibility: this.setEducationDialogVisibility,
-      setEducationDialogIndex: this.setEducationDialogIndex,
-      setEducationDegreeLevel: this.setEducationDegreeLevel,
-      setEducationDegreeInclusions: this.setEducationDegreeInclusions,
       fetchProfile: this.fetchProfile,
-      setUserPageDialogVisibility: this.setUserPageDialogVisibility,
-      setShowEducationDeleteDialog: this.setShowEducationDeleteDialog,
-      setShowWorkDeleteDialog: this.setShowWorkDeleteDialog,
-      setDeletionIndex: this.setDeletionIndex,
-      setShowWorkDeleteAllDialog: this.setShowWorkDeleteAllDialog,
-      setShowEducationDeleteAllDialog: this.setShowEducationDeleteAllDialog
-    });
+    }, ...this.simpleActionHelpers(), ...this.asyncActionHelpers()
+    );
   };
 
   childrenWithProps: Function = (profileFromStore: ProfileGetResult) => {

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -9,6 +9,7 @@ import {
   makeProfileProgressDisplay,
 } from '../util/util';
 import { FETCH_PROCESSING } from '../actions';
+import { setProfileStep } from '../actions/ui';
 import Jumbotron from '../components/Jumbotron';
 import ErrorMessage from '../components/ErrorMessage';
 import ProfileFormContainer from './ProfileFormContainer';
@@ -22,6 +23,7 @@ import {
   EMPLOYMENT_STEP,
   PRIVACY_STEP,
 } from '../constants';
+import { createActionHelper } from '../util/redux';
 import type { Profile } from '../flow/profileTypes';
 
 class ProfilePage extends ProfileFormContainer {
@@ -31,19 +33,21 @@ class ProfilePage extends ProfileFormContainer {
   }
 
   stepTransitions: Function = (): [void|() => void, () => void] => {
-    let setStep = step => () => this.setProfileStep(step);
+    const { dispatch } = this.props;
+    let setStep = createActionHelper(dispatch, setProfileStep);
+    let createStepFunc = step => () => setStep(step);
     switch ( this.currentStep() ) {
     case EDUCATION_STEP:
-      return [setStep(PERSONAL_STEP), setStep(EMPLOYMENT_STEP)];
+      return [createStepFunc(PERSONAL_STEP), createStepFunc(EMPLOYMENT_STEP)];
     case EMPLOYMENT_STEP:
-      return [setStep(EDUCATION_STEP), setStep(PRIVACY_STEP)];
+      return [createStepFunc(EDUCATION_STEP), createStepFunc(PRIVACY_STEP)];
     case PRIVACY_STEP:
       return [
-        setStep(EMPLOYMENT_STEP),
+        createStepFunc(EMPLOYMENT_STEP),
         () => this.context.router.push('/dashboard')
       ];
     default:
-      return [undefined, setStep(EDUCATION_STEP)];
+      return [undefined, createStepFunc(EDUCATION_STEP)];
     }
   };
 

--- a/static/js/flow/generalTypes.js
+++ b/static/js/flow/generalTypes.js
@@ -1,20 +1,9 @@
 // @flow
-import type { Dispatch } from 'redux';
 
 export type Option = {
   value: string;
   label: string;
 };
-
-export type Action = {
-  type: string;
-  payload: any
-};
-
-export type Dispatcher = (d: Dispatch) => Promise;
-export type AsyncActionHelper = (...a: any) => Promise;
-
-
 export type Settings = {
   gaTrackingID: string;
   reactGaDebug: boolean;

--- a/static/js/flow/reduxTypes.js
+++ b/static/js/flow/reduxTypes.js
@@ -1,0 +1,15 @@
+// @flow
+import type { Dispatch } from 'redux';
+
+export type Action = {
+  type: string;
+  payload: any
+};
+
+export type Dispatcher = (d: Dispatch) => Promise;
+
+export type AsyncActionHelper = (...a: any) => Promise;
+
+export type ActionCreator = (...a: any) => Action;
+
+export type AsyncActionCreator = (...a: any) => Dispatcher;

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -24,7 +24,7 @@ import {
   FETCH_SUCCESS,
 } from '../actions';
 import { ui } from './ui';
-import type { Action } from '../flow/generalTypes';
+import type { Action } from '../flow/reduxTypes';
 import type { ProfileGetResult } from '../flow/profileTypes';
 
 export const INITIAL_PROFILES_STATE = {};

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -37,7 +37,7 @@ import {
   PERSONAL_STEP,
 } from '../constants';
 import { calculateDegreeInclusions } from '../util/util';
-import type { Action } from '../flow/generalTypes';
+import type { Action } from '../flow/reduxTypes';
 
 export type UIState = {
   workHistoryEdit:              boolean;

--- a/static/js/util/redux.js
+++ b/static/js/util/redux.js
@@ -1,0 +1,33 @@
+// @flow
+import type {
+  ActionCreator,
+  AsyncActionHelper,
+  AsyncActionCreator
+} from '../flow/reduxTypes';
+import type { Dispatch } from 'redux';
+
+export function createActionHelper(dispatch: Dispatch, actionCreator: Function): (...args: any) => void {
+  return (...args) => dispatch(actionCreator(...args));
+}
+
+/*
+ * returns an array of simple (synchronous) action helpers when passed the
+ * dispatch function and an array of synchronous action creators
+ */
+export type ActionHelpers = Array<{[k: string]: (...args: any) => void}>;
+export function createSimpleActionHelpers(dispatch: Dispatch, actionList: ActionCreator[]): ActionHelpers {
+  return actionList.map(actionCreator => (
+    { [actionCreator.name]: createActionHelper(dispatch, actionCreator) }
+  ));
+}
+
+/*
+ * returns an array of async action helpers from async action creators (those
+ * that return a function taking dispatch as an argument)
+ */
+export type AsyncActionHelpers = Array<{[k: string]: AsyncActionHelper}>;
+export function createAsyncActionHelpers(dispatch: Dispatch, actionList: AsyncActionCreator[]): AsyncActionHelpers {
+  return actionList.map(actionCreator => (
+    { [actionCreator.name]: createActionHelper(dispatch, actionCreator) }
+  ));
+}

--- a/static/js/util/redux_test.js
+++ b/static/js/util/redux_test.js
@@ -1,0 +1,99 @@
+// @flow
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+import {
+  createActionHelper,
+  createSimpleActionHelpers,
+  createAsyncActionHelpers,
+} from './redux';
+
+describe('redux helpers', () => {
+  const MY_ACTION = 'MY_ACTION';
+  let dispatch = sinon.spy();
+  let actionCreator = (arg) => ({
+    type: MY_ACTION, payload: arg
+  });
+
+  describe('createActionHelper', () => {
+    let helper;
+    beforeEach(() => {
+      helper = createActionHelper(dispatch, actionCreator);
+    });
+
+    it('should return a function', () => {
+      assert.isFunction(helper);
+    });
+
+    it('should return a function that calls dispatch', () => {
+      helper();
+      assert(dispatch.called);
+    });
+
+    it('should return a function that passes arguments to dispatch', () => {
+      helper(3);
+      assert(dispatch.calledWith({
+        type: MY_ACTION, payload: 3
+      }));
+    });
+  });
+
+  describe('createSimpleActionHelpers', () => {
+    let actionList = [actionCreator];
+
+    let actions;
+    beforeEach(() => {
+      actions = createSimpleActionHelpers(dispatch, actionList);
+    });
+
+    it('should return an array of objects containing functions', () => {
+      assert.isArray(actions);
+      let [ { actionCreator } ] = actions;
+      assert.isFunction(actionCreator);
+    });
+
+    it('the functions returned should call dispatch with arguments', () => {
+      let [ { actionCreator } ] = actions;
+      actionCreator(3);
+      assert(dispatch.calledWith({
+        type: MY_ACTION, payload: 3
+      }));
+    });
+  });
+
+  describe('createAsyncActionHelpers', () => {
+    const MY_ASYNC_ACTION = 'MY_ASYNC_ACTION';
+    let asyncActionCreator = arg => (dispatch => dispatch({
+      type: MY_ASYNC_ACTION, payload: arg
+    }));
+    let actionList = [asyncActionCreator];
+    let dispatchSpy = sinon.stub().returns(Promise.resolve());
+    let asyncDispatch = (createdActionFunc) => {
+      if ( typeof(createdActionFunc) === 'function' ) {
+        return createdActionFunc(dispatchSpy);
+      }
+    };
+
+
+    let actions;
+    beforeEach(() => {
+      actions = createAsyncActionHelpers(asyncDispatch, actionList);
+    });
+
+    it('should return an array of objects containing functions', () => {
+      assert.isArray(actions);
+      let [ { asyncActionCreator } ] = actions;
+      assert.isFunction(asyncActionCreator);
+    });
+
+
+    it('should return an array of asyncActionCreators', () => {
+      let [ { asyncActionCreator } ] = actions;
+      let dispatched = asyncActionCreator(2);
+      assert.isFulfilled(dispatched);
+      assert(dispatchSpy.calledWith({
+        type: MY_ASYNC_ACTION, payload: 2
+      }));
+    });
+  });
+});


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #712 

#### What's this PR do?

Just abstracts out a little bit of boilerplate. We had a lot of helper methods on `ProfileFormFields` like the following:

```js
dispatchSomeAction: Function = (arg: someType): void => {
  const { dispatch } = this.props;
  dispatch(someAction(arg));
};
```

this abstracts that pattern, so instead we do:

```js
createActionHelper: Function = (actionCreator: Function): (...args: any) => void  => {
  const { dispatch } = this.props;
  return (...args) => dispatch(actionCreator(...args));
};
createActionHelper(someAction);
```

We can do this for most of the action creator helpers we had on `ProfileFormFields`, although anything with more specialized logic than the example above (e.g. `saveProfile`) needs to be left alone.

#### Where should the reviewer start?

Read over the changes.

#### How should this be manually tested?

Make sure there are no regressions on any of the profile components (on `/profile` and `/users`).

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

