### PR TITLE
Hooked up front end to mail API endpoint

### DIFF
--- a/static/js/actions/email.js
+++ b/static/js/actions/email.js
@@ -1,4 +1,9 @@
 // @flow
+import type { Dispatch } from 'redux';
+import type { Dispatcher } from '../flow/reduxTypes';
+import type { EmailSendResponse } from '../flow/emailTypes';
+import * as api from '../util/api';
+
 export const actionCreatorGenerator = (type: string) => (
   (args: any) => args === undefined ? { type: type } : { type: type, payload: args }
 );
@@ -14,3 +19,25 @@ export const clearEmailEdit = actionCreatorGenerator(CLEAR_EMAIL_EDIT);
 
 export const UPDATE_EMAIL_VALIDATION = 'UPDATE_EMAIL_VALIDATION';
 export const updateEmailValidation = actionCreatorGenerator(UPDATE_EMAIL_VALIDATION);
+
+export const INITIATE_SEND_EMAIL = 'INITIATE_SEND_EMAIL';
+export const initiateSendEmail = actionCreatorGenerator(INITIATE_SEND_EMAIL);
+
+export const SEND_EMAIL_SUCCESS = 'SEND_EMAIL_SUCCESS';
+export const sendEmailSuccess = actionCreatorGenerator(SEND_EMAIL_SUCCESS);
+
+export const SEND_EMAIL_FAILURE = 'SEND_EMAIL_FAILURE';
+export const sendEmailFailure = actionCreatorGenerator(SEND_EMAIL_FAILURE);
+
+export function sendSearchResultMail(subject: string, body: string, searchRequest: Object): Dispatcher<EmailSendResponse> {
+  return (dispatch: Dispatch) => {
+    dispatch(initiateSendEmail());
+    return api.sendSearchResultMail(subject, body, searchRequest).
+      then(response => {
+        dispatch(sendEmailSuccess());
+        return Promise.resolve(response);
+      }).catch(error => {
+        dispatch(sendEmailFailure(error));
+      });
+  };
+}

--- a/static/js/components/EmailCompositionDialog.js
+++ b/static/js/components/EmailCompositionDialog.js
@@ -3,7 +3,10 @@ import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import Button from 'react-mdl/lib/Button';
 import R from 'ramda';
-import type { Email, EmailValidationErrors } from '../reducers/email';
+import type {
+  Email,
+  EmailValidationErrors
+} from '../flow/emailTypes';
 
 const createDialogActions = (close, send) => ([
   <Button
@@ -24,7 +27,7 @@ const createDialogActions = (close, send) => ([
   </Button>
 ]);
 
-const showValidationError = R.curry((getter, object) => {
+const showValidationError = R.curry((getter, object: EmailValidationErrors) => {
   let val = getter(object);
   if ( val !== undefined ) {
     return <span className="validation-error">{ val }</span>;
@@ -42,7 +45,6 @@ type EmailDialogProps = {
   updateEmailEdit:  Function,
   open:             boolean,
   email:            Email,
-  errors:           EmailValidationErrors,
   searchkit:        Object,
   sendEmail:        (e: Email) => void,
 };
@@ -52,8 +54,7 @@ const EmailCompositionDialog = (props: EmailDialogProps) => {
     closeEmailDialog,
     updateEmailEdit,
     open,
-    email,
-    errors,
+    email: { email, validationErrors },
     searchkit,
     sendEmail,
   } = props;
@@ -76,7 +77,7 @@ const EmailCompositionDialog = (props: EmailDialogProps) => {
         value={email.subject || ""}
         onChange={updateEmailEdit('subject')}
       />
-      { showSubjectError(errors) }
+      { showSubjectError(validationErrors) }
       <textarea
         rows="7"
         className="email-body"
@@ -84,7 +85,7 @@ const EmailCompositionDialog = (props: EmailDialogProps) => {
         value={email.body || ""}
         onChange={updateEmailEdit('body')}
       />
-      { showBodyError(errors) }
+      { showBodyError(validationErrors) }
     </div>
   </Dialog>;
 };

--- a/static/js/components/EmailCompositionDialog_test.js
+++ b/static/js/components/EmailCompositionDialog_test.js
@@ -7,7 +7,7 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import R from 'ramda';
 import TestUtils from 'react-addons-test-utils';
 
-import { NEW_EMAIL_EDIT } from '../reducers/email';
+import { INITIAL_EMAIL_STATE, NEW_EMAIL_EDIT } from '../reducers/email';
 import { modifyTextField } from '../util/test_utils';
 
 import EmailCompositionDialog from './EmailCompositionDialog';
@@ -19,8 +19,10 @@ describe('EmailCompositionDialog', () => {
     closeEmailDialog: sinon.stub().returns(updateStub),
     updateEmailEdit: sinon.stub().returns(updateStub),
     open: true,
-    email: Object.assign({}, NEW_EMAIL_EDIT),
-    errors: {},
+    email: {
+      ...INITIAL_EMAIL_STATE,
+      email: NEW_EMAIL_EDIT
+    },
     searchkit: {
       getHitsCount: sinon.stub().returns(20)
     },
@@ -52,10 +54,10 @@ describe('EmailCompositionDialog', () => {
     );
   });
 
-  it('should fire sendEmail when the "send" button is clicked', () => {
+  it('should fire sendSearchResultMail when the "send" button is clicked', () => {
     renderDialog();
     TestUtils.Simulate.click(getDialog().querySelector('.save-button'));
-    assert(defaultProps.sendEmail.called, "called sendEmail method");
+    assert(defaultProps.sendEmail.called, "called sendSearchResultMail method");
   });
 
   ['subject', 'body'].forEach(field => {
@@ -69,8 +71,7 @@ describe('EmailCompositionDialog', () => {
 
       it('should display the value from the store', () => {
         let newProps = R.clone(defaultProps);
-
-        newProps.email[field] = "a field value!";
+        newProps.email.email[field] = "a field value!";
         renderDialog(newProps);
         assert.equal(getField().value, "a field value!");
       });
@@ -83,10 +84,11 @@ describe('EmailCompositionDialog', () => {
       });
 
       it('should show an error if an error for the field is passed in', () => {
-        let errorProps = R.clone(defaultProps);
+        let props = R.clone(defaultProps);
+        let validationErrors = props.email.validationErrors;
         let errorMessage = `An error message for ${field}`;
-        errorProps.errors[field] = errorMessage;
-        renderDialog(errorProps);
+        validationErrors[field] = errorMessage;
+        renderDialog(props);
         let message = getDialog().querySelector('.validation-error').textContent;
         assert.equal(message, errorMessage);
       });

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -23,7 +23,7 @@ import FilterVisibilityToggle from './search/FilterVisibilityToggle';
 import HitsCount from './search/HitsCount';
 import EmailCompositionDialog from './EmailCompositionDialog';
 import type { Option } from '../flow/generalTypes';
-import type { Email, EmailValidationErrors } from '../reducers/email';
+import type { Email } from '../flow/emailTypes';
 
 let makeSearchkitTranslations: () => Object = () => {
   let translations = {};
@@ -82,7 +82,6 @@ export default class LearnerSearch extends SearchkitComponent {
     updateEmailEdit:        (o: Object) => void,
     sendEmail:              () => void,
     email:                  Email,
-    errors:                 EmailValidationErrors,
     children:               React$Element<*>[],
   };
 
@@ -100,7 +99,6 @@ export default class LearnerSearch extends SearchkitComponent {
       updateEmailEdit,
       sendEmail,
       email,
-      errors,
       openEmailComposer,
     } = this.props;
     return (
@@ -110,7 +108,6 @@ export default class LearnerSearch extends SearchkitComponent {
           closeEmailDialog={closeEmailDialog}
           updateEmailEdit={updateEmailEdit}
           email={email}
-          errors={errors}
           sendEmail={sendEmail}
           searchkit={this.searchkit}
         />

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -1,0 +1,24 @@
+export type Email = {
+  subject?:   ?string;
+  body?:      ?string;
+  query?:     ?Object;
+};
+
+export type EmailSendResponse = {
+  errorStatusCode?:  number;
+};
+
+export type EmailSendError = EmailSendResponse;
+
+export type EmailValidationErrors = {
+  subject?:   ?string;
+  body?:      ?string;
+  query?:     ?string;
+};
+
+export type EmailState = {
+  email:  Email;
+  validationErrors: EmailValidationErrors,
+  sendError: EmailSendError,
+  fetchStatus?: ?string;
+}

--- a/static/js/reducers/email.js
+++ b/static/js/reducers/email.js
@@ -4,29 +4,25 @@ import {
   UPDATE_EMAIL_EDIT,
   CLEAR_EMAIL_EDIT,
   UPDATE_EMAIL_VALIDATION,
+  INITIATE_SEND_EMAIL,
+  SEND_EMAIL_SUCCESS,
+  SEND_EMAIL_FAILURE
 } from '../actions/email';
+import {
+  FETCH_FAILURE,
+  FETCH_SUCCESS,
+  FETCH_PROCESSING
+} from '../actions';
 import type { Action } from '../flow/reduxTypes';
+import type {
+  Email,
+  EmailState
+} from '../flow/emailTypes';
 
-export type Email = {
-    subject?:   ?string;
-    body?:      ?string;
-    query?:     ?Object;
-};
-
-export type EmailValidationErrors = {
-    subject?:   ?string;
-    body?:      ?string;
-    query?:     ?string;
-};
-
-export type EmailEditState = {
-  email:  Email;
-  errors: EmailValidationErrors;
-}
-
-export const INITIAL_EMAIL_STATE: EmailEditState = {
+export const INITIAL_EMAIL_STATE: EmailState = {
   email:  {},
-  errors: {},
+  validationErrors: {},
+  sendError: {},
 };
 
 export const NEW_EMAIL_EDIT: Email = {
@@ -35,7 +31,7 @@ export const NEW_EMAIL_EDIT: Email = {
   query:      null,
 };
 
-export const email = (state: EmailEditState = INITIAL_EMAIL_STATE, action: Action) => {
+export const email = (state: EmailState = INITIAL_EMAIL_STATE, action: Action) => {
   switch (action.type) {
   case START_EMAIL_EDIT:
     return { ...state, email: { ...NEW_EMAIL_EDIT, query: action.payload } };
@@ -44,7 +40,13 @@ export const email = (state: EmailEditState = INITIAL_EMAIL_STATE, action: Actio
   case CLEAR_EMAIL_EDIT:
     return { ...INITIAL_EMAIL_STATE };
   case UPDATE_EMAIL_VALIDATION:
-    return { ...state, errors: action.payload };
+    return { ...state, validationErrors: action.payload };
+  case INITIATE_SEND_EMAIL:
+    return { ...state, fetchStatus: FETCH_PROCESSING };
+  case SEND_EMAIL_SUCCESS:
+    return { ...INITIAL_EMAIL_STATE, fetchStatus: FETCH_SUCCESS };
+  case SEND_EMAIL_FAILURE:
+    return { ...state, fetchStatus: FETCH_FAILURE, sendError: action.payload };
   default:
     return state;
   }

--- a/static/js/util/api.js
+++ b/static/js/util/api.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import type { Profile, ProfileGetResult, ProfilePatchResult } from '../flow/profileTypes';
 import type { CheckoutResponse } from '../flow/checkoutTypes';
 import type { Dashboard } from '../flow/dashboardTypes';
+import type { EmailSendResponse } from '../flow/emailTypes';
 
 export function getCookie(name: string): string|null {
   let cookieValue = null;
@@ -126,6 +127,17 @@ export function checkout(courseId: string): Promise<CheckoutResponse> {
     method: 'POST',
     body: JSON.stringify({
       course_id: courseId
+    })
+  });
+}
+
+export function sendSearchResultMail(subject: string, body: string, searchRequest: Object): Promise<EmailSendResponse> {
+  return mockableFetchJSONWithCSRF('/api/v0/mail/', {
+    method: 'POST',
+    body: JSON.stringify({
+      email_subject: subject,
+      email_body: body,
+      searchRequest: searchRequest
     })
   });
 }

--- a/static/js/util/api_test.js
+++ b/static/js/util/api_test.js
@@ -10,6 +10,7 @@ import {
   fetchJSONWithCSRF,
   csrfSafeMethod,
   checkout,
+  sendSearchResultMail
 } from './api';
 import * as api from './api';
 import {
@@ -128,6 +129,34 @@ describe('api', function() {
           method: 'POST',
           body: JSON.stringify({course_id: 'course_id'})
         }));
+      });
+    });
+
+    describe('for email', () => {
+      let MAIL_RESPONSE = {errorStatusCode: 200};
+      let searchRequest = {size: 50};
+
+      it('returns expected values when a POST to send email succeeds', () => {
+        fetchStub.returns(Promise.resolve(MAIL_RESPONSE));
+        fetchMock.mock('/api/v0/mail/', (url, opts) => {  // eslint-disable-line no-unused-vars
+          return {status: 200};
+        });
+        return sendSearchResultMail('subject', 'body', searchRequest).then(mailResp => {
+          assert.ok(fetchStub.calledWith('/api/v0/mail/', {
+            method: 'POST',
+            body: JSON.stringify({
+              email_subject: 'subject',
+              email_body: 'body',
+              searchRequest: searchRequest
+            })
+          }));
+          assert.deepEqual(mailResp, MAIL_RESPONSE);
+        });
+      });
+
+      it('returns a rejected Promise when a POST to send email fails', () => {
+        fetchStub.returns(Promise.reject());
+        return assert.isRejected(sendSearchResultMail('subject', 'body', searchRequest));
       });
     });
   });

--- a/static/js/util/validation.js
+++ b/static/js/util/validation.js
@@ -9,7 +9,7 @@ import type {
   ValidationErrors
 } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
-import type { Email } from '../reducers/email';
+import type { Email } from '../flow/emailTypes';
 import { filterPositiveInt } from './util';
 import {
   HIGH_SCHOOL,


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #889 

#### What's this PR do?

Hooks up the micromasters front end to the mail API endpoint

#### Where should the reviewer start?

Probably static/js/util/api.js, static/js/actions/email.js, and static/js/reducers/email.js

#### How should this be manually tested?

Use the 'Email Selected' button on the search to send an email. Since this PR doesn't implement the actual sending of the email, you can effectively stub out the sending functionality by replacing the body of mail.views.MailgunViews.post with this:

```python
        if request.data['email_subject'].startswith('error'):
            status = 400
        else:
            status = 200
        return Response(
            status=status
        )
```

That will allow you to test an error in the view if you use something that starts with 'error' in the subject line. If you'd like to send an actual email, you'll need the Mailgun API key.

