### PR TITLE
Added elastisearch auth

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -1,0 +1,15 @@
+"""
+Admin views for Dashboard
+"""
+
+from django.contrib import admin
+
+from dashboard.models import ProgramEnrollment
+
+
+class ProgramEnrollmentAdmin(admin.ModelAdmin):
+    """ModelAdmin for ProgramEnrollment"""
+    list_display = ('user', 'program',)
+    list_filter = ('program', 'program__live',)
+
+admin.site.register(ProgramEnrollment, ProgramEnrollmentAdmin)

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -433,6 +433,7 @@ CELERY_TIMEZONE = 'UTC'
 # Elasticsearch
 ELASTICSEARCH_URL = get_var("ELASTICSEARCH_URL", None)
 ELASTICSEARCH_INDEX = get_var('ELASTICSEARCH_INDEX', 'micromasters')
+ELASTICSEARCH_X_API_KEY = get_var("ELASTICSEARCH_X_API_KEY", None)
 
 # django-role-permissions
 ROLEPERMISSIONS_MODULE = 'roles.roles'

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -43,7 +43,10 @@ def get_conn(verify=True):
 
     do_verify = False
     if _CONN is None:
-        _CONN = connections.create_connection(hosts=[settings.ELASTICSEARCH_URL])
+        headers = None
+        if settings.ELASTICSEARCH_X_API_KEY is not None:
+            headers = {'X-Api-Key': settings.ELASTICSEARCH_X_API_KEY}
+        _CONN = connections.create_connection(hosts=[settings.ELASTICSEARCH_URL], headers=headers)
         # Verify connection on first connect if verify=True.
         do_verify = verify
 


### PR DESCRIPTION
#### What are the relevant tickets?
closes #782

#### What's this PR do?
Adds authentication key for elasticsearch.
It also adds a new admin (I needed to do some tests and I left it), but this is not necessary for this PR.
The key is not mandatory and is used only if set. 
If the backend is not set up to handle authentication, even if the key is set, everything will keep working.

#### Where should the reviewer start?
`search/indexing_api.py`

#### How should this be manually tested?
This part is tricky: the docker elasticsearch should keep working. The actual authentication should be tested against the elasticsearch cluster when @blarghmatey finishes to set it up
