### PR TITLE
added validation to the email composition dialog

### DIFF
--- a/static/js/actions/email.js
+++ b/static/js/actions/email.js
@@ -11,3 +11,6 @@ export const updateEmailEdit = actionCreatorGenerator(UPDATE_EMAIL_EDIT);
 
 export const CLEAR_EMAIL_EDIT = 'CLEAR_EMAIL_EDIT';
 export const clearEmailEdit = actionCreatorGenerator(CLEAR_EMAIL_EDIT);
+
+export const UPDATE_EMAIL_VALIDATION = 'UPDATE_EMAIL_VALIDATION';
+export const updateEmailValidation = actionCreatorGenerator(UPDATE_EMAIL_VALIDATION);

--- a/static/js/actions/email_test.js
+++ b/static/js/actions/email_test.js
@@ -6,10 +6,12 @@ import {
   startEmailEdit,
   updateEmailEdit,
   clearEmailEdit,
+  updateEmailValidation,
 
   START_EMAIL_EDIT,
   UPDATE_EMAIL_EDIT,
   CLEAR_EMAIL_EDIT,
+  UPDATE_EMAIL_VALIDATION,
 } from './email';
 
 describe('email actions', () => {
@@ -45,6 +47,7 @@ describe('email actions', () => {
       [startEmailEdit, START_EMAIL_EDIT],
       [updateEmailEdit, UPDATE_EMAIL_EDIT],
       [clearEmailEdit, CLEAR_EMAIL_EDIT],
+      [updateEmailValidation, UPDATE_EMAIL_VALIDATION],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/components/EmailCompositionDialog.js
+++ b/static/js/components/EmailCompositionDialog.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import Button from 'react-mdl/lib/Button';
 import R from 'ramda';
-import type { EmailEditState } from '../reducers/email';
+import type { Email, EmailValidationErrors } from '../reducers/email';
 
 const createDialogActions = (close, send) => ([
   <Button
@@ -24,15 +24,27 @@ const createDialogActions = (close, send) => ([
   </Button>
 ]);
 
+const showValidationError = R.curry((getter, object) => {
+  let val = getter(object);
+  if ( val !== undefined ) {
+    return <span className="validation-error">{ val }</span>;
+  }
+});
+
+const showSubjectError = showValidationError(R.prop('subject'));
+
+const showBodyError = showValidationError(R.prop('body'));
+
 const hitsCount = searchkit => R.isNil(searchkit) ? 0 : searchkit.getHitsCount();
 
 type EmailDialogProps = {
   closeEmailDialog: () => void,
   updateEmailEdit:  Function,
   open:             boolean,
-  email:            EmailEditState,
+  email:            Email,
+  errors:           EmailValidationErrors,
   searchkit:        Object,
-  sendEmail:        (e: EmailEditState) => void,
+  sendEmail:        (e: Email) => void,
 };
 
 const EmailCompositionDialog = (props: EmailDialogProps) => {
@@ -41,6 +53,7 @@ const EmailCompositionDialog = (props: EmailDialogProps) => {
     updateEmailEdit,
     open,
     email,
+    errors,
     searchkit,
     sendEmail,
   } = props;
@@ -63,6 +76,7 @@ const EmailCompositionDialog = (props: EmailDialogProps) => {
         value={email.subject || ""}
         onChange={updateEmailEdit('subject')}
       />
+      { showSubjectError(errors) }
       <textarea
         rows="7"
         className="email-body"
@@ -70,6 +84,7 @@ const EmailCompositionDialog = (props: EmailDialogProps) => {
         value={email.body || ""}
         onChange={updateEmailEdit('body')}
       />
+      { showBodyError(errors) }
     </div>
   </Dialog>;
 };

--- a/static/js/components/EmailCompositionDialog_test.js
+++ b/static/js/components/EmailCompositionDialog_test.js
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import R from 'ramda';
+import TestUtils from 'react-addons-test-utils';
 
 import { NEW_EMAIL_EDIT } from '../reducers/email';
 import { modifyTextField } from '../util/test_utils';
@@ -19,10 +20,14 @@ describe('EmailCompositionDialog', () => {
     updateEmailEdit: sinon.stub().returns(updateStub),
     open: true,
     email: Object.assign({}, NEW_EMAIL_EDIT),
+    errors: {},
     searchkit: {
       getHitsCount: sinon.stub().returns(20)
-    }
+    },
+    sendEmail: sinon.stub(),
   };
+
+  const getDialog = () => document.querySelector('.email-composition-dialog');
 
   const renderDialog = (props = defaultProps) => (
     mount (
@@ -47,6 +52,12 @@ describe('EmailCompositionDialog', () => {
     );
   });
 
+  it('should fire sendEmail when the "send" button is clicked', () => {
+    renderDialog();
+    TestUtils.Simulate.click(getDialog().querySelector('.save-button'));
+    assert(defaultProps.sendEmail.called, "called sendEmail method");
+  });
+
   ['subject', 'body'].forEach(field => {
     describe(`editing ${field}`, () => {
       let getField = () => document.querySelector(`.email-${field}`);
@@ -69,6 +80,15 @@ describe('EmailCompositionDialog', () => {
         let field = getField();
         modifyTextField(field, "HI");
         assert(updateStub.called, "onChange callback was called");
+      });
+
+      it('should show an error if an error for the field is passed in', () => {
+        let errorProps = R.clone(defaultProps);
+        let errorMessage = `An error message for ${field}`;
+        errorProps.errors[field] = errorMessage;
+        renderDialog(errorProps);
+        let message = getDialog().querySelector('.validation-error').textContent;
+        assert.equal(message, errorMessage);
       });
     });
   });

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -23,7 +23,7 @@ import FilterVisibilityToggle from './search/FilterVisibilityToggle';
 import HitsCount from './search/HitsCount';
 import EmailCompositionDialog from './EmailCompositionDialog';
 import type { Option } from '../flow/generalTypes';
-import type { EmailEditState } from '../reducers/email';
+import type { Email, EmailValidationErrors } from '../reducers/email';
 
 let makeSearchkitTranslations: () => Object = () => {
   let translations = {};
@@ -81,7 +81,8 @@ export default class LearnerSearch extends SearchkitComponent {
     closeEmailDialog:       () => void,
     updateEmailEdit:        (o: Object) => void,
     sendEmail:              () => void,
-    email:                  EmailEditState,
+    email:                  Email,
+    errors:                 EmailValidationErrors,
     children:               React$Element<*>[],
   };
 
@@ -99,6 +100,7 @@ export default class LearnerSearch extends SearchkitComponent {
       updateEmailEdit,
       sendEmail,
       email,
+      errors,
       openEmailComposer,
     } = this.props;
     return (
@@ -108,6 +110,7 @@ export default class LearnerSearch extends SearchkitComponent {
           closeEmailDialog={closeEmailDialog}
           updateEmailEdit={updateEmailEdit}
           email={email}
+          errors={errors}
           sendEmail={sendEmail}
           searchkit={this.searchkit}
         />

--- a/static/js/reducers/email.js
+++ b/static/js/reducers/email.js
@@ -3,18 +3,33 @@ import {
   START_EMAIL_EDIT,
   UPDATE_EMAIL_EDIT,
   CLEAR_EMAIL_EDIT,
+  UPDATE_EMAIL_VALIDATION,
 } from '../actions/email';
 import type { Action } from '../flow/reduxTypes';
 
-export type EmailEditState = {
-  subject?:   ?string;
-  body?:      ?string;
-  query?:     ?Object;
+export type Email = {
+    subject?:   ?string;
+    body?:      ?string;
+    query?:     ?Object;
 };
 
-export const INITIAL_EMAIL_STATE: EmailEditState = {};
+export type EmailValidationErrors = {
+    subject?:   ?string;
+    body?:      ?string;
+    query?:     ?string;
+};
 
-export const NEW_EMAIL_EDIT: EmailEditState = {
+export type EmailEditState = {
+  email:  Email;
+  errors: EmailValidationErrors;
+}
+
+export const INITIAL_EMAIL_STATE: EmailEditState = {
+  email:  {},
+  errors: {},
+};
+
+export const NEW_EMAIL_EDIT: Email = {
   subject:    null,
   body:       null,
   query:      null,
@@ -23,11 +38,13 @@ export const NEW_EMAIL_EDIT: EmailEditState = {
 export const email = (state: EmailEditState = INITIAL_EMAIL_STATE, action: Action) => {
   switch (action.type) {
   case START_EMAIL_EDIT:
-    return { ...state, ...NEW_EMAIL_EDIT, ...{query: action.payload} };
+    return { ...state, email: { ...NEW_EMAIL_EDIT, query: action.payload } };
   case UPDATE_EMAIL_EDIT:
-    return { ...state, ...action.payload };
+    return { ...state, email: action.payload };
   case CLEAR_EMAIL_EDIT:
-    return { ...INITIAL_EMAIL_STATE};
+    return { ...INITIAL_EMAIL_STATE };
+  case UPDATE_EMAIL_VALIDATION:
+    return { ...state, errors: action.payload };
   default:
     return state;
   }

--- a/static/js/reducers/email_test.js
+++ b/static/js/reducers/email_test.js
@@ -4,14 +4,17 @@ import {
   startEmailEdit,
   updateEmailEdit,
   clearEmailEdit,
+  updateEmailValidation,
   START_EMAIL_EDIT,
   UPDATE_EMAIL_EDIT,
   CLEAR_EMAIL_EDIT,
+  UPDATE_EMAIL_VALIDATION,
 } from '../actions/email';
 import rootReducer from '../reducers';
-import { NEW_EMAIL_EDIT } from './email';
+import { NEW_EMAIL_EDIT, INITIAL_EMAIL_STATE } from './email';
 import { assert } from 'chai';
 import sinon from 'sinon';
+import R from 'ramda';
 
 describe('email reducers', () => {
   let sandbox, store, dispatchThen;
@@ -30,7 +33,10 @@ describe('email reducers', () => {
 
   let query = { query: "Hi, I'm a query!" };
 
-  let initialExpectation = { ...NEW_EMAIL_EDIT, query: query };
+  let initialExpectation = {
+    email: { ...NEW_EMAIL_EDIT, query: query },
+    errors: {}
+  };
 
   it('should let you start editing an email', () => {
     return dispatchThen(startEmailEdit(query), [START_EMAIL_EDIT]).then(state => {
@@ -40,16 +46,25 @@ describe('email reducers', () => {
 
   it('should let you update an email edit in progress', () => {
     store.dispatch(startEmailEdit(query));
-    let update = { body: "The body of my email" };
+    let update = R.clone(initialExpectation.email);
+    update.body = 'The body of my email';
     return dispatchThen(updateEmailEdit(update), [UPDATE_EMAIL_EDIT]).then(state => {
-      assert.deepEqual(state, { ...initialExpectation, ...update });
+      assert.deepEqual(state, { ...initialExpectation, email: update });
     });
   });
 
   it('should let you clear an existing email edit', () => {
     return assert.eventually.deepEqual(
       dispatchThen(clearEmailEdit(), [CLEAR_EMAIL_EDIT]),
-      {}
+      INITIAL_EMAIL_STATE,
     );
+  });
+
+  it('should let you update email validation', () => {
+    store.dispatch(startEmailEdit(query));
+    let errors = { subject: "NO SUBJECT" };
+    return dispatchThen(updateEmailValidation(errors), [UPDATE_EMAIL_VALIDATION]).then(state => {
+      assert.deepEqual(state.errors, errors);
+    });
   });
 });

--- a/static/js/util/validation.js
+++ b/static/js/util/validation.js
@@ -9,6 +9,7 @@ import type {
   ValidationErrors
 } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
+import type { Email } from '../reducers/email';
 import { filterPositiveInt } from './util';
 import {
   HIGH_SCHOOL,
@@ -170,6 +171,18 @@ export function privacyValidation(profile: Profile): ValidationErrors {
     'account_privacy': 'Privacy level is required'
   };
   return checkFieldPresence(profile, requiredFields, messages);
+}
+
+/**
+ * validate an email for presence of the 'subject' and 'body' fields
+ */
+export function emailValidation(email: Email): ValidationErrors {
+  let requiredFields = [ ['subject'], ['body'] ];
+  let messages = {
+    'subject': 'Please fill in a subject',
+    'body': 'Please fill in a body',
+  };
+  return checkFieldPresence(email, requiredFields, messages);
 }
 
 /*

--- a/static/js/util/validation_test.js
+++ b/static/js/util/validation_test.js
@@ -15,6 +15,7 @@ import {
   validateYear,
   combineValidators,
   sanitizeDate,
+  emailValidation,
 } from './validation';
 import {
   USER_PROFILE_RESPONSE,
@@ -483,5 +484,37 @@ describe('Profile validation functions', () => {
       assert(mergeStub.calledWith({}, "ret1", "ret2"));
       assert.equal(result, mergeResult);
     });
+  });
+});
+
+describe("email validation", () => {
+  let email = {
+    subject: 'a great email',
+    body: 'hi, how are you?'
+  };
+
+  let blank = field => {
+    let emailClone = _.cloneDeep(email);
+    emailClone[field] = null;
+    return emailClone;
+  };
+
+  it('should require a subject', () => {
+    assert.deepEqual(
+      emailValidation(blank('subject')),
+      { 'subject': 'Please fill in a subject' }
+    );
+  });
+
+  it('should require a body', () => {
+    assert.deepEqual(
+      emailValidation(blank('body')),
+      { 'body': 'Please fill in a body' }
+    );
+  });
+
+  it('should return no errors if all fields are filled out', () => {
+    let errors = emailValidation(email);
+    assert.deepEqual(errors, {});
   });
 });

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -21,6 +21,7 @@ $help-icon-blue: #1976e5;
 $dashboard-button-teal: #30bcd6;
 $border-color: #cccccc;
 $search-filter: #D2E4F9;
+$validation-red: #f44336;
 
 // other
 $block-padding: 20px;

--- a/static/scss/email_composition_dialog.scss
+++ b/static/scss/email_composition_dialog.scss
@@ -8,17 +8,18 @@
       font-style: italic;
     }
 
+    .validation-error {
+      font-size: 12px;
+      color: $validation-red;
+    }
+
     textarea {
       padding: 15px;
       border-color: $border-color;
+      border-radius: 2px;
 
       &.email-subject {
-        border-bottom: none;
-        border-radius: 5px 5px 0 0;
-      }
-
-      &.email-body {
-        border-radius: 0 0 5px 5px;
+        margin-bottom: 5px;
       }
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #888 

#### What's this PR do?

This adds a new function to `util/validation.js` to check the email fields, and then adds some UI to show the validation errors if they are present.

#### Where should the reviewer start?

Read over the changes to `util/validation.js`. I had to refactor the email reducer a bit as well, probably important to look that over closely.

#### How should this be manually tested?

Go to the learners search. Click the 'Email Selected' button. If you then click 'send' you should see two validation errors (no subject and no body).

These errors should go away as you fix the problems. You shouldn't be able to 'send' the email (currently `send === console.log`) until the validation errors are cleared away.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

![email_validation](https://cloud.githubusercontent.com/assets/6207644/17983911/f1572abc-6adc-11e6-8c31-ea7c16cb41e9.png)


#### What GIF best describes this PR or how it makes you feel?
