### PR TITLE
Added some server side verification for profiles

### DIFF
--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -1,10 +1,17 @@
 """
 Tests for profile serializers
 """
+from copy import deepcopy
 
 from django.db.models.signals import post_save
 from factory.django import mute_signals
-from rest_framework.fields import DateTimeField
+from rest_framework.fields import (
+    CharField,
+    DateTimeField,
+    ReadOnlyField,
+    SerializerMethodField,
+)
+from rest_framework.serializers import ListSerializer
 from rest_framework.exceptions import ValidationError
 
 from backends.edxorg import EdxOrgOAuth2
@@ -24,6 +31,7 @@ from profiles.serializers import (
     EmploymentSerializer,
     ProfileLimitedSerializer,
     ProfileSerializer,
+    ProfileFilledOutSerializer,
 )
 from profiles.util import (
     GravatarImgSize,
@@ -303,3 +311,116 @@ class ProfileTests(ESTestCase):
 
         # Other profile is unaffected
         assert employment3.profile.work_history.count() == 1
+
+
+class ProfileFilledOutTests(ESTestCase):
+    """Tests for validating filled out profiles"""
+
+    @classmethod
+    def setUpTestData(cls):
+        """
+        Create a profile and social auth
+        """
+        with mute_signals(post_save):
+            cls.profile = ProfileFactory.create(
+                filled_out=True,
+                agreed_to_terms_of_service=True,
+            )
+        EmploymentFactory.create(profile=cls.profile)
+        EducationFactory.create(profile=cls.profile)
+        cls.profile.user.social_auth.create(
+            provider=EdxOrgOAuth2.name,
+            uid="{}_edx".format(cls.profile.user.username)
+        )
+
+    def setUp(self):
+        """
+        Create a profile and social auth
+        """
+        serializer = ProfileFilledOutSerializer(self.profile)
+        self.data = serializer.to_representation(self.profile)
+
+    def assert_required_fields(self, field_names, parent_getter, field_parent_getter):
+        """
+        Helper function to assert required fields
+        """
+        for key in field_names:
+            field = field_parent_getter(ProfileFilledOutSerializer().fields)[key]
+            # skip fields that are generated, read only, or that tie to other serializers which are tested elsewhere
+            if isinstance(field, (ListSerializer, SerializerMethodField, ReadOnlyField)):
+                continue
+
+            clone = deepcopy(self.data)
+            parent_getter(clone)[key] = None
+            with self.assertRaises(ValidationError) as ex:
+                ProfileFilledOutSerializer(data=clone).is_valid(raise_exception=True)
+            assert parent_getter(ex.exception.args[0]) == {key: ['This field may not be null.']}
+
+            if isinstance(field, CharField):
+                # test blank string too
+                parent_getter(clone)[key] = ""
+                with self.assertRaises(ValidationError) as ex:
+                    ProfileFilledOutSerializer(data=clone).is_valid(raise_exception=True)
+                assert parent_getter(ex.exception.args[0]) == {key: ['This field may not be blank.']}
+
+    def test_success(self):
+        """
+        Test a successful validation
+        """
+        ProfileFilledOutSerializer(data=self.data).is_valid(raise_exception=True)
+
+    def test_filled_out_false(self):
+        """
+        filled_out cannot be set to false
+        """
+        self.data['filled_out'] = False
+        with self.assertRaises(ValidationError) as ex:
+            ProfileFilledOutSerializer(data=self.data).is_valid(raise_exception=True)
+        assert ex.exception.args[0] == {'non_field_errors': ['filled_out cannot be set to false']}
+
+    def test_agreed_to_terms_of_service_false(self):
+        """
+        agreed_to_terms_of_service cannot be set to false
+        """
+        self.data['agreed_to_terms_of_service'] = False
+        with self.assertRaises(ValidationError) as ex:
+            ProfileFilledOutSerializer(data=self.data).is_valid(raise_exception=True)
+        assert ex.exception.args[0] == {'non_field_errors': ['agreed_to_terms_of_service cannot be set to false']}
+
+    def test_required_fields(self):
+        """
+        All fields are required after a profile is marked filled_out
+        """
+        keys = set(ProfileFilledOutSerializer.Meta.fields)
+        self.assert_required_fields(keys, lambda profile: profile, lambda profile: profile)
+
+    def test_work_history(self):
+        """
+        All fields are required after a profile is marked filled_out
+        """
+        # end date may be null for work history
+        keys = set(EmploymentSerializer.Meta.fields) - {'end_date'}
+        self.assert_required_fields(
+            keys,
+            lambda profile: profile['work_history'][0],
+            lambda profile: profile['work_history'].child,
+        )
+
+    def test_work_history_end_date(self):
+        """
+        Make sure end_date can be set to null on filled out profiles
+        """
+        self.data['work_history'][0]['end_date'] = None
+        # No exception should be raised by the next line
+        ProfileFilledOutSerializer(data=self.data).is_valid(raise_exception=True)
+
+    def test_education(self):
+        """
+        All fields are required after a profile is marked filled_out
+        """
+        keys = set(EducationSerializer.Meta.fields) - {'field_of_study'}
+        self.assert_required_fields(
+            keys,
+            lambda profile: profile['education'][0],
+            lambda profile: profile['education'].child,
+        )

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -12,6 +12,7 @@ from roles.roles import (
 from profiles.models import Profile
 from profiles.serializers import (
     ProfileSerializer,
+    ProfileFilledOutSerializer,
     ProfileLimitedSerializer,
 )
 from profiles.permissions import (
@@ -32,6 +33,7 @@ class ProfileViewSet(RetrieveModelMixin, UpdateModelMixin, GenericViewSet):
     # possible serializers
     serializer_class_staff = ProfileSerializer
     serializer_class_owner = ProfileSerializer
+    serializer_class_filled_out = ProfileFilledOutSerializer
     serializer_class_limited = ProfileLimitedSerializer
 
     def get_serializer_class(self):
@@ -42,7 +44,10 @@ class ProfileViewSet(RetrieveModelMixin, UpdateModelMixin, GenericViewSet):
 
         # Owner of the profile
         if self.request.user == profile.user:
-            return self.serializer_class_owner
+            if profile.filled_out or self.request.data.get('filled_out'):
+                return self.serializer_class_filled_out
+            else:
+                return self.serializer_class_owner
         # Staff or instructor is looking at profile
         elif not self.request.user.is_anonymous() and self.request.user.role_set.filter(
                 role__in=(Staff.ROLE_ID, Instructor.ROLE_ID),

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -8,6 +8,12 @@ from dateutil.parser import parse
 from django.core.urlresolvers import resolve, reverse
 from django.db.models.signals import post_save
 from factory.django import mute_signals
+from rest_framework.fields import (
+    DateField,
+    ReadOnlyField,
+    SerializerMethodField,
+)
+from rest_framework.serializers import ListSerializer
 from rest_framework.status import (
     HTTP_405_METHOD_NOT_ALLOWED,
     HTTP_404_NOT_FOUND
@@ -23,6 +29,7 @@ from profiles.permissions import (
     CanSeeIfNotPrivate,
 )
 from profiles.serializers import (
+    ProfileFilledOutSerializer,
     ProfileLimitedSerializer,
     ProfileSerializer,
 )
@@ -35,35 +42,37 @@ from roles.roles import (
 from search.base import ESTestCase
 
 
-class ProfileTests(ESTestCase):
+class ProfileBaseTests(ESTestCase):
     """
-    Tests for GET on profile view
+    Tests for profile views
     """
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """
-        Create a user and profile
+        Create a user
         """
-        super(ProfileTests, self).setUp()
-
         with mute_signals(post_save):
-            self.user1 = UserFactory.create()
-            username = "{}_edx".format(self.user1.username)
-            self.user1.social_auth.create(
+            cls.user1 = UserFactory.create()
+            username = "{}_edx".format(cls.user1.username)
+            cls.user1.social_auth.create(
                 provider=EdxOrgOAuth2.name,
                 uid=username
             )
-        self.url1 = reverse('profile-detail', kwargs={'user': username})
+        cls.url1 = reverse('profile-detail', kwargs={'user': username})
 
         with mute_signals(post_save):
-            self.user2 = UserFactory.create()
-            username = "{}_edx".format(self.user2.username)
-            self.user2.social_auth.create(
+            cls.user2 = UserFactory.create()
+            username = "{}_edx".format(cls.user2.username)
+            cls.user2.social_auth.create(
                 provider=EdxOrgOAuth2.name,
                 uid=username
             )
-        self.url2 = reverse('profile-detail', kwargs={'user': username})
+        cls.url2 = reverse('profile-detail', kwargs={'user': username})
 
+
+class ProfileGETTests(ProfileBaseTests):
+    """Tests for GET requests on profiles"""
     def test_viewset(self):
         """
         Assert that the URL links up with the viewset
@@ -207,46 +216,6 @@ class ProfileTests(ESTestCase):
         resp = self.client.get(self.url2)
         assert resp.status_code == HTTP_404_NOT_FOUND
 
-    def test_patch_own_profile(self):
-        """
-        A user PATCHes their own profile
-        """
-        with mute_signals(post_save):
-            ProfileFactory.create(user=self.user1)
-        self.client.force_login(self.user1)
-
-        with mute_signals(post_save):
-            new_profile = ProfileFactory.create()
-        new_profile.user.social_auth.create(
-            provider=EdxOrgOAuth2.name,
-            uid="{}_edx".format(new_profile.user.username)
-        )
-        patch_data = ProfileSerializer().to_representation(new_profile)
-
-        resp = self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
-        assert resp.status_code == 200
-
-        old_profile = Profile.objects.get(user__username=self.user1.username)
-        for key, value in patch_data.items():
-            if key in ("username", "filled_out", "pretty_printed_student_id",
-                       "work_history", "education", "profile_url_full",
-                       "profile_url_large", "profile_url_medium", "profile_url_small",):
-                # these fields are readonly
-                continue
-            elif key == "date_of_birth":
-                assert getattr(old_profile, key) == parse(value).date()
-            else:
-                assert getattr(old_profile, key) == value
-
-    def test_forbidden_methods(self):
-        """
-        POST is not implemented.
-        """
-        with mute_signals(post_save):
-            ProfileFactory.create(user=self.user1)
-        self.client.force_login(self.user1)
-        assert self.client.post(self.url1).status_code == HTTP_405_METHOD_NOT_ALLOWED
-
     def test_instructor_sees_entire_profile(self):
         """
         An instructor should be able to see the entire profile despite the account privacy
@@ -292,3 +261,89 @@ class ProfileTests(ESTestCase):
         self.client.force_login(self.user1)
         resp = self.client.get(self.url2)
         assert resp.json() == ProfileSerializer().to_representation(profile)
+
+
+class ProfilePATCHTests(ProfileBaseTests):
+    """
+    Tests for profile PATCH
+    """
+    def test_patch_own_profile(self):
+        """
+        A user PATCHes their own profile
+        """
+        with mute_signals(post_save):
+            ProfileFactory.create(user=self.user1, filled_out=False, agreed_to_terms_of_service=False)
+        self.client.force_login(self.user1)
+
+        with mute_signals(post_save):
+            new_profile = ProfileFactory.create(filled_out=False)
+        new_profile.user.social_auth.create(
+            provider=EdxOrgOAuth2.name,
+            uid="{}_edx".format(new_profile.user.username)
+        )
+        patch_data = ProfileSerializer().to_representation(new_profile)
+
+        resp = self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
+        assert resp.status_code == 200
+
+        old_profile = Profile.objects.get(user__username=self.user1.username)
+        for key, value in patch_data.items():
+            field = ProfileSerializer().fields[key]
+
+            if isinstance(field, (ListSerializer, SerializerMethodField, ReadOnlyField)):
+                # these fields are readonly
+                continue
+            elif isinstance(field, DateField):
+                assert getattr(old_profile, key) == parse(value).date()
+            else:
+                assert getattr(old_profile, key) == value
+
+    def test_serializer(self):
+        """
+        Get a user's own profile, ensure that we used ProfileSerializer and not ProfileFilledOutSerializer
+        """
+        with mute_signals(post_save):
+            profile = ProfileFactory.create(user=self.user1, filled_out=False)
+        self.client.force_login(self.user1)
+
+        patch_data = ProfileSerializer().to_representation(profile)
+        # PATCH may not succeed, we just care that the right serializer was used
+        with patch(
+            'profiles.views.ProfileFilledOutSerializer.__new__',
+            autospec=True,
+            side_effect=ProfileFilledOutSerializer.__new__
+        ) as mocked_filled_out, patch(
+            'profiles.views.ProfileSerializer.__new__',
+            autospec=True,
+            side_effect=ProfileSerializer.__new__
+        ) as mocked:
+            self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
+        assert mocked.called
+        assert not mocked_filled_out.called
+
+    def test_filled_out_serializer(self):
+        """
+        Get a user's own profile, ensure that we used ProfileFilledOutSerializer
+        """
+        with mute_signals(post_save):
+            profile = ProfileFactory.create(user=self.user1, filled_out=True)
+        self.client.force_login(self.user1)
+
+        patch_data = ProfileSerializer().to_representation(profile)
+        # PATCH may not succeed, we just care that the right serializer was used
+        with patch(
+            'profiles.views.ProfileFilledOutSerializer.__new__',
+            autospec=True,
+            side_effect=ProfileFilledOutSerializer.__new__
+        ) as mocked:
+            self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
+        assert mocked.called
+
+    def test_forbidden_methods(self):
+        """
+        POST is not implemented.
+        """
+        with mute_signals(post_save):
+            ProfileFactory.create(user=self.user1)
+        self.client.force_login(self.user1)
+        assert self.client.post(self.url1).status_code == HTTP_405_METHOD_NOT_ALLOWED


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #847

#### What's this PR do?
If `filled_out` is true or is being set to true, it does some extra validation on the profile data. See the issue to see what is being validated and what is skipped.

#### Where should the reviewer start?

#### How should this be manually tested?
In the user page for your own user, try clearing the end date for some field of employment. You should still be able to.

Then, go to `/api/v0/profiles/your_user_name_here/`. Try to PATCH a profile to clear a field, eg

    {
      "country": ""
    }

You should see 'This profile may not be blank'


#### What GIF best describes this PR or how it makes you feel?
![](http://i.giphy.com/8xBsX4fCR89UY.gif)