### PR TITLE
Filtered out programs which are not live from program enrollments API

### DIFF
--- a/courses/views.py
+++ b/courses/views.py
@@ -58,7 +58,7 @@ class ProgramEnrollmentListView(ListCreateAPIView):
         """
         Filter programs by the user enrollment
         """
-        queryset = Program.objects.filter(programenrollment__user=self.request.user)
+        queryset = Program.objects.filter(programenrollment__user=self.request.user, live=True)
         return queryset.order_by('title')
 
     @transaction.atomic

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -118,6 +118,19 @@ class ProgramEnrollmentTests(ESTestCase, APITestCase):
         for enr in resp.data:
             assert enr.get('id') in expected_enrollments_ids
 
+    def test_not_live_enrollments(self):
+        """Programs which are not live are hidden from the list"""
+        program = ProgramFactory.create(live=False)
+        ProgramEnrollment.objects.create(user=self.user1, program=program)
+        resp = self.client.get(self.url)
+        assert resp.status_code == status.HTTP_200_OK
+        assert len(resp.data) == 2
+        expected_enrollments_ids = [
+            program.pk for program in (self.program1, self.program2,)
+        ]
+        for enr in resp.data:
+            assert enr.get('id') in expected_enrollments_ids
+
     def test_create_no_program_id(self):
         """Missing mandatory program_id parameter"""
         self.assert_program_enrollments_count()


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #969

#### What's this PR do?
Filters out program enrollments for programs that aren't live. We filter this in the REST API when the user POSTs to create the program enrollment but there's still the possibility a program may stop being live at some point in the future, so we should filter on GET too.

#### How should this be manually tested?
Go to `/api/v0/enrolledprograms/`. Make sure there is at least one enrollment there. In the Django shell set `live=False` for that program. Go to `/api/v0/enrolledprograms/` and see that this program enrollment no longer appears in the API.
