### PR TITLE
Removed switch validation from profile flow

### DIFF
--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -191,7 +191,6 @@ class EducationForm extends ProfileFormFields {
   render() {
     let {
       profile,
-      errors,
       ui: {
         educationDegreeInclusions,
         showEducationDeleteDialog,
@@ -226,11 +225,6 @@ class EducationForm extends ProfileFormFields {
             { this.educationLevelRadioSwitch(educationDegreeInclusions, level) }
           </Cell>
           {this.renderEducationLevel(level)}
-          <Cell col={12}>
-            <span className="validation-error-text-large">
-              {errors[`education_${level.value}_required`]}
-            </span>
-          </Cell>
         </Grid>
       </Card>
     ));

--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -3,11 +3,7 @@ import React from 'react';
 
 import ProfileProgressControls from './ProfileProgressControls';
 import EducationForm from './EducationForm';
-import {
-  educationUiValidation,
-  educationValidation,
-  combineValidators,
-} from '../util/validation';
+import { educationValidation } from '../util/validation';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
@@ -21,15 +17,14 @@ class EducationTab extends React.Component {
   };
 
   render() {
-    let validator = combineValidators(educationValidation, educationUiValidation);
     return (
       <div>
-        <EducationForm {...this.props} validator={validator} />
+        <EducationForm {...this.props} validator={educationValidation} />
         <ProfileProgressControls
           {...this.props}
           nextBtnLabel="Next"
           isLastTab={false}
-          validator={validator}
+          validator={educationValidation}
         />
       </div>
     );

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -257,7 +257,6 @@ class EmploymentForm extends ProfileFormFields {
         showWorkDeleteDialog,
         showWorkDeleteAllDialog,
       },
-      errors,
       showSwitch,
     } = this.props;
     const actions = <ValidationAlert {...this.props}>
@@ -325,11 +324,6 @@ class EmploymentForm extends ProfileFormFields {
               { workSwitch() }
             </Cell>
             {this.renderWorkHistory()}
-            <Cell col={12}>
-              <span className="validation-error-text-large">
-                {errors.work_history_required}
-              </span>
-            </Cell>
           </Grid>
         </Card>
       </div>

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -3,11 +3,7 @@ import React from 'react';
 
 import EmploymentForm from './EmploymentForm';
 import ProfileProgressControls from './ProfileProgressControls';
-import {
-  employmentValidation,
-  employmentUiValidation,
-  combineValidators,
-} from '../util/validation';
+import { employmentValidation } from '../util/validation';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
@@ -21,15 +17,14 @@ class EmploymentTab extends React.Component {
   };
 
   render () {
-    const validator = combineValidators(employmentValidation, employmentUiValidation);
     return (
       <div>
-        <EmploymentForm {...this.props} showSwitch={true} validator={validator} />
+        <EmploymentForm {...this.props} showSwitch={true} validator={employmentValidation} />
         <ProfileProgressControls
           {...this.props}
           nextBtnLabel="Next"
           isLastTab={false}
-          validator={validator}
+          validator={employmentValidation}
         />
       </div>
     );

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -351,64 +351,6 @@ describe("ProfilePage", function() {
     });
   });
 
-  it("validates education switches on the education page", () => {
-    setStep(EDUCATION_STEP);
-    return renderComponent('/profile').then(([, div]) => {
-      // close all switches and remove all education so we don't get validation errors
-      let receivedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
-        education: [],
-        email_optin: true,
-      });
-      helper.store.dispatch(receiveGetUserProfileSuccess(SETTINGS.username, receivedProfile));
-      helper.store.dispatch(setEducationDegreeInclusions(
-        Object.assign({}, noInclusions, {
-          [HIGH_SCHOOL]: true
-        })
-      ));
-      helper.store.dispatch(setWorkHistoryEdit(true));
-
-      let button = div.querySelector(nextButtonSelector);
-      assert(button.innerHTML.includes("Next"));
-      let updatedProfile = Object.assign({}, receivedProfile, {
-        email_optin: true,
-        filled_out: true
-      });
-
-      return confirmSaveButtonBehavior(updatedProfile, {button: button}, true).then(state => {
-        assert.deepEqual(state.profiles[SETTINGS.username].edit.errors, {
-          [`education_${HIGH_SCHOOL}_required`]:
-            `High school is required if switch is on. Please add a degree or switch it off.`
-        });
-      });
-    });
-  });
-
-  it(`validates employment switches when saving the employment page`, () => {
-    setStep(EMPLOYMENT_STEP);
-    return renderComponent('/profile').then(([, div]) => {
-      // close all switches and remove all education so we don't get validation errors
-      let receivedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
-        work_history: [],
-        email_optin: true,
-      });
-      helper.store.dispatch(receiveGetUserProfileSuccess(SETTINGS.username, receivedProfile));
-      helper.store.dispatch(setWorkHistoryEdit(true));
-
-      let button = div.querySelector(nextButtonSelector);
-      assert(button.innerHTML.includes("Next"));
-      let updatedProfile = Object.assign({}, receivedProfile, {
-        email_optin: true,
-        filled_out: true
-      });
-
-      return confirmSaveButtonBehavior(updatedProfile, {button: button}, true).then(state => {
-        assert.deepEqual(state.profiles[SETTINGS.username].edit.errors, {
-          work_history_required: "Work history is required if switch is on. Please add work history or switch it off."
-        });
-      });
-    });
-  });
-
   it('does not validate education and employment switches when saving the privacy page', () => {
     setStep(PRIVACY_STEP);
     return renderComponent('/profile').then(([, div]) => {

--- a/static/js/containers/SettingsPage.js
+++ b/static/js/containers/SettingsPage.js
@@ -13,10 +13,7 @@ import {
 import ProfileFormContainer from './ProfileFormContainer';
 import PrivacyForm from '../components/PrivacyForm';
 import ProfileProgressControls from '../components/ProfileProgressControls';
-import {
-    combineValidators,
-    privacyValidation,
-} from '../util/validation';
+import { privacyValidation } from '../util/validation';
 import { getPreferredName } from '../util/util';
 
 class SettingsPage extends ProfileFormContainer {
@@ -57,9 +54,7 @@ class SettingsPage extends ProfileFormContainer {
                   nextBtnLabel="Save"
                   {...props}
                   isLastTab={true}
-                  validator={
-                    combineValidators(privacyValidation)
-                  }
+                  validator={privacyValidation}
                 />
               </Cell>
             </Grid>

--- a/static/js/util/validation.js
+++ b/static/js/util/validation.js
@@ -12,7 +12,6 @@ import type { UIState } from '../reducers/ui';
 import { filterPositiveInt } from './util';
 import {
   HIGH_SCHOOL,
-  EDUCATION_LEVELS,
   PERSONAL_STEP,
   EDUCATION_STEP,
   EMPLOYMENT_STEP,
@@ -118,27 +117,6 @@ export function educationValidation(profile: Profile): ValidationErrors {
   }
 }
 
-export function educationUiValidation(profile: Profile, ui: UIState): ValidationErrors {
-  if (profile.education === undefined) {
-    profile = Object.assign({}, profile, {
-      education: []
-    });
-  }
-
-  let errors = {};
-  if ( profile.education === undefined ) {
-    return errors;
-  }
-  for (let {value, label} of EDUCATION_LEVELS) {
-    let items = profile.education.filter(education => education.degree_name === value);
-    if (ui.educationDegreeInclusions[value] && items.length === 0) {
-      errors[`education_${value}_required`] =
-        `${label} is required if switch is on. Please add a degree or switch it off.`;
-    }
-  }
-  return errors;
-}
-
 export type WorkEntry = [string, WorkHistoryEntry];
 export function employmentValidation(profile: Profile): ValidationErrors {
   let messages = {
@@ -179,16 +157,6 @@ export function employmentValidation(profile: Profile): ValidationErrors {
     });
 
     return errors;
-  } else {
-    return {};
-  }
-}
-
-export function employmentUiValidation(profile: Profile, ui: UIState): ValidationErrors {
-  if (ui.workHistoryEdit && _.isEmpty(profile.work_history)) {
-    return {
-      work_history_required: "Work history is required if switch is on. Please add work history or switch it off."
-    };
   } else {
     return {};
   }

--- a/static/js/util/validation_test.js
+++ b/static/js/util/validation_test.js
@@ -7,9 +7,7 @@ import { Just } from 'sanctuary';
 import {
   personalValidation,
   educationValidation,
-  educationUiValidation,
   employmentValidation,
-  employmentUiValidation,
   privacyValidation,
   validateProfileComplete,
   validateDay,
@@ -20,14 +18,11 @@ import {
 } from './validation';
 import {
   USER_PROFILE_RESPONSE,
-  EDUCATION_LEVELS,
-  BACHELORS,
   HIGH_SCHOOL,
   PERSONAL_STEP,
   EMPLOYMENT_STEP,
   PRIVACY_STEP,
 } from '../constants';
-import { INITIAL_UI_STATE } from '../reducers/ui';
 import { assertMaybeEquality, assertIsNothing } from './sanctuary_test';
 
 describe('Profile validation functions', () => {
@@ -139,24 +134,6 @@ describe('Profile validation functions', () => {
         }]
       }, educationValidation(clone));
     });
-
-    it('should complain about switches being on if there are no elements in the list', () => {
-      let profile = Object.assign({}, USER_PROFILE_RESPONSE, {
-        education: [{
-          degree_name: BACHELORS
-        }]
-      });
-      let ui = Object.assign({}, INITIAL_UI_STATE);
-      ui.educationDegreeInclusions[HIGH_SCHOOL] = true;
-      ui.educationDegreeInclusions[BACHELORS] = true;
-
-      let errors = educationUiValidation(profile, ui);
-      let highSchoolLabel = EDUCATION_LEVELS.find(education => education.value === HIGH_SCHOOL).label;
-      assert.deepEqual(errors, {
-        [`education_${HIGH_SCHOOL}_required`]:
-          `${highSchoolLabel} is required if switch is on. Please add a degree or switch it off.`
-      });
-    });
   });
 
   describe('Employment validation', () => {
@@ -187,20 +164,6 @@ describe('Profile validation functions', () => {
           company_name: 'Company Name is required'
         }]
       }, employmentValidation(clone));
-    });
-
-    it('should complain about the switch being on if there are no elements in the list', () => {
-      let profile = Object.assign({}, USER_PROFILE_RESPONSE, {
-        work_history: []
-      });
-      let ui = Object.assign({}, INITIAL_UI_STATE, {
-        workHistoryEdit: true
-      });
-
-      let errors = employmentUiValidation(profile, ui);
-      assert.deepEqual(errors, {
-        work_history_required: `Work history is required if switch is on. Please add work history or switch it off.`
-      });
     });
 
     it('should reject end date before start date', () => {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #821 

#### What's this PR do?

This removes all of the validation code relating to the 'yes' / 'no' switches on the education and work history forms. The switches are still there, we just do not validate their position any longer.

#### Where should the reviewer start?

#### How should this be manually tested?

When navigating the profile (e.g. on the education step), having a switch switched to 'yes' shouldn't cause a validation error when you click 'Next'.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

