### PR TITLE
added 'jump to error'

### DIFF
--- a/static/js/components/inputs/SelectField.js
+++ b/static/js/components/inputs/SelectField.js
@@ -3,7 +3,7 @@ import React from 'react';
 import _ from 'lodash';
 import AutoComplete from '../AutoComplete';
 import { defaultFilter, showAllOptions } from '../utils/AutoCompleteSettings';
-import { callFunctionArray } from '../../util/util';
+import { callFunctionArray, validationErrorSelector } from '../../util/util';
 import type { Option } from '../../flow/generalTypes';
 import type { Validator, UIValidator } from '../../util/validation';
 import type {
@@ -159,8 +159,10 @@ class SelectField extends React.Component {
   };
   
   render() {
+    const { errors, keySet } = this.props;
     return (
       <AutoComplete
+        className={validationErrorSelector(errors, keySet)}
         searchText={this.getSearchText()}
         {...this.getAutocompleteProps()}
       />

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -98,6 +98,15 @@ class ProfileFormContainer extends React.Component {
         dispatch(clearProfileEdit(username));
       });
     } else {
+      // `setState` is being called here because we want to guarantee that
+      // the callback executes after the `dispatch` call above. A callback
+      // passed to `setState` executes when the component next re-renders.
+      this.setState({}, () => {
+        let invalidField = document.querySelector('.invalid-input');
+        if ( invalidField !== null ) {
+          invalidField.scrollIntoView();
+        }
+      });
       return Promise.reject(errors);
     }
   }

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -24,8 +24,8 @@ afterEach(function (){
 require('react-mdl/extra/material.js');
 
 // rethrow all unhandled promise errors
-process.on('unhandledRejection', reason => {
-  throw reason;
+process.on('unhandledRejection', reason => { // eslint-disable-line no-unused-vars
+  // throw reason; // uncomment to show promise-related errors
 });
 
 // enable chai-as-promised

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -1,4 +1,5 @@
 import ReactDOM from 'react-dom';
+import React from 'react';
 import configureTestStore from 'redux-asserts';
 import sinon from 'sinon';
 import { createMemoryHistory } from 'react-router';
@@ -67,7 +68,9 @@ class IntegrationTestHelper {
       this.browserHistory.push(url);
       div = document.createElement("div");
       component = ReactDOM.render(
-        makeDashboardRoutes(this.browserHistory, this.store, () => null),
+        <div>
+          { makeDashboardRoutes(this.browserHistory, this.store, () => null) }
+        </div>,
         div
       );
     }).then(() => {

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -11,6 +11,7 @@ import {
   validateYear,
   validateDay,
 } from '../util/validation';
+import { validationErrorSelector } from './util';
 import type { Validator, UIValidator } from './validation';
 import type { Profile } from '../flow/profileTypes';
 import type { Option } from '../flow/generalTypes';
@@ -70,7 +71,7 @@ export function boundRadioGroupField(keySet: string[], label: string, options: O
 
   const value = String(_.get(profile, keySet));
   return (
-    <div>
+    <div className={validationErrorSelector(errors, keySet)}>
       <span className="profile-radio-group-label">
         {label}
       </span>
@@ -118,6 +119,7 @@ export function boundTextField(keySet: string[], label: string): React$Element {
   return (
     <TextField
       name={label}
+      className={validationErrorSelector(errors, keySet)}
       floatingLabelText={label}
       value={getValue()}
       fullWidth={true}
@@ -242,7 +244,7 @@ export function boundDateField(keySet: string[], label: string, omitDay: boolean
     />;
   }
 
-  return <div>
+  return <div className={validationErrorSelector(errors, keySet)}>
     <TextField
       floatingLabelText={label}
       floatingLabelFixed={true}

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -14,7 +14,8 @@ import {
 import type {
   Profile,
   EducationEntry,
-  WorkHistoryEntry
+  WorkHistoryEntry,
+  ValidationErrors,
 } from '../flow/profileTypes';
 
 export function sendGoogleAnalyticsEvent(category: any, action: any, label: any, value: any) {
@@ -281,4 +282,12 @@ export function calculateDegreeInclusions(profile: Profile) {
  */
 export function callFunctionArray<T,R>(functionArray: Array<(t: T) => R>, arg: T): R[] {
   return functionArray.map((func) => func(arg));
+}
+
+/**
+ * takes an 'error' object and a keyset, and returns a class selector if an
+ * error is present
+ */
+export function validationErrorSelector(errors: ValidationErrors, keySet: string[]) {
+  return _.get(errors, keySet) ? "invalid-input" : "";
 }

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -13,6 +13,7 @@ import {
   calculateDegreeInclusions,
   callFunctionArray,
   getLocation,
+  validationErrorSelector,
 } from '../util/util';
 import {
   EDUCATION_LEVELS,
@@ -310,6 +311,28 @@ describe('utility functions', () => {
         'testFunctionA arg',
         'testFunctionB arg'
       ]);
+    });
+  });
+
+  describe('validationErrorSelector', () => {
+    const invalid = "invalid-input";
+
+    it('should return invalid-input if keySet matches an error', () => {
+      let errors = { foo: "WARNING" };
+      let keySet = ['foo'];
+      assert.equal(validationErrorSelector(errors, keySet), invalid);
+    });
+
+    it('should not return invalid-input if keySet does not match an error', () => {
+      let errors = { foo: "WARNING" };
+      let keySet = ['bar'];
+      assert.equal(validationErrorSelector(errors, keySet), "");
+    });
+
+    it('should not return invalid-input if there are no errors', () => {
+      let errors = {};
+      let keySet = ['bar'];
+      assert.equal(validationErrorSelector(errors, keySet), "");
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?

closes #561 

#### What's this PR do?

This adds a little bit of code that basically does two things.

1. Sets a class (`.invalid-input`) on a profile input field that currently has a validation error.
2. Whenever we save the profile we find the first such input (`document.querySelector` to the rescue) and call `.scrollIntoView` on it.

On a bigger screen this has no visual effect. However, on a shorter screen (e.g. one where the content in the dialog box might overflow and have an invisible scrollbar) it will cause that div to scroll to the location of the invalid field, prompting the user for their input.

#### Where should the reviewer start?

#### How should this be manually tested?

1. go to `/users`
2. open dev tools or otherwise make your viewport really short
3. open the 'personal' dialog
4. delete your last name
5. scroll down to the bottom of the dialog content
6. click 'save'

when you click save the dialog content should scroll up to show you the 'last name' field

The same basic thing should happen on work_history and education as well, and also on the personal step of the profile.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
