### PR TITLE
Removed box-shadow from Navbar

### DIFF
--- a/static/scss/navbar.scss
+++ b/static/scss/navbar.scss
@@ -11,6 +11,8 @@
 }
 
 .micromasters-nav {
+  box-shadow: none !important;
+
   .micromasters-title {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
#### What are the relevant tickets?

closes #741 

#### What's this PR do?

just sets `box-shadow: none !important` on the navbar.

#### Where should the reviewer start?

#### How should this be manually tested?

Make sure the navbar doesn't have a shadow. I couldn't get the styling to apply without `!important`, if you know of a sneaky way to avoid using the important keyword that would be :100: (I think some of the difficulty is because some styles are applied via JS by material design lite).

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

