### PR TITLE
Made edx_level_of_education read only

### DIFF
--- a/profiles/factories.py
+++ b/profiles/factories.py
@@ -64,7 +64,7 @@ class ProfileFactory(DjangoModelFactory):
     edx_requires_parental_consent = FuzzyAttribute(FAKE.boolean)
     date_of_birth = FuzzyDate(date(1850, 1, 1))
     edx_level_of_education = FuzzyChoice(
-        [choice[0] for choice in [None, Profile.LEVEL_OF_EDUCATION_CHOICES]]
+        [None] + [choice[0] for choice in Profile.LEVEL_OF_EDUCATION_CHOICES]
     )
     edx_goals = FuzzyText()
     preferred_language = FuzzyText(suffix=" language")

--- a/profiles/factories.py
+++ b/profiles/factories.py
@@ -64,7 +64,7 @@ class ProfileFactory(DjangoModelFactory):
     edx_requires_parental_consent = FuzzyAttribute(FAKE.boolean)
     date_of_birth = FuzzyDate(date(1850, 1, 1))
     edx_level_of_education = FuzzyChoice(
-        [choice[0] for choice in Profile.LEVEL_OF_EDUCATION_CHOICES]
+        [choice[0] for choice in [None, Profile.LEVEL_OF_EDUCATION_CHOICES]]
     )
     edx_goals = FuzzyText()
     preferred_language = FuzzyText(suffix=" language")

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -235,6 +235,7 @@ class ProfileSerializer(ProfileBaseSerializer):
             'edx_level_of_education',
             'education'
         )
+        read_only_fields = ('edx_level_of_education',)
 
 
 class ProfileLimitedSerializer(ProfileBaseSerializer):
@@ -268,6 +269,7 @@ class ProfileLimitedSerializer(ProfileBaseSerializer):
             'edx_level_of_education',
             'education'
         )
+        read_only_fields = ('edx_level_of_education',)
 
 
 class ProfileFilledOutSerializer(ProfileSerializer):

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -349,6 +349,8 @@ class ProfileFilledOutTests(ESTestCase):
             # skip fields that are generated, read only, or that tie to other serializers which are tested elsewhere
             if isinstance(field, (ListSerializer, SerializerMethodField, ReadOnlyField)):
                 continue
+            elif field.read_only is True:
+                continue
 
             clone = deepcopy(self.data)
             parent_getter(clone)[key] = None

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -290,7 +290,7 @@ class ProfilePATCHTests(ProfileBaseTests):
         for key, value in patch_data.items():
             field = ProfileSerializer().fields[key]
 
-            if isinstance(field, (ListSerializer, SerializerMethodField, ReadOnlyField)):
+            if isinstance(field, (ListSerializer, SerializerMethodField, ReadOnlyField)) or field.read_only is True:
                 # these fields are readonly
                 continue
             elif isinstance(field, DateField):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #971

#### What's this PR do?
Makes edx_level_of_education readonly to prevent users from overwriting its value, and to fix a `filled_out` validation error when it was blank

#### How should this be manually tested?
In the Django shell set your `Profile`'s `edx_level_of_education` to `None`. Then try to edit your profile. No validation errors should be seen and you should get a 200 back from the server.

