### PR TITLE
Fixed course tests

### DIFF
--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -5,7 +5,7 @@ from django.core.urlresolvers import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from courses.factories import ProgramFactory, CourseFactory
+from courses.factories import ProgramFactory, CourseRunFactory
 from dashboard.factories import ProgramEnrollmentFactory
 from dashboard.models import ProgramEnrollment
 from profiles.factories import UserFactory
@@ -18,18 +18,18 @@ class ProgramTests(ESTestCase):
         """Live programs should show up"""
         prog = ProgramFactory.create(live=True)
 
-        resp = self.client.get(reverse('programs-list'))
+        resp = self.client.get(reverse('program-list'))
 
-        assert len(resp.json) == 1
-        assert prog.title == resp.json[0]['title']
+        assert len(resp.json()) == 1
+        assert prog.title == resp.json()[0]['title']
 
     def test_doesnt_list_unlive_programs(self):
         """Not-live programs should NOT show up"""
         ProgramFactory.create(live=False)
 
-        resp = self.client.get(reverse('programs-list'))
+        resp = self.client.get(reverse('program-list'))
 
-        assert len(resp.json) == 0
+        assert len(resp.json()) == 0
 
 
 class CourseTests(ESTestCase):
@@ -38,22 +38,22 @@ class CourseTests(ESTestCase):
         """
         If the course belongs to a live program, show it.
         """
-        course = CourseFactory.create(program__live=True)
+        course = CourseRunFactory.create(course__program__live=True)
 
-        resp = self.client.get(reverse('course-list'))
+        resp = self.client.get(reverse('courserun-list'))
 
-        assert len(resp.json) == 1
-        assert resp.json[0]['id'] == course.id
+        assert len(resp.json()) == 1
+        assert resp.json()[0]['id'] == course.id
 
     def test_doesnt_list_courses_from_unlive_programs(self):
         """
         If the course belongs to a non-live program, hide it.
         """
-        CourseFactory.create(program__live=False)
+        CourseRunFactory.create(course__program__live=False)
 
-        resp = self.client.get(reverse('course-list'))
+        resp = self.client.get(reverse('courserun-list'))
 
-        assert len(resp.json) == 0
+        assert len(resp.json()) == 0
 
 
 class ProgramEnrollmentTests(ESTestCase, APITestCase):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #977

#### What's this PR do?
Renames `courses/views_tests.py` to `courses/views_test.py` and fixes the test failures in the test

#### How should this be manually tested?
Look in the Travis output and make sure that there are tests being executed under `courses/views_test.py` and that they all pass.

#### Any background context you want to provide?
I think we should get rid of the courses and programs API altogether since we don't use them: #237 

