### PR TITLE
Switched to use enzyme in IntegrationTestHelper

### DIFF
--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -1,5 +1,5 @@
-import ReactDOM from 'react-dom';
 import React from 'react';
+import { mount } from 'enzyme';
 import configureTestStore from 'redux-asserts';
 import sinon from 'sinon';
 import { createMemoryHistory } from 'react-router';
@@ -62,19 +62,21 @@ class IntegrationTestHelper {
     }
     expectedTypes.push(...extraTypesToAssert);
 
-    let component, div;
+    let wrapper, div;
 
     return this.listenForActions(expectedTypes, () => {
       this.browserHistory.push(url);
       div = document.createElement("div");
-      component = ReactDOM.render(
+      wrapper = mount(
         <div>
           { makeDashboardRoutes(this.browserHistory, this.store, () => null) }
         </div>,
-        div
+        {
+          attachTo: div
+        }
       );
     }).then(() => {
-      return Promise.resolve([component, div]);
+      return Promise.resolve([wrapper, div]);
     });
   }
 }


### PR DESCRIPTION
#### What's this PR do?
Passes an enzyme wrapper as the first argument of `renderComponent` instead of the React component. We don't actually use the component anywhere at the moment so this shouldn't cause any problems