### PR TITLE
Replaced filtering with hierarchical filtering

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -207,7 +207,7 @@ def program_enrolled_user_mapping():
     mapping = Mapping(USER_DOC_TYPE)
     mapping.field("id", "long")
     mapping.field("user_id", "long")
-    mapping.field("profile", "nested", properties={
+    mapping.field("profile", "object", properties={
         'account_privacy': NOT_ANALYZED_STRING_TYPE,
         'agreed_to_terms_of_service': BOOL_TYPE,
         'birth_city': NOT_ANALYZED_STRING_TYPE,
@@ -252,7 +252,7 @@ def program_enrolled_user_mapping():
             'state_or_territory': NOT_ANALYZED_STRING_TYPE,
         }},
     })
-    mapping.field("program", "nested", properties={
+    mapping.field("program", "object", properties={
         'id': LONG_TYPE,
         'grade_average': LONG_TYPE,
         'enrollments': {'type': 'nested', 'properties': {

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   SearchkitComponent,
+  HierarchicalMenuFilter,
   Hits,
   NoHits,
   SelectedFilters,
@@ -10,12 +11,25 @@ import {
 } from 'searchkit';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Card from 'react-mdl/lib/Card/Card';
+import iso3166 from 'iso-3166-2';
 
 import LearnerResult from './search/LearnerResult';
 import CountryRefinementOption from './search/CountryRefinementOption';
 import FilterVisibilityToggle from './search/FilterVisibilityToggle';
 import HitsCount from './search/HitsCount';
 import type { Option } from '../flow/generalTypes';
+
+let makeSearchkitTranslations: () => Object = () => {
+  let translations = {};
+  for (let code of Object.keys(iso3166.data)) {
+    translations[code] = iso3166.data[code].name;
+    for (let stateCode of Object.keys(iso3166.data[code].sub)) {
+      translations[stateCode] = iso3166.data[code].sub[stateCode].name;
+    }
+  }
+
+  return translations;
+};
 
 export default class LearnerSearch extends SearchkitComponent {
   props: {
@@ -28,12 +42,7 @@ export default class LearnerSearch extends SearchkitComponent {
     { value: 'dob', label: "Sort: dob" },
   ];
 
-  profileFieldOptions: Function = (): Object => ({
-    type: 'nested',
-    options: {
-      path: 'profile'
-    }
-  });
+  searchkitTranslations: Object = makeSearchkitTranslations();
 
   render () {
     return (
@@ -43,13 +52,12 @@ export default class LearnerSearch extends SearchkitComponent {
             <Card className="fullwidth">
               <FilterVisibilityToggle
                 {...this.props}
-                filterName="birth-country"
+                filterName="birth-location"
               >
                 <RefinementListFilter
-                  id="country"
-                  title="Country of Birth"
+                  id="birth_location"
+                  title="Place of Birth"
                   field="profile.birth_country"
-                  fieldOptions={this.profileFieldOptions()}
                   itemComponent={CountryRefinementOption}
                 />
               </FilterVisibilityToggle>
@@ -57,12 +65,11 @@ export default class LearnerSearch extends SearchkitComponent {
                 {...this.props}
                 filterName="residence-country"
               >
-                <RefinementListFilter
+                <HierarchicalMenuFilter
+                  fields={["profile.country", "profile.state_or_territory"]}
+                  title="Current Location"
                   id="country"
-                  title="Country of Residence"
-                  field="profile.country"
-                  fieldOptions={this.profileFieldOptions()}
-                  itemComponent={CountryRefinementOption}
+                  translations={this.searchkitTranslations}
                 />
               </FilterVisibilityToggle>
             </Card>

--- a/static/scss/search_page.scss
+++ b/static/scss/search_page.scss
@@ -43,6 +43,26 @@
       }
     }
 
+    .sk-hierarchical-menu-list {
+      .sk-hierarchical-menu-list__header {
+        margin: 15px;
+        font-size: 17px;
+      }
+
+      .sk-hierarchical-menu-list__root {
+        margin-left: 25px;
+        margin-right: 40px;
+        .sk-hierarchical-menu-option {
+          >div {
+            justify-content: space-between;
+          }
+          .sk-hierarchical-menu-option__text {
+            margin-right: 15px;
+          }
+        }
+      }
+    }
+
     .filter-visibility-toggle.closed {
       i.closed {
         transform: rotate(0.75turn);
@@ -52,7 +72,7 @@
         -o-transform: rotate(0.75turn);
       }
 
-      .sk-panel__content {
+      .sk-panel__content, .sk-hierarchical-menu-list__root {
         display: none;
       }
     }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #785

#### What's this PR do?
Replaces the country facets with a hierarchical facets

#### Where should the reviewer start?
LearnerSearch.js

#### How should this be manually tested?
Run `./manage.py recreate_index`. Then go to the learner search and try faceting on a state or territory

#### Any background context you want to provide?
`profile` and `program` don't need to be nested because there is only one of them, so these are now indexed as `object`. We don't have checkboxes for now because there's no equivalent `itemComponent` prop available for `HierarchicalMenuFilter`. Also, countries and states are translated in the Javascript, but we may want to change our indexing to store with their full names in the future.

`birth_country` was left alone because we're planning on removing `birth_state_or_territory` in the near future: #737 

#### Screenshots (if appropriate)
![screenshot from 2016-08-08 15-37-49](https://cloud.githubusercontent.com/assets/863262/17493382/15fd425a-5d7e-11e6-9748-9bdd1ed97234.png)

