### PR TITLE
add celerybeat-schedule to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ coverage/
 
 # Django stuff:
 *.log
+celerybeat-schedule.db
 
 # Sphinx documentation
 docs/_build/


### PR DESCRIPTION
I believe there are plans to fix this issue, but I think we should add this until we sort out the fix.