### PR TITLE
Added program grade to search result UI

### DIFF
--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -59,10 +59,10 @@ describe("ErrorInfo", () => {
             }
           };
           let errorMessage = renderErrorMessage(that);
-          assert.equal(true, errorMessage.includes(String(code)));
-          assert.equal(true, errorMessage.includes(errorString));
-          assert.equal(true, errorMessage.includes(contactExpectation));
-          assert.equal(true, errorMessage.includes(message));
+          assert.include(errorMessage, String(code));
+          assert.include(errorMessage, errorString);
+          assert.include(errorMessage, contactExpectation);
+          assert.include(errorMessage, message);
         });
       });
     });

--- a/static/js/components/search/CountryRefinementOption_test.js
+++ b/static/js/components/search/CountryRefinementOption_test.js
@@ -27,12 +27,12 @@ describe('CountryRefinementOption', () => {
 
   it('should render a country name, given a country code', () => {
     let option = renderCountryOption(props);
-    assert.deepEqual(option.includes('Afghanistan'), true);
+    assert.include(option, 'Afghanistan');
   });
 
   it('should display the result count for the option', () => {
     let option = renderCountryOption(props);
-    assert.deepEqual(option.includes('42'), true);
+    assert.include(option, '42');
   });
 
   it('should bind an onClick handler', () => {

--- a/static/js/components/search/FilterVisibilityToggle_test.js
+++ b/static/js/components/search/FilterVisibilityToggle_test.js
@@ -35,7 +35,7 @@ describe('FilterVisibilityToggle', () => {
 
   it('renders children', () => {
     let toggle = renderToggle(props, <div>Test Text</div>);
-    assert.deepEqual(toggle.includes("Test Text"), true);
+    assert.include(toggle, "Test Text");
   });
 
   it('checks for filter visibility when rendering', () => {

--- a/static/js/components/search/LearnerResult.js
+++ b/static/js/components/search/LearnerResult.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
-
+import _ from 'lodash';
 import ProfileImage from '../ProfileImage';
 import UserChip from '../UserChip';
 import { getPreferredName, getLocation } from '../../util/util';
@@ -12,8 +12,12 @@ export default class LearnerResult extends React.Component {
     result: { _source: SearchResult }
   };
 
+  static hasGrade = program => (
+    _.has(program, 'grade_average') && _.isNumber(program.grade_average)
+  );
+
   render () {
-    const { result: { _source: { profile } } } = this.props;
+    const { result: { _source: { profile, program } } } = this.props;
     return (
       <Grid className="search-grid learner-result">
         <Cell col={2}>
@@ -30,10 +34,12 @@ export default class LearnerResult extends React.Component {
           </span>
         </Cell>
         <Cell col={2} className="learner-grade">
-          <span className="percent">75%</span>
+          <span className="percent">
+            { LearnerResult.hasGrade(program) ? `${program.grade_average}%` : '-' }
+          </span>
           <span className="hint">Current grade</span>
         </Cell>
-        <Cell col = {4}></Cell>
+        <Cell col={4} />
         <UserChip profile={profile} />
       </Grid>
     );

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -210,6 +210,10 @@ export const USER_PROFILE_RESPONSE = {
   "edx_level_of_education": null
 };
 
+export const USER_PROGRAM_RESPONSE = {
+  "grade_average": 83
+};
+
 export const STATUS_PASSED = 'passed';
 export const STATUS_NOT_PASSED = 'not-passed';
 export const STATUS_VERIFIED_NOT_COMPLETED = 'verified-not-completed';

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -15,3 +15,7 @@ export type CourseRun = {
   status?: string;
   enrollment_start_date?: string;
 };
+
+export type UserProgram = {
+  grade_average: number
+};

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -1,6 +1,8 @@
 // @flow
 import type { Profile } from './profileTypes';
+import type { UserProgram } from './programTypes';
 
 export type SearchResult = {
-  profile: Profile
+  profile: Profile,
+  program: UserProgram
 };


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #681 

#### What's this PR do?

Adds the program grade average to search results (when it exists). Also made a minor refactor to a few assertions in other JS test cases

#### Where should the reviewer start?

static/js/components/search/LearnerResult.js

#### How should this be manually tested?

Go to the search tab and observe the grades. It will help to have users in your DB with actual grades, so the realistic user set is useful here.

#### Any background context you want to provide?

w/r/t the assertion refactor: i just saw test cases that could use a more accurate assertion in the same file that i was editing, so i fixed those. it was easy enough to search for other examples in the codebase, so i fixed those too. when these test fail, it now prints out a more helpful message

#### Screenshots (if appropriate)

![ss 2016-08-17 at 17 30 12](https://cloud.githubusercontent.com/assets/14932219/17754301/dac1778a-64a1-11e6-96aa-8b68564b50f5.png)

#### What GIF best describes this PR or how it makes you feel?

https://66.media.tumblr.com/tumblr_megu6kysDx1rg0w3to1_500.gif