### PR TITLE
UI for sending learner email

### DIFF
--- a/static/js/actions/email.js
+++ b/static/js/actions/email.js
@@ -1,0 +1,13 @@
+// @flow
+export const actionCreatorGenerator = (type: string) => (
+  (args: any) => args === undefined ? { type: type } : { type: type, payload: args }
+);
+
+export const START_EMAIL_EDIT = 'START_EMAIL_EDIT';
+export const startEmailEdit = actionCreatorGenerator(START_EMAIL_EDIT);
+
+export const UPDATE_EMAIL_EDIT = 'UPDATE_EMAIL_EDIT';
+export const updateEmailEdit = actionCreatorGenerator(UPDATE_EMAIL_EDIT);
+
+export const CLEAR_EMAIL_EDIT = 'CLEAR_EMAIL_EDIT';
+export const clearEmailEdit = actionCreatorGenerator(CLEAR_EMAIL_EDIT);

--- a/static/js/actions/email_test.js
+++ b/static/js/actions/email_test.js
@@ -1,0 +1,50 @@
+// @flow
+import { assert } from 'chai';
+
+import {
+  actionCreatorGenerator,
+  startEmailEdit,
+  updateEmailEdit,
+  clearEmailEdit,
+
+  START_EMAIL_EDIT,
+  UPDATE_EMAIL_EDIT,
+  CLEAR_EMAIL_EDIT,
+} from './email';
+
+describe('email actions', () => {
+  describe('actionCreatorGenerator', () => {
+    it('should return a function', () => {
+      assert.isFunction(actionCreatorGenerator(START_EMAIL_EDIT));
+    });
+
+    it('returned function should return a simple action when no args are passed', () => {
+      let creator = actionCreatorGenerator(START_EMAIL_EDIT);
+      assert.deepEqual({ type: START_EMAIL_EDIT }, creator());
+    });
+
+    it('returned function should return an action w/ payload when args are passed', () => {
+      let creator = actionCreatorGenerator(START_EMAIL_EDIT);
+      let expected = { type: START_EMAIL_EDIT, payload: "HI" };
+      assert.deepEqual(expected, creator('HI'));
+    });
+  });
+
+  describe('email action helpers', () => {
+    const assertCreatedActionHelper = ([actionHelper, actionType]) => {
+      it(`should create the ${actionType} simple action helper correctly`, () => {
+        assert.deepEqual(actionHelper(), {type: actionType});
+      });
+
+      it(`should create the ${actionType} action helper with args correctly`, () => {
+        assert.deepEqual(actionHelper({foo: "bar"}), { type: actionType, payload: { foo: "bar" } });
+      });
+    };
+
+    [
+      [startEmailEdit, START_EMAIL_EDIT],
+      [updateEmailEdit, UPDATE_EMAIL_EDIT],
+      [clearEmailEdit, CLEAR_EMAIL_EDIT],
+    ].forEach(assertCreatedActionHelper);
+  });
+});

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -119,3 +119,8 @@ export const SET_TOS_DIALOG_VISIBILITY = 'SET_TOS_DIALOG_VISIBILITY';
 export const setTOSDialogVisibility = (visibility: boolean): Action => (
   { type: SET_TOS_DIALOG_VISIBILITY, payload: visibility }
 );
+
+export const SET_EMAIL_DIALOG_VISIBILITY = 'SET_EMAIL_DIALOG_VISIBILITY';
+export const setEmailDialogVisibility = (visibility: boolean): Action => (
+  { type: SET_EMAIL_DIALOG_VISIBILITY, payload: visibility }
+);

--- a/static/js/components/EmailCompositionDialog.js
+++ b/static/js/components/EmailCompositionDialog.js
@@ -1,0 +1,77 @@
+// @flow
+import React from 'react';
+import Dialog from 'material-ui/Dialog';
+import Button from 'react-mdl/lib/Button';
+import R from 'ramda';
+import type { EmailEditState } from '../reducers/email';
+
+const createDialogActions = (close, send) => ([
+  <Button
+    type="button"
+    className="dialog-button cancel-button"
+    key="first"
+    onClick={close}
+  >
+    Cancel
+  </Button>,
+  <Button
+    type="button"
+    className="dialog-button save-button"
+    key="second"
+    onClick={send}
+  >
+    Send
+  </Button>
+]);
+
+const hitsCount = searchkit => R.isNil(searchkit) ? 0 : searchkit.getHitsCount();
+
+type EmailDialogProps = {
+  closeEmailDialog: () => void,
+  updateEmailEdit:  Function,
+  open:             boolean,
+  email:            EmailEditState,
+  searchkit:        Object,
+  sendEmail:        (e: EmailEditState) => void,
+};
+
+const EmailCompositionDialog = (props: EmailDialogProps) => {
+  const {
+    closeEmailDialog,
+    updateEmailEdit,
+    open,
+    email,
+    searchkit,
+    sendEmail,
+  } = props;
+
+  return <Dialog
+    open={open}
+    className="email-composition-dialog"
+    actions={createDialogActions(closeEmailDialog, sendEmail)}
+    onRequestClose={closeEmailDialog}
+    title="New Email"
+  >
+    <div className="email-composition-contents">
+      <span className="user-count">
+        {hitsCount(searchkit)} recipients selected
+      </span>
+      <textarea
+        rows="1"
+        className="email-subject"
+        placeholder="Subject"
+        value={email.subject || ""}
+        onChange={updateEmailEdit('subject')}
+      />
+      <textarea
+        rows="7"
+        className="email-body"
+        placeholder="Type a message"
+        value={email.body || ""}
+        onChange={updateEmailEdit('body')}
+      />
+    </div>
+  </Dialog>;
+};
+
+export default EmailCompositionDialog;

--- a/static/js/components/EmailCompositionDialog_test.js
+++ b/static/js/components/EmailCompositionDialog_test.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import R from 'ramda';
+
+import { NEW_EMAIL_EDIT } from '../reducers/email';
+import { modifyTextField } from '../util/test_utils';
+
+import EmailCompositionDialog from './EmailCompositionDialog';
+
+describe('EmailCompositionDialog', () => {
+  let updateStub = sinon.stub();
+
+  let defaultProps = {
+    closeEmailDialog: sinon.stub().returns(updateStub),
+    updateEmailEdit: sinon.stub().returns(updateStub),
+    open: true,
+    email: Object.assign({}, NEW_EMAIL_EDIT),
+    searchkit: {
+      getHitsCount: sinon.stub().returns(20)
+    }
+  };
+
+  const renderDialog = (props = defaultProps) => (
+    mount (
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <EmailCompositionDialog {...props} />
+      </MuiThemeProvider>
+    )
+  );
+
+  it('should have a title', () => {
+    renderDialog();
+    assert.equal(document.querySelector('h3').textContent, 'New Email');
+  });
+
+  it('should have a results count', () => {
+    renderDialog();
+    let count = document.querySelector('.user-count').textContent;
+    assert.equal(count, '20 recipients selected');
+    assert(
+      defaultProps.searchkit.getHitsCount.called,
+      "called searchkit getHitsCount method"
+    );
+  });
+
+  ['subject', 'body'].forEach(field => {
+    describe(`editing ${field}`, () => {
+      let getField = () => document.querySelector(`.email-${field}`);
+
+      it('should show placeholder text if the store value is empty', () => {
+        renderDialog();
+        assert.notEqual(getField().placeholder, "");
+      });
+
+      it('should display the value from the store', () => {
+        let newProps = R.clone(defaultProps);
+
+        newProps.email[field] = "a field value!";
+        renderDialog(newProps);
+        assert.equal(getField().value, "a field value!");
+      });
+
+      it('should fire the updateEmailEdit callback on change', () => {
+        renderDialog();
+        let field = getField();
+        modifyTextField(field, "HI");
+        assert(updateStub.called, "onChange callback was called");
+      });
+    });
+  });
+});

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import {
   SearchkitComponent,
@@ -20,7 +21,9 @@ import LearnerResult from './search/LearnerResult';
 import CountryRefinementOption from './search/CountryRefinementOption';
 import FilterVisibilityToggle from './search/FilterVisibilityToggle';
 import HitsCount from './search/HitsCount';
+import EmailCompositionDialog from './EmailCompositionDialog';
 import type { Option } from '../flow/generalTypes';
+import type { EmailEditState } from '../reducers/email';
 
 let makeSearchkitTranslations: () => Object = () => {
   let translations = {};
@@ -73,6 +76,13 @@ export default class LearnerSearch extends SearchkitComponent {
   props: {
     checkFilterVisibility:  (s: string) => boolean,
     setFilterVisibility:    (s: string, v: boolean) => void,
+    openEmailComposer:      () => void,
+    emailDialogVisibility:  boolean,
+    closeEmailDialog:       () => void,
+    updateEmailEdit:        (o: Object) => void,
+    sendEmail:              () => void,
+    email:                  EmailEditState,
+    children:               React$Element<*>[],
   };
 
   dropdownOptions: Option[] = [
@@ -83,8 +93,24 @@ export default class LearnerSearch extends SearchkitComponent {
   searchkitTranslations: Object = makeSearchkitTranslations();
 
   render () {
+    const {
+      emailDialogVisibility,
+      closeEmailDialog,
+      updateEmailEdit,
+      sendEmail,
+      email,
+      openEmailComposer,
+    } = this.props;
     return (
       <div className="learners-search">
+        <EmailCompositionDialog
+          open={emailDialogVisibility}
+          closeEmailDialog={closeEmailDialog}
+          updateEmailEdit={updateEmailEdit}
+          email={email}
+          sendEmail={sendEmail}
+          searchkit={this.searchkit}
+        />
         <Grid className="search-grid">
           <Cell col={3} className="search-sidebar">
             <Card className="fullwidth">
@@ -142,6 +168,7 @@ export default class LearnerSearch extends SearchkitComponent {
                     role="button"
                     id="email-selected"
                     className="mm-button"
+                    onClick={() => openEmailComposer(this.searchkit)}
                   >
                     Email Selected
                   </div>

--- a/static/js/containers/LearnerSearchPage.js
+++ b/static/js/containers/LearnerSearchPage.js
@@ -8,15 +8,19 @@ import {
 } from 'searchkit';
 import _ from 'lodash';
 import type { Dispatch } from 'redux';
+import R from 'ramda';
 
 import LearnerSearch from '../components/LearnerSearch';
-import { setSearchFilterVisibility } from '../actions/ui';
+import { setSearchFilterVisibility, setEmailDialogVisibility } from '../actions/ui';
+import { startEmailEdit, updateEmailEdit, clearEmailEdit } from '../actions/email';
 import type { UIState } from '../reducers/ui';
+import type { EmailEditState } from '../reducers/email';
 import { getCookie } from '../util/api';
 
 class LearnerSearchPage extends React.Component {
   props: {
     ui:       UIState,
+    email:    EmailEditState,
     dispatch: Dispatch,
   };
 
@@ -33,26 +37,67 @@ class LearnerSearchPage extends React.Component {
     dispatch(setSearchFilterVisibility(clone));
   };
 
+  openEmailComposer: Function = (sk) => {
+    const { dispatch } = this.props;
+    const query = JSON.stringify(sk.query);
+    dispatch(startEmailEdit(query));
+    dispatch(setEmailDialogVisibility(true));
+  };
+
+  closeEmailComposerAndCancel: Function = () => {
+    const { dispatch } = this.props;
+    dispatch(clearEmailEdit());
+    dispatch(setEmailDialogVisibility(false));
+  };
+
+  closeEmailComposeAndSend: Function = () => {
+    const { dispatch, email } = this.props;
+    console.log(email); // eslint-disable-line no-console
+    dispatch(clearEmailEdit());
+    dispatch(setEmailDialogVisibility(false));
+  };
+
+  updateEmailEdit: Function = R.curry((fieldName, e) => {
+    const { email, dispatch } = this.props;
+    let emailClone = R.clone(email);
+    emailClone[fieldName] = e.target.value;
+    dispatch(updateEmailEdit(emailClone));
+  });
+
   render () {
+    const {
+      ui: { emailDialogVisibility },
+      email,
+    } = this.props;
+
     let searchKit = new SearchkitManager(SETTINGS.search_url, {
       httpHeaders: {
         'X-CSRFToken': getCookie('csrftoken')
       }
     });
     return (
-      <SearchkitProvider searchkit={searchKit}>
-        <LearnerSearch
-          checkFilterVisibility={this.checkFilterVisibility}
-          setFilterVisibility={this.setFilterVisibility}
-        />
-      </SearchkitProvider>
+      <div>
+        <SearchkitProvider searchkit={searchKit}>
+          <LearnerSearch
+            checkFilterVisibility={this.checkFilterVisibility}
+            setFilterVisibility={this.setFilterVisibility}
+            openEmailComposer={this.openEmailComposer}
+            emailDialogVisibility={emailDialogVisibility}
+            closeEmailDialog={this.closeEmailComposerAndCancel}
+            updateEmailEdit={this.updateEmailEdit}
+            sendEmail={this.closeEmailComposeAndSend}
+            email={email}
+          />
+        </SearchkitProvider>
+      </div>
     );
   }
 }
 
 const mapStateToProps = state => {
   return {
-    ui: state.ui,
+    ui:     state.ui,
+    email:  state.email,
   };
 };
 

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -38,18 +38,13 @@ import * as api from '../util/api';
 import { USER_PROFILE_RESPONSE, HIGH_SCHOOL, DOCTORATE } from '../constants';
 import { workEntriesByDate, educationEntriesByDate } from '../util/sorting';
 import ValidationAlert from '../components/ValidationAlert';
+import { modifyTextField } from '../util/test_utils';
 
 describe("UserPage", function() {
   this.timeout(5000);
 
   let listenForActions, renderComponent, helper, patchUserProfileStub;
   let userActions = [RECEIVE_GET_USER_PROFILE_SUCCESS, REQUEST_GET_USER_PROFILE];
-
-  let modifyTextField = (field, text) => {
-    field.value = text;
-    TestUtils.Simulate.change(field);
-    TestUtils.Simulate.keyDown(field, {key: "Enter", keyCode: 13, which: 13});
-  };
 
   let openDialog = () => {
     return [...document.getElementsByClassName('deletion-confirmation')].find(dialog => (

--- a/static/js/reducers/email.js
+++ b/static/js/reducers/email.js
@@ -1,0 +1,34 @@
+// @flow
+import {
+  START_EMAIL_EDIT,
+  UPDATE_EMAIL_EDIT,
+  CLEAR_EMAIL_EDIT,
+} from '../actions/email';
+import type { Action } from '../flow/reduxTypes';
+
+export type EmailEditState = {
+  subject?:   ?string;
+  body?:      ?string;
+  query?:     ?Object;
+};
+
+export const INITIAL_EMAIL_STATE: EmailEditState = {};
+
+export const NEW_EMAIL_EDIT: EmailEditState = {
+  subject:    null,
+  body:       null,
+  query:      null,
+};
+
+export const email = (state: EmailEditState = INITIAL_EMAIL_STATE, action: Action) => {
+  switch (action.type) {
+  case START_EMAIL_EDIT:
+    return { ...state, ...NEW_EMAIL_EDIT, ...{query: action.payload} };
+  case UPDATE_EMAIL_EDIT:
+    return { ...state, ...action.payload };
+  case CLEAR_EMAIL_EDIT:
+    return { ...INITIAL_EMAIL_STATE};
+  default:
+    return state;
+  }
+};

--- a/static/js/reducers/email_test.js
+++ b/static/js/reducers/email_test.js
@@ -1,0 +1,55 @@
+import configureTestStore from 'redux-asserts';
+
+import {
+  startEmailEdit,
+  updateEmailEdit,
+  clearEmailEdit,
+  START_EMAIL_EDIT,
+  UPDATE_EMAIL_EDIT,
+  CLEAR_EMAIL_EDIT,
+} from '../actions/email';
+import rootReducer from '../reducers';
+import { NEW_EMAIL_EDIT } from './email';
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+describe('email reducers', () => {
+  let sandbox, store, dispatchThen;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    store = configureTestStore(rootReducer);
+    dispatchThen = store.createDispatchThen(state => state.email);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    store = null;
+    dispatchThen = null;
+  });
+
+  let query = { query: "Hi, I'm a query!" };
+
+  let initialExpectation = { ...NEW_EMAIL_EDIT, query: query };
+
+  it('should let you start editing an email', () => {
+    return dispatchThen(startEmailEdit(query), [START_EMAIL_EDIT]).then(state => {
+      assert.deepEqual(initialExpectation, state);
+    });
+  });
+
+  it('should let you update an email edit in progress', () => {
+    store.dispatch(startEmailEdit(query));
+    let update = { body: "The body of my email" };
+    return dispatchThen(updateEmailEdit(update), [UPDATE_EMAIL_EDIT]).then(state => {
+      assert.deepEqual(state, { ...initialExpectation, ...update });
+    });
+  });
+
+  it('should let you clear an existing email edit', () => {
+    return assert.eventually.deepEqual(
+      dispatchThen(clearEmailEdit(), [CLEAR_EMAIL_EDIT]),
+      {}
+    );
+  });
+});

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -24,6 +24,7 @@ import {
   FETCH_SUCCESS,
 } from '../actions';
 import { ui } from './ui';
+import { email } from './email';
 import type { Action } from '../flow/reduxTypes';
 import type { ProfileGetResult } from '../flow/profileTypes';
 
@@ -159,4 +160,5 @@ export default combineReducers({
   profiles,
   dashboard,
   ui,
+  email,
 });

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -29,6 +29,7 @@ import {
   SET_SEARCH_FILTER_VISIBILITY,
 
   SET_TOS_DIALOG_VISIBILITY,
+  SET_EMAIL_DIALOG_VISIBILITY,
 } from '../actions/ui';
 import {
   HIGH_SCHOOL,
@@ -60,6 +61,7 @@ export type UIState = {
   userMenuOpen:                 boolean;
   searchFilterVisibility:       {[s: string]: boolean};
   tosDialogVisibility:          boolean;
+  emailDialogVisibility:        boolean;
 };
 
 export const INITIAL_UI_STATE: UIState = {
@@ -86,7 +88,8 @@ export const INITIAL_UI_STATE: UIState = {
   workDialogIndex:  null,
   userMenuOpen: false,
   searchFilterVisibility: {},
-  tosDialogVisibility: false
+  tosDialogVisibility: false,
+  emailDialogVisibility: false,
 };
 
 export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
@@ -202,6 +205,11 @@ export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
   case SET_TOS_DIALOG_VISIBILITY: {
     return Object.assign({}, state, {
       tosDialogVisibility: action.payload
+    });
+  }
+  case SET_EMAIL_DIALOG_VISIBILITY: {
+    return Object.assign({}, state, {
+      emailDialogVisibility: action.payload
     });
   }
   default:

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -21,6 +21,7 @@ import {
   SET_USER_MENU_OPEN,
   SET_SEARCH_FILTER_VISIBILITY,
   SET_TOS_DIALOG_VISIBILITY,
+  SET_EMAIL_DIALOG_VISIBILITY,
 
   clearUI,
   updateDialogText,
@@ -43,6 +44,7 @@ import {
   setUserMenuOpen,
   setSearchFilterVisibility,
   setTOSDialogVisibility,
+  setEmailDialogVisibility,
 } from '../actions/ui';
 import { receiveGetUserProfileSuccess } from '../actions';
 import { INITIAL_UI_STATE } from '../reducers/ui';
@@ -325,4 +327,17 @@ describe('ui reducers', () => {
       });
     });
   });
+
+  describe('Email dialog visibility', () => {
+    [true, false].forEach(bool => {
+      it(`should let you set email dialog visibility to ${bool}`, () => {
+        return dispatchThen(setEmailDialogVisibility(bool), [
+          SET_EMAIL_DIALOG_VISIBILITY
+        ]).then(state => {
+          assert.equal(state.emailDialogVisibility, bool);
+        });
+      });
+    });
+  });
+
 });

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -1,0 +1,7 @@
+import TestUtils from 'react-addons-test-utils';
+
+export const modifyTextField = (field, text) => {
+  field.value = text;
+  TestUtils.Simulate.change(field);
+  TestUtils.Simulate.keyDown(field, {key: "Enter", keyCode: 13, which: 13});
+};

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -31,3 +31,19 @@
   background-color: $mm-brand-bg;
   color: white;
 }
+
+.dialog-button {
+  width: 120px;
+
+  &.cancel-button {
+    color: white;
+    background-color: $medgrey;
+    margin: 0 5px 15px 5px;
+  }
+
+  &.save-button {
+    background-color: $dashboard-button-teal;
+    color: white;
+    margin: 0 15px 15px 5px;
+  }
+}

--- a/static/scss/email_composition_dialog.scss
+++ b/static/scss/email_composition_dialog.scss
@@ -1,0 +1,25 @@
+.email-composition-dialog {
+  .email-composition-contents {
+    display: flex;
+    flex-direction: column;
+
+    .user-count {
+      padding-bottom: 20px;
+      font-style: italic;
+    }
+
+    textarea {
+      padding: 15px;
+      border-color: $border-color;
+
+      &.email-subject {
+        border-bottom: none;
+        border-radius: 5px 5px 0 0;
+      }
+
+      &.email-body {
+        border-radius: 0 0 5px 5px;
+      }
+    }
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -16,6 +16,7 @@
 @import "bound_check_box";
 @import "terms_of_service_dialog";
 @import "user_chip";
+@import "email_composition_dialog";
 
 $border-box-sizing: true !global;
 


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #719 

#### What's this PR do?

This adds the ui for sending email to users based on a search query. The API isn't there yet, so for now we just dump the email on the floor when you click send.

#### Where should the reviewer start?

Read over the new changes, especially the `EmailCompositionDialog` component and the new email reducer.

#### How should this be manually tested?

Go to the `learners` page. Click 'Email Selected', then you should see a dialog box. The 'recipient count' in the box should match what is shown in the normal search interface. You should be able to edit the 'subject' and 'body' fields in the email. Editing these fields should dispatch redux actions. You should be able to click the 'send' button, but it will just `console.log` the email for now.

Also, if you inspect the redux store, you should see the search query stringified in there, so we'll have it ready to `PATCH` later.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

![email_compose](https://cloud.githubusercontent.com/assets/6207644/17899259/b49153d8-6928-11e6-97fb-d520004ff4d1.png)

#### What GIF best describes this PR or how it makes you feel?
