### PR TITLE
implemented ValidationAlert to alert user to problems in form dialogs

### DIFF
--- a/static/js/components/EducationDialog.js
+++ b/static/js/components/EducationDialog.js
@@ -12,6 +12,8 @@ import SelectField from './inputs/SelectField';
 import CountrySelectField from './inputs/CountrySelectField';
 import StateSelectField from './inputs/StateSelectField';
 import FieldsOfStudySelectField from './inputs/FieldsOfStudySelectField';
+import ValidationAlert from './ValidationAlert';
+
 import type { UIState } from '../reducers/ui';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { Validator, UIValidator } from '../util/validation';
@@ -130,22 +132,20 @@ export default class EducationDialog extends ProfileFormFields {
   render () {
     const { ui: {educationDialogVisibility } } = this.props;
 
-    let actions = [
+    let actions = <ValidationAlert {...this.props}>
       <Button
         type='button'
-        key='cancel'
         className="cancel-button"
         onClick={this.clearEducationEdit}>
         Cancel
-      </Button>,
+      </Button>
       <Button
-        key='save'
         type='button'
         className="save-button"
         onClick={this.saveEducationForm}>
         Save
-      </Button>,
-    ];
+      </Button>
+    </ValidationAlert>;
 
     return (
       <Dialog

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -19,6 +19,8 @@ import ConfirmDeletion from './ConfirmDeletion';
 import SelectField from './inputs/SelectField';
 import CountrySelectField from './inputs/CountrySelectField';
 import StateSelectField from './inputs/StateSelectField';
+import ValidationAlert from './ValidationAlert';
+
 import type { WorkHistoryEntry } from '../flow/profileTypes';
 import type { Validator, UIValidator } from '../util/validation';
 import type {
@@ -257,22 +259,20 @@ class EmploymentForm extends ProfileFormFields {
       errors,
       showSwitch,
     } = this.props;
-    const actions = [
+    const actions = <ValidationAlert {...this.props}>
       <Button
         type='button'
-        key='cancel'
         className="cancel-button"
         onClick={this.closeWorkDialog}>
         Cancel
-      </Button>,
+      </Button>
       <Button
-        key='save'
         type='button'
         className="save-button"
         onClick={this.saveWorkHistoryEntry}>
         Save
-      </Button>,
-    ];
+      </Button>
+    </ValidationAlert>;
     let workSwitch = () => {
       if ( showSwitch ) {
         return (

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -5,6 +5,7 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 import PersonalForm from './PersonalForm';
 import ProfileProgressControls from './ProfileProgressControls';
 import { personalValidation } from '../util/validation';
+import ValidationAlert  from './ValidationAlert';
 import type {
   Profile,
   SaveProfileFunc,
@@ -40,6 +41,7 @@ class PersonalTab extends React.Component {
         <Cell col={1} />
         <Cell col={1} />
         <Cell col={10}>
+          <ValidationAlert {...this.props} />
           <ProfileProgressControls
             {...this.props}
             nextBtnLabel="Save and Continue"

--- a/static/js/components/PrivacyTab.js
+++ b/static/js/components/PrivacyTab.js
@@ -5,6 +5,7 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 import PrivacyForm from './PrivacyForm';
 import ProfileProgressControls from './ProfileProgressControls';
 import ProfileFormFields from '../util/ProfileFormFields';
+import ValidationAlert from './ValidationAlert';
 import {
   combineValidators,
   personalValidation,
@@ -38,6 +39,7 @@ class PrivacyTab extends ProfileFormFields {
             <PrivacyForm {...this.props} />
           </Cell>
           <Cell col={12}>
+            <ValidationAlert {...this.props} />
             <ProfileProgressControls
               {...this.props}
               nextBtnLabel="I'm Done!"

--- a/static/js/components/UserPagePersonalDialog.js
+++ b/static/js/components/UserPagePersonalDialog.js
@@ -5,6 +5,7 @@ import Button from 'react-mdl/lib/Button';
 
 import { personalValidation } from '../util/validation';
 import PersonalForm from './PersonalForm';
+import ValidationAlert from './ValidationAlert';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
@@ -36,22 +37,20 @@ export default class UserPagePersonalDialog extends React.Component {
 
   render () {
     const { ui: { userPageDialogVisibility } } = this.props;
-    const actions = [
+    const actions = <ValidationAlert {...this.props}>
       <Button
         type='button'
-        key='cancel'
         className='cancel-button'
         onClick={this.closePersonalDialog}>
         Cancel
-      </Button>,
+      </Button>
       <Button
-        key='save'
         type='button'
         className='save-button'
         onClick={this.savePersonalInfo}>
         Save
       </Button>
-    ];
+    </ValidationAlert>;
 
     return (
       <Dialog

--- a/static/js/components/ValidationAlert.js
+++ b/static/js/components/ValidationAlert.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import _ from 'lodash';
+
+import type { ValidationErrors } from '../flow/profileTypes';
+
+export default class ValidationAlert extends React.Component {
+  props: {
+    errors:   ValidationErrors,
+    children: React$Element[],
+  };
+
+  static message = "Please fix the errors above and try again";
+
+  alertMessage: Function = (): React$Element|void => {
+    const { errors } = this.props;
+    if ( !_.isEmpty(errors) ) {
+      return (
+        <span className="message">
+          { this.constructor.message }
+        </span>
+      );
+    }
+  };
+
+  render () {
+    const { children } = this.props;
+    return (
+      <div className="validation-alert">
+        { this.alertMessage() }
+        <div className="actions">
+          { children }
+        </div>
+      </div>
+    );
+  }
+}

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -33,6 +33,7 @@ import IntegrationTestHelper from '../util/integration_test_helper';
 import * as api from '../util/api';
 import { USER_PROFILE_RESPONSE, HIGH_SCHOOL, DOCTORATE } from '../constants';
 import { workEntriesByDate, educationEntriesByDate } from '../util/sorting';
+import ValidationAlert from '../components/ValidationAlert';
 
 describe("UserPage", function() {
   this.timeout(5000);
@@ -135,6 +136,9 @@ describe("UserPage", function() {
             TestUtils.Simulate.click(save);
             let state = helper.store.getState();
             assert.deepEqual(state.profiles.jane.edit.errors, validationExpectation);
+            let validationInfoText = document.querySelector('.validation-alert').
+              querySelector('.message').textContent;
+            assert.equal(validationInfoText, ValidationAlert.message);
             modifyTextField(input, removeErrorValue);
           }).then(() => {
             let state = helper.store.getState();

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -5,6 +5,7 @@
 @import "homepage";
 @import "program_page";
 @import "user_menu";
+@import "validation-alert";
 
 $border-box-sizing: true !global;
 

--- a/static/scss/validation-alert.scss
+++ b/static/scss/validation-alert.scss
@@ -1,0 +1,6 @@
+.validation-alert {
+  .message {
+    color: red;
+    padding-right: 16px;
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #635 

#### What's this PR do?

This adds a visual indicator to the profile dialogs which lives right above the 'cancel' and 'save' buttons. If there's a validation error it will look like this:

![error_alert](https://cloud.githubusercontent.com/assets/6207644/17153055/a5c953a0-5348-11e6-8d23-8b12bfdd4538.png)

Otherwise it looks as it currently does on master.

#### Where should the reviewer start?

Read the changes!

#### How should this be manually tested?

Go to `/users` and do the following:

1. open the personal info dialog
2. enter something invalid (like deleting your last name)
3. click 'save'
4. confirm the message shows up
5. fix the error (add a last name)
6. confirm the error message goes away

then do the same thing for the education and work history dialogs as well.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

