### PR TITLE
Added new ProfileImage component

### DIFF
--- a/static/js/components/Jumbotron.js
+++ b/static/js/components/Jumbotron.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 
-import { makeProfileImageUrl } from '../util/util';
+import ProfileImage from './ProfileImage';
 import type { Profile } from '../flow/profileTypes';
 
 class Jumbotron extends React.Component {
@@ -15,18 +15,10 @@ class Jumbotron extends React.Component {
 
   render() {
     const { profile, text } = this.props;
-    let imageUrl = makeProfileImageUrl(profile);
-    return <div className="card">
+    return <div className="card jumbotron">
       <Grid className="card-user">
         <Cell col={2} className="card-image-box">
-          <img
-            src={imageUrl}
-            alt={`Profile image for ${SETTINGS.name}`}
-            className="card-image"
-            style={{
-              marginLeft: "50px"
-            }}
-          />
+          <ProfileImage profile={profile} />
         </Cell>
         <Cell col={5} className="card-name">
           { text }

--- a/static/js/components/ProfileImage.js
+++ b/static/js/components/ProfileImage.js
@@ -1,0 +1,24 @@
+// @flow
+/* global SETTINGS: false */
+import React from 'react';
+
+import { makeProfileImageUrl, getPreferredName } from '../util/util';
+import type { Profile } from '../flow/profileTypes';
+
+export default class ProfileImage extends React.Component {
+  props: {
+    profile: Profile
+  };
+
+  render () {
+    const { profile } = this.props;
+    const imageUrl = makeProfileImageUrl(profile);
+    return (
+      <img
+        src={imageUrl}
+        alt={`Profile image for ${getPreferredName(profile, false)}`}
+        className="card-image"
+      />
+    );
+  }
+}

--- a/static/js/components/User.js
+++ b/static/js/components/User.js
@@ -5,7 +5,7 @@ import { Card, CardMenu } from 'react-mdl/lib/Card';
 import IconButton from 'react-mdl/lib/IconButton';
 import iso3166 from 'iso-3166-2';
 
-import { makeProfileImageUrl } from '../util/util';
+import ProfileImage from './ProfileImage';
 import EmploymentForm from './EmploymentForm';
 import EducationDisplay from './EducationDisplay';
 import UserPagePersonalDialog from './UserPagePersonalDialog.js';
@@ -42,22 +42,12 @@ export default class User extends React.Component {
       }
     };
 
-    let imageUrl = makeProfileImageUrl(profile);
     return <div className="card">
       <UserPagePersonalDialog {...this.props} />
       <Grid className="card-user">
         <Cell col={5} />
-        <Cell col={2} className="card-image-box">
-          <img
-            src={imageUrl}
-            alt={`Profile image for ${profile.preferred_name}`}
-            className="card-image"
-            style={{
-              top: "50%",
-              position: "relative",
-              zIndex: 2
-            }}
-          />
+        <Cell col={2} className="card-image-box user-page-image">
+          <ProfileImage profile={profile} />
         </Cell>
       </Grid>
       <Card shadow={0} style={{width: "100%"}}>

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -12,6 +12,16 @@ c.validation-wrapper {
 .main-content {
   padding: 20px 0px;
 
+  .jumbotron img {
+     margin-left: 50px;
+   }
+
+   .user-page-image img {
+     top: 50%;
+     position: relative;
+     z-index: 2;
+   }
+
   .card {
     border: 1px solid #dddddd;
     border-radius: 5px;


### PR DESCRIPTION
#### What are the relevant tickets?

closes #735 

#### What's this PR do?

This just adds a small utility component that takes a `Profile` and displays the user's profile image.

#### Where should the reviewer start?

Take a look at the new class, make sure it makes sense.

#### How should this be manually tested?

You should still see the same profile image when you go to the dashboard or to the `/users` page.

#### Any background context you want to provide?

I want to use profile images in a couple more places in the searchkit and user menu PRs, this is just a small atomic change in that direction.

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

