### PR TITLE
Removed .name call on anonymous functions for createActionHelper

### DIFF
--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -105,26 +105,26 @@ class ProfileFormContainer extends React.Component {
   simpleActionHelpers: Function = (): ActionHelpers => {
     const { dispatch } = this.props;
     return createSimpleActionHelpers(dispatch, [
-      setWorkDialogVisibility,
-      setWorkDialogIndex,
-      clearProfileEdit,
-      setEducationDialogVisibility,
-      setEducationDialogIndex,
-      setEducationDegreeLevel,
-      setUserPageDialogVisibility,
-      setShowEducationDeleteDialog,
-      setShowWorkDeleteDialog,
-      setDeletionIndex,
-      setShowWorkDeleteAllDialog,
-      setShowEducationDeleteAllDialog,
+      ['setWorkDialogVisibility', setWorkDialogVisibility],
+      ['setWorkDialogIndex', setWorkDialogIndex],
+      ['clearProfileEdit', clearProfileEdit],
+      ['setEducationDialogVisibility', setEducationDialogVisibility],
+      ['setEducationDialogIndex', setEducationDialogIndex],
+      ['setEducationDegreeLevel', setEducationDegreeLevel],
+      ['setUserPageDialogVisibility', setUserPageDialogVisibility],
+      ['setShowEducationDeleteDialog', setShowEducationDeleteDialog],
+      ['setShowWorkDeleteDialog', setShowWorkDeleteDialog],
+      ['setDeletionIndex', setDeletionIndex],
+      ['setShowWorkDeleteAllDialog', setShowWorkDeleteAllDialog],
+      ['setShowEducationDeleteAllDialog', setShowEducationDeleteAllDialog],
     ]);
   };
 
   asyncActionHelpers: Function = (): AsyncActionHelpers => {
     const { dispatch } = this.props;
     return createAsyncActionHelpers(dispatch, [
-      setEducationDegreeInclusions,
-      setWorkHistoryEdit
+      ['setEducationDegreeInclusions', setEducationDegreeInclusions],
+      ['setWorkHistoryEdit', setWorkHistoryEdit],
     ]);
   };
 

--- a/static/js/util/redux.js
+++ b/static/js/util/redux.js
@@ -15,9 +15,10 @@ export function createActionHelper(dispatch: Dispatch, actionCreator: Function):
  * dispatch function and an array of synchronous action creators
  */
 export type ActionHelpers = Array<{[k: string]: (...args: any) => void}>;
-export function createSimpleActionHelpers(dispatch: Dispatch, actionList: ActionCreator[]): ActionHelpers {
-  return actionList.map(actionCreator => (
-    { [actionCreator.name]: createActionHelper(dispatch, actionCreator) }
+export type ActionManifest = Array<[string, ActionCreator]>;
+export function createSimpleActionHelpers(dispatch: Dispatch, actionList: ActionManifest): ActionHelpers {
+  return actionList.map(([name, actionCreator]) => (
+    { [name]: createActionHelper(dispatch, actionCreator) }
   ));
 }
 
@@ -26,8 +27,9 @@ export function createSimpleActionHelpers(dispatch: Dispatch, actionList: Action
  * that return a function taking dispatch as an argument)
  */
 export type AsyncActionHelpers = Array<{[k: string]: AsyncActionHelper}>;
-export function createAsyncActionHelpers(dispatch: Dispatch, actionList: AsyncActionCreator[]): AsyncActionHelpers {
-  return actionList.map(actionCreator => (
-    { [actionCreator.name]: createActionHelper(dispatch, actionCreator) }
+export type AsyncActionManifest = Array<[string, AsyncActionCreator]>;
+export function createAsyncActionHelpers(dispatch: Dispatch, actionList: AsyncActionManifest): AsyncActionHelpers {
+  return actionList.map(([name, actionCreator]) => (
+    { [name]: createActionHelper(dispatch, actionCreator) }
   ));
 }

--- a/static/js/util/redux_test.js
+++ b/static/js/util/redux_test.js
@@ -39,7 +39,9 @@ describe('redux helpers', () => {
   });
 
   describe('createSimpleActionHelpers', () => {
-    let actionList = [actionCreator];
+    let actionList = [
+      ['actionCreator', actionCreator],
+    ];
 
     let actions;
     beforeEach(() => {
@@ -66,7 +68,10 @@ describe('redux helpers', () => {
     let asyncActionCreator = arg => (dispatch => dispatch({
       type: MY_ASYNC_ACTION, payload: arg
     }));
-    let actionList = [asyncActionCreator];
+    let actionList = [
+      ['asyncActionCreator', asyncActionCreator],
+    ];
+
     let dispatchSpy = sinon.stub().returns(Promise.resolve());
     let asyncDispatch = (createdActionFunc) => {
       if ( typeof(createdActionFunc) === 'function' ) {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #788 

#### What's this PR do?

Removes the call to `.name` on anonymous functions, because this value isn't invariant under minification (the variable name the function is bound to changes to `a` or something).

#### Where should the reviewer start?

#### How should this be manually tested?

Make sure that there are no changes in any of the profile functionality.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

