### PR TITLE
Added program selector menu

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4071,6 +4071,11 @@
         }
       }
     },
+    "react-tooltip": {
+      "version": "3.1.6",
+      "from": "react-tooltip@>=3.1.6 <4.0.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.1.6.tgz"
+    },
     "react-virtualized": {
       "version": "7.11.6",
       "from": "react-virtualized@>=7.7.1 <8.0.0",
@@ -4183,6 +4188,11 @@
       "version": "0.0.8",
       "from": "redux-asserts@0.0.8",
       "resolved": "https://registry.npmjs.org/redux-asserts/-/redux-asserts-0.0.8.tgz"
+    },
+    "redux-localstorage": {
+      "version": "0.4.1",
+      "from": "redux-localstorage@latest",
+      "resolved": "https://registry.npmjs.org/redux-localstorage/-/redux-localstorage-0.4.1.tgz"
     },
     "redux-logger": {
       "version": "2.6.1",
@@ -5198,9 +5208,9 @@
       "resolved": "https://registry.npmjs.org/wowjs/-/wowjs-1.1.3.tgz",
       "dependencies": {
         "animate.css": {
-          "version": "3.5.1",
+          "version": "3.5.2",
           "from": "animate.css@latest",
-          "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-3.5.1.tgz"
+          "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-3.5.2.tgz"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4002,6 +4002,11 @@
         }
       }
     },
+    "react-input-autosize": {
+      "version": "1.1.0",
+      "from": "react-input-autosize@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-1.1.0.tgz"
+    },
     "react-loader": {
       "version": "2.4.0",
       "from": "react-loader@2.4.0",
@@ -4048,6 +4053,11 @@
       "version": "0.23.0",
       "from": "react-router-bootstrap@0.23.0",
       "resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.23.0.tgz"
+    },
+    "react-select": {
+      "version": "1.0.0-rc.1",
+      "from": "react-select@latest",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.1.tgz"
     },
     "react-tap-event-plugin": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-redux": "4.4.5",
     "react-router": "2.4.0",
     "react-router-bootstrap": "0.23.0",
+    "react-select": "^1.0.0-rc.1",
     "react-tap-event-plugin": "1.0.0",
     "react-tooltip": "^3.1.6",
     "react-virtualized": "^7.7.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "redux": "3.5.2",
     "redux-actions": "^0.11.0",
     "redux-asserts": "0.0.8",
+    "redux-localstorage": "^0.4.1",
     "redux-logger": "2.6.1",
     "redux-thunk": "2.0.1",
     "sanctuary": "^0.11.1",

--- a/static/js/actions/enrollments.js
+++ b/static/js/actions/enrollments.js
@@ -54,3 +54,6 @@ export const addProgramEnrollment = (programId: number): Dispatcher<ProgramEnrol
 
 export const CLEAR_ENROLLMENTS = 'CLEAR_ENROLLMENTS';
 export const clearEnrollments = createAction(CLEAR_ENROLLMENTS);
+
+export const SET_CURRENT_PROGRAM_ENROLLMENT = 'SET_CURRENT_PROGRAM_ENROLLMENT';
+export const setCurrentProgramEnrollment = createAction(SET_CURRENT_PROGRAM_ENROLLMENT);

--- a/static/js/actions/enrollments_test.js
+++ b/static/js/actions/enrollments_test.js
@@ -7,6 +7,7 @@ import {
   receiveAddProgramEnrollmentSuccess,
   receiveAddProgramEnrollmentFailure,
   clearEnrollments,
+  setCurrentProgramEnrollment,
 
   REQUEST_GET_PROGRAM_ENROLLMENTS,
   RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
@@ -15,6 +16,7 @@ import {
   RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS,
   RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE,
   CLEAR_ENROLLMENTS,
+  SET_CURRENT_PROGRAM_ENROLLMENT,
 } from './enrollments';
 import { assertCreatedActionHelper } from './util';
 
@@ -28,6 +30,7 @@ describe('enrollment actions', () => {
       [receiveAddProgramEnrollmentSuccess, RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS],
       [receiveAddProgramEnrollmentFailure, RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE],
       [clearEnrollments, CLEAR_ENROLLMENTS],
+      [setCurrentProgramEnrollment, SET_CURRENT_PROGRAM_ENROLLMENT],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -82,9 +82,6 @@ export const setSearchFilterVisibility = createAction(SET_SEARCH_FILTER_VISIBILI
 export const SET_EMAIL_DIALOG_VISIBILITY = 'SET_EMAIL_DIALOG_VISIBILITY';
 export const setEmailDialogVisibility = createAction(SET_EMAIL_DIALOG_VISIBILITY);
 
-export const SET_PROGRAM_SELECTOR_OPEN = 'SET_PROGRAM_SELECTOR_OPEN';
-export const setProgramSelectorOpen = createAction(SET_PROGRAM_SELECTOR_OPEN);
-
 export const SET_ENROLL_DIALOG_VISIBILITY = 'SET_ENROLL_DIALOG_VISIBILITY';
 export const setEnrollDialogVisibility = createAction(SET_ENROLL_DIALOG_VISIBILITY);
 

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -81,3 +81,12 @@ export const setSearchFilterVisibility = createAction(SET_SEARCH_FILTER_VISIBILI
 
 export const SET_EMAIL_DIALOG_VISIBILITY = 'SET_EMAIL_DIALOG_VISIBILITY';
 export const setEmailDialogVisibility = createAction(SET_EMAIL_DIALOG_VISIBILITY);
+
+export const SET_PROGRAM_SELECTOR_OPEN = 'SET_PROGRAM_SELECTOR_OPEN';
+export const setProgramSelectorOpen = createAction(SET_PROGRAM_SELECTOR_OPEN);
+
+export const SET_ENROLL_DIALOG_VISIBILITY = 'SET_ENROLL_DIALOG_VISIBILITY';
+export const setEnrollDialogVisibility = createAction(SET_ENROLL_DIALOG_VISIBILITY);
+
+export const SET_ENROLL_SELECTED_PROGRAM = 'SET_ENROLL_SELECTED_PROGRAM';
+export const setEnrollSelectedProgram = createAction(SET_ENROLL_SELECTED_PROGRAM);

--- a/static/js/actions/ui_test.js
+++ b/static/js/actions/ui_test.js
@@ -18,6 +18,9 @@ import {
   SET_USER_MENU_OPEN,
   SET_SEARCH_FILTER_VISIBILITY,
   SET_EMAIL_DIALOG_VISIBILITY,
+  SET_PROGRAM_SELECTOR_OPEN,
+  SET_ENROLL_DIALOG_VISIBILITY,
+  SET_ENROLL_SELECTED_PROGRAM,
 
   clearUI,
   updateDialogText,
@@ -38,6 +41,9 @@ import {
   setUserMenuOpen,
   setSearchFilterVisibility,
   setEmailDialogVisibility,
+  setProgramSelectorOpen,
+  setEnrollDialogVisibility,
+  setEnrollSelectedProgram,
 } from '../actions/ui';
 import { assertCreatedActionHelper } from './util';
 
@@ -62,7 +68,10 @@ describe('generated UI action helpers', () => {
       [setProfileStep, SET_PROFILE_STEP],
       [setUserMenuOpen, SET_USER_MENU_OPEN],
       [setSearchFilterVisibility, SET_SEARCH_FILTER_VISIBILITY],
-      [setEmailDialogVisibility, SET_EMAIL_DIALOG_VISIBILITY]
+      [setEmailDialogVisibility, SET_EMAIL_DIALOG_VISIBILITY],
+      [setProgramSelectorOpen, SET_PROGRAM_SELECTOR_OPEN],
+      [setEnrollDialogVisibility, SET_ENROLL_DIALOG_VISIBILITY],
+      [setEnrollSelectedProgram, SET_ENROLL_SELECTED_PROGRAM],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/actions/ui_test.js
+++ b/static/js/actions/ui_test.js
@@ -18,7 +18,6 @@ import {
   SET_USER_MENU_OPEN,
   SET_SEARCH_FILTER_VISIBILITY,
   SET_EMAIL_DIALOG_VISIBILITY,
-  SET_PROGRAM_SELECTOR_OPEN,
   SET_ENROLL_DIALOG_VISIBILITY,
   SET_ENROLL_SELECTED_PROGRAM,
 
@@ -41,7 +40,6 @@ import {
   setUserMenuOpen,
   setSearchFilterVisibility,
   setEmailDialogVisibility,
-  setProgramSelectorOpen,
   setEnrollDialogVisibility,
   setEnrollSelectedProgram,
 } from '../actions/ui';
@@ -69,7 +67,6 @@ describe('generated UI action helpers', () => {
       [setUserMenuOpen, SET_USER_MENU_OPEN],
       [setSearchFilterVisibility, SET_SEARCH_FILTER_VISIBILITY],
       [setEmailDialogVisibility, SET_EMAIL_DIALOG_VISIBILITY],
-      [setProgramSelectorOpen, SET_PROGRAM_SELECTOR_OPEN],
       [setEnrollDialogVisibility, SET_ENROLL_DIALOG_VISIBILITY],
       [setEnrollSelectedProgram, SET_ENROLL_SELECTED_PROGRAM],
     ].forEach(assertCreatedActionHelper);

--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -240,5 +240,16 @@ describe("ErrorMessage", () => {
         });
       });
     });
+
+    describe('learners page', () => {
+      it('shows an error if there is no matching current program enrollment', () => {
+        helper.enrollmentsGetStub.returns(Promise.resolve([]));
+
+        return renderComponent("/learners").then(([wrapper]) => {
+          let message = wrapper.find('.page-content').text();
+          assert(message.includes("Additional info: No program enrollment is available."));
+        });
+      });
+    });
   });
 });

--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -145,6 +145,24 @@ describe("ErrorMessage", () => {
           assert.equal(message, undefined);
         });
       });
+
+      it('shows an error if there are no programs', () => {
+        helper.dashboardStub.returns(Promise.resolve([]));
+
+        return renderComponent("/dashboard").then(([wrapper]) => {
+          let message = wrapper.find('.page-content').text();
+          assert(message.includes("Additional info: No program enrollment is available."));
+        });
+      });
+
+      it('shows an error if there is no matching current program enrollment', () => {
+        helper.enrollmentsGetStub.returns(Promise.resolve([]));
+
+        return renderComponent("/dashboard").then(([wrapper]) => {
+          let message = wrapper.find('.page-content').text();
+          assert(message.includes("Additional info: No program enrollment is available."));
+        });
+      });
     });
 
     describe('profile page', () => {

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -17,6 +17,7 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Card from 'react-mdl/lib/Card/Card';
 import iso3166 from 'iso-3166-2';
 
+import ProgramFilter from './ProgramFilter';
 import LearnerResult from './search/LearnerResult';
 import CountryRefinementOption from './search/CountryRefinementOption';
 import FilterVisibilityToggle from './search/FilterVisibilityToggle';
@@ -24,6 +25,7 @@ import HitsCount from './search/HitsCount';
 import EmailCompositionDialog from './EmailCompositionDialog';
 import type { Option } from '../flow/generalTypes';
 import type { Email } from '../flow/emailTypes';
+import type { ProgramEnrollment } from '../flow/enrollmentTypes';
 
 let makeSearchkitTranslations: () => Object = () => {
   let translations = {};
@@ -74,15 +76,16 @@ const sortOptions = [
 
 export default class LearnerSearch extends SearchkitComponent {
   props: {
-    checkFilterVisibility:  (s: string) => boolean,
-    setFilterVisibility:    (s: string, v: boolean) => void,
-    openEmailComposer:      () => void,
-    emailDialogVisibility:  boolean,
-    closeEmailDialog:       () => void,
-    updateEmailEdit:        (o: Object) => void,
-    sendEmail:              () => void,
-    email:                  Email,
-    children:               React$Element<*>[],
+    checkFilterVisibility:    (s: string) => boolean,
+    setFilterVisibility:      (s: string, v: boolean) => void,
+    openEmailComposer:        () => void,
+    emailDialogVisibility:    boolean,
+    closeEmailDialog:         () => void,
+    updateEmailEdit:          (o: Object) => void,
+    sendEmail:                () => void,
+    email:                    Email,
+    children:                 React$Element<*>[],
+    currentProgramEnrollment: ProgramEnrollment,
   };
 
   dropdownOptions: Option[] = [
@@ -100,9 +103,13 @@ export default class LearnerSearch extends SearchkitComponent {
       sendEmail,
       email,
       openEmailComposer,
+      currentProgramEnrollment,
     } = this.props;
     return (
       <div className="learners-search">
+        <ProgramFilter
+          currentProgramEnrollment={currentProgramEnrollment}
+        />
         <EmailCompositionDialog
           open={emailDialogVisibility}
           closeEmailDialog={closeEmailDialog}

--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -1,14 +1,31 @@
 // @flow
 import React from 'react';
-import UserMenu from '../containers/UserMenu';
 import { HeaderTabs, Header, HeaderRow, Tab } from 'react-mdl';
 
-class Navbar extends React.Component {
+import type { DashboardState } from '../flow/dashboardTypes';
+import type {
+  ProgramEnrollment,
+  ProgramEnrollmentsState,
+} from '../flow/enrollmentTypes';
+import ProgramSelector from './ProgramSelector';
+import UserMenu from '../containers/UserMenu';
+
+export default class Navbar extends React.Component {
   props: {
-    empty:      boolean,
-    children?:  React$Element<*>[],
-    pathname:   string,
-    changeUrl:  (i: number) => void,
+    empty:                       boolean,
+    children?:                   React$Element<*>[],
+    pathname:                    string,
+    changeUrl:                   (i: number) => void,
+    currentProgramEnrollment:    ProgramEnrollment,
+    dashboard:                   DashboardState,
+    enrollments:                 ProgramEnrollmentsState,
+    enrollDialogVisibility:      boolean,
+    enrollSelectedProgram:       ?number,
+    programSelectorOpen:         boolean,
+    setCurrentProgramEnrollment: (enrollment: ProgramEnrollment) => void,
+    setEnrollDialogVisibility:   (open: boolean) => void,
+    setEnrollSelectedProgram:    (programId: number) => void,
+    setProgramSelectorOpen:      (open: boolean) => void,
   };
 
   makeTabs: Function = (): React$Element<*>[] => {
@@ -33,7 +50,17 @@ class Navbar extends React.Component {
   render () {
     const {
       changeUrl,
+      currentProgramEnrollment,
+      dashboard,
+      enrollDialogVisibility,
+      enrollSelectedProgram,
+      enrollments,
       pathname,
+      programSelectorOpen,
+      setCurrentProgramEnrollment,
+      setEnrollDialogVisibility,
+      setEnrollSelectedProgram,
+      setProgramSelectorOpen,
     } = this.props;
     const onChange = tabId => {
       let path = this.tabs[tabId].path;
@@ -48,6 +75,18 @@ class Navbar extends React.Component {
               <span className="mdl-layout-title">
                 MicroMasters
               </span>
+              <ProgramSelector
+                currentProgramEnrollment={currentProgramEnrollment}
+                dashboard={dashboard}
+                enrollDialogVisibility={enrollDialogVisibility}
+                enrollSelectedProgram={enrollSelectedProgram}
+                enrollments={enrollments}
+                programSelectorOpen={programSelectorOpen}
+                setCurrentProgramEnrollment={setCurrentProgramEnrollment}
+                setProgramSelectorOpen={setProgramSelectorOpen}
+                setEnrollDialogVisibility={setEnrollDialogVisibility}
+                setEnrollSelectedProgram={setEnrollSelectedProgram}
+              />
             </div>
             { this.userMenu() }
           </HeaderRow>
@@ -61,5 +100,3 @@ class Navbar extends React.Component {
     );
   }
 }
-
-export default Navbar;

--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -21,11 +21,9 @@ export default class Navbar extends React.Component {
     enrollments:                 ProgramEnrollmentsState,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
-    programSelectorOpen:         boolean,
     setCurrentProgramEnrollment: (enrollment: ProgramEnrollment) => void,
     setEnrollDialogVisibility:   (open: boolean) => void,
     setEnrollSelectedProgram:    (programId: number) => void,
-    setProgramSelectorOpen:      (open: boolean) => void,
   };
 
   makeTabs: Function = (): React$Element<*>[] => {
@@ -56,11 +54,9 @@ export default class Navbar extends React.Component {
       enrollSelectedProgram,
       enrollments,
       pathname,
-      programSelectorOpen,
       setCurrentProgramEnrollment,
       setEnrollDialogVisibility,
       setEnrollSelectedProgram,
-      setProgramSelectorOpen,
     } = this.props;
     const onChange = tabId => {
       let path = this.tabs[tabId].path;
@@ -81,9 +77,7 @@ export default class Navbar extends React.Component {
                 enrollDialogVisibility={enrollDialogVisibility}
                 enrollSelectedProgram={enrollSelectedProgram}
                 enrollments={enrollments}
-                programSelectorOpen={programSelectorOpen}
                 setCurrentProgramEnrollment={setCurrentProgramEnrollment}
-                setProgramSelectorOpen={setProgramSelectorOpen}
                 setEnrollDialogVisibility={setEnrollDialogVisibility}
                 setEnrollSelectedProgram={setEnrollSelectedProgram}
               />

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -1,11 +1,8 @@
 // @flow
 import {
   AnonymousAccessor,
-  BoolMust,
-  FilteredQuery,
   TermQuery,
   SearchkitComponent,
-  FilterBasedAccessor,
 } from 'searchkit';
 import _ from 'lodash';
 

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -5,6 +5,7 @@ import {
   FilteredQuery,
   TermQuery,
   SearchkitComponent,
+  FilterBasedAccessor,
 } from 'searchkit';
 import _ from 'lodash';
 
@@ -29,7 +30,7 @@ export default class ProgramFilter extends SearchkitComponent {
     const [prevProps] = args;
     if (!_.isEqual(prevProps.currentProgramEnrollment, this.props.currentProgramEnrollment)) {
       // (╯°□°)╯︵ ┻━┻
-      this.context.searchkit.performSearch();
+      this.context.searchkit.reloadSearch();
     }
   }
 

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import {
+  AnonymousAccessor,
+  BoolMust,
+  FilteredQuery,
+  TermQuery,
+  SearchkitComponent,
+} from 'searchkit';
+import _ from 'lodash';
+
+export default class ProgramFilter extends SearchkitComponent {
+  defineAccessor() {
+    return new AnonymousAccessor(query => {
+      const { currentProgramEnrollment } = this.props;
+      console.trace();
+      console.log("accessor", currentProgramEnrollment);
+      if (currentProgramEnrollment === null) {
+        return query;
+      }
+      return query.addQuery(FilteredQuery({
+        filter: BoolMust([
+          TermQuery("program.id", currentProgramEnrollment.id)
+        ])
+      }));
+    });
+  }
+
+  componentDidUpdate(...args) {
+    if (super.componentWillUpdate) {
+      super.componentWillUpdate(...args);
+    }
+    const [prevProps] = args;
+    if (!_.isEqual(prevProps.currentProgramEnrollment, this.props.currentProgramEnrollment)) {
+      // searchkit  (╯°□°)╯︵ ┻━┻
+      this.context.searchkit.reloadSearch();
+    }
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -9,17 +9,17 @@ import {
 import _ from 'lodash';
 
 export default class ProgramFilter extends SearchkitComponent {
-  accessor = new AnonymousAccessor(query => {
+  _accessor = new AnonymousAccessor(query => {
     const { currentProgramEnrollment } = this.props;
     if (currentProgramEnrollment === null) {
       return query;
     }
-    return query.addFilter("program.id", TermQuery("program.id", currentProgramEnrollment.id));
+    return query.addFilter("program_filter", TermQuery("program.id", currentProgramEnrollment.id));
   });
 
 
   defineAccessor() {
-    return this.accessor;
+    return this._accessor;
   }
 
   componentDidUpdate(...args) {

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -1,4 +1,4 @@
-import React from 'react';
+// @flow
 import {
   AnonymousAccessor,
   BoolMust,
@@ -12,8 +12,6 @@ export default class ProgramFilter extends SearchkitComponent {
   defineAccessor() {
     return new AnonymousAccessor(query => {
       const { currentProgramEnrollment } = this.props;
-      console.trace();
-      console.log("accessor", currentProgramEnrollment);
       if (currentProgramEnrollment === null) {
         return query;
       }

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -9,28 +9,27 @@ import {
 import _ from 'lodash';
 
 export default class ProgramFilter extends SearchkitComponent {
+  accessor = new AnonymousAccessor(query => {
+    const { currentProgramEnrollment } = this.props;
+    if (currentProgramEnrollment === null) {
+      return query;
+    }
+    return query.addFilter("program.id", TermQuery("program.id", currentProgramEnrollment.id));
+  });
+
+
   defineAccessor() {
-    return new AnonymousAccessor(query => {
-      const { currentProgramEnrollment } = this.props;
-      if (currentProgramEnrollment === null) {
-        return query;
-      }
-      return query.addQuery(FilteredQuery({
-        filter: BoolMust([
-          TermQuery("program.id", currentProgramEnrollment.id)
-        ])
-      }));
-    });
+    return this.accessor;
   }
 
   componentDidUpdate(...args) {
-    if (super.componentWillUpdate) {
-      super.componentWillUpdate(...args);
+    if (super.componentDidUpdate) {
+      super.componentDidUpdate(...args);
     }
     const [prevProps] = args;
     if (!_.isEqual(prevProps.currentProgramEnrollment, this.props.currentProgramEnrollment)) {
-      // searchkit  (╯°□°)╯︵ ┻━┻
-      this.context.searchkit.reloadSearch();
+      // (╯°□°)╯︵ ┻━┻
+      this.context.searchkit.performSearch();
     }
   }
 

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -9,7 +9,13 @@ import {
 } from 'searchkit';
 import _ from 'lodash';
 
+import type { ProgramEnrollment } from '../flow/enrollmentTypes';
+
 export default class ProgramFilter extends SearchkitComponent {
+  props: {
+    currentProgramEnrollment: ProgramEnrollment,
+  };
+
   _accessor = new AnonymousAccessor(query => {
     const { currentProgramEnrollment } = this.props;
     if (currentProgramEnrollment === null) {
@@ -23,8 +29,7 @@ export default class ProgramFilter extends SearchkitComponent {
     return this._accessor;
   }
 
-  componentDidUpdate(...args) {
-    const [prevProps] = args;
+  componentDidUpdate(prevProps: Object): void {
     if (!_.isEqual(prevProps.currentProgramEnrollment, this.props.currentProgramEnrollment)) {
       // (╯°□°)╯︵ ┻━┻
       this.context.searchkit.reloadSearch();

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -24,9 +24,6 @@ export default class ProgramFilter extends SearchkitComponent {
   }
 
   componentDidUpdate(...args) {
-    if (super.componentDidUpdate) {
-      super.componentDidUpdate(...args);
-    }
     const [prevProps] = args;
     if (!_.isEqual(prevProps.currentProgramEnrollment, this.props.currentProgramEnrollment)) {
       // (╯°□°)╯︵ ┻━┻

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -38,7 +38,7 @@ export default class ProgramSelector extends React.Component {
     }
   };
 
-  makeOptions = () => {
+  makeOptions = (): Array<Option> => {
     const {
       currentProgramEnrollment,
       enrollments: { programEnrollments },
@@ -51,9 +51,6 @@ export default class ProgramSelector extends React.Component {
     }
 
     const sortedProgramEnrollments = _.sortBy(programEnrollments, 'title');
-    if (sortedProgramEnrollments.length === 0) {
-      return <div className="program-selector" />;
-    }
 
     let unselected = sortedProgramEnrollments.filter(enrollment => enrollment.id !== currentId);
     let options = unselected.map(enrollment => ({
@@ -84,15 +81,19 @@ export default class ProgramSelector extends React.Component {
     let selected = programEnrollments.find(enrollment => enrollment.id === currentId);
     let options = this.makeOptions();
 
-    return <div className="program-selector">
-      <Select
-        options={options}
-        onChange={this.selectEnrollment}
-        searchable={false}
-        placeholder={selected ? selected.title : ""}
-        clearable={false}
-        tabSelectsValue={false}
-      />
-    </div>;
+    if (programEnrollments.length === 0) {
+      return <div className="program-selector" />;
+    } else {
+      return <div className="program-selector">
+        <Select
+          options={options}
+          onChange={this.selectEnrollment}
+          searchable={false}
+          placeholder={selected ? selected.title : ""}
+          clearable={false}
+          tabSelectsValue={false}
+        />
+      </div>;
+    }
   }
 }

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -1,0 +1,119 @@
+// @flow
+import React from 'react';
+import _ from 'lodash';
+import { ReactPageClick } from 'react-page-click';
+
+import type { DashboardState } from '../flow/dashboardTypes';
+import type {
+  ProgramEnrollment,
+  ProgramEnrollmentsState,
+} from '../flow/enrollmentTypes';
+
+export default class ProgramSelector extends React.Component {
+  props: {
+    currentProgramEnrollment:    ProgramEnrollment,
+    enrollments:                 ProgramEnrollmentsState,
+    enrollDialogVisibility:      boolean,
+    enrollSelectedProgram:       ?number,
+    dashboard:                   DashboardState,
+    programSelectorOpen:         boolean,
+    setCurrentProgramEnrollment: (enrollment: ProgramEnrollment) => void,
+    setEnrollDialogVisibility:   (open: boolean) => void,
+    setEnrollSelectedProgram:    (programId: number) => void,
+    setProgramSelectorOpen:      (open: boolean) => void,
+  };
+
+  handleProgramChange = (event: any): void => {
+    const { enrollments, setCurrentProgramEnrollment } = this.props;
+    const value = parseInt(event.target.value);
+
+    const enrollment = enrollments.programEnrollments.find(enrollment => enrollment.id === value);
+    setCurrentProgramEnrollment(enrollment);
+  };
+
+  handleOpenSelect = () => {
+    const { programSelectorOpen, setProgramSelectorOpen } = this.props;
+    setProgramSelectorOpen(!programSelectorOpen);
+  };
+
+  selectEnrollment = (enrollment: ProgramEnrollment): void => {
+    const { setCurrentProgramEnrollment, setProgramSelectorOpen } = this.props;
+    setCurrentProgramEnrollment(enrollment);
+    setProgramSelectorOpen(false);
+  };
+
+  showNewEnrollmentDialog = () => {
+    let { setEnrollDialogVisibility } = this.props;
+    setEnrollDialogVisibility(true);
+  };
+
+  render() {
+    let {
+      enrollments: { programEnrollments },
+      programSelectorOpen,
+      dashboard: { programs },
+    } = this.props;
+    let { currentProgramEnrollment } = this.props;
+    let currentId;
+    if (currentProgramEnrollment !== null) {
+      currentId = currentProgramEnrollment.id;
+    }
+
+    programEnrollments = _.sortBy(programEnrollments, 'title');
+    if (programEnrollments.length === 0) {
+      return <div className="program-selector" />;
+    }
+
+    let selected = programEnrollments.find(enrollment => enrollment.id === currentId);
+    let unselected = programEnrollments.filter(enrollment => enrollment.id !== currentId);
+    let options = unselected.map(enrollment => (
+      <div
+        className="option"
+        key={enrollment.id}
+        onClick={() => this.selectEnrollment(enrollment)}
+      >
+        {enrollment.title}
+      </div>
+    ));
+
+    let enrollmentLookup = new Map(programEnrollments.map(enrollment => [enrollment.id, null]));
+    let unenrolledPrograms = programs.filter(program => !enrollmentLookup.has(program.id));
+    unenrolledPrograms = _.sortBy(unenrolledPrograms, 'title');
+
+    let enrollOption;
+    if (unenrolledPrograms.length > 0) {
+      enrollOption = <div
+        className="option"
+        key="enroll-new-program"
+        onClick={() => this.showNewEnrollmentDialog()}
+      >
+        Enroll in a new program
+      </div>;
+    }
+
+    let select = <div className="select-container">
+      <div className="select">
+        <div className="selected-option" onClick={this.handleOpenSelect}>
+          {selected.title} <i className="material-icons">arrow_drop_down</i>
+        </div>
+        <div className={`select-dropdown ${programSelectorOpen ? 'open' : ''}`}>
+          {options}
+          {enrollOption}
+        </div>
+      </div>
+    </div>;
+
+    let inner;
+    if (programSelectorOpen) {
+      inner = <ReactPageClick notify={this.handleOpenSelect}>
+        {select}
+      </ReactPageClick>;
+    } else {
+      inner = select;
+    }
+
+    return <div className="program-selector">
+      {inner}
+    </div>;
+  }
+}

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -69,17 +69,15 @@ export default class ProgramSelector extends React.Component {
       options.push({label: "Enroll in a new program", value: ENROLL_SENTINEL});
     }
 
-    let select = <Select
-      options={options}
-      onChange={this.selectEnrollment}
-      searchable={false}
-      placeholder={selected ? selected.title : ""}
-      clearable={false}
-      tabSelectsValue={false}
-    />;
-
     return <div className="program-selector">
-      {select}
+      <Select
+        options={options}
+        onChange={this.selectEnrollment}
+        searchable={false}
+        placeholder={selected ? selected.title : ""}
+        clearable={false}
+        tabSelectsValue={false}
+      />
     </div>;
   }
 }

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -8,7 +8,7 @@ import type {
   ProgramEnrollment,
   ProgramEnrollmentsState,
 } from '../flow/enrollmentTypes';
-import type { ReactSelectOption } from '../flow/generalTypes';
+import type { Option } from '../flow/generalTypes';
 
 const ENROLL_SENTINEL = 'enroll';
 
@@ -24,7 +24,7 @@ export default class ProgramSelector extends React.Component {
     setEnrollSelectedProgram:    (programId: number) => void,
   };
 
-  selectEnrollment = (option: ReactSelectOption): void => {
+  selectEnrollment = (option: Option): void => {
     const {
       enrollments: { programEnrollments },
       setCurrentProgramEnrollment,

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import _ from 'lodash';
 import Select from 'react-select';
-import 'style!css!react-select/dist/react-select.css';
 
 import type { DashboardState } from '../flow/dashboardTypes';
 import type {

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -68,6 +68,7 @@ export default class ProgramSelector extends React.Component {
     if (unenrolledPrograms.length > 0) {
       options.push({label: "Enroll in a new program", value: ENROLL_SENTINEL});
     }
+    return options;
   };
 
   render() {

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -38,36 +38,50 @@ export default class ProgramSelector extends React.Component {
     }
   };
 
-  render() {
-    let {
+  makeOptions = () => {
+    const {
       currentProgramEnrollment,
       enrollments: { programEnrollments },
       dashboard: { programs },
     } = this.props;
+
     let currentId;
     if (currentProgramEnrollment !== null) {
       currentId = currentProgramEnrollment.id;
     }
 
-    programEnrollments = _.sortBy(programEnrollments, 'title');
-    if (programEnrollments.length === 0) {
+    const sortedProgramEnrollments = _.sortBy(programEnrollments, 'title');
+    if (sortedProgramEnrollments.length === 0) {
       return <div className="program-selector" />;
     }
 
-    let selected = programEnrollments.find(enrollment => enrollment.id === currentId);
-    let unselected = programEnrollments.filter(enrollment => enrollment.id !== currentId);
+    let unselected = sortedProgramEnrollments.filter(enrollment => enrollment.id !== currentId);
     let options = unselected.map(enrollment => ({
       value: enrollment.id,
       label: enrollment.title,
     }));
 
-    let enrollmentLookup = new Map(programEnrollments.map(enrollment => [enrollment.id, null]));
+    let enrollmentLookup = new Map(sortedProgramEnrollments.map(enrollment => [enrollment.id, null]));
     let unenrolledPrograms = programs.filter(program => !enrollmentLookup.has(program.id));
     unenrolledPrograms = _.sortBy(unenrolledPrograms, 'title');
 
     if (unenrolledPrograms.length > 0) {
       options.push({label: "Enroll in a new program", value: ENROLL_SENTINEL});
     }
+  };
+
+  render() {
+    let {
+      enrollments: { programEnrollments },
+      currentProgramEnrollment,
+    } = this.props;
+    let currentId;
+    if (currentProgramEnrollment !== null) {
+      currentId = currentProgramEnrollment.id;
+    }
+
+    let selected = programEnrollments.find(enrollment => enrollment.id === currentId);
+    let options = this.makeOptions();
 
     return <div className="program-selector">
       <Select

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -23,14 +23,6 @@ export default class ProgramSelector extends React.Component {
     setProgramSelectorOpen:      (open: boolean) => void,
   };
 
-  handleProgramChange = (event: any): void => {
-    const { enrollments, setCurrentProgramEnrollment } = this.props;
-    const value = parseInt(event.target.value);
-
-    const enrollment = enrollments.programEnrollments.find(enrollment => enrollment.id === value);
-    setCurrentProgramEnrollment(enrollment);
-  };
-
   handleOpenSelect = () => {
     const { programSelectorOpen, setProgramSelectorOpen } = this.props;
     setProgramSelectorOpen(!programSelectorOpen);

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -83,7 +83,7 @@ export default class ProgramSelector extends React.Component {
     let enrollOption;
     if (unenrolledPrograms.length > 0) {
       enrollOption = <div
-        className="option"
+        className="option enroll-new-program"
         key="enroll-new-program"
         onClick={() => this.showNewEnrollmentDialog()}
       >

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -40,10 +40,10 @@ export default class ProgramSelector extends React.Component {
 
   render() {
     let {
+      currentProgramEnrollment,
       enrollments: { programEnrollments },
       dashboard: { programs },
     } = this.props;
-    let { currentProgramEnrollment } = this.props;
     let currentId;
     if (currentProgramEnrollment !== null) {
       currentId = currentProgramEnrollment.id;

--- a/static/js/components/ProgramSelector_test.js
+++ b/static/js/components/ProgramSelector_test.js
@@ -49,27 +49,6 @@ describe('ProgramSelector', () => {
     assert.equal(wrapper.find("div").children().length, 0);
   });
 
-  it("renders within a ReactPageClick element if the program selector is open", () => {
-    let setProgramSelectorOpen = sandbox.stub();
-    let wrapper = renderProgramSelector({
-      programSelectorOpen: true,
-      setProgramSelectorOpen
-    });
-    let pageClick = wrapper.find(ReactPageClick);
-
-    // also check that the notify prop will close the selector
-    let notify = pageClick.props().notify;
-    notify();
-    assert(setProgramSelectorOpen.calledWith(false));
-  });
-
-  it("renders no ReactPageClick element if the program selector is not open", () => {
-    let wrapper = renderProgramSelector({
-      programSelectorOpen: false,
-    });
-    assert(wrapper.find(ReactPageClick).length === 0, "ReactPageClick should not be present");
-  });
-
   it("renders the currently selected enrollment first, then all other enrollments", () => {
     let wrapper = renderProgramSelector();
     assert.equal(wrapper.find(".selected-option").text(), `${selectedEnrollment.title} arrow_drop_down`);
@@ -102,18 +81,6 @@ describe('ProgramSelector', () => {
     assert.deepEqual(text, expectedEnrollments);
   });
 
-  for (let value of [true, false]) {
-    it(`sets the dropdown open value to ${!value}`, () => {
-      let setProgramSelectorOpen = sandbox.stub();
-      let wrapper = renderProgramSelector({
-        setProgramSelectorOpen,
-        programSelectorOpen: value
-      });
-      wrapper.find(".selected-option").simulate('click');
-      assert(setProgramSelectorOpen.calledWith(!value), `setProgramSelectorOpen not called with ${!value}`);
-    });
-  }
-
   it("shows the enrollment dialog when the 'Enroll in a new program' option is clicked", () => {
     let setEnrollDialogVisibility = sandbox.stub();
     let wrapper = renderProgramSelector({
@@ -125,17 +92,14 @@ describe('ProgramSelector', () => {
 
   it("switches to a new current enrollment when a new option is clicked", () => {
     let setCurrentProgramEnrollment = sandbox.stub();
-    let setProgramSelectorOpen = sandbox.stub();
 
     let wrapper = renderProgramSelector({
       setCurrentProgramEnrollment,
-      setProgramSelectorOpen,
     });
     let option = wrapper.find(".option").first();
     let newSelectedEnrollment = enrollments.find(enrollment => enrollment.title === option.text());
     option.simulate('click');
 
     assert(setCurrentProgramEnrollment.calledWith(newSelectedEnrollment));
-    assert(setProgramSelectorOpen.calledWith(false));
   });
 });

--- a/static/js/components/ProgramSelector_test.js
+++ b/static/js/components/ProgramSelector_test.js
@@ -123,4 +123,20 @@ describe('ProgramSelector', () => {
     wrapper.find(".enroll-new-program").simulate('click');
     assert(setEnrollDialogVisibility.calledWith(true), 'setEnrollDialogVisibility not called with true');
   });
+
+  it("switches to a new current enrollment when a new option is clicked", () => {
+    let setCurrentProgramEnrollment = sandbox.stub();
+    let setProgramSelectorOpen = sandbox.stub();
+
+    let wrapper = renderProgramSelector({
+      setCurrentProgramEnrollment,
+      setProgramSelectorOpen,
+    });
+    let option = wrapper.find(".option").first();
+    let newSelectedEnrollment = enrollments.find(enrollment => enrollment.title === option.text());
+    option.simulate('click');
+
+    assert(setCurrentProgramEnrollment.calledWith(newSelectedEnrollment));
+    assert(setProgramSelectorOpen.calledWith(false));
+  });
 });

--- a/static/js/components/ProgramSelector_test.js
+++ b/static/js/components/ProgramSelector_test.js
@@ -1,4 +1,3 @@
-// @flow
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import _ from 'lodash';

--- a/static/js/components/ProgramSelector_test.js
+++ b/static/js/components/ProgramSelector_test.js
@@ -1,59 +1,126 @@
 // @flow
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
+import _ from 'lodash';
 import React from 'react';
 import { ReactPageClick } from 'react-page-click';
+import sinon from 'sinon';
 
 import ProgramSelector from './ProgramSelector';
 import {
-  PROGRAM_ENROLLMENTS,
   DASHBOARD_RESPONSE,
 } from '../constants';
 
 describe('ProgramSelector', () => {
-  let renderProgramSelector = (
-    enrollments = PROGRAM_ENROLLMENTS,
-    currentProgramEnrollment = PROGRAM_ENROLLMENTS[1],
-    programs = DASHBOARD_RESPONSE,
-  ) => {
+  let sandbox;
+  // define our own enrollments
+  const enrollments = DASHBOARD_RESPONSE.map(program => ({
+    id: program.id,
+    title: program.title,
+  }));
+  // remove one enrollment so that not all programs are enrolled
+  const unenrolled = enrollments.splice(0, 1)[0];
+  const selectedEnrollment = enrollments[1];
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  let renderProgramSelector = (props) => {
     return shallow(
       <ProgramSelector
         enrollments={{programEnrollments: enrollments}}
-        dashboard={{programs: programs}}
-        currentProgramEnrollment={currentProgramEnrollment}
+        dashboard={{programs: DASHBOARD_RESPONSE}}
+        currentProgramEnrollment={selectedEnrollment}
+        {...props}
       />
     );
   };
 
   it('renders an empty div if there are no program enrollments', () => {
-    let wrapper = renderProgramSelector([], null);
-    assert.equal(wrapper.find("div").text(), "");
+    let wrapper = renderProgramSelector({
+      enrollments: {
+        programEnrollments: []
+      },
+    });
+    assert.equal(wrapper.find("div").children().length, 0);
   });
 
   it("renders within a ReactPageClick element if the program selector is open", () => {
+    let setProgramSelectorOpen = sandbox.stub();
+    let wrapper = renderProgramSelector({
+      programSelectorOpen: true,
+      setProgramSelectorOpen
+    });
+    let pageClick = wrapper.find(ReactPageClick);
+
+    // also check that the notify prop will close the selector
+    let notify = pageClick.props().notify;
+    notify();
+    assert(setProgramSelectorOpen.calledWith(false));
+  });
+
+  it("renders no ReactPageClick element if the program selector is not open", () => {
+    let wrapper = renderProgramSelector({
+      programSelectorOpen: false,
+    });
+    assert(wrapper.find(ReactPageClick).length === 0, "ReactPageClick should not be present");
   });
 
   it("renders the currently selected enrollment first, then all other enrollments", () => {
+    let wrapper = renderProgramSelector();
+    assert.equal(wrapper.find(".selected-option").text(), `${selectedEnrollment.title} arrow_drop_down`);
 
-  });
-
-  it("renders an 'Enroll in a new program' option if there is at least one available program", () => {
-
+    let sortedEnrollments = _.sortBy(enrollments, 'title');
+    // make sure we are testing sorting meaningfully
+    assert.notDeepEqual(sortedEnrollments, enrollments);
+    let text = wrapper.find(".option").map(item => item.text());
+    // include 'Enroll in a new program' which comes at the end if user can enroll in a new program
+    let expectedEnrollments = sortedEnrollments.
+      filter(enrollment => enrollment.id !== selectedEnrollment.id).
+      map(enrollment => enrollment.title).
+      concat("Enroll in a new program");
+    assert.deepEqual(text, expectedEnrollments);
   });
 
   it("does not render the 'Enroll in a new program' option if there is not at least one available program", () => {
-
+    let allEnrollments = enrollments.concat(unenrolled);
+    let wrapper = renderProgramSelector({
+      enrollments: {
+        programEnrollments: allEnrollments
+      }
+    });
+    let sortedEnrollments = _.sortBy(allEnrollments, 'title');
+    // make sure we are testing sorting meaningfully
+    assert.notDeepEqual(sortedEnrollments, allEnrollments);
+    let text = wrapper.find(".option").map(item => item.text());
+    let expectedEnrollments = sortedEnrollments.filter(enrollment => enrollment.id !== selectedEnrollment.id).
+      map(enrollment => enrollment.title);
+    assert.deepEqual(text, expectedEnrollments);
   });
 
-  it('has a sorted list of program enrollments', () => {
-
-  });
-
-  it('opens the dropdown when clicked, and closes it when clicked again', () => {
-
-  });
+  for (let value of [true, false]) {
+    it(`sets the dropdown open value to ${!value}`, () => {
+      let setProgramSelectorOpen = sandbox.stub();
+      let wrapper = renderProgramSelector({
+        setProgramSelectorOpen,
+        programSelectorOpen: value
+      });
+      wrapper.find(".selected-option").simulate('click');
+      assert(setProgramSelectorOpen.calledWith(!value), `setProgramSelectorOpen not called with ${!value}`);
+    });
+  }
 
   it("shows the enrollment dialog when the 'Enroll in a new program' option is clicked", () => {
-
+    let setEnrollDialogVisibility = sandbox.stub();
+    let wrapper = renderProgramSelector({
+      setEnrollDialogVisibility,
+    });
+    wrapper.find(".enroll-new-program").simulate('click');
+    assert(setEnrollDialogVisibility.calledWith(true), 'setEnrollDialogVisibility not called with true');
   });
 });

--- a/static/js/components/ProgramSelector_test.js
+++ b/static/js/components/ProgramSelector_test.js
@@ -1,0 +1,59 @@
+// @flow
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { ReactPageClick } from 'react-page-click';
+
+import ProgramSelector from './ProgramSelector';
+import {
+  PROGRAM_ENROLLMENTS,
+  DASHBOARD_RESPONSE,
+} from '../constants';
+
+describe('ProgramSelector', () => {
+  let renderProgramSelector = (
+    enrollments = PROGRAM_ENROLLMENTS,
+    currentProgramEnrollment = PROGRAM_ENROLLMENTS[1],
+    programs = DASHBOARD_RESPONSE,
+  ) => {
+    return shallow(
+      <ProgramSelector
+        enrollments={{programEnrollments: enrollments}}
+        dashboard={{programs: programs}}
+        currentProgramEnrollment={currentProgramEnrollment}
+      />
+    );
+  };
+
+  it('renders an empty div if there are no program enrollments', () => {
+    let wrapper = renderProgramSelector([], null);
+    assert.equal(wrapper.find("div").text(), "");
+  });
+
+  it("renders within a ReactPageClick element if the program selector is open", () => {
+  });
+
+  it("renders the currently selected enrollment first, then all other enrollments", () => {
+
+  });
+
+  it("renders an 'Enroll in a new program' option if there is at least one available program", () => {
+
+  });
+
+  it("does not render the 'Enroll in a new program' option if there is not at least one available program", () => {
+
+  });
+
+  it('has a sorted list of program enrollments', () => {
+
+  });
+
+  it('opens the dropdown when clicked, and closes it when clicked again', () => {
+
+  });
+
+  it("shows the enrollment dialog when the 'Enroll in a new program' option is clicked", () => {
+
+  });
+});

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -4,10 +4,12 @@ import React from 'react';
 import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
+import ErrorMessage from '../components/ErrorMessage';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
 import {
   FETCH_SUCCESS,
+  FETCH_FAILURE,
   fetchDashboard,
   clearDashboard,
 } from '../actions';
@@ -20,26 +22,36 @@ import {
 import {
   clearEnrollments,
   fetchProgramEnrollments,
+  setCurrentProgramEnrollment,
 } from '../actions/enrollments';
+import {
+  setProgramSelectorOpen,
+  setEnrollDialogVisibility,
+  setEnrollSelectedProgram,
+} from '../actions/ui';
 import { clearUI, setProfileStep } from '../actions/ui';
 import { validateProfileComplete } from '../util/validation';
-import type { Dashboard } from '../flow/dashboardTypes';
-import type { ProgramEnrollments } from '../flow/enrollmentTypes';
-import type { Profile } from '../flow/profileTypes';
+import type { DashboardState } from '../flow/dashboardTypes';
+import type {
+  ProgramEnrollment,
+  ProgramEnrollmentsState,
+} from '../flow/enrollmentTypes';
+import type { ProfileGetResult } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
 const PROFILE_REGEX = /^\/profile\/?[a-z]?/;
 
 class App extends React.Component {
   props: {
-    children:     React$Element<*>[],
-    userProfile:  {profile: Profile, getStatus: string},
-    location:     Object,
-    dispatch:     Dispatch,
-    dashboard:    Dashboard,
-    enrollments:  ProgramEnrollments,
-    history:      Object,
-    ui:           UIState,
+    children:                 React$Element<*>[],
+    userProfile:              ProfileGetResult,
+    location:                 Object,
+    currentProgramEnrollment: ProgramEnrollment,
+    dispatch:                 Dispatch,
+    dashboard:                DashboardState,
+    enrollments:              ProgramEnrollmentsState,
+    history:                  Object,
+    ui:                       UIState,
   };
 
   static contextTypes = {
@@ -124,8 +136,40 @@ class App extends React.Component {
     }
   }
 
+  setEnrollDialogVisibility = (visibility: boolean): void => {
+    const { dispatch } = this.props;
+    dispatch(setEnrollDialogVisibility(visibility));
+  };
+
+  setEnrollSelectedProgram = (programId: number): void => {
+    const { dispatch } = this.props;
+    dispatch(setEnrollSelectedProgram(programId));
+  };
+
+  setCurrentProgramEnrollment = (enrollment: ProgramEnrollment): void => {
+    const { dispatch } = this.props;
+    dispatch(setCurrentProgramEnrollment(enrollment));
+  };
+
+  setProgramSelectorOpen = (open: boolean): void => {
+    const { dispatch } = this.props;
+    console.log("open", open, setProgramSelectorOpen);
+    dispatch(setProgramSelectorOpen(open));
+  };
+
   render() {
-    const { children, location: { pathname } } = this.props;
+    const {
+      currentProgramEnrollment,
+      enrollments,
+      ui: {
+        programSelectorOpen,
+        enrollDialogVisibility,
+        enrollSelectedProgram,
+      },
+      location: { pathname },
+      dashboard,
+    } = this.props;
+    let { children } = this.props;
     const { router } = this.context;
 
     let empty = false;
@@ -134,19 +178,31 @@ class App extends React.Component {
     }
     let pushUrl = url => router.push(url);
 
-    return (
-      <div id="app">
-        <Navbar
-          empty={empty}
-          changeUrl={pushUrl}
-          pathname={pathname}
-        />
-        <div className="page-content">
-          { children }
-        </div>
-        <Footer />
+    if (enrollments.getStatus === FETCH_FAILURE) {
+      children = <ErrorMessage errorInfo={enrollments.getErrorInfo} />;
+      empty = true;
+    }
+    return <div id="app">
+      <Navbar
+        changeUrl={pushUrl}
+        currentProgramEnrollment={currentProgramEnrollment}
+        dashboard={dashboard}
+        empty={empty}
+        enrollDialogVisibility={enrollDialogVisibility}
+        enrollSelectedProgram={enrollSelectedProgram}
+        enrollments={enrollments}
+        pathname={pathname}
+        programSelectorOpen={programSelectorOpen}
+        setCurrentProgramEnrollment={this.setCurrentProgramEnrollment}
+        setProgramSelectorOpen={this.setProgramSelectorOpen}
+        setEnrollDialogVisibility={this.setEnrollDialogVisibility}
+        setEnrollSelectedProgram={this.setEnrollSelectedProgram}
+      />
+      <div className="page-content">
+        { children }
       </div>
-    );
+      <Footer />
+    </div>;
   }
 }
 
@@ -158,10 +214,11 @@ const mapStateToProps = (state) => {
     profile = state.profiles[SETTINGS.username];
   }
   return {
-    userProfile:  profile,
-    dashboard:    state.dashboard,
-    ui:           state.ui,
-    enrollments:  state.enrollments,
+    userProfile:              profile,
+    dashboard:                state.dashboard,
+    ui:                       state.ui,
+    currentProgramEnrollment: state.currentProgramEnrollment,
+    enrollments:              state.enrollments,
   };
 };
 

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -153,7 +153,6 @@ class App extends React.Component {
 
   setProgramSelectorOpen = (open: boolean): void => {
     const { dispatch } = this.props;
-    console.log("open", open, setProgramSelectorOpen);
     dispatch(setProgramSelectorOpen(open));
   };
 

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -25,7 +25,6 @@ import {
   setCurrentProgramEnrollment,
 } from '../actions/enrollments';
 import {
-  setProgramSelectorOpen,
   setEnrollDialogVisibility,
   setEnrollSelectedProgram,
 } from '../actions/ui';
@@ -151,17 +150,11 @@ class App extends React.Component {
     dispatch(setCurrentProgramEnrollment(enrollment));
   };
 
-  setProgramSelectorOpen = (open: boolean): void => {
-    const { dispatch } = this.props;
-    dispatch(setProgramSelectorOpen(open));
-  };
-
   render() {
     const {
       currentProgramEnrollment,
       enrollments,
       ui: {
-        programSelectorOpen,
         enrollDialogVisibility,
         enrollSelectedProgram,
       },
@@ -191,9 +184,7 @@ class App extends React.Component {
         enrollSelectedProgram={enrollSelectedProgram}
         enrollments={enrollments}
         pathname={pathname}
-        programSelectorOpen={programSelectorOpen}
         setCurrentProgramEnrollment={this.setCurrentProgramEnrollment}
-        setProgramSelectorOpen={this.setProgramSelectorOpen}
         setEnrollDialogVisibility={this.setEnrollDialogVisibility}
         setEnrollSelectedProgram={this.setEnrollSelectedProgram}
       />

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -7,16 +7,21 @@ import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import _ from 'lodash';
 
-import App from './App';
+import ErrorMessage from '../components/ErrorMessage';
 import Navbar from '../components/Navbar';
 import { CLEAR_DASHBOARD } from '../actions';
 import {
+  RECEIVE_DASHBOARD_SUCCESS,
+} from '../actions';
+import {
+  RECEIVE_GET_USER_PROFILE_SUCCESS,
   CLEAR_PROFILE,
   START_PROFILE_EDIT,
   UPDATE_PROFILE_VALIDATION,
 } from '../actions/profile';
 import {
   CLEAR_ENROLLMENTS,
+  RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE,
 } from '../actions/enrollments';
 import * as enrollmentActions from '../actions/enrollments';
 import {
@@ -123,9 +128,17 @@ describe('App', () => {
   });
 
   describe('enrollments', () => {
-    const fakeAction = {type: "fake"};
     it('shows an error message if the enrollments GET fetch fails', () => {
-
+      helper.enrollmentsGetStub.returns(Promise.reject());
+      let types = [
+        RECEIVE_DASHBOARD_SUCCESS,
+        RECEIVE_GET_USER_PROFILE_SUCCESS,
+        RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE,
+      ];
+      return renderComponent("/dashboard", types, false).then(([wrapper]) => {
+        let text = wrapper.find('.page-content').text();
+        assert(text.includes("Sorry, we were unable to load the data"));
+      });
     });
 
     it('setEnrollDialogVisibility dispatches the value to the action with the same name', () => {

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -1,10 +1,14 @@
 /* global document: false, window: false */
 import '../global_init';
 
+import React from 'react';
 import ReactDOM from 'react-dom';
 import { assert } from 'chai';
+import { shallow } from 'enzyme';
 import _ from 'lodash';
 
+import App from './App';
+import Navbar from '../components/Navbar';
 import { CLEAR_DASHBOARD } from '../actions';
 import {
   CLEAR_PROFILE,
@@ -14,10 +18,12 @@ import {
 import {
   CLEAR_ENROLLMENTS,
 } from '../actions/enrollments';
+import * as enrollmentActions from '../actions/enrollments';
 import {
   CLEAR_UI,
   SET_PROFILE_STEP,
 } from '../actions/ui';
+import * as uiActions from '../actions/ui';
 import {
   USER_PROFILE_RESPONSE,
   PERSONAL_STEP,
@@ -112,6 +118,53 @@ describe('App', () => {
       return renderComponent("/dashboard", editProfileActions).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile");
         assert.equal(checkStep(), EDUCATION_STEP);
+      });
+    });
+  });
+
+  describe('enrollments', () => {
+    const fakeAction = {type: "fake"};
+    it('shows an error message if the enrollments GET fetch fails', () => {
+
+    });
+
+    it('setEnrollDialogVisibility dispatches the value to the action with the same name', () => {
+      return renderComponent("/dashboard").then(([wrapper]) => {
+        let props = wrapper.find(Navbar).props();
+        let stub = helper.sandbox.stub(uiActions, 'setEnrollDialogVisibility');
+        stub.returns({type: "fake"});
+        props.setEnrollDialogVisibility("value");
+        assert(stub.calledWith("value"));
+      });
+    });
+
+    it('setEnrollSelectedProgram dispatches the value to the action with the same name', () => {
+      return renderComponent("/dashboard").then(([wrapper]) => {
+        let props = wrapper.find(Navbar).props();
+        let stub = helper.sandbox.stub(uiActions, 'setEnrollSelectedProgram');
+        stub.returns({type: "fake"});
+        props.setEnrollSelectedProgram("value");
+        assert(stub.calledWith("value"));
+      });
+    });
+
+    it('setCurrentProgramEnrollment dispatches the value to the action with the same name', () => {
+      return renderComponent("/dashboard").then(([wrapper]) => {
+        let props = wrapper.find(Navbar).props();
+        let stub = helper.sandbox.stub(enrollmentActions, 'setCurrentProgramEnrollment');
+        stub.returns({type: "fake"});
+        props.setCurrentProgramEnrollment("value");
+        assert(stub.calledWith("value"));
+      });
+    });
+
+    it('setProgramSelectorOpen dispatches the value to the action with the same name', () => {
+      return renderComponent("/dashboard").then(([wrapper]) => {
+        let props = wrapper.find(Navbar).props();
+        let stub = helper.sandbox.stub(uiActions, 'setProgramSelectorOpen');
+        stub.returns({type: "fake"});
+        props.setProgramSelectorOpen("value");
+        assert(stub.calledWith("value"));
       });
     });
   });

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -167,15 +167,5 @@ describe('App', () => {
         assert(stub.calledWith("value"));
       });
     });
-
-    it('setProgramSelectorOpen dispatches the value to the action with the same name', () => {
-      return renderComponent("/dashboard").then(([wrapper]) => {
-        let props = wrapper.find(Navbar).props();
-        let stub = helper.sandbox.stub(uiActions, 'setProgramSelectorOpen');
-        stub.returns({type: "fake"});
-        props.setProgramSelectorOpen("value");
-        assert(stub.calledWith("value"));
-      });
-    });
   });
 });

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -1,13 +1,10 @@
 /* global document: false, window: false */
 import '../global_init';
 
-import React from 'react';
 import ReactDOM from 'react-dom';
 import { assert } from 'chai';
-import { shallow } from 'enzyme';
 import _ from 'lodash';
 
-import ErrorMessage from '../components/ErrorMessage';
 import Navbar from '../components/Navbar';
 import { CLEAR_DASHBOARD } from '../actions';
 import {

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -32,10 +32,10 @@ describe('DashboardPage', () => {
   });
 
   it('has all the cards we expect', () => {
-    return renderComponent('/dashboard').then(([, div]) => {
-      assert(div.querySelector(".dashboard-user-card"), "Unable to find user card");
-      assert(div.querySelector(".course-list"), "Unable to find course listing card");
-      assert(div.querySelector(".progress-widget"), "Unable to find progress card");
+    return renderComponent('/dashboard').then(([wrapper]) => {
+      assert.equal(wrapper.find(".dashboard-user-card").length, 1);
+      assert.equal(wrapper.find(".course-list").length, 1);
+      assert.equal(wrapper.find(".progress-widget").length, 1);
     });
   });
 
@@ -67,4 +67,6 @@ describe('DashboardPage', () => {
       });
     });
   });
+
+
 });

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -67,6 +67,4 @@ describe('DashboardPage', () => {
       });
     });
   });
-
-
 });

--- a/static/js/containers/LearnerSearchPage.js
+++ b/static/js/containers/LearnerSearchPage.js
@@ -3,11 +3,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import {
-  BoolMust,
-  FilteredQuery,
   SearchkitManager,
   SearchkitProvider,
-  TermQuery,
 } from 'searchkit';
 import _ from 'lodash';
 import type { Dispatch } from 'redux';
@@ -27,6 +24,12 @@ import type { UIState } from '../reducers/ui';
 import type { EmailState } from '../flow/emailTypes';
 import type { ProgramEnrollment } from '../flow/enrollmentTypes';
 import { getCookie } from '../util/api';
+
+const searchKit = new SearchkitManager(SETTINGS.search_url, {
+  httpHeaders: {
+    'X-CSRFToken': getCookie('csrftoken')
+  }
+});
 
 class LearnerSearchPage extends React.Component {
   props: {
@@ -97,22 +100,6 @@ class LearnerSearchPage extends React.Component {
       email
     } = this.props;
 
-    let searchKit = new SearchkitManager(SETTINGS.search_url, {
-      httpHeaders: {
-        'X-CSRFToken': getCookie('csrftoken')
-      }
-    });
-    searchKit.addDefaultQuery(query => {
-      //console.log("currentProgramEnrollment", currentProgramEnrollment);
-      if (currentProgramEnrollment === null) {
-        return query;
-      }
-      return query.addQuery(FilteredQuery({
-        filter: BoolMust([
-          TermQuery("program.id", currentProgramEnrollment.id)
-        ])
-      }));
-    });
     return (
       <div>
         <SearchkitProvider searchkit={searchKit}>
@@ -125,6 +112,7 @@ class LearnerSearchPage extends React.Component {
             updateEmailEdit={this.updateEmailEdit}
             sendEmail={this.closeEmailComposeAndSend}
             email={email}
+            currentProgramEnrollment={currentProgramEnrollment}
           />
         </SearchkitProvider>
       </div>

--- a/static/js/containers/LearnerSearchPage.js
+++ b/static/js/containers/LearnerSearchPage.js
@@ -10,6 +10,7 @@ import _ from 'lodash';
 import type { Dispatch } from 'redux';
 import R from 'ramda';
 
+import ErrorMessage from '../components/ErrorMessage';
 import LearnerSearch from '../components/LearnerSearch';
 import { setSearchFilterVisibility, setEmailDialogVisibility } from '../actions/ui';
 import {
@@ -99,6 +100,10 @@ class LearnerSearchPage extends React.Component {
       currentProgramEnrollment,
       email
     } = this.props;
+
+    if (_.isNil(currentProgramEnrollment)) {
+      return <ErrorMessage errorInfo={{user_message: "No program enrollment is available."}} />;
+    }
 
     return (
       <div>

--- a/static/js/containers/LearnerSearchPage.js
+++ b/static/js/containers/LearnerSearchPage.js
@@ -3,8 +3,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import {
+  BoolMust,
+  FilteredQuery,
   SearchkitManager,
   SearchkitProvider,
+  TermQuery,
 } from 'searchkit';
 import _ from 'lodash';
 import type { Dispatch } from 'redux';
@@ -22,13 +25,15 @@ import {
 import { emailValidation } from '../util/validation';
 import type { UIState } from '../reducers/ui';
 import type { EmailState } from '../flow/emailTypes';
+import type { ProgramEnrollment } from '../flow/enrollmentTypes';
 import { getCookie } from '../util/api';
 
 class LearnerSearchPage extends React.Component {
   props: {
-    ui:       UIState,
-    email:    EmailState,
-    dispatch: Dispatch,
+    currentProgramEnrollment: ProgramEnrollment,
+    dispatch:                 Dispatch,
+    email:                    EmailState,
+    ui:                       UIState,
   };
 
   checkFilterVisibility: Function = (filterName: string): boolean => {
@@ -88,6 +93,7 @@ class LearnerSearchPage extends React.Component {
   render () {
     const {
       ui: { emailDialogVisibility },
+      currentProgramEnrollment,
       email
     } = this.props;
 
@@ -95,6 +101,16 @@ class LearnerSearchPage extends React.Component {
       httpHeaders: {
         'X-CSRFToken': getCookie('csrftoken')
       }
+    });
+    searchKit.addDefaultQuery(query => {
+      if (currentProgramEnrollment === null) {
+        return query;
+      }
+      return query.addQuery(FilteredQuery({
+        filter: BoolMust([
+          TermQuery("program.id", currentProgramEnrollment.id)
+        ])
+      }));
     });
     return (
       <div>
@@ -117,8 +133,9 @@ class LearnerSearchPage extends React.Component {
 
 const mapStateToProps = state => {
   return {
-    ui:     state.ui,
-    email:  state.email,
+    ui:                       state.ui,
+    email:                    state.email,
+    currentProgramEnrollment: state.currentProgramEnrollment,
   };
 };
 

--- a/static/js/containers/LearnerSearchPage.js
+++ b/static/js/containers/LearnerSearchPage.js
@@ -103,6 +103,7 @@ class LearnerSearchPage extends React.Component {
       }
     });
     searchKit.addDefaultQuery(query => {
+      //console.log("currentProgramEnrollment", currentProgramEnrollment);
       if (currentProgramEnrollment === null) {
         return query;
       }

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -2,6 +2,7 @@
 // import TestUtils from 'react-addons-test-utils';
 import { assert } from 'chai';
 import _ from 'lodash';
+import { SearchkitManager } from 'searchkit';
 
 import IntegrationTestHelper from '../util/integration_test_helper';
 import {
@@ -44,7 +45,7 @@ describe('LearnerSearchPage', function () {
     return renderComponent('/learners').then(() => {
       let request = server.requests[server.requests.length - 1];
       let body = JSON.parse(request.requestBody);
-      assert.deepEqual(body.filter.bool.must[0].term['program.id'], PROGRAM_ENROLLMENTS[0].id);
+      assert.deepEqual(body.filter.term['program.id'], PROGRAM_ENROLLMENTS[0].id);
     });
   });
 
@@ -54,7 +55,7 @@ describe('LearnerSearchPage', function () {
     return renderComponent('/learners').then(() => {
       let request = server.requests[server.requests.length - 1];
       let body = JSON.parse(request.requestBody);
-      assert.equal(body.filter, undefined);
+      assert.deepEqual(body.filter, undefined);
     });
   });
 
@@ -71,8 +72,7 @@ describe('LearnerSearchPage', function () {
             assert.equal(server.requests.length, searchCount + 1);
             let lastRequest = server.requests[server.requests.length - 1];
             let body = JSON.parse(lastRequest.requestBody);
-            console.log(JSON.stringify(body.filter.bool.must, null, 4));
-            assert.equal(body.filter.bool.must[0].term['program.id'], PROGRAM_ENROLLMENTS[1].id);
+            assert.equal(body.filter.term['program.id'], PROGRAM_ENROLLMENTS[1].id);
             resolve();
           }, 300);
         });

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -39,7 +39,7 @@ describe('LearnerSearchPage', function () {
     return renderComponent('/learners').then(() => {
       let request = server.requests[server.requests.length - 1];
       let body = JSON.parse(request.requestBody);
-      assert.deepEqual(body.filter.term['program.id'], PROGRAM_ENROLLMENTS[0].id);
+      assert.deepEqual(body.filter.bool.must[0].term['program.id'], PROGRAM_ENROLLMENTS[0].id);
     });
   });
 
@@ -47,9 +47,7 @@ describe('LearnerSearchPage', function () {
     helper.enrollmentsGetStub.returns(Promise.resolve([]));
 
     return renderComponent('/learners').then(() => {
-      let request = server.requests[server.requests.length - 1];
-      let body = JSON.parse(request.requestBody);
-      assert.deepEqual(body.filter, undefined);
+      assert.equal(server.requests.length, 0);
     });
   });
 });

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -36,7 +36,6 @@ describe('LearnerSearchPage', function () {
     return renderComponent('/learners').then(() => {
       assert(!_.isEmpty(server.requests));
       let request = server.requests[0];
-      console.log(JSON.parse(request.requestBody));
       throw "";
     });
   });
@@ -44,10 +43,8 @@ describe('LearnerSearchPage', function () {
   it("doesn't filter by program id for current enrollment if it's not set to anything", () => {
 
     return renderComponent('/learners').then(() => {
-      console.log(helper.store.getState());
       assert(!_.isEmpty(server.requests));
       let request = server.requests[0];
-      console.log(request.requestBody);
       throw "";
     });
   });

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -58,25 +58,4 @@ describe('LearnerSearchPage', function () {
       assert.deepEqual(body.filter, undefined);
     });
   });
-
-  it("refreshes the search when the current enrollment is updated", () => {
-    return renderComponent('/learners').then(() => {
-      let searchCount = server.requests.length;
-
-      return helper.dispatchThen(
-        setCurrentProgramEnrollment(PROGRAM_ENROLLMENTS[1]),
-        [SET_CURRENT_PROGRAM_ENROLLMENT]
-      ).then(() => {
-        return new Promise(resolve => {
-          setTimeout(() => {
-            assert.equal(server.requests.length, searchCount + 1);
-            let lastRequest = server.requests[server.requests.length - 1];
-            let body = JSON.parse(lastRequest.requestBody);
-            assert.equal(body.filter.term['program.id'], PROGRAM_ENROLLMENTS[1].id);
-            resolve();
-          }, 300);
-        });
-      });
-    });
-  });
 });

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -31,4 +31,24 @@ describe('LearnerSearchPage', function () {
       assert.deepEqual(request.method, "POST");
     });
   });
+
+  it('filters by program id for current enrollment', () => {
+    return renderComponent('/learners').then(() => {
+      assert(!_.isEmpty(server.requests));
+      let request = server.requests[0];
+      console.log(JSON.parse(request.requestBody));
+      throw "";
+    });
+  });
+
+  it("doesn't filter by program id for current enrollment if it's not set to anything", () => {
+
+    return renderComponent('/learners').then(() => {
+      console.log(helper.store.getState());
+      assert(!_.isEmpty(server.requests));
+      let request = server.requests[0];
+      console.log(request.requestBody);
+      throw "";
+    });
+  });
 });

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -4,7 +4,15 @@ import { assert } from 'chai';
 import _ from 'lodash';
 
 import IntegrationTestHelper from '../util/integration_test_helper';
-import { ELASTICSEARCH_RESPONSE } from '../constants';
+import {
+  PROGRAM_ENROLLMENTS,
+  ELASTICSEARCH_RESPONSE,
+} from '../constants';
+import {
+  setCurrentProgramEnrollment,
+
+  SET_CURRENT_PROGRAM_ENROLLMENT,
+} from '../actions/enrollments';
 
 describe('LearnerSearchPage', function () {
   let renderComponent, helper, server;
@@ -34,18 +42,41 @@ describe('LearnerSearchPage', function () {
 
   it('filters by program id for current enrollment', () => {
     return renderComponent('/learners').then(() => {
-      assert(!_.isEmpty(server.requests));
-      let request = server.requests[0];
-      throw "";
+      let request = server.requests[server.requests.length - 1];
+      let body = JSON.parse(request.requestBody);
+      assert.deepEqual(body.filter.bool.must[0].term['program.id'], PROGRAM_ENROLLMENTS[0].id);
     });
   });
 
   it("doesn't filter by program id for current enrollment if it's not set to anything", () => {
+    helper.enrollmentsGetStub.returns(Promise.resolve([]));
 
     return renderComponent('/learners').then(() => {
-      assert(!_.isEmpty(server.requests));
-      let request = server.requests[0];
-      throw "";
+      let request = server.requests[server.requests.length - 1];
+      let body = JSON.parse(request.requestBody);
+      assert.equal(body.filter, undefined);
+    });
+  });
+
+  it("refreshes the search when the current enrollment is updated", () => {
+    return renderComponent('/learners').then(() => {
+      let searchCount = server.requests.length;
+
+      return helper.dispatchThen(
+        setCurrentProgramEnrollment(PROGRAM_ENROLLMENTS[1]),
+        [SET_CURRENT_PROGRAM_ENROLLMENT]
+      ).then(() => {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            assert.equal(server.requests.length, searchCount + 1);
+            let lastRequest = server.requests[server.requests.length - 1];
+            let body = JSON.parse(lastRequest.requestBody);
+            console.log(JSON.stringify(body.filter.bool.must, null, 4));
+            assert.equal(body.filter.bool.must[0].term['program.id'], PROGRAM_ENROLLMENTS[1].id);
+            resolve();
+          }, 300);
+        });
+      });
     });
   });
 });

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -2,18 +2,12 @@
 // import TestUtils from 'react-addons-test-utils';
 import { assert } from 'chai';
 import _ from 'lodash';
-import { SearchkitManager } from 'searchkit';
 
 import IntegrationTestHelper from '../util/integration_test_helper';
 import {
   PROGRAM_ENROLLMENTS,
   ELASTICSEARCH_RESPONSE,
 } from '../constants';
-import {
-  setCurrentProgramEnrollment,
-
-  SET_CURRENT_PROGRAM_ENROLLMENT,
-} from '../actions/enrollments';
 
 describe('LearnerSearchPage', function () {
   let renderComponent, helper, server;

--- a/static/js/flow/dashboardTypes.js
+++ b/static/js/flow/dashboardTypes.js
@@ -2,3 +2,7 @@
 import type { Program } from './programTypes';
 // likely to change in very near future
 export type Dashboard = Array<Program>;
+export type DashboardState = {
+  programs:     Dashboard,
+  fetchStatus?: string,
+};

--- a/static/js/flow/enrollmentTypes.js
+++ b/static/js/flow/enrollmentTypes.js
@@ -1,4 +1,6 @@
 // @flow
+import type { APIErrorInfo } from './generalTypes';
+
 export type ProgramEnrollment = {
   id: number,
   title: string,
@@ -9,5 +11,6 @@ export type ProgramEnrollments = Array<ProgramEnrollment>;
 export type ProgramEnrollmentsState = {
   programEnrollments: ProgramEnrollments,
   getStatus?: string,
+  getErrorInfo?: APIErrorInfo,
   postStatus?: string,
 };

--- a/static/js/flow/generalTypes.js
+++ b/static/js/flow/generalTypes.js
@@ -20,3 +20,10 @@ export type APIErrorInfo = {
   detail?: string,
   errorStatusCode?: number,
 };
+
+
+export type ReactSelectOption = {
+  label: string,
+  value: any,
+  disabled?: boolean,
+}

--- a/static/js/flow/generalTypes.js
+++ b/static/js/flow/generalTypes.js
@@ -1,7 +1,7 @@
 // @flow
 
 export type Option = {
-  value:     string;
+  value:     any;
   label:     string;
   disabled?: boolean;
 };

--- a/static/js/flow/generalTypes.js
+++ b/static/js/flow/generalTypes.js
@@ -1,8 +1,9 @@
 // @flow
 
 export type Option = {
-  value: string;
-  label: string;
+  value:     string;
+  label:     string;
+  disabled?: boolean;
 };
 export type Settings = {
   gaTrackingID: string;
@@ -20,10 +21,3 @@ export type APIErrorInfo = {
   detail?: string,
   errorStatusCode?: number,
 };
-
-
-export type ReactSelectOption = {
-  label: string,
-  value: any,
-  disabled?: boolean,
-}

--- a/static/js/flow/generalTypes.js
+++ b/static/js/flow/generalTypes.js
@@ -18,5 +18,5 @@ export type APIErrorInfo = {
   error_code?: string,
   user_message?: string,
   detail?: string,
-  errorStatusCode: number,
+  errorStatusCode?: number,
 };

--- a/static/js/flow/profileTypes.js
+++ b/static/js/flow/profileTypes.js
@@ -63,7 +63,7 @@ export type Profiles = {
 };
 
 export type ProfileGetResult = {
-  profile?: Profile,
+  profile: Profile,
   errorInfo?: APIErrorInfo,
   getStatus: string,
   edit?: {errors: ValidationErrors, profile: Profile},

--- a/static/js/reducers/enrollments.js
+++ b/static/js/reducers/enrollments.js
@@ -7,6 +7,7 @@ import {
   RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS,
   RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE,
   CLEAR_ENROLLMENTS,
+  SET_CURRENT_PROGRAM_ENROLLMENT,
 } from '../actions/enrollments';
 import {
   FETCH_FAILURE,
@@ -42,6 +43,29 @@ export const enrollments = (state: ProgramEnrollmentsState = INITIAL_ENROLLMENTS
     return { ...state, postStatus: FETCH_FAILURE, postErrorInfo: action.payload };
   case CLEAR_ENROLLMENTS:
     return INITIAL_ENROLLMENTS_STATE;
+  default:
+    return state;
+  }
+};
+
+// state is of type ProgramEnrollment but I can't convince flow that we do all necessary null checks
+export const currentProgramEnrollment = (state: any = null, action: Action) => {
+  switch (action.type) {
+  case SET_CURRENT_PROGRAM_ENROLLMENT:
+    return action.payload;
+  case RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS:
+    if (state !== null) {
+      let enrollment = action.payload.find(enrollment => enrollment.id === state.id);
+      if (enrollment === undefined) {
+        // current enrollment not found in list
+        state = null;
+      }
+    }
+    if (state === null && action.payload.length > 0) {
+      // no current enrollment selected, pick first from list if there are any
+      state = action.payload[0];
+    }
+    return state;
   default:
     return state;
   }

--- a/static/js/reducers/enrollments_test.js
+++ b/static/js/reducers/enrollments_test.js
@@ -12,6 +12,7 @@ import {
   fetchProgramEnrollments,
   receiveGetProgramEnrollmentsSuccess,
   clearEnrollments,
+  setCurrentProgramEnrollment,
 
   REQUEST_GET_PROGRAM_ENROLLMENTS,
   RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
@@ -20,17 +21,17 @@ import {
   RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS,
   RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE,
   CLEAR_ENROLLMENTS,
+  SET_CURRENT_PROGRAM_ENROLLMENT,
 } from '../actions/enrollments';
 import * as api from '../util/api';
 import rootReducer from '../reducers';
 
-describe('enrollment reducers', () => {
-  let sandbox, store, dispatchThen, getProgramEnrollmentsStub, addProgramEnrollmentStub;
+describe('enrollments', () => {
+  let sandbox, store, getProgramEnrollmentsStub, addProgramEnrollmentStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     store = configureTestStore(rootReducer);
-    dispatchThen = store.createDispatchThen(state => state.enrollments);
     getProgramEnrollmentsStub = sandbox.stub(api, 'getProgramEnrollments');
     addProgramEnrollmentStub = sandbox.stub(api, 'addProgramEnrollment');
   });
@@ -44,81 +45,131 @@ describe('enrollment reducers', () => {
     title: "New enrollment"
   };
 
-  it('should have an empty default state', () => {
-    return dispatchThen({type: 'unknown'}, ['unknown']).then(state => {
-      assert.deepEqual(state, {
-        programEnrollments: []
+  describe('enrollments reducer', () => {
+    let dispatchThen;
+    beforeEach(() => {
+      dispatchThen = store.createDispatchThen(state => state.enrollments);
+    });
+
+    it('should have an empty default state', () => {
+      return dispatchThen({type: 'unknown'}, ['unknown']).then(state => {
+        assert.deepEqual(state, {
+          programEnrollments: []
+        });
+      });
+    });
+
+    it('should fetch program enrollments successfully', () => {
+      getProgramEnrollmentsStub.returns(Promise.resolve(PROGRAM_ENROLLMENTS));
+
+      return dispatchThen(
+        fetchProgramEnrollments(),
+        [REQUEST_GET_PROGRAM_ENROLLMENTS, RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS]
+      ).then(enrollmentsState => {
+        assert.equal(enrollmentsState.getStatus, FETCH_SUCCESS);
+        assert.deepEqual(enrollmentsState.programEnrollments, PROGRAM_ENROLLMENTS);
+        assert.equal(getProgramEnrollmentsStub.callCount, 1);
+        assert.deepEqual(getProgramEnrollmentsStub.args[0], []);
+      });
+    });
+
+    it('should fail to fetch program enrollments', () => {
+      getProgramEnrollmentsStub.returns(Promise.reject("error"));
+
+      return dispatchThen(
+        fetchProgramEnrollments(),
+        [REQUEST_GET_PROGRAM_ENROLLMENTS, RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE]
+      ).then(enrollmentsState => {
+        assert.equal(enrollmentsState.getStatus, FETCH_FAILURE);
+        assert.equal(enrollmentsState.getErrorInfo, "error");
+        assert.deepEqual(enrollmentsState.programEnrollments, []);
+        assert.equal(getProgramEnrollmentsStub.callCount, 1);
+        assert.deepEqual(getProgramEnrollmentsStub.args[0], []);
+      });
+    });
+
+    it('should add a program enrollment successfully to the existing enrollments', () => {
+      addProgramEnrollmentStub.returns(Promise.resolve(newEnrollment));
+      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
+
+      return dispatchThen(
+        addProgramEnrollment(newEnrollment.id),
+        [REQUEST_ADD_PROGRAM_ENROLLMENT, RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS]
+      ).then(enrollmentsState => {
+        assert.equal(enrollmentsState.postStatus, FETCH_SUCCESS);
+        assert.deepEqual(enrollmentsState.programEnrollments, PROGRAM_ENROLLMENTS.concat(newEnrollment));
+        assert.equal(addProgramEnrollmentStub.callCount, 1);
+        assert.deepEqual(addProgramEnrollmentStub.args[0], [newEnrollment.id]);
+      });
+    });
+
+    it('should fail to add a program enrollment and leave the existing state alone', () => {
+      addProgramEnrollmentStub.returns(Promise.reject("addError"));
+      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
+
+      return dispatchThen(
+        addProgramEnrollment(newEnrollment.id),
+        [REQUEST_ADD_PROGRAM_ENROLLMENT, RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE]
+      ).then(enrollmentsState => {
+        assert.equal(enrollmentsState.postStatus, FETCH_FAILURE);
+        assert.equal(enrollmentsState.postErrorInfo, "addError");
+        assert.deepEqual(enrollmentsState.programEnrollments, PROGRAM_ENROLLMENTS);
+        assert.equal(addProgramEnrollmentStub.callCount, 1);
+        assert.deepEqual(addProgramEnrollmentStub.args[0], [newEnrollment.id]);
+      });
+    });
+
+    it('should clear the enrollments', () => {
+      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
+
+      return dispatchThen(clearEnrollments(), [CLEAR_ENROLLMENTS]).then(enrollmentsState => {
+        assert.deepEqual(enrollmentsState, {
+          programEnrollments: []
+        });
       });
     });
   });
 
-  it('should fetch program enrollments successfully', () => {
-    getProgramEnrollmentsStub.returns(Promise.resolve(PROGRAM_ENROLLMENTS));
-
-    return dispatchThen(
-      fetchProgramEnrollments(),
-      [REQUEST_GET_PROGRAM_ENROLLMENTS, RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS]
-    ).then(enrollmentsState => {
-      assert.equal(enrollmentsState.getStatus, FETCH_SUCCESS);
-      assert.deepEqual(enrollmentsState.programEnrollments, PROGRAM_ENROLLMENTS);
-      assert.equal(getProgramEnrollmentsStub.callCount, 1);
-      assert.deepEqual(getProgramEnrollmentsStub.args[0], []);
+  describe('currentProgramEnrollment reducer', () => {
+    let dispatchThen;
+    beforeEach(() => {
+      dispatchThen = store.createDispatchThen(state => state.currentProgramEnrollment);
     });
-  });
 
-  it('should fail to fetch program enrollments', () => {
-    getProgramEnrollmentsStub.returns(Promise.reject("error"));
-
-    return dispatchThen(
-      fetchProgramEnrollments(),
-      [REQUEST_GET_PROGRAM_ENROLLMENTS, RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE]
-    ).then(enrollmentsState => {
-      assert.equal(enrollmentsState.getStatus, FETCH_FAILURE);
-      assert.equal(enrollmentsState.getErrorInfo, "error");
-      assert.deepEqual(enrollmentsState.programEnrollments, []);
-      assert.equal(getProgramEnrollmentsStub.callCount, 1);
-      assert.deepEqual(getProgramEnrollmentsStub.args[0], []);
+    it('should have a null default state', () => {
+      assert.equal(store.getState().currentProgramEnrollment, null);
     });
-  });
 
-  it('should add a program enrollment successfully to the existing enrollments', () => {
-    addProgramEnrollmentStub.returns(Promise.resolve(newEnrollment));
-    store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
-
-    return dispatchThen(
-      addProgramEnrollment(newEnrollment.id),
-      [REQUEST_ADD_PROGRAM_ENROLLMENT, RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS]
-    ).then(enrollmentsState => {
-      assert.equal(enrollmentsState.postStatus, FETCH_SUCCESS);
-      assert.deepEqual(enrollmentsState.programEnrollments, PROGRAM_ENROLLMENTS.concat(newEnrollment));
-      assert.equal(addProgramEnrollmentStub.callCount, 1);
-      assert.deepEqual(addProgramEnrollmentStub.args[0], [newEnrollment.id]);
+    it('should set the current enrollment', () => {
+      return dispatchThen(setCurrentProgramEnrollment(PROGRAM_ENROLLMENTS[1]), [SET_CURRENT_PROGRAM_ENROLLMENT]).
+        then(state => {
+          assert.deepEqual(state, PROGRAM_ENROLLMENTS[1]);
+        });
     });
-  });
 
-  it('should fail to add a program enrollment and leave the existing state alone', () => {
-    addProgramEnrollmentStub.returns(Promise.reject("addError"));
-    store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
-
-    return dispatchThen(
-      addProgramEnrollment(newEnrollment.id),
-      [REQUEST_ADD_PROGRAM_ENROLLMENT, RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE]
-    ).then(enrollmentsState => {
-      assert.equal(enrollmentsState.postStatus, FETCH_FAILURE);
-      assert.equal(enrollmentsState.postErrorInfo, "addError");
-      assert.deepEqual(enrollmentsState.programEnrollments, PROGRAM_ENROLLMENTS);
-      assert.equal(addProgramEnrollmentStub.callCount, 1);
-      assert.deepEqual(addProgramEnrollmentStub.args[0], [newEnrollment.id]);
+    it("should pick the first enrollment if none is already set after receiving a list of enrollments", () => {
+      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
+      assert.deepEqual(store.getState().currentProgramEnrollment, PROGRAM_ENROLLMENTS[0]);
     });
-  });
 
-  it('should clear the enrollments', () => {
-    store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
+    it("should replace the current enrollment if it can't be found in the list of enrollments", () => {
+      let enrollment = {"id": 999, "title": "not an enrollment anymore"};
+      store.dispatch(setCurrentProgramEnrollment(enrollment));
+      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
+      assert.deepEqual(store.getState().currentProgramEnrollment, PROGRAM_ENROLLMENTS[0]);
+    });
 
-    return dispatchThen(clearEnrollments(), [CLEAR_ENROLLMENTS]).then(enrollmentsState => {
-      assert.deepEqual(enrollmentsState, {
-        programEnrollments: []
-      });
+    it("should clear the current enrollment if it can't be found in an empty list of enrollments", () => {
+      let enrollment = {"id": 999, "title": "not an enrollment anymore"};
+      store.dispatch(setCurrentProgramEnrollment(enrollment));
+      store.dispatch(receiveGetProgramEnrollmentsSuccess([]));
+      assert.deepEqual(store.getState().currentProgramEnrollment, null);
+    });
+
+    it("should not pick a current enrollment after receiving a list of enrollments if one is already picked", () => {
+      store.dispatch(setCurrentProgramEnrollment(PROGRAM_ENROLLMENTS[1]));
+      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
+      assert.deepEqual(store.getState().currentProgramEnrollment, PROGRAM_ENROLLMENTS[1]);
     });
   });
 });

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -30,13 +30,19 @@ import {
 } from '../actions';
 import { ui } from './ui';
 import { email } from './email';
-import { enrollments } from './enrollments';
+import {
+  currentProgramEnrollment,
+  enrollments,
+} from './enrollments';
+import type { DashboardState } from '../flow/dashboardTypes';
 import type { Action } from '../flow/reduxTypes';
-import type { ProfileGetResult } from '../flow/profileTypes';
+import type {
+  ProfileGetResult,
+  Profiles,
+} from '../flow/profileTypes';
 
 export const INITIAL_PROFILES_STATE = {};
-type ProfileState = {};
-export const profiles = (state: ProfileState = INITIAL_PROFILES_STATE, action: Action) => {
+export const profiles = (state: Profiles = INITIAL_PROFILES_STATE, action: Action) => {
   let patchProfile = newProfile => {
     let clone = Object.assign({}, state);
     let username = action.payload.username;
@@ -133,8 +139,7 @@ export const profiles = (state: ProfileState = INITIAL_PROFILES_STATE, action: A
   }
 };
 
-type DashboardState = {programs: any[]};
-const INITIAL_DASHBOARD_STATE: any = {
+const INITIAL_DASHBOARD_STATE: DashboardState = {
   programs: []
 };
 
@@ -190,4 +195,5 @@ export default combineReducers({
   email,
   checkout,
   enrollments,
+  currentProgramEnrollment,
 });

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -30,7 +30,6 @@ import {
 
   SET_EMAIL_DIALOG_VISIBILITY,
 
-  SET_PROGRAM_SELECTOR_OPEN,
   SET_ENROLL_DIALOG_VISIBILITY,
   SET_ENROLL_SELECTED_PROGRAM,
 } from '../actions/ui';
@@ -65,7 +64,6 @@ export type UIState = {
   searchFilterVisibility:       {[s: string]: boolean};
   tosDialogVisibility:          boolean;
   emailDialogVisibility:        boolean;
-  programSelectorOpen:          boolean;
   enrollDialogVisibility:       boolean;
   enrollSelectedProgram:       ?number;
 };
@@ -96,7 +94,6 @@ export const INITIAL_UI_STATE: UIState = {
   searchFilterVisibility: {},
   tosDialogVisibility: false,
   emailDialogVisibility: false,
-  programSelectorOpen: false,
   enrollDialogVisibility: false,
   enrollSelectedProgram: null,
 };
@@ -214,11 +211,6 @@ export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
   case SET_EMAIL_DIALOG_VISIBILITY: {
     return Object.assign({}, state, {
       emailDialogVisibility: action.payload
-    });
-  }
-  case SET_PROGRAM_SELECTOR_OPEN: {
-    return Object.assign({}, state, {
-      programSelectorOpen: action.payload
     });
   }
   case SET_ENROLL_SELECTED_PROGRAM: {

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -29,6 +29,10 @@ import {
   SET_SEARCH_FILTER_VISIBILITY,
 
   SET_EMAIL_DIALOG_VISIBILITY,
+
+  SET_PROGRAM_SELECTOR_OPEN,
+  SET_ENROLL_DIALOG_VISIBILITY,
+  SET_ENROLL_SELECTED_PROGRAM,
 } from '../actions/ui';
 import {
   HIGH_SCHOOL,
@@ -61,6 +65,9 @@ export type UIState = {
   searchFilterVisibility:       {[s: string]: boolean};
   tosDialogVisibility:          boolean;
   emailDialogVisibility:        boolean;
+  programSelectorOpen:          boolean;
+  enrollDialogVisibility:       boolean;
+  enrollSelectedProgram:       ?number;
 };
 
 export const INITIAL_UI_STATE: UIState = {
@@ -89,6 +96,9 @@ export const INITIAL_UI_STATE: UIState = {
   searchFilterVisibility: {},
   tosDialogVisibility: false,
   emailDialogVisibility: false,
+  programSelectorOpen: false,
+  enrollDialogVisibility: false,
+  enrollSelectedProgram: null,
 };
 
 export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
@@ -204,6 +214,21 @@ export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
   case SET_EMAIL_DIALOG_VISIBILITY: {
     return Object.assign({}, state, {
       emailDialogVisibility: action.payload
+    });
+  }
+  case SET_PROGRAM_SELECTOR_OPEN: {
+    return Object.assign({}, state, {
+      programSelectorOpen: action.payload
+    });
+  }
+  case SET_ENROLL_SELECTED_PROGRAM: {
+    return Object.assign({}, state, {
+      enrollSelectedProgram: action.payload
+    });
+  }
+  case SET_ENROLL_DIALOG_VISIBILITY: {
+    return Object.assign({}, state, {
+      enrollDialogVisibility: action.payload
     });
   }
   default:

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -21,6 +21,9 @@ import {
   SET_USER_MENU_OPEN,
   SET_SEARCH_FILTER_VISIBILITY,
   SET_EMAIL_DIALOG_VISIBILITY,
+  SET_PROGRAM_SELECTOR_OPEN,
+  SET_ENROLL_DIALOG_VISIBILITY,
+  SET_ENROLL_SELECTED_PROGRAM,
 
   clearUI,
   updateDialogText,
@@ -43,6 +46,9 @@ import {
   setUserMenuOpen,
   setSearchFilterVisibility,
   setEmailDialogVisibility,
+  setProgramSelectorOpen,
+  setEnrollDialogVisibility,
+  setEnrollSelectedProgram,
 } from '../actions/ui';
 import { receiveGetUserProfileSuccess } from '../actions/profile';
 import { INITIAL_UI_STATE } from '../reducers/ui';
@@ -326,4 +332,47 @@ describe('ui reducers', () => {
     });
   });
 
+  describe('Enrollment', () => {
+    describe('program selector', () => {
+      it('should have a false default value', () => {
+        assert.equal(store.getState().ui.programSelectorOpen, false);
+      });
+
+      it('should let you toggle the program selector visibility', () => {
+        return dispatchThen(setProgramSelectorOpen("value"), [
+          SET_PROGRAM_SELECTOR_OPEN
+        ]).then(state => {
+          assert.equal(state.programSelectorOpen, "value");
+        });
+      });
+    });
+
+    describe('enrollment dialog visibility', () => {
+      it('should have a false default value', () => {
+        assert.equal(store.getState().ui.enrollDialogVisibility, false);
+      });
+
+      it('should let you toggle the program selector visibility', () => {
+        return dispatchThen(setEnrollDialogVisibility("value"), [
+          SET_ENROLL_DIALOG_VISIBILITY
+        ]).then(state => {
+          assert.equal(state.enrollDialogVisibility, "value");
+        });
+      });
+    });
+
+    describe('enrollment dialog currently selected program', () => {
+      it('should have no default value', () => {
+        assert.equal(store.getState().ui.enrollSelectedProgram, undefined);
+      });
+
+      it('should let you toggle the program selector visibility', () => {
+        return dispatchThen(setEnrollSelectedProgram("value"), [
+          SET_ENROLL_SELECTED_PROGRAM
+        ]).then(state => {
+          assert.equal(state.enrollSelectedProgram, "value");
+        });
+      });
+    });
+  });
 });

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -21,7 +21,6 @@ import {
   SET_USER_MENU_OPEN,
   SET_SEARCH_FILTER_VISIBILITY,
   SET_EMAIL_DIALOG_VISIBILITY,
-  SET_PROGRAM_SELECTOR_OPEN,
   SET_ENROLL_DIALOG_VISIBILITY,
   SET_ENROLL_SELECTED_PROGRAM,
 
@@ -46,7 +45,6 @@ import {
   setUserMenuOpen,
   setSearchFilterVisibility,
   setEmailDialogVisibility,
-  setProgramSelectorOpen,
   setEnrollDialogVisibility,
   setEnrollSelectedProgram,
 } from '../actions/ui';
@@ -333,20 +331,6 @@ describe('ui reducers', () => {
   });
 
   describe('Enrollment', () => {
-    describe('program selector', () => {
-      it('should have a false default value', () => {
-        assert.equal(store.getState().ui.programSelectorOpen, false);
-      });
-
-      it('should let you toggle the program selector visibility', () => {
-        return dispatchThen(setProgramSelectorOpen("value"), [
-          SET_PROGRAM_SELECTOR_OPEN
-        ]).then(state => {
-          assert.equal(state.programSelectorOpen, "value");
-        });
-      });
-    });
-
     describe('enrollment dialog visibility', () => {
       it('should have a false default value', () => {
         assert.equal(store.getState().ui.enrollDialogVisibility, false);

--- a/static/js/store/configureStore.js
+++ b/static/js/store/configureStore.js
@@ -3,6 +3,7 @@
 import { compose, createStore, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import createLogger from 'redux-logger';
+import persistState from 'redux-localstorage';
 import rootReducer from '../reducers';
 
 let createStoreWithMiddleware;
@@ -12,13 +13,15 @@ if (process.env.NODE_ENV !== "production") {
       thunkMiddleware,
       createLogger()
     ),
+    persistState("currentProgramEnrollment"),
     window.devToolsExtension ? window.devToolsExtension() : f => f
   )(createStore);
 } else {
   createStoreWithMiddleware = compose(
     applyMiddleware(
       thunkMiddleware
-    )
+    ),
+    persistState("currentProgramEnrollment")
   )(createStore);
 }
 

--- a/static/js/style.js
+++ b/static/js/style.js
@@ -4,5 +4,8 @@ import 'style!css!react-mdl/extra/material.css';
 // react-virtualized requirement
 import 'style!css!react-virtualized/styles.css';
 
+// react-select styles
+import 'style!css!react-select/dist/react-select.css';
+
 // This should come last to override other styles
 import '../scss/layout.scss';

--- a/static/js/util/api.js
+++ b/static/js/util/api.js
@@ -144,7 +144,7 @@ export function sendSearchResultMail(subject: string, body: string, searchReques
 }
 
 export function getProgramEnrollments(): Promise<ProgramEnrollments> {
-  return mockableFetchJSONWithCSRF('/api/v0/enrolledprograms/', {}, true).then(() => Promise.resolve([]));
+  return mockableFetchJSONWithCSRF('/api/v0/enrolledprograms/', {}, true);
 }
 
 export function addProgramEnrollment(programId: number): Promise<ProgramEnrollment> {

--- a/static/js/util/api.js
+++ b/static/js/util/api.js
@@ -144,7 +144,7 @@ export function sendSearchResultMail(subject: string, body: string, searchReques
 }
 
 export function getProgramEnrollments(): Promise<ProgramEnrollments> {
-  return mockableFetchJSONWithCSRF('/api/v0/enrolledprograms/', {}, true);
+  return mockableFetchJSONWithCSRF('/api/v0/enrolledprograms/', {}, true).then(() => Promise.resolve([]));
 }
 
 export function addProgramEnrollment(programId: number): Promise<ProgramEnrollment> {

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -50,7 +50,8 @@ class IntegrationTestHelper {
     this.browserHistory.listen(url => {
       this.currentLocation = url;
     });
-    this.sandbox.stub(history, 'createHistory', createMemoryHistory);
+    //this.sandbox.stub(history, 'createHistory', createMemoryHistory);
+
   }
 
   cleanup() {

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -50,8 +50,6 @@ class IntegrationTestHelper {
     this.browserHistory.listen(url => {
       this.currentLocation = url;
     });
-    //this.sandbox.stub(history, 'createHistory', createMemoryHistory);
-
   }
 
   cleanup() {

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -3,7 +3,6 @@ import { mount } from 'enzyme';
 import configureTestStore from 'redux-asserts';
 import sinon from 'sinon';
 import { createMemoryHistory } from 'react-router';
-import * as history from 'history';
 
 import * as api from '../util/api';
 import {

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import configureTestStore from 'redux-asserts';
 import sinon from 'sinon';
 import { createMemoryHistory } from 'react-router';
+import * as history from 'history';
 
 import * as api from '../util/api';
 import {
@@ -49,6 +50,7 @@ class IntegrationTestHelper {
     this.browserHistory.listen(url => {
       this.currentLocation = url;
     });
+    this.sandbox.stub(history, 'createHistory', createMemoryHistory);
   }
 
   cleanup() {

--- a/static/scss/navbar.scss
+++ b/static/scss/navbar.scss
@@ -111,48 +111,38 @@
 }
 
 $program_selector_border: #87ddae;
-// matching height of user-menu
-$program_selector_height: 40px;
-$option_padding: 10px;
+$header_font_color: white;
 .program-selector {
   margin-left: 30px;
   font-size: 16px;
   padding-right: 30px;
   padding-left: 10px;
+  width: 300px;
 
-  .select-container {
-    // select-container has relative position but select has absolute position
-    height: $program_selector_height;
-    .select {
-      background-color: $mm-brand-bg;
-      border: 1px solid $program_selector_border;
-      border-radius: 5px;
-      position: absolute;
+  .Select-control {
+    border: 1px solid $program_selector_border !important;
+    box-shadow: none !important;
+    cursor: pointer;
+  }
 
-      .select-dropdown {
-        display: none;
-      }
-
-      .select-dropdown.open {
-        display: flex;
-        align-items: center;
-        flex-direction: column;
-        z-index: 2;
-      }
-
-      .option, .selected-option {
-        display: flex;
-        align-items: center;
-        padding: $option_padding;
-        cursor: pointer;
-        height: $program_selector_height;
-        width: 100%;
-      }
-
-      .selected-option {
-        font-weight: 500;
-      }
-    }
+  .Select-menu-outer,.Select-control,.Select-value-label,.Select-menu-outer,.Select-option {
+    background-color: $mm-brand-bg !important;
+  }
+  .Select-menu-outer,.Select-control,.Select-value-label,.Select-placeholder,.Select-option {
+    color: $header_font_color !important;
+  }
+  .Select-arrow {
+    border-color: $header_font_color transparent transparent !important;
+  }
+  .Select-option {
+    border: none !important;
+  }
+  .Select-menu-outer {
+    box-shadow: none;
+    border-top: none;
+    border-left: 1px solid $program_selector_border;
+    border-right: 1px solid $program_selector_border;
+    border-bottom: 1px solid $program_selector_border;
   }
 }
 

--- a/static/scss/navbar.scss
+++ b/static/scss/navbar.scss
@@ -110,6 +110,56 @@
   margin-right:10px;
 }
 
+$program_selector_border: #87ddae;
+// matching height of user-menu
+$program_selector_height: 40px;
+$option_padding: 10px;
+.program-selector {
+  margin-left: 30px;
+  font-size: 16px;
+  padding-right: 30px;
+  padding-left: 10px;
+
+  .select-container {
+    // select-container has relative position but select has absolute position
+    height: $program_selector_height;
+    .select {
+      background-color: $mm-brand-bg;
+      border: 1px solid $program_selector_border;
+      border-radius: 5px;
+      position: absolute;
+
+      .select-dropdown {
+        display: none;
+      }
+
+      .select-dropdown.open {
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+        z-index: 2;
+      }
+
+      .option, .selected-option {
+        display: flex;
+        align-items: center;
+        padding: $option_padding;
+        cursor: pointer;
+        height: $program_selector_height;
+        width: 100%;
+
+        .invisible {
+          visibility: hidden;
+        }
+      }
+
+      .selected-option {
+        font-weight: 500;
+      }
+    }
+  }
+}
+
 .site-menu {
   border-bottom:1px solid #ececec;
 }

--- a/static/scss/navbar.scss
+++ b/static/scss/navbar.scss
@@ -144,6 +144,9 @@ $header_font_color: white;
     border-right: 1px solid $program_selector_border;
     border-bottom: 1px solid $program_selector_border;
   }
+  .Select-placeholder {
+    font-weight: 500;
+  }
 }
 
 .site-menu {

--- a/static/scss/navbar.scss
+++ b/static/scss/navbar.scss
@@ -143,6 +143,7 @@ $header_font_color: white;
     border-left: 1px solid $program_selector_border;
     border-right: 1px solid $program_selector_border;
     border-bottom: 1px solid $program_selector_border;
+    z-index: 2;
   }
   .Select-placeholder {
     font-weight: 500;

--- a/static/scss/navbar.scss
+++ b/static/scss/navbar.scss
@@ -128,15 +128,19 @@ $header_font_color: white;
   .Select-menu-outer,.Select-control,.Select-value-label,.Select-menu-outer,.Select-option {
     background-color: $mm-brand-bg !important;
   }
+
   .Select-menu-outer,.Select-control,.Select-value-label,.Select-placeholder,.Select-option {
     color: $header_font_color !important;
   }
+
   .Select-arrow {
     border-color: $header_font_color transparent transparent !important;
   }
+
   .Select-option {
     border: none !important;
   }
+
   .Select-menu-outer {
     box-shadow: none;
     border-top: none;
@@ -145,6 +149,7 @@ $header_font_color: white;
     border-bottom: 1px solid $program_selector_border;
     z-index: 2;
   }
+
   .Select-placeholder {
     font-weight: 500;
   }

--- a/static/scss/navbar.scss
+++ b/static/scss/navbar.scss
@@ -147,10 +147,6 @@ $option_padding: 10px;
         cursor: pointer;
         height: $program_selector_height;
         width: 100%;
-
-        .invisible {
-          visibility: hidden;
-        }
       }
 
       .selected-option {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #969 
Part of #796 

#### What's this PR do?
Adds a UI allowing the user to select their current program enrollment as well as some missing plumbing for the UI. This should allow the user to choose their current program and have this affect the search listings shown as well as the courses displayed in the dashboard. 

#### How should this be manually tested?
It is especially important to test the learner search manually since I couldn't get automated tests to work to assert this behavior. You should make sure that when you switch programs the search refreshes. If you go to the dashboard and back the search should also refresh. Basically you should never see one program's learners when the other program is selected from the dropdown.

If there is no program enrollment for a user (you can edit `getProgramEnrollments` to return a promise `[]` for this), you should see an error on both the learner and dashboard pages.

You should be able to open the dropdown and click anywhere on the page to close it again.

#### Any background context you want to provide?
Some infrastructure exists for the next PR which will add a dialog box to let the user select an enrollment

#### Screenshots (if appropriate)
![screenshot from 2016-09-08 11-33-17](https://cloud.githubusercontent.com/assets/863262/18355736/11bc7a1a-75b8-11e6-890b-988265996fea.png)
