### PR TITLE
Added new terms of service page

### DIFF
--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -18,9 +18,7 @@
 @import "terms_of_service_dialog";
 @import "user_chip";
 @import "email_composition_dialog";
-
-
-
+@import "terms_of_service";
 
 .selected {
   font-weight: bold;

--- a/static/scss/terms_of_service.scss
+++ b/static/scss/terms_of_service.scss
@@ -1,0 +1,15 @@
+#terms-of-service {
+  .title {
+    margin-top: 0;
+    font-size: 22px;
+    font-weight: 600;
+  }
+
+  p, li {
+    text-align: justify;
+  }
+
+  ol {
+    padding-left: 20px;
+  }
+}

--- a/ui/templates/header.html
+++ b/ui/templates/header.html
@@ -1,0 +1,12 @@
+<div class="micromasters-navbar">
+  <header class="mdl-layout__header micromasters-nav">
+    <div class="mdl-layout__header-row micromasters-header">
+      <div class="micromasters-title">
+        <img src="/static/images/mit-logo-transparent.svg" alt="MIT" />
+        <span class="mdl-layout-title">
+          MicroMasters Portal
+        </span>
+      </div>
+    </div>
+  </header>
+</div>

--- a/ui/templates/terms_of_service.html
+++ b/ui/templates/terms_of_service.html
@@ -1,0 +1,127 @@
+{% extends "base.html" %}
+{% load i18n static %}
+
+{% block title %}{% trans "MIT MicroMasters: Terms of Service" %}{% endblock %}
+
+{% block content %}
+  {% include "header.html" %}
+
+  <div class="page-content">
+    <div class="single-column" id="terms-of-service">
+      <h4 class="title">
+        MIT MicroMasters Terms of Service
+      </h4>
+      <div class="mdl-card">
+        <div className="terms-of-service-content">
+          <p>
+          Welcome to the MITx MicroMasters website (the “Site”).  By accessing this Site, users agree to be
+          bound by the following terms and conditions which MIT may revise at any time.  Users are encouraged
+          to visit this page periodically to review current terms and conditions, as your continued use of this
+          Site signifies your agreement to these term and conditions.  If you do not understand or do not agree
+          to be bound by these terms and conditions, please exit this Site immediately.
+          </p>
+          <ol>
+            <li>
+              Your use of this Site is entirely voluntary.  This Site is designed to assist and facilitate your
+              successful attainment of the MITx MicroMasters credential, but use of this Site is not required
+              in order to participate in the MITx MicroMasters program. These terms and conditions govern
+              your use of this Site alone. When enrolled in specific MITx courses, all users must adhere to
+              the edX terms of service, including its Honor Code, which are available
+              at <a href="https://www.edx.org/edx-terms-service"
+                    target='_blank'> https://www.edx.org/edx-terms-service</a>.
+            </li>
+            <li>
+              MIT respects your privacy.  We do not collect personally identifiable information about you unless
+              you voluntarily provide it.  Our primary aim in collecting personally identifiable information
+              is to provide you with the best educational experience possible.  By
+              "personally identifiable information," we are referring to (1) data that uniquely identifies you
+              or permits us to contact you, such as your name, email address, mailing address, phone number; (2)
+              other information that we collect through the Site and combine and maintain in combination with
+              that personally identifiable information, such as your area of interest; educational and
+              employment background; and (3) your participation and progress in MITx courses and your online
+              education.  Among other things, MIT may use the personally identifiable information that you
+              provide to respond to your questions; provide you the specific courses and/or services you select;
+              send you updates about courses and information, including specifically the MITx MicroMasters
+              program and information about MIT events; send you information about Site maintenance or updates;
+              and for all appropriate MIT administrative and research purposes. Except as set forth herein or
+              as specifically agreed to by you, MIT will not disclose any personally identifiable information
+              we gather from you on the Site to any third parties. By logging into this Site through your edX
+              account, you acknowledge and understand that personally identifiable information will be shared by
+              edX with MIT and may be used by MIT to facilitate your use of this Site. In addition, please note
+              that your education records are protected by the Family Educational Rights and Privacy Act ("FERPA")
+              to the extent FERPA applies.
+            </li>
+            <li>
+              Comments or other information posted by you to our forums, boards or other areas of the Site designed
+              for public communications or communications among class members may be viewed and downloaded by others
+              and are available to MIT faculty and staff for research and administrative purposes. For this reason,
+              we encourage you to use discretion when deciding to post in these forums.
+            </li>
+            <li>
+              You agree to use the Site in accordance with all applicable laws. You are responsible for
+              your own communications, including the upload, transmission and posting of information, and are
+              responsible for the consequences of their posting on or through the Site. You further agree that
+              you will not email or post malicious or harmful content anywhere on the Site, or on any other MIT
+              computing resources including without limitation the following:
+              <ul>
+                <li>Content that defames or threatens others.</li>
+                <li>Harassing statements or content that violates federal or state law.</li>
+                <li>Content that discusses illegal activities with the intent to commit them.</li>
+                <li>Content that is not your own, or infringes another’s intellectual property
+                  including, but not limited to, copyrights, trademarks or trade secrets.</li>
+                <li>Material that contains obscene (i.e. pornographic) language or images.</li>
+                <li>
+                  Advertising or any form of commercial solicitation or promotion,
+                  including links to other sites.
+                </li>
+                <li>Content that is otherwise unlawful.</li>
+                <li>Intentionally incomplete, misleading or inaccurate content.</li>
+              </ul>
+            </li>
+            <li>
+              "MIT", "Massachusetts Institute of Technology", and its logos and seal are trademarks of the
+              Massachusetts Institute of Technology.  Except for purposes of attribution, you may not use MIT’s
+              names or logos, or any variations thereof, without prior written consent of MIT. You may not use
+              the MIT name in any of its forms nor MIT seals or logos for promotional purposes, or in any way
+              that deliberately or inadvertently claims, suggests, or in MIT’s sole judgment gives the
+              appearance or impression of a relationship with or endorsement by MIT.
+            </li>
+            <li>
+              NEITHER MIT, ITS AFFILIATES, TRUSTEES, DIRECTORS, OFFICERS, EMPLOYEES AND AGENTS SHALL HAVE ANY
+              LIABIITY FOR ANY DAMAGES, INCLUDING WITHOUT LIMITATION, ANY DIRECT, INDIRECT, INCIDENTIAL,
+              COMPENSATORY, PUNITIVE, SPECIAL OR CONSEQUENTIAL DAMAGES (EVEN IF MIT HAS BEEN ADVISED OF
+              THE POSSIBILITY OF SUCH DAMAGES) ARISING FROM OR RELATED TO THE USE OF THE SITE, CONTENT,
+              AND/OR COMPILATION.
+            </li>
+            <li>
+              You agree to defend, hold harmless and indemnify MIT, and its subsidiaries, affiliates,
+              officers, agents, and employees from and against any third-party claims, actions or demands
+              arising out of, resulting from or in any way related to your use of the Site, including any
+              liability or expense arising from any and all claims, losses, damages (actual and consequential),
+              suits, judgments, litigation costs and attorneys’ fees, of every kind and nature.
+              In such a case, MIT will provide you with written notice of such claim, suit or action.
+            </li>
+            <li>
+              These terms and conditions constitute the entire agreement between you and MIT with respect
+              to your use of the Site, superseding any prior agreements between you and MIT regarding your
+              use of the Site. The failure of MIT to exercise or enforce any right or provision of the terms
+              and conditions shall not constitute a waiver of such right or provision. If any provision of
+              the terms and conditions is found by a court of competent jurisdiction to be invalid, the parties
+              nevertheless agree that the court should endeavor to give effect to the parties’ intentions as
+              reflected in the provision, and the other provisions of the terms and conditions remain in full
+              force and effect.
+            </li>
+            <li>
+              You agree that any dispute arising out of or relating to these terms and conditions or any
+              content posted to a Site will be governed by the laws of the Commonwealth of Massachusetts,
+              excluding its conflicts of law provisions. You further consent to the personal jurisdiction of
+              and exclusive venue in the federal and state courts located in and serving Boston, Massachusetts
+              as the legal forum for any such dispute.
+            </li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% include "footer.html" %}
+{% endblock %}

--- a/ui/url_utils.py
+++ b/ui/url_utils.py
@@ -4,5 +4,6 @@ Utils for URLs (to avoid circular imports)
 
 DASHBOARD_URL = '/dashboard/'
 PROFILE_URL = '/profile/'
+TERMS_OF_SERVICE_URL = '/terms_of_service/'
 SETTINGS_URL = "/settings/"
 SEARCH_URL = "/learners/"

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -6,12 +6,14 @@ from django.conf.urls import url
 from ui.url_utils import (
     DASHBOARD_URL,
     PROFILE_URL,
+    TERMS_OF_SERVICE_URL,
     SETTINGS_URL,
     SEARCH_URL,
 )
 from ui.views import (
     DashboardView,
     UsersView,
+    terms_of_service,
     page_404,
     page_500,
 )
@@ -31,4 +33,5 @@ urlpatterns = [
     url(r'^404/$', page_404, name='ui-404'),
     url(r'^500/$', page_500, name='ui-500'),
     url(r'^users/(?P<user>[-\w]+)?/?', UsersView.as_view(), name='ui-users'),
+    url(r'^{}$'.format(TERMS_OF_SERVICE_URL.lstrip("/")), terms_of_service, name='terms_of_service'),
 ] + dashboard_urlpatterns

--- a/ui/views.py
+++ b/ui/views.py
@@ -135,6 +135,20 @@ def standard_error_page(request, status_code, template_filename):
     return response
 
 
+def terms_of_service(request):
+    """
+    Handles the terms of service page
+    """
+    return render(
+        request,
+        "terms_of_service.html",
+        context={
+            "style_src": get_bundle_url(request, "style.js"),
+            "js_settings_json": "{}",
+        }
+    )
+
+
 def page_404(request):
     """
     Overridden handler for the 404 error pages.

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -21,7 +21,7 @@ from profiles.api import get_social_username
 from profiles.factories import ProfileFactory
 from roles.models import Role
 from search.base import ESTestCase
-from ui.urls import DASHBOARD_URL
+from ui.urls import DASHBOARD_URL, TERMS_OF_SERVICE_URL
 
 
 class ViewsTests(ESTestCase):
@@ -473,3 +473,17 @@ class TestUsersPage(ViewsTests):
         """
         resp = self.client.get(reverse('ui-users'))
         assert resp.status_code == 404
+
+
+class TestTermsOfService(ViewsTests):
+    """
+    tests for the ToS page
+    """
+
+    def test_tos_settings(self):
+        """
+        test the settings we pass to the ToS page
+        """
+        response = self.client.get(TERMS_OF_SERVICE_URL)
+        js_settings = json.loads(response.context['js_settings_json'])
+        assert js_settings == {}


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #948

#### What's this PR do?

This PR adds a new standalone page to display the terms of service. It's a django template with the same look-and-feel as what we have on the dashboard pages.

For this I also implemented a new header partial, which we'll hopefully be able to use on the homepage.

#### Where should the reviewer start?

Read over the code, make sure it makes sense?

#### How should this be manually tested?

You should be able to visit `/terms_of_service`, when logged in or no, and see there ToS there.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

![tos](https://cloud.githubusercontent.com/assets/6207644/18096590/b7ef8556-6ea8-11e6-9254-19f2db953864.png)