### PR TITLE
Added program grade filter and histogram to UI

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -9,6 +9,7 @@ import {
   HitsStats,
   Pagination,
   ResetFilters,
+  RangeFilter
 } from 'searchkit';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Card from 'react-mdl/lib/Card/Card';
@@ -71,6 +72,19 @@ export default class LearnerSearch extends SearchkitComponent {
                   title="Current Location"
                   id="country"
                   translations={this.searchkitTranslations}
+                />
+              </FilterVisibilityToggle>
+              <FilterVisibilityToggle
+                {...this.props}
+                filterName="grade-average"
+              >
+                <RangeFilter
+                  field="program.grade_average"
+                  id="grade-average"
+                  min={0}
+                  max={100}
+                  showHistogram={true}
+                  title="Program Avg. Grade"
                 />
               </FilterVisibilityToggle>
             </Card>

--- a/static/js/components/search/LearnerResult.js
+++ b/static/js/components/search/LearnerResult.js
@@ -37,7 +37,7 @@ export default class LearnerResult extends React.Component {
           <span className="percent">
             { LearnerResult.hasGrade(program) ? `${program.grade_average}%` : '-' }
           </span>
-          <span className="hint">Current grade</span>
+          <span className="hint">Program Avg. Grade</span>
         </Cell>
         <Cell col={4} />
         <UserChip profile={profile} />

--- a/static/js/components/search/LearnerResult_test.js
+++ b/static/js/components/search/LearnerResult_test.js
@@ -40,7 +40,7 @@ describe('LearnerResult', () => {
 
   it("should show an indicator when a user has a missing/null program grade", () => {
     let emptyGradeElasticHit = R.clone(elasticHit),
-      strippedEmptyGradeOutput = '-Current grade';
+      strippedEmptyGradeOutput = '-Program Avg. Grade';
     emptyGradeElasticHit.result._source.program.grade_average = null;
     let result = renderLearnerResult(emptyGradeElasticHit);
     assert.include(result, strippedEmptyGradeOutput);

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -4,6 +4,7 @@ $medlightgrey: #8d8d8d;
 $medgrey: #a1a1a1;
 $lightgrey: #eee;
 $fg-grey: #F5F5F5;
+$histogramgrey: #C6C6C6;
 
 $font-black: #000000;
 

--- a/static/scss/search_page.scss
+++ b/static/scss/search_page.scss
@@ -87,6 +87,29 @@
         padding-top: 15px;
       }
     }
+
+    .filter--grade-average {
+      .sk-panel__content {
+        padding-right: 25px;
+      }
+
+      .sk-range-histogram > * {
+        background-color: $histogramgrey;
+      }
+
+      .rc-slider-step {
+        background-color: $medgrey;
+      }
+
+      .rc-slider-handle {
+        border-color: $medgrey;
+      }
+
+      .rc-slider-mark-text {
+        color: $medgrey;
+        background-color: transparent;
+      }
+    }
   }
 
   .search-sidebar * {


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #731 

#### What's this PR do?

Adds the program grade range filter to the search page

#### How should this be manually tested?

Load up the search page and mess around with the range filter. Note that learners with no program grade should be shown _only_ when the range filter is set to the full range

#### Screenshots (if appropriate)

![ss 2016-08-19 at 10 50 28](https://cloud.githubusercontent.com/assets/14932219/17813791/c7b9b7c4-65fa-11e6-87e5-630c40aa99bd.png)