### PR TITLE
Removed signals creating or deleting a ProgramEnrollment

### DIFF
--- a/dashboard/factories.py
+++ b/dashboard/factories.py
@@ -67,18 +67,12 @@ class ProgramEnrollmentFactory(DjangoModelFactory):
     def create(cls, **kwargs):
         """
         Overrides default ProgramEnrollment object creation for the factory.
-
-        ProgramEnrollments should only exist if there is a CachedEnrollment associated with
-        the given User and Program. Instead of creating a new record with the factory, we
-        will create the necessary objects to trigger its creation.
         """
         user = kwargs.get('user', UserFactory.create())
         program = kwargs.get('program', ProgramFactory.create())
         course = CourseFactory.create(program=program)
         course_run = CourseRunFactory.create(course=course)
         CachedEnrollmentFactory.create(user=user, course_run=course_run)
-        # CachedCertificate isn't strictly necessary to create a ProgramEnrollment. This is here for test convenience.
         CachedCertificateFactory.create(user=user, course_run=course_run)
-        # Signal from the creation of a CachedEnrollment should have created a ProgramEnrollment
-        program_enrollment = ProgramEnrollment.objects.get(user=user, program=program)
+        program_enrollment = ProgramEnrollment.objects.create(user=user, program=program)
         return program_enrollment

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -56,7 +56,7 @@ class UserProgramSerializerTests(TestCase):
                     data={'grade': certificate_grades[i]}
                 )
             )
-        cls.program_enrollment = ProgramEnrollment.objects.get(user=profile.user, program=program)
+        cls.program_enrollment = ProgramEnrollment.objects.create(user=profile.user, program=program)
 
     def test_full_program_user_serialization(self):
         """

--- a/dashboard/signals.py
+++ b/dashboard/signals.py
@@ -1,11 +1,22 @@
 """
 Signals for user profiles
 """
-from django.db.models.signals import pre_save, post_save, post_delete
+from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 
 from dashboard.models import CachedEnrollment, CachedCertificate, ProgramEnrollment
-from search.tasks import index_program_enrolled_users, index_users, remove_program_enrolled_user
+from search.tasks import index_program_enrolled_users, remove_program_enrolled_user
+
+
+def _index_enrollment(user, program):
+    """
+    Helper function to index a ProgramEnrollment if one exists for a user and program
+    """
+    try:
+        program_enrollment = ProgramEnrollment.objects.get(user=user, program=program)
+        index_program_enrolled_users.delay([program_enrollment])
+    except ProgramEnrollment.DoesNotExist:
+        pass
 
 
 @receiver(post_save, sender=ProgramEnrollment, dispatch_uid="programenrollment_post_save")
@@ -24,45 +35,12 @@ def handle_delete_programenrollment(sender, instance, **kwargs):  # pylint: disa
     remove_program_enrolled_user.delay(instance)
 
 
-@receiver(pre_save, sender=CachedEnrollment, dispatch_uid="preupdate_programenrollment")
-def precreate_programenrollment(sender, instance, **kwargs):  # pylint: disable=unused-argument
-    """
-    Signal handler to delete Program enrollment when the CachedEnrollment table is updated
-    in case there are no other enrollment in the same program.
-    This is done in a pre_save handler because here it is easier to catch the proper kind
-    of update (from enrolled to not enrolled).
-    """
-    # if the id is not None means this is an update
-    # if the data is None means we need to check if before was not None
-    # meaning if the student was enrolled and now she is not any more
-    if instance.data is None and instance.id is not None:
-        user = instance.user
-        program = instance.course_run.course.program
-        # checking if the instance in the db has data
-        instance_in_db = CachedEnrollment.objects.filter(id=instance.id).exclude(data__isnull=True).count()
-        # if the count is 1, it means the student unenrolled from the course run
-        if instance_in_db == 1:
-            # if there is only one enrollment with data non None, it means that it is the
-            # current instance is the only one for the program, so the program enrollment
-            # needs to be deleted
-            if CachedEnrollment.active_count(user, program) <= 1:  # theoretically this cannot be <1, but just in case
-                ProgramEnrollment.objects.filter(
-                    user=user,
-                    program=program
-                ).delete()
-
-
 @receiver(post_save, sender=CachedEnrollment, dispatch_uid="cachedenrollment_post_save")
 def handle_update_enrollment(sender, instance, **kwargs):  # pylint: disable=unused-argument
     """
     Create ProgramEnrollment when a CachedEnrollment is created/updated, and update the index.
     """
-    if instance.data is not None:
-        program_enrollment, _ = ProgramEnrollment.objects.get_or_create(
-            user=instance.user,
-            program=instance.course_run.course.program
-        )
-        index_program_enrolled_users.delay([program_enrollment])
+    _index_enrollment(instance.user, instance.course_run.course.program)
 
 
 @receiver(post_save, sender=CachedCertificate, dispatch_uid="cachedcertificate_post_save")
@@ -70,12 +48,7 @@ def handle_update_certificate(sender, instance, **kwargs):  # pylint: disable=un
     """
     When a CachedCertificate model is updated, update index.
     """
-    if instance.data is not None:
-        program_enrollment, _ = ProgramEnrollment.objects.get_or_create(
-            user=instance.user,
-            program=instance.course_run.course.program
-        )
-        index_program_enrolled_users.delay([program_enrollment])
+    _index_enrollment(instance.user, instance.course_run.course.program)
 
 
 @receiver(post_delete, sender=CachedEnrollment, dispatch_uid="cachedenrollment_post_delete")
@@ -83,15 +56,7 @@ def handle_delete_enrollment(sender, instance, **kwargs):  # pylint: disable=unu
     """
     Update index when CachedEnrollment model instance is deleted.
     """
-    user = instance.user
-    program = instance.course_run.course.program
-    program_enrollment = ProgramEnrollment.objects.filter(user=user, program=program).first()
-    if program_enrollment is not None:
-        if CachedEnrollment.active_count(user, program) == 0:
-            program_enrollment.delete()
-            index_users.delay([user])
-        else:
-            index_program_enrolled_users.delay([program_enrollment])
+    _index_enrollment(instance.user, instance.course_run.course.program)
 
 
 @receiver(post_delete, sender=CachedCertificate, dispatch_uid="cachedcertificate_post_delete")
@@ -99,8 +64,4 @@ def handle_delete_certificate(sender, instance, **kwargs):  # pylint: disable=un
     """
     Update index when CachedCertificate model instance is deleted.
     """
-    user = instance.user
-    program = instance.course_run.course.program
-    program_enrollment = ProgramEnrollment.objects.filter(user=user, program=program).first()
-    if program_enrollment is not None:
-        index_program_enrolled_users.delay([program_enrollment])
+    _index_enrollment(instance.user, instance.course_run.course.program)

--- a/dashboard/signals_test.py
+++ b/dashboard/signals_test.py
@@ -2,91 +2,205 @@
 Tests for signals
 """
 
-import datetime
-import pytz
+from django.db.models.signals import post_save
+from django.test import (
+    override_settings,
+    TestCase,
+)
+from factory.django import mute_signals
+from mock import patch
 
-from django.contrib.auth.models import User
-
-from courses.factories import CourseRunFactory
-from dashboard.models import ProgramEnrollment, CachedEnrollment
-from search.base import ESTestCase
+from courses.factories import ProgramFactory
+from dashboard.factories import (
+    CachedCertificateFactory,
+    CachedEnrollmentFactory,
+    CourseRunFactory,
+)
+from dashboard.models import ProgramEnrollment
+from profiles.factories import ProfileFactory
 
 
 # pylint: disable=no-self-use
-class SignalProgramEnrollmentTest(ESTestCase):
+# Make sure that any unmocked ES activity results in an error
+@override_settings(ELASTICSEARCH_URL="fake")
+class IndexingTests(TestCase):
     """
-    Test class for signals that creates ProgramEnrollment when user enrolls in a class
+    Test class for signals that index certain objects in Elasticsearch
     """
     @classmethod
     def setUpTestData(cls):
-        super(SignalProgramEnrollmentTest, cls).setUpTestData()
-        cls.user = User.objects.create(username='test', password='test')
-        cls.course_run = CourseRunFactory.create()
+        super(IndexingTests, cls).setUpTestData()
+        with mute_signals(post_save):
+            cls.user = ProfileFactory.create().user
+            cls.program = ProgramFactory.create()
 
-    def setUp(self):
-        ESTestCase.setUp(self)
-        self.now = datetime.datetime.now(tz=pytz.utc)
 
-    def test_program_enrollment_creation(self):
+class ProgramEnrollmentTests(IndexingTests):
+    """
+    Test indexing on program enrollment
+    """
+    def test_create(self):
         """
-        Tests that if a CachedEnrollment is updated with data
-        then ProgramEnrollment is created
+        Tests that the database is reindexed when a ProgramEnrollment is created
         """
-        assert ProgramEnrollment.objects.count() == 0
-        assert CachedEnrollment.objects.count() == 0
-        enrollment = CachedEnrollment.objects.create(
-            user=self.user,
-            course_run=self.course_run,
-            data=None,
-            last_request=self.now
-        )
-        assert ProgramEnrollment.objects.count() == 0
-        enrollment.data = {'data': 'data'}
-        enrollment.save()
-        assert ProgramEnrollment.objects.count() == 1
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            enrollment = ProgramEnrollment.objects.create(user=self.user, program=self.program)
+        mocked.assert_called_once_with([enrollment])
 
-    def test_program_enrollment_deletion(self):
+    def test_update(self):
         """
-        Tests that if a CachedEnrollment is updated with data=None
-        and there is no other enrollment for runs with the same program
-        then the enrollment in the program is deleted.
+        Tests that the database is reindexed when a ProgramEnrollment is created
         """
-        enrollment = CachedEnrollment.objects.create(
-            user=self.user,
-            course_run=self.course_run,
-            data={'data': 'data'},
-            last_request=self.now
-        )
-        assert ProgramEnrollment.objects.count() == 1
-        enrollment.data = None
-        enrollment.save()
-        assert ProgramEnrollment.objects.count() == 0
+        with mute_signals(post_save):
+            enrollment = ProgramEnrollment.objects.create(user=self.user, program=self.program)
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            enrollment.save()
+        mocked.assert_called_once_with([enrollment])
 
-    def test_program_enrollment_no_deletion(self):
+    def test_delete(self):
         """
-        Tests that if a CachedEnrollment is updated with data=None
-        and there is another enrollment for runs with the same program
-        then the enrollment in the program is not deleted.
+        Tests that if a CachedEnrollment is updated with data=None, the enrollment in the program is not deleted.
         """
-        CachedEnrollment.objects.create(
-            user=self.user,
-            course_run=self.course_run,
-            data={'data': 'data'},
-            last_request=self.now
-        )
-        assert ProgramEnrollment.objects.count() == 1
-        # create another run under the same program
-        another_run = CourseRunFactory.create(course=self.course_run.course)
-        # create another enrollment
-        another_enrollment = CachedEnrollment.objects.create(
-            user=self.user,
-            course_run=another_run,
-            data={'data': 'data'},
-            last_request=self.now
-        )
-        # the number of enrollments in the programs is still the same
-        assert ProgramEnrollment.objects.count() == 1
-        # removing the data, will not change the program enrollment
-        another_enrollment.data = None
-        another_enrollment.save()
-        assert ProgramEnrollment.objects.count() == 1
+        with mute_signals(post_save):
+            enrollment = ProgramEnrollment.objects.create(user=self.user, program=self.program)
+        with patch('search.tasks._remove_program_enrolled_user', autospec=True) as mocked:
+            enrollment.delete()
+        mocked.assert_called_once_with(enrollment)
+
+
+class CachedEnrollmentTests(IndexingTests):
+    """Tests for CachedEnrollment"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super(CachedEnrollmentTests, cls).setUpTestData()
+
+        with mute_signals(post_save):
+            cls.program_enrollment = ProgramEnrollment.objects.create(user=cls.user, program=cls.program)
+            cls.course_run = CourseRunFactory.create(program=cls.program)
+            cls.separate_course_run = CourseRunFactory.create()
+
+    def test_create_linked(self):
+        """
+        The database is reindexed when a CachedEnrollment is created and linked to a ProgramEnrollment
+        """
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            CachedEnrollmentFactory.create(user=self.user, course_run=self.course_run)
+        mocked.assert_called_once_with([self.program_enrollment])
+
+    def test_create_unlinked(self):
+        """
+        The database is not reindexed when a CachedEnrollment is created but not linked to a ProgramEnrollment
+        """
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            CachedEnrollmentFactory.create(user=self.user, course_run=self.separate_course_run)
+        assert not mocked.called
+
+    def test_update_linked(self):
+        """
+        The database is reindexed when a CachedEnrollment is updated and linked to a ProgramEnrollment
+        """
+        with mute_signals(post_save):
+            enrollment = CachedEnrollmentFactory.create(user=self.user, course_run=self.course_run)
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            enrollment.save()
+        mocked.assert_called_once_with([self.program_enrollment])
+
+    def test_update_unlinked(self):
+        """
+        The database is not reindexed when a CachedEnrollment is updated but not linked to a ProgramEnrollment
+        """
+        with mute_signals(post_save):
+            enrollment = CachedEnrollmentFactory.create(user=self.user, course_run=self.separate_course_run)
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            enrollment.save()
+        assert not mocked.called
+
+    def test_delete_linked(self):
+        """
+        The database is reindexed when a CachedEnrollment is deleted when linked to a ProgramEnrollment
+        """
+        with mute_signals(post_save):
+            enrollment = CachedEnrollmentFactory.create(user=self.user, course_run=self.course_run)
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            enrollment.delete()
+        mocked.assert_called_once_with([self.program_enrollment])
+
+    def test_delete_unlinked(self):
+        """
+        The database is not reindexed when a CachedEnrollment is deleted when not linked to a ProgramEnrollment
+        """
+        with mute_signals(post_save):
+            enrollment = CachedEnrollmentFactory.create(user=self.user, course_run=self.separate_course_run)
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            enrollment.delete()
+        assert not mocked.called
+
+
+class CachedCertificateTests(IndexingTests):
+    """Tests for CachedCertificate"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super(CachedCertificateTests, cls).setUpTestData()
+
+        with mute_signals(post_save):
+            cls.program_enrollment = ProgramEnrollment.objects.create(user=cls.user, program=cls.program)
+            cls.course_run = CourseRunFactory.create(program=cls.program)
+            cls.separate_course_run = CourseRunFactory.create()
+
+    def test_create_linked(self):
+        """
+        The database is reindexed when a CachedCertificate is created and linked to a ProgramEnrollment
+        """
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            CachedCertificateFactory.create(user=self.user, course_run=self.course_run)
+        mocked.assert_called_once_with([self.program_enrollment])
+
+    def test_create_unlinked(self):
+        """
+        The database is not reindexed when a CachedCertificate is created but not linked to a ProgramEnrollment
+        """
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            CachedCertificateFactory.create(user=self.user, course_run=self.separate_course_run)
+        assert not mocked.called
+
+    def test_update_linked(self):
+        """
+        The database is reindexed when a CachedCertificate is updated and linked to a ProgramEnrollment
+        """
+        with mute_signals(post_save):
+            certificate = CachedCertificateFactory.create(user=self.user, course_run=self.course_run)
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            certificate.save()
+        mocked.assert_called_once_with([self.program_enrollment])
+
+    def test_update_unlinked(self):
+        """
+        The database is not reindexed when a CachedCertificate is updated but not linked to a ProgramEnrollment
+        """
+        with mute_signals(post_save):
+            certificate = CachedCertificateFactory.create(user=self.user, course_run=self.separate_course_run)
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            certificate.save()
+        assert not mocked.called
+
+    def test_delete_linked(self):
+        """
+        The database is reindexed when a CachedCertificate is deleted when linked to a ProgramEnrollment
+        """
+        with mute_signals(post_save):
+            certificate = CachedCertificateFactory.create(user=self.user, course_run=self.course_run)
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            certificate.delete()
+        mocked.assert_called_once_with([self.program_enrollment])
+
+    def test_delete_unlinked(self):
+        """
+        The database is not reindexed when a CachedCertificate is deleted when not linked to a ProgramEnrollment
+        """
+        with mute_signals(post_save):
+            certificate = CachedCertificateFactory.create(user=self.user, course_run=self.separate_course_run)
+        with patch('search.tasks._index_program_enrolled_users', autospec=True) as mocked:
+            certificate.delete()
+        assert not mocked.called

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -281,7 +281,7 @@ class SerializerTests(ESTestCase):
         for course_run in course_runs:
             CachedCertificateFactory.create(user=profile.user, course_run=course_run)
             CachedEnrollmentFactory.create(user=profile.user, course_run=course_run)
-        program_enrollment = ProgramEnrollment.objects.get(user=profile.user, program=program)
+        program_enrollment = ProgramEnrollment.objects.create(user=profile.user, program=program)
 
         assert serialize_program_enrolled_user(program_enrollment) == {
             '_id': program_enrollment.id,


### PR DESCRIPTION
#### What are the relevant tickets?
Part 5 of #796

#### What's this PR do?
`CachedEnrollment` and `CachedCertificate` no longer automatically create `ProgramEnrollment`s when they are created. To create a `ProgramEnrollment` the user must now use the REST API

#### How should this be manually tested?
Delete all `ProgramEnrollment` using the Django shell or admin. Go to the dashboard. Wait five minutes, refresh the dashboard. Verify that there are still no `ProgramEnrollment`s in the database. Then add back the `ProgramEnrollment`s you created in the first place using the shell.
