### PR TITLE
Enforced permissions on profiles REST API

### DIFF
--- a/profiles/permissions.py
+++ b/profiles/permissions.py
@@ -8,6 +8,10 @@ from rest_framework.permissions import (
     SAFE_METHODS,
 )
 
+from roles.roles import (
+    Instructor,
+    Staff,
+)
 from profiles.models import Profile
 
 
@@ -40,6 +44,13 @@ class CanSeeIfNotPrivate(BasePermission):
         profile = get_object_or_404(Profile, user__social_auth__uid=view.kwargs['user'])
 
         if request.user == profile.user:
+            return True
+
+        # If viewer is instructor or staff in the program, skip this check
+        if not request.user.is_anonymous() and request.user.role_set.filter(
+                role__in=(Staff.ROLE_ID, Instructor.ROLE_ID),
+                program__programenrollment__user__profile=profile,
+        ).exists():
             return True
 
         # private profiles


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #89 

#### What's this PR do?
Enforces permissions on the profiles API

#### Where should the reviewer start?
profiles/permissions.py

#### How should this be manually tested?
Create two users and a program if necessary. One user should have `account_privacy` set to private and be assigned to the program in the `ProgramEnrollment` model. The other user should have an instructor or staff role added for the same program using the `Role` model.

Log in as the instructor or staff, then view the profile of the other user by going to `/api/v0/profiles/username/`. You should see everything that that user can see for their own profile. For example you should see `agreed_to_terms_of_service` which is not shown even in public profiles to other students.

