### PR TITLE
Fixed react warnings, added check to error on React warnings

### DIFF
--- a/js_test.sh
+++ b/js_test.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 set -euf -o pipefail
 
-node ./node_modules/mocha/bin/_mocha --compilers js:babel-register static/js/global_init.js ${1:-'static/**/*/*_test.js'}
+export TMP_FILE=$(mktemp)
+node ./node_modules/mocha/bin/_mocha --compilers js:babel-register static/js/global_init.js ${1:-'static/**/*/*_test.js'} 2> >(tee "$TMP_FILE")
 
+if [[ -s "$TMP_FILE" ]]  # is file empty?
+then
+    echo "Error output found, see test output logs to see which test they came from."
+    rm -f "$TMP_FILE"
+    exit 1
+fi
+
+rm -f "$TMP_FILE"

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -302,7 +302,7 @@ export function boundCheckbox(keySet: string[], label: string|React$Element<*>):
   };
 
   const style = {
-    'background-color': '#30BB5C'
+    'backgroundColor': '#30BB5C'
   };
 
   return (

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -101,6 +101,7 @@ export function makeProfileProgressDisplay(active: string) {
           xmlns="http://www.w3.org/2000/svg"
           x={circleX - 12}
           y={circleY - 12}
+          key={`check_${i}`}
         >
           <path d="M0 0h24v24H0z" fill="none"/>
           <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/>


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #910 
Fixes #909

#### What's this PR do?
Fixes some React warnings and adds a check to fail the build if they come up again

#### Where should the reviewer start?
js_test.sh

#### How should this be manually tested?
Try undoing one of the fixes and running the tests. All tests should pass but the command should return a non-zero value due to the warning, failing the tests overall.

