### PR TITLE
pass the username to clearProfileEdit

### DIFF
--- a/static/js/components/EducationDialog.js
+++ b/static/js/components/EducationDialog.js
@@ -44,11 +44,12 @@ export default class EducationDialog extends ProfileFormFields {
       setEducationDegreeLevel,
       setEducationDialogIndex,
       clearProfileEdit,
+      profile: { username },
     } = this.props;
     setEducationDialogVisibility(false);
     setEducationDegreeLevel('');
     setEducationDialogIndex(null);
-    clearProfileEdit();
+    clearProfileEdit(username);
   };
 
   saveEducationForm: Function = (): void => {

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -76,9 +76,13 @@ class EmploymentForm extends ProfileFormFields {
   };
 
   closeWorkDialog: Function = (): void => {
-    const { setWorkDialogVisibility, clearProfileEdit } = this.props;
+    const {
+      setWorkDialogVisibility,
+      clearProfileEdit,
+      profile: { username }
+    } = this.props;
     setWorkDialogVisibility(false);
-    clearProfileEdit();
+    clearProfileEdit(username);
   };
 
   addWorkHistoryEntry: Function = (): void => {

--- a/static/js/components/UserPagePersonalDialog.js
+++ b/static/js/components/UserPagePersonalDialog.js
@@ -18,9 +18,13 @@ export default class UserPagePersonalDialog extends React.Component {
   };
 
   closePersonalDialog: Function = (): void => {
-    const { setUserPageDialogVisibility, clearProfileEdit } = this.props;
+    const {
+      setUserPageDialogVisibility,
+      clearProfileEdit,
+      profile: { username }
+    } = this.props;
     setUserPageDialogVisibility(false);
-    clearProfileEdit();
+    clearProfileEdit(username);
   };
 
   savePersonalInfo: Function = (): void => {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #748 

#### What's this PR do?

We need to pass a username to the `clearProfileEdit` action helper because redux has to know the username for which it should clear the `edit` object. We weren't doing so, which meant that validation errors that should have been removed by `clearProfileEdit` were hanging around and doing some strange things.

#### Where should the reviewer start?

Read over the code!

#### How should this be manually tested?

Currently, on master, if you do the following:

1. go to `/users`
2. create a validation error on the personal info form
3. click 'save'
4. click 'cancel'

you should see the `clearProfileEdit` action being dispatched, but if you inspect the redux state you'll note that the `edit` object is actually still there (`profiles -> ${username} -> edit`). The same holds for editing a work history or education history entry.

Basically, these changes should ensure that the correct `edit` object is actually cleared.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

