### PR TITLE
fixed JS console error ('key' prop required)

### DIFF
--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -235,7 +235,7 @@ class EmploymentForm extends ProfileFormFields {
       );
     };
     return (
-      <Cell col={12} className="profile-form-row">
+      <Cell col={12} className="profile-form-row" key={index}>
         <div className="basic-info">
           <div className="profile-row-name">
             {`${position.company_name}, ${position.position}`}


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #835 

#### What's this PR do?

I had inadvertently stopped passing a `key` prop to the JSX returned from the `jobRow` method on `EmploymentForm`. We map across the work history objects with this method (`work_history.map(entry => this.jobRow(entry)`), which is what triggered the warning.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

