### PR TITLE
Search REST API Proxy

### DIFF
--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -11,6 +11,7 @@ from wagtail.wagtailcore import urls as wagtail_urls
 from courses.views import ProgramViewSet, CourseRunViewSet
 from dashboard.views import UserDashboard
 from profiles.views import ProfileViewSet
+from search.views import ElasticProxyView
 
 router = routers.DefaultRouter()
 router.register(r'programs', ProgramViewSet)
@@ -23,6 +24,7 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^api/v0/', include(router.urls)),
     url(r'^api/v0/dashboard/$', UserDashboard.as_view(), name='dashboard_api'),
+    url(r'^api/v0/search/(?P<elastic_url>.*)', ElasticProxyView.as_view(), name='search_api'),
     url(r'^status/', include('server_status.urls')),
 
     # Wagtail

--- a/roles/api.py
+++ b/roles/api.py
@@ -1,0 +1,23 @@
+"""
+API for roles
+"""
+from rolepermissions.verifications import has_object_permission
+
+from roles.models import Role
+
+
+def get_advance_searchable_programs(user):
+    """
+    Helper function to retrieve all the programs where the user is allowed to search
+
+    Args:
+        user (User): Django user instance
+    Returns:
+        list: list of courses.models.Program instances
+    """
+    user_role_program = Role.objects.filter(user=user)
+    programs = [
+        role.program for role in user_role_program
+        if has_object_permission('can_advance_search', user, role.program)
+    ]
+    return programs

--- a/roles/api_test.py
+++ b/roles/api_test.py
@@ -1,0 +1,37 @@
+"""
+Tests for the API module
+"""
+
+from courses.factories import ProgramFactory
+from profiles.factories import UserFactory
+from roles.api import get_advance_searchable_programs
+from roles.models import Role
+from roles.roles import Staff
+from search.base import ESTestCase
+
+
+class APITests(ESTestCase):
+    """Tests for the roles apis"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super(APITests, cls).setUpTestData()
+        # create an user
+        cls.user = UserFactory.create()
+        # create the programs
+        cls.program1 = ProgramFactory.create(live=True)
+        cls.program2 = ProgramFactory.create(live=True)
+
+    def test_get_advance_searchable_programs(self):
+        """
+        Test that the user can only search the programs she has permissions on
+        """
+        assert len(get_advance_searchable_programs(self.user)) == 0
+        Role.objects.create(
+            user=self.user,
+            program=self.program1,
+            role=Staff.ROLE_ID
+        )
+        search_progs = get_advance_searchable_programs(self.user)
+        assert len(search_progs) == 1
+        assert self.program1.id == search_progs[0].id

--- a/search/base.py
+++ b/search/base.py
@@ -3,7 +3,7 @@ Base test classes for search
 """
 from django.test import TestCase
 
-from search.api import clear_index
+from search.api import recreate_index
 
 
 class ESTestCase(TestCase):
@@ -13,4 +13,4 @@ class ESTestCase(TestCase):
 
     def setUp(self):
         super(ESTestCase, self).setUp()
-        clear_index()
+        recreate_index()

--- a/search/permissions.py
+++ b/search/permissions.py
@@ -1,0 +1,20 @@
+"""
+Permission classes for search views
+"""
+
+from rolepermissions.verifications import has_permission
+from rest_framework.permissions import BasePermission
+
+from roles.roles import Permissions
+
+
+class UserCanSearchPermission(BasePermission):
+    """
+    Allow the user if she has the permission to search any program.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Returns True if the user has the 'can_advance_search' permission.
+        """
+        return has_permission(request.user, Permissions.CAN_ADVANCE_SEARCH)

