### PR TITLE
Fixed key name for search request API param

### DIFF
--- a/static/js/util/api.js
+++ b/static/js/util/api.js
@@ -138,7 +138,7 @@ export function sendSearchResultMail(subject: string, body: string, searchReques
     body: JSON.stringify({
       email_subject: subject,
       email_body: body,
-      searchRequest: searchRequest
+      search_request: searchRequest
     })
   });
 }

--- a/static/js/util/api_test.js
+++ b/static/js/util/api_test.js
@@ -150,7 +150,7 @@ describe('api', function() {
             body: JSON.stringify({
               email_subject: 'subject',
               email_body: 'body',
-              searchRequest: searchRequest
+              search_request: searchRequest
             })
           }));
           assert.deepEqual(mailResp, MAIL_RESPONSE);


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #973 

#### What's this PR do?

Fixes a bug where the search request API param was named incorrectly when passed to the mail API endpoint.

#### How should this be manually tested?

Go to the search page, apply a filter or two, and send an email with MAILGUN_RECIPIENT_OVERRIDE set in your .env. You should see the correct intended recipients in the email body
