### PR TITLE
Added test case to mock out Elasticsearch to speed up tests

### DIFF
--- a/search/base.py
+++ b/search/base.py
@@ -1,7 +1,12 @@
 """
 Base test classes for search
 """
-from django.test import TestCase
+from mock import patch
+
+from django.test import (
+    override_settings,
+    TestCase,
+)
 
 from search.api import recreate_index
 
@@ -14,3 +19,32 @@ class ESTestCase(TestCase):
     def setUp(self):
         super(ESTestCase, self).setUp()
         recreate_index()
+
+
+@override_settings(ELASTICSEARCH_URL="fake")
+class MockedESTestCase(TestCase):
+    """
+    Mock ES signals
+    """
+
+    def setUp(self):
+        self.patchers = [
+            patch('search.api.get_conn', autospec=True),
+            patch('search.api.bulk', autospec=True, return_value=(0, [])),
+            patch('search.api.Mapping', autospec=True),
+        ]
+        for patcher in self.patchers:
+            patcher.start()
+        try:
+            super(MockedESTestCase, self).setUp()
+        except:
+            for patcher in self.patchers:
+                patcher.stop()
+            raise
+
+    def tearDown(self):
+        try:
+            super(MockedESTestCase, self).tearDown()
+        finally:
+            for patcher in self.patchers:
+                patcher.stop()


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #721

#### What's this PR do?
 - Adds `MockedESTestCase` to mock Elasticsearch to speed up tests which don't use it

#### How should this be manually tested?
There shouldn't be any non-testing code changed