--- a/search/permissions_test.py
+++ b/search/permissions_test.py
@@ -1,0 +1,47 @@
+"""
+Tests for permissions classes
+"""
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+
+from courses.factories import ProgramFactory
+from profiles.factories import UserFactory
+from roles.models import Role
+from roles.roles import Staff
+from search import permissions
+from search.base import ESTestCase
+
+
+class PermissionsTests(ESTestCase):
+    """Tests for the search view permissions"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super(PermissionsTests, cls).setUpTestData()
+        # create an user
+        cls.user = UserFactory.create()
+        # create the program
+        cls.program = ProgramFactory.create(live=True)
+
+    def setUp(self):
+        super(PermissionsTests, self).setUp()
+        self.request = RequestFactory().get('/')
+        self.request.user = AnonymousUser()
+
+    def test_user_can_search(self):
+        """
+        Checks that an user can search only if she has the right permissions
+        """
+        perm = permissions.UserCanSearchPermission()
+        # the anonymous user does not have permission to search
+        assert perm.has_permission(self.request, None) is False
+        # neither the user by default
+        self.request.user = self.user
+        assert perm.has_permission(self.request, None) is False
+        # but if the user has a proper role, she has permission
+        Role.objects.create(
+            user=self.user,
+            program=self.program,
+            role=Staff.ROLE_ID
+        )
+        assert perm.has_permission(self.request, None) is True

--- a/search/views.py
+++ b/search/views.py
@@ -1,0 +1,85 @@
+"""
+Views for the Search app
+"""
+
+import logging
+
+from django.conf import settings
+from elasticsearch_dsl import Search, Q
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from roles.api import get_advance_searchable_programs
+from search.api import (
+    DOC_TYPES,
+    get_conn
+)
+
+log = logging.getLogger(__name__)
+
+
+class ElasticProxyView(APIView):
+    """
+    Elasticsearch proxy needed to enforce authentication and permissions
+    """
+    authentication_classes = (SessionAuthentication, )
+    permission_classes = (IsAuthenticated, )
+
+    def dispatch(self, request, *args, **kwargs):
+        # import pdb
+        # pdb.set_trace()
+        return APIView.dispatch(self, request, *args, **kwargs)
+
+    def _search_elasicsearch(self, request):
+        """
+        Common function that will take care of handling requests coming from different methods.
+        """
+        # make sure there is a live connection
+        get_conn()
+
+        # create a search object and load the query coming from the client
+        search = Search(index=settings.ELASTICSEARCH_INDEX, doc_type=DOC_TYPES)
+        search = search.from_dict(request.data)
+
+        # extract all the programs where the user is allowed to search
+        users_allowed_programs = get_advance_searchable_programs(request.user)
+        # if the user cannot search any program, return an error
+        if not users_allowed_programs:
+            return Response(
+                status=status.HTTP_403_FORBIDDEN,
+                data={'error': 'no_available_programs'}
+            )
+        # no matter what the query is, limit the programs to the allowed ones
+        # if this is a superset of what searchkit sends, this will not impact the result
+        query_limit = Q(
+            'nested',
+            path="program",
+            query=Q(
+                'bool',
+                should=[
+                    Q('term', **{'program.id': program.id}) for program in users_allowed_programs
+                ]
+            ),
+        )
+        search = search.query(query_limit)
+        # execute the query
+        results = search.execute()
+        # return the result as a dictionary
+        return Response(
+            results.to_dict()
+        )
+
+    def get(self, request, *args, **kwargs):
+        """
+        Handler for GET requests
+        """
+        return self._search_elasicsearch(request)
+
+    def post(self, request, *args, **kwargs):
+        """
+        Handler for POST requests
+        """
+        return self._search_elasicsearch(request)

--- a/search/views_test.py
+++ b/search/views_test.py
@@ -1,0 +1,164 @@
+"""
+Tests for the search view
+"""
+from django.core.urlresolvers import reverse
+from django.db.models.signals import post_save
+from factory.django import mute_signals
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from courses.factories import ProgramFactory
+from dashboard.factories import ProgramEnrollmentFactory
+from profiles.factories import ProfileFactory, UserFactory
+from roles.models import Role
+from roles.roles import Staff
+from search.base import ESTestCase
+
+
+class SearchTests(ESTestCase, APITestCase):
+    """Tests for the search api view"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super(SearchTests, cls).setUpTestData()
+        # create some students
+        with mute_signals(post_save):
+            cls.students = [(ProfileFactory.create()).user for _ in range(30)]
+        # create the programs
+        cls.program1 = ProgramFactory.create(live=True)
+        cls.program2 = ProgramFactory.create(live=True)
+        cls.program3 = ProgramFactory.create(live=True)
+
+        # enroll the users in the programs
+        for num, student in enumerate(cls.students):
+            if num % 3 == 0:
+                program = cls.program1
+            elif num % 3 == 1:
+                program = cls.program2
+            else:
+                program = cls.program3
+            ProgramEnrollmentFactory.create(
+                user=student,
+                program=program
+            )
+
+        # create an user with a role for one program
+        cls.staff = UserFactory.create()
+        Role.objects.create(
+            user=cls.staff,
+            program=cls.program1,
+            role=Staff.ROLE_ID
+        )
+        # create another user without any role
+        cls.user = UserFactory.create()
+
+        # search URL
+        cls.search_url = reverse('search_api', kwargs={'elastic_url': ''})
+
+    def setUp(self):
+        super(SearchTests, self).setUp()
+        self.client.force_login(self.staff)
+
+    def assert_status_code(self, status_code=status.HTTP_200_OK, json=None):
+        """
+        Helper function to assert the status code for POST and GET
+        """
+        if json is None:
+            json = {}
+        resp_get = self.client.get(self.search_url)
+        assert resp_get.status_code == status_code
+        resp_post = self.client.post(self.search_url, json, format='json')
+        assert resp_post.status_code == status_code
+        return resp_get, resp_post
+
+    def get_program_ids_in_hits(self, hits):  # pylint: disable=no-self-use
+        """
+        Helper function to extract the program ids in a list of elasticsearch hits.
+        """
+        return list(set(hit['_source']['program']['id'] for hit in hits))
+
+    def test_access(self):
+        """
+        Test access with different user types
+        """
+        self.client.logout()
+        # anonymous user cannot access
+        self.assert_status_code(status.HTTP_403_FORBIDDEN)
+        # normal user without role cannot access
+        self.client.force_login(self.user)
+        self.assert_status_code(status.HTTP_403_FORBIDDEN)
+        # user with role can access
+        self.client.force_login(self.staff)
+        self.assert_status_code()
+
+    def test_proxy_woks(self):
+        """
+        Test the proxy actually returns something
+        """
+        resp, _ = self.assert_status_code()
+        assert 'hits' in resp.data
+        assert 'hits' in resp.data['hits']
+        assert len(resp.data['hits']['hits']) > 0
+        assert isinstance(resp.data['hits']['hits'][0], dict)
+
+    def test_get_post_equivalent(self):
+        """
+        Get and post return the same result for the same query
+        """
+        resp_get, resp_post = self.assert_status_code()
+        assert len(resp_get.data['hits']['hits']) == len(resp_post.data['hits']['hits'])
+        hits_get = resp_get.data['hits']['hits']
+        hits_post = resp_post.data['hits']['hits']
+        hits_get.sort(key=lambda x: x['_id'])
+        hits_post.sort(key=lambda x: x['_id'])
+        for get_item, post_item in zip(hits_get, hits_post):
+            assert get_item == post_item
+
+    def test_user_visibility(self):
+        """
+        Test that the user with the role can see only users belonging to the
+        programs where she is power user
+        """
+        resp, _ = self.assert_status_code()
+        hits = resp.data['hits']['hits']
+        for hit in hits:
+            assert '_source' in hit
+            assert 'program' in hit['_source']
+            assert 'id' in hit['_source']['program']
+            assert hit['_source']['program']['id'] == self.program1.id
+
+    def test_limits_work_with_filters(self):
+        """
+        Test that if the user sends a query that filter by a subset
+        of the programs she has power access, the filter in the rest api does not add unwanted
+        results.
+        """
+        # enroll the user in another program
+        Role.objects.create(
+            user=self.staff,
+            program=self.program3,
+            role=Staff.ROLE_ID
+        )
+        # verify that by default the user sees all the users programs she has access to
+        resp, _ = self.assert_status_code()
+        program_ids_in_hits = self.get_program_ids_in_hits(resp.data['hits']['hits'])
+        assert len(program_ids_in_hits) == 2
+        assert self.program1.id in program_ids_in_hits
+        assert self.program3.id in program_ids_in_hits
+
+        # request just users in one program
+        wanted_program_id = self.program3.id
+        filter_data = {
+            "query": {
+                "bool": {
+                    "should": [
+                        {"term": {"program.id": wanted_program_id}}
+                    ]
+                }
+            }
+        }
+        # verify that only the wanted program is in the hits
+        _, resp = self.assert_status_code(json=filter_data)
+        program_ids_in_hits = self.get_program_ids_in_hits(resp.data['hits']['hits'])
+        assert len(program_ids_in_hits) == 1
+        assert program_ids_in_hits[0] == wanted_program_id

--- a/static/js/containers/LearnerSearchPage.js
+++ b/static/js/containers/LearnerSearchPage.js
@@ -12,6 +12,7 @@ import type { Dispatch } from 'redux';
 import LearnerSearch from '../components/LearnerSearch';
 import { setSearchFilterVisibility } from '../actions/ui';
 import type { UIState } from '../reducers/ui';
+import { getCookie } from '../util/api';
 
 class LearnerSearchPage extends React.Component {
   props: {
@@ -33,7 +34,11 @@ class LearnerSearchPage extends React.Component {
   };
 
   render () {
-    let searchKit = new SearchkitManager(SETTINGS.search_url);
+    let searchKit = new SearchkitManager(SETTINGS.search_url, {
+      httpHeaders: {
+        'X-CSRFToken': getCookie('csrftoken')
+      }
+    });
     return (
       <SearchkitProvider searchkit={searchKit}>
         <LearnerSearch


### PR DESCRIPTION
#### What are the relevant tickets?
closes #701 

#### What's this PR do?
Introduces a REST API to proxy requests to elasticsearch, enforce permissions and limit results to allowed ones

#### Where should the reviewer start?
`search.views`

#### How should this be manually tested?
In your `.env` you should set the variable
`ELASTICSEARCH_URL=http://elastic:9200` (not sure about the actual value for not Mac users) 


To check that the rest API actually works, access its url `/api/v0/search/`
To verify that searchkit works, edit your `.env` file and include/edit the entry
`CLIENT_ELASTICSEARCH_URL=http://<your_ip>:8079/api/v0/search/`

You should also verify that the user cannot see students from programs he is not supposed to.
To do that, load fake users with the proper management command and make your user `Staff` of only one of these programs.

#### Any background context you want to provide?
This PR does not take care of setting a basic filter for the program at the SearchKit level: I think that should go together with the refactoring of the UI in general.