### PR TITLE
sudo is required per https://docs.travis-ci.com/user/docker/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,17 @@
 # Set Ruby as the language so it doesn't download the pip things. Instead, let docker do that.
+
+sudo: required
+services:
+  - docker
+
+env:
+  COMPOSE_VERSION: 1.4.2
+
+before_install:
+ - curl -L https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+ - chmod +x docker-compose
+ - sudo mv docker-compose /usr/local/bin
+
 language: ruby
 cache: bundler
 script:
@@ -7,5 +20,3 @@ script:
   - docker-compose -f travis-docker-compose.yml run watch npm run-script coverage
   - docker-compose -f travis-docker-compose.yml run watch npm run-script lint
   - docker-compose -f travis-docker-compose.yml run watch ./webpack_if_prod.sh
-services:
-  - docker


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #824

#### What's this PR do?

Tests one way to fix the current build failures

#### How should this be manually tested?

Did it build?

#### Any background context you want to provide?

Travis recently [changed their Trusty image](https://www.traviscistatus.com/incidents/11hp8bhkrkn7). Other than that, I don't know why `docker-compose` is no longer available. 

The solution was cribbed from cribbed from https://github.com/heroku/logplex/blob/master/.travis.yml which Travis points to as an example

I'm thinking about e-mail travis support to confirm whether this is necessary

