### PR TITLE
Removed CLIENT_ELASTICSEARCH_URL environment variable

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -419,7 +419,6 @@ CELERY_EAGER_PROPAGATES_EXCEPTIONS = get_var(
 # Elasticsearch
 ELASTICSEARCH_URL = get_var("ELASTICSEARCH_URL", None)
 ELASTICSEARCH_INDEX = get_var('ELASTICSEARCH_INDEX', 'micromasters')
-CLIENT_ELASTICSEARCH_URL = get_var("CLIENT_ELASTICSEARCH_URL", "http://localhost:9100")
 
 # django-role-permissions
 ROLEPERMISSIONS_MODULE = 'roles.roles'

--- a/ui/views.py
+++ b/ui/views.py
@@ -7,6 +7,7 @@ import logging
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.core.urlresolvers import reverse
 from django.views.generic import View
 from django.shortcuts import (
     render,
@@ -69,7 +70,7 @@ class ReactView(View):  # pylint: disable=unused-argument
             "host": webpack_dev_server_host(request),
             "edx_base_url": settings.EDXORG_BASE_URL,
             "roles": roles,
-            "search_url": settings.CLIENT_ELASTICSEARCH_URL,
+            "search_url": reverse('search_api', kwargs={"elastic_url": ""}),
         }
 
         return render(

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -175,7 +175,6 @@ class DashboardTests(ViewsTests):
             REACT_GA_DEBUG=react_ga_debug,
             EDXORG_BASE_URL=edx_base_url,
             WEBPACK_DEV_SERVER_HOST=host,
-            CLIENT_ELASTICSEARCH_URL="http://localhost:9200",
         ):
             resp = self.client.get(DASHBOARD_URL)
             js_settings = json.loads(resp.context['js_settings_json'])
@@ -188,7 +187,7 @@ class DashboardTests(ViewsTests):
                 'host': host,
                 'edx_base_url': edx_base_url,
                 'roles': [],
-                'search_url': 'http://localhost:9200',
+                'search_url': reverse('search_api', kwargs={"elastic_url": ""}),
             }
 
     def test_roles_setting(self):
@@ -392,7 +391,6 @@ class TestUsersPage(ViewsTests):
             REACT_GA_DEBUG=react_ga_debug,
             EDXORG_BASE_URL=edx_base_url,
             WEBPACK_DEV_SERVER_HOST=host,
-            CLIENT_ELASTICSEARCH_URL="http://localhost:9200",
         ):
             # Mock has_permission so we don't worry about testing permissions here
             has_permission = Mock(return_value=True)
@@ -409,7 +407,7 @@ class TestUsersPage(ViewsTests):
                     'host': host,
                     'edx_base_url': edx_base_url,
                     'roles': [],
-                    'search_url': 'http://localhost:9200',
+                    'search_url': reverse('search_api', kwargs={"elastic_url": ""}),
                 }
                 assert has_permission.called
 
@@ -431,7 +429,6 @@ class TestUsersPage(ViewsTests):
             REACT_GA_DEBUG=react_ga_debug,
             EDXORG_BASE_URL=edx_base_url,
             WEBPACK_DEV_SERVER_HOST=host,
-            CLIENT_ELASTICSEARCH_URL="http://localhost:9200",
         ):
             # Mock has_permission so we don't worry about testing permissions here
             has_permission = Mock(return_value=True)
@@ -448,7 +445,7 @@ class TestUsersPage(ViewsTests):
                     'host': host,
                     'edx_base_url': edx_base_url,
                     'roles': [],
-                    'search_url': 'http://localhost:9200'
+                    'search_url': reverse('search_api', kwargs={"elastic_url": ""})
                 }
                 assert has_permission.called
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #839 

#### What's this PR do?
Removes CLIENT_ELASTICSEARCH_URL setting, this should always point to `/api/v0/search/` now

#### How should this be manually tested?
You should be able to remove CLIENT_ELASTICSEARCH_URL from `.env` and restart Docker. Search should be unaffected.

