### PR TITLE
Added enrollment dialog

### DIFF
--- a/static/js/actions/enrollments.js
+++ b/static/js/actions/enrollments.js
@@ -2,6 +2,7 @@
 import type { Dispatch } from 'redux';
 import { createAction } from 'redux-actions';
 
+import { setEnrollMessage } from '../actions/ui';
 import type { Dispatcher } from '../flow/reduxTypes';
 import type {
   ProgramEnrollment,
@@ -44,9 +45,13 @@ export const addProgramEnrollment = (programId: number): Dispatcher<ProgramEnrol
   return (dispatch: Dispatch) => {
     dispatch(requestAddProgramEnrollment(programId));
     return api.addProgramEnrollment(programId).
-      then(enrollment => dispatch(receiveAddProgramEnrollmentSuccess(enrollment))).
+      then(enrollment => {
+        dispatch(receiveAddProgramEnrollmentSuccess(enrollment));
+        dispatch(setEnrollMessage(`You are now enrolled in the ${enrollment.title} MicroMasters`));
+      }).
       catch(error => {
         dispatch(receiveAddProgramEnrollmentFailure(error));
+        dispatch(setEnrollMessage(`There was an error during enrollment`));
         // the exception is assumed handled and will not be propagated
       });
   };

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -74,8 +74,14 @@ export const setSearchFilterVisibility = createAction(SET_SEARCH_FILTER_VISIBILI
 export const SET_EMAIL_DIALOG_VISIBILITY = 'SET_EMAIL_DIALOG_VISIBILITY';
 export const setEmailDialogVisibility = createAction(SET_EMAIL_DIALOG_VISIBILITY);
 
+export const SET_ENROLL_DIALOG_ERROR = 'SET_ENROLL_DIALOG_ERROR';
+export const setEnrollDialogError = createAction(SET_ENROLL_DIALOG_ERROR);
+
 export const SET_ENROLL_DIALOG_VISIBILITY = 'SET_ENROLL_DIALOG_VISIBILITY';
 export const setEnrollDialogVisibility = createAction(SET_ENROLL_DIALOG_VISIBILITY);
+
+export const SET_ENROLL_MESSAGE = 'SET_ENROLL_MESSAGE';
+export const setEnrollMessage = createAction(SET_ENROLL_MESSAGE);
 
 export const SET_ENROLL_SELECTED_PROGRAM = 'SET_ENROLL_SELECTED_PROGRAM';
 export const setEnrollSelectedProgram = createAction(SET_ENROLL_SELECTED_PROGRAM);

--- a/static/js/actions/ui_test.js
+++ b/static/js/actions/ui_test.js
@@ -17,7 +17,9 @@ import {
   SET_USER_MENU_OPEN,
   SET_SEARCH_FILTER_VISIBILITY,
   SET_EMAIL_DIALOG_VISIBILITY,
+  SET_ENROLL_DIALOG_ERROR,
   SET_ENROLL_DIALOG_VISIBILITY,
+  SET_ENROLL_MESSAGE,
   SET_ENROLL_SELECTED_PROGRAM,
 
   clearUI,
@@ -38,7 +40,9 @@ import {
   setUserMenuOpen,
   setSearchFilterVisibility,
   setEmailDialogVisibility,
+  setEnrollDialogError,
   setEnrollDialogVisibility,
+  setEnrollMessage,
   setEnrollSelectedProgram,
 } from '../actions/ui';
 import { assertCreatedActionHelper } from './util';
@@ -64,7 +68,9 @@ describe('generated UI action helpers', () => {
       [setUserMenuOpen, SET_USER_MENU_OPEN],
       [setSearchFilterVisibility, SET_SEARCH_FILTER_VISIBILITY],
       [setEmailDialogVisibility, SET_EMAIL_DIALOG_VISIBILITY],
+      [setEnrollDialogError, SET_ENROLL_DIALOG_ERROR],
       [setEnrollDialogVisibility, SET_ENROLL_DIALOG_VISIBILITY],
+      [setEnrollMessage, SET_ENROLL_MESSAGE],
       [setEnrollSelectedProgram, SET_ENROLL_SELECTED_PROGRAM],
     ].forEach(assertCreatedActionHelper);
   });

--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -13,14 +13,17 @@ import UserMenu from '../containers/UserMenu';
 
 export default class Navbar extends React.Component {
   props: {
+    addProgramEnrollment:        (programId: number) => void,
     empty:                       boolean,
     children?:                   React$Element<*>[],
     currentProgramEnrollment:    ProgramEnrollment,
     dashboard:                   DashboardState,
     enrollments:                 ProgramEnrollmentsState,
+    enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
     setCurrentProgramEnrollment: (enrollment: ProgramEnrollment) => void,
+    setEnrollDialogError:        (error: string) => void,
     setEnrollDialogVisibility:   (open: boolean) => void,
     setEnrollSelectedProgram:    (programId: number) => void,
   };
@@ -32,12 +35,15 @@ export default class Navbar extends React.Component {
 
   render () {
     const {
+      addProgramEnrollment,
       currentProgramEnrollment,
       dashboard,
+      enrollDialogError,
       enrollDialogVisibility,
       enrollSelectedProgram,
       enrollments,
       setCurrentProgramEnrollment,
+      setEnrollDialogError,
       setEnrollDialogVisibility,
       setEnrollSelectedProgram,
     } = this.props;
@@ -56,12 +62,15 @@ export default class Navbar extends React.Component {
                 </Link>
               </span>
               <ProgramSelector
+                addProgramEnrollment={addProgramEnrollment}
                 currentProgramEnrollment={currentProgramEnrollment}
                 dashboard={dashboard}
+                enrollDialogError={enrollDialogError}
                 enrollDialogVisibility={enrollDialogVisibility}
                 enrollSelectedProgram={enrollSelectedProgram}
                 enrollments={enrollments}
                 setCurrentProgramEnrollment={setCurrentProgramEnrollment}
+                setEnrollDialogError={setEnrollDialogError}
                 setEnrollDialogVisibility={setEnrollDialogVisibility}
                 setEnrollSelectedProgram={setEnrollSelectedProgram}
               />

--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -23,9 +23,9 @@ export default class Navbar extends React.Component {
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
     setCurrentProgramEnrollment: (enrollment: ProgramEnrollment) => void,
-    setEnrollDialogError:        (error: string) => void,
+    setEnrollDialogError:        (error: ?string) => void,
     setEnrollDialogVisibility:   (open: boolean) => void,
-    setEnrollSelectedProgram:    (programId: number) => void,
+    setEnrollSelectedProgram:    (programId: ?number) => void,
   };
 
   userMenu: Function = (): void|React$Element<*> => {

--- a/static/js/components/NewEnrollmentDialog.js
+++ b/static/js/components/NewEnrollmentDialog.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import Dialog from 'material-ui/Dialog';
+import Button from 'react-mdl/lib/Button';
+import _ from 'lodash';
+
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
+import type { DashboardState } from '../flow/dashboardTypes';
+import type { ProgramEnrollmentsState } from '../flow/enrollmentTypes';
+
+export default class NewEnrollmentDialog extends React.Component {
+  props: {
+    addProgramEnrollment:        (programId: number) => void,
+    dashboard:                   DashboardState,
+    enrollments:                 ProgramEnrollmentsState,
+    enrollDialogError:           ?string,
+    enrollDialogVisibility:      boolean,
+    enrollSelectedProgram:       ?number,
+    setEnrollDialogError:        (error: string) => void,
+    setEnrollDialogVisibility:   (open: boolean) => void,
+    setEnrollSelectedProgram:    (programId: number) => void,
+  };
+
+  closeDialog = () => {
+    const { setEnrollDialogVisibility } = this.props;
+    setEnrollDialogVisibility(false);
+  };
+
+  addEnrollment = () => {
+    const {
+      addProgramEnrollment,
+      enrollSelectedProgram,
+      setEnrollDialogError,
+      setEnrollDialogVisibility,
+    } = this.props;
+
+    if (_.isNil(enrollSelectedProgram)) {
+      setEnrollDialogError("No program selected");
+    } else {
+      addProgramEnrollment(enrollSelectedProgram);
+      setEnrollDialogVisibility(false);
+    }
+  };
+
+  createDialogActions = () => {
+    return [
+      <Button
+        className="dialog-button cancel-button"
+        key="cancel"
+        onClick={this.closeDialog}
+      >
+        Cancel
+      </Button>,
+      <Button
+        className="dialog-button enroll-button"
+        key="enroll"
+        onClick={this.addEnrollment}
+      >
+        Enroll
+      </Button>,
+    ]
+  };
+
+  handleEnrollSelectedProgram = (event, index, value) => {
+    const { setEnrollSelectedProgram } = this.props;
+    setEnrollSelectedProgram(value);
+  };
+
+  render() {
+    const {
+      dashboard: { programs },
+      enrollDialogError,
+      enrollDialogVisibility,
+      enrollSelectedProgram,
+      enrollments: { programEnrollments },
+    } = this.props;
+
+    let enrollmentLookup = new Map(programEnrollments.map(enrollment => [enrollment.id, null]));
+    let unenrolledPrograms = programs.filter(program => !enrollmentLookup.has(program.id));
+    unenrolledPrograms = _.sortBy(unenrolledPrograms, 'title');
+    let options = unenrolledPrograms.map(program =>
+      <MenuItem value={program.id} primaryText={program.title} key={program.id} />
+    );
+
+    // onRequestClose is not used below because an extra click or touch event causes material-ui
+    // to close the dialog right after opening it. See https://github.com/JedWatson/react-select/issues/532
+    return <Dialog
+      open={enrollDialogVisibility}
+      title="Enroll in a new MicroMasters Program"
+      actions={this.createDialogActions()}
+    >
+      <SelectField
+        value={enrollSelectedProgram}
+        onChange={this.handleEnrollSelectedProgram}
+        floatingLabelText="Select Program"
+        errorText={enrollDialogError}
+      >
+        {options}
+      </SelectField>
+    </Dialog>;
+  }
+}

--- a/static/js/components/NewEnrollmentDialog.js
+++ b/static/js/components/NewEnrollmentDialog.js
@@ -16,9 +16,9 @@ export default class NewEnrollmentDialog extends React.Component {
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
-    setEnrollDialogError:        (error: string) => void,
+    setEnrollDialogError:        (error: ?string) => void,
     setEnrollDialogVisibility:   (open: boolean) => void,
-    setEnrollSelectedProgram:    (programId: number) => void,
+    setEnrollSelectedProgram:    (programId: ?number) => void,
   };
 
   closeDialog = () => {

--- a/static/js/components/NewEnrollmentDialog.js
+++ b/static/js/components/NewEnrollmentDialog.js
@@ -58,7 +58,7 @@ export default class NewEnrollmentDialog extends React.Component {
       >
         Enroll
       </Button>,
-    ]
+    ];
   };
 
   handleEnrollSelectedProgram = (event, index, value) => {

--- a/static/js/components/NewEnrollmentDialog.js
+++ b/static/js/components/NewEnrollmentDialog.js
@@ -61,7 +61,7 @@ export default class NewEnrollmentDialog extends React.Component {
     ];
   };
 
-  handleEnrollSelectedProgram = (event, index, value) => {
+  handleSelectedProgramChange = (event, index, value) => {
     const { setEnrollSelectedProgram } = this.props;
     setEnrollSelectedProgram(value);
   };
@@ -91,7 +91,7 @@ export default class NewEnrollmentDialog extends React.Component {
     >
       <SelectField
         value={enrollSelectedProgram}
-        onChange={this.handleEnrollSelectedProgram}
+        onChange={this.handleSelectedProgramChange}
         floatingLabelText="Select Program"
         errorText={enrollDialogError}
       >

--- a/static/js/components/NewEnrollmentDialog_test.js
+++ b/static/js/components/NewEnrollmentDialog_test.js
@@ -1,21 +1,15 @@
 // @flow
 import React from 'react';
 import { assert } from 'chai';
-import MenuItem from 'material-ui/MenuItem'
+import MenuItem from 'material-ui/MenuItem';
 import _ from 'lodash';
 import { shallow } from 'enzyme';
 import Dialog from 'material-ui/Dialog';
 import SelectField from 'material-ui/SelectField';
-import Button from 'react-mdl/lib/Button';
 
 import {
 } from '../actions/enrollments';
 import * as enrollmentActions from '../actions/enrollments';
-import {
-  SET_ENROLL_DIALOG_ERROR,
-  SET_ENROLL_DIALOG_VISIBILITY,
-  SET_ENROLL_SELECTED_PROGRAM,
-} from '../actions/ui';
 import * as uiActions from '../actions/ui';
 
 import {

--- a/static/js/components/NewEnrollmentDialog_test.js
+++ b/static/js/components/NewEnrollmentDialog_test.js
@@ -1,0 +1,192 @@
+// @flow
+import React from 'react';
+import { assert } from 'chai';
+import MenuItem from 'material-ui/MenuItem'
+import _ from 'lodash';
+import { shallow } from 'enzyme';
+import Dialog from 'material-ui/Dialog';
+import SelectField from 'material-ui/SelectField';
+import Button from 'react-mdl/lib/Button';
+
+import {
+} from '../actions/enrollments';
+import * as enrollmentActions from '../actions/enrollments';
+import {
+  SET_ENROLL_DIALOG_ERROR,
+  SET_ENROLL_DIALOG_VISIBILITY,
+  SET_ENROLL_SELECTED_PROGRAM,
+} from '../actions/ui';
+import * as uiActions from '../actions/ui';
+
+import {
+  DASHBOARD_RESPONSE,
+  PROGRAM_ENROLLMENTS,
+} from '../constants';
+import NewEnrollmentDialog from './NewEnrollmentDialog';
+import IntegrationTestHelper from '../util/integration_test_helper';
+
+describe("NewEnrollmentDialog", () => {
+  let helper;
+  beforeEach(() => {
+    helper = new IntegrationTestHelper();
+  });
+
+  afterEach(() => {
+    helper.cleanup();
+  });
+
+  it('renders a dialog', () => {
+    return helper.renderComponent("/dashboard").then(([wrapper]) => {
+      let dialog = wrapper.find(NewEnrollmentDialog);
+      let props = dialog.props();
+
+      assert.deepEqual(props.enrollments.programEnrollments, PROGRAM_ENROLLMENTS);
+      assert.deepEqual(props.dashboard.programs, DASHBOARD_RESPONSE);
+    });
+  });
+
+  for (let [funcName, propName, value] of [
+    ['setEnrollDialogError', 'enrollDialogError', 'error'],
+    ['setEnrollDialogVisibility', 'enrollDialogVisibility', true],
+    ['setEnrollSelectedProgram', 'enrollSelectedProgram', 3],
+  ]) {
+    it(`dispatches ${funcName}`, () => {
+      let stub = helper.sandbox.spy(uiActions, funcName);
+      return helper.renderComponent("/dashboard").then(([wrapper]) => {
+        let handler = wrapper.find(NewEnrollmentDialog).props()[funcName];
+        handler(value);
+        assert(stub.calledWith(value));
+      });
+    });
+
+    it(`the prop ${propName} comes from the state`, () => {
+      helper.store.dispatch(uiActions[funcName](value));
+
+      return helper.renderComponent("/dashboard").then(([wrapper]) => {
+        let actual = wrapper.find(NewEnrollmentDialog).props()[propName];
+        assert.equal(actual, value);
+      });
+    });
+  }
+
+  it('dispatches addProgramEnrollment', () => {
+    let stub = helper.sandbox.stub(enrollmentActions, 'addProgramEnrollment');
+    stub.returns({type: "fake"});
+    return helper.renderComponent("/dashboard").then(([wrapper]) => {
+      let handler = wrapper.find(NewEnrollmentDialog).props().addProgramEnrollment;
+      handler(3);
+      assert(stub.calledWith(3));
+    });
+  });
+
+  it('can select the program enrollment via SelectField', () => {
+    let enrollment = PROGRAM_ENROLLMENTS[0];
+    let stub = helper.sandbox.stub();
+    let wrapper = shallow(
+      <NewEnrollmentDialog
+        dashboard={{programs: DASHBOARD_RESPONSE}}
+        enrollments={{programEnrollments: PROGRAM_ENROLLMENTS}}
+        enrollDialogVisibility={true}
+        setEnrollSelectedProgram={stub}
+      />);
+    wrapper.find(SelectField).props().onChange(null, null, enrollment);
+    assert(stub.calledWith(enrollment));
+  });
+
+  it('can dispatch an addProgramEnrollment action for the currently selected enrollment', () => {
+    let selectedEnrollment = PROGRAM_ENROLLMENTS[0];
+    let visibilityStub = helper.sandbox.stub();
+    let enrollStub = helper.sandbox.stub();
+    let wrapper = shallow(
+      <NewEnrollmentDialog
+        dashboard={{programs: DASHBOARD_RESPONSE}}
+        enrollments={{programEnrollments: PROGRAM_ENROLLMENTS}}
+        enrollDialogVisibility={true}
+        setEnrollDialogVisibility={visibilityStub}
+        addProgramEnrollment={enrollStub}
+        enrollSelectedProgram={selectedEnrollment}
+      />);
+    let button = wrapper.find(Dialog).props().actions.find(
+      button => button.props.className.includes("enroll")
+    );
+    button.props.onClick();
+    assert(enrollStub.calledWith(selectedEnrollment));
+    assert(visibilityStub.calledWith(false));
+  });
+
+  it("shows an error if the user didn't select any program when they click enroll", () => {
+    let stub = helper.sandbox.stub();
+    let wrapper = shallow(
+      <NewEnrollmentDialog
+        dashboard={{programs: DASHBOARD_RESPONSE}}
+        enrollments={{programEnrollments: PROGRAM_ENROLLMENTS}}
+        enrollDialogVisibility={true}
+        setEnrollDialogError={stub}
+      />);
+    let button = wrapper.find(Dialog).props().actions.find(
+      button => button.props.className.includes("enroll")
+    );
+    button.props.onClick();
+    assert(stub.calledWith("No program selected"));
+  });
+
+  it("clears the dialog when the user clicks cancel", () => {
+    let stub = helper.sandbox.stub();
+    let wrapper = shallow(
+      <NewEnrollmentDialog
+        dashboard={{programs: DASHBOARD_RESPONSE}}
+        enrollments={{programEnrollments: PROGRAM_ENROLLMENTS}}
+        enrollDialogVisibility={true}
+        setEnrollDialogVisibility={stub}
+      />);
+    let button = wrapper.find(Dialog).props().actions.find(
+      button => button.props.className.includes("cancel")
+    );
+    button.props.onClick();
+    assert(stub.calledWith(false));
+  });
+
+  it("only shows programs which the user is not already enrolled in", () => {
+    let enrollmentLookup = new Map(PROGRAM_ENROLLMENTS.map(enrollment => [enrollment.id, null]));
+    let unenrolledPrograms = DASHBOARD_RESPONSE.filter(program => !enrollmentLookup.has(program.id));
+    unenrolledPrograms = _.sortBy(unenrolledPrograms, 'title');
+    unenrolledPrograms = unenrolledPrograms.map(program => ({
+      title: program.title,
+      id: program.id,
+    }));
+
+    let selectedEnrollment = PROGRAM_ENROLLMENTS[0];
+
+    let wrapper = shallow(
+      <NewEnrollmentDialog
+        dashboard={{programs: DASHBOARD_RESPONSE}}
+        enrollments={{programEnrollments: PROGRAM_ENROLLMENTS}}
+        enrollDialogVisibility={false}
+        enrollSelectedProgram={selectedEnrollment}
+      />);
+
+    let list = wrapper.find(MenuItem).map(menuItem => {
+      let props = menuItem.props();
+      return {
+        title: props.primaryText,
+        id: props.value
+      };
+    });
+
+    assert.deepEqual(list, unenrolledPrograms);
+  });
+
+  it("shows the current enrollment in the SelectField", () => {
+    let selectedEnrollment = PROGRAM_ENROLLMENTS[0];
+
+    let wrapper = shallow(
+      <NewEnrollmentDialog
+        dashboard={{programs: DASHBOARD_RESPONSE}}
+        enrollments={{programEnrollments: PROGRAM_ENROLLMENTS}}
+        enrollSelectedProgram={selectedEnrollment}
+        enrollDialogVisibility={false}
+      />);
+    let select = wrapper.find(SelectField);
+    assert.equal(select.props().value, selectedEnrollment);
+  });
+});

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -15,7 +15,7 @@ export default class ProgramFilter extends SearchkitComponent {
 
   _accessor = new AnonymousAccessor(query => {
     const { currentProgramEnrollment } = this.props;
-    if (currentProgramEnrollment === null) {
+    if (_.isNil(currentProgramEnrollment)) {
       return query;
     }
     return query.addFilter("program_filter", TermQuery("program.id", currentProgramEnrollment.id));

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -54,7 +54,7 @@ export default class ProgramSelector extends React.Component {
     } = this.props;
 
     let currentId;
-    if (currentProgramEnrollment !== null) {
+    if (!_.isNil(currentProgramEnrollment)) {
       currentId = currentProgramEnrollment.id;
     }
 
@@ -91,7 +91,7 @@ export default class ProgramSelector extends React.Component {
       setEnrollSelectedProgram,
     } = this.props;
     let currentId;
-    if (currentProgramEnrollment !== null) {
+    if (!_.isNil(currentProgramEnrollment)) {
       currentId = currentProgramEnrollment.id;
     }
 

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -23,9 +23,9 @@ export default class ProgramSelector extends React.Component {
     enrollSelectedProgram:       ?number,
     dashboard:                   DashboardState,
     setCurrentProgramEnrollment: (enrollment: ProgramEnrollment) => void,
-    setEnrollDialogError:        (error: string) => void,
+    setEnrollDialogError:        (error: ?string) => void,
     setEnrollDialogVisibility:   (open: boolean) => void,
-    setEnrollSelectedProgram:    (programId: number) => void,
+    setEnrollSelectedProgram:    (programId: ?number) => void,
   };
 
   selectEnrollment = (option: Option): void => {

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -3,6 +3,7 @@ import React from 'react';
 import _ from 'lodash';
 import Select from 'react-select';
 
+import NewEnrollmentDialog from './NewEnrollmentDialog';
 import type { DashboardState } from '../flow/dashboardTypes';
 import type {
   ProgramEnrollment,
@@ -14,12 +15,15 @@ const ENROLL_SENTINEL = 'enroll';
 
 export default class ProgramSelector extends React.Component {
   props: {
+    addProgramEnrollment:        (programId: number) => void,
     currentProgramEnrollment:    ProgramEnrollment,
     enrollments:                 ProgramEnrollmentsState,
+    enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
     dashboard:                   DashboardState,
     setCurrentProgramEnrollment: (enrollment: ProgramEnrollment) => void,
+    setEnrollDialogError:        (error: string) => void,
     setEnrollDialogVisibility:   (open: boolean) => void,
     setEnrollSelectedProgram:    (programId: number) => void,
   };
@@ -28,10 +32,14 @@ export default class ProgramSelector extends React.Component {
     const {
       enrollments: { programEnrollments },
       setCurrentProgramEnrollment,
+      setEnrollDialogError,
       setEnrollDialogVisibility,
+      setEnrollSelectedProgram,
     } = this.props;
     if (option.value === ENROLL_SENTINEL) {
       setEnrollDialogVisibility(true);
+      setEnrollSelectedProgram(null);
+      setEnrollDialogError(null);
     } else {
       let selected = programEnrollments.find(enrollment => enrollment.id === option.value);
       setCurrentProgramEnrollment(selected);
@@ -70,8 +78,17 @@ export default class ProgramSelector extends React.Component {
 
   render() {
     let {
-      enrollments: { programEnrollments },
+      addProgramEnrollment,
+      dashboard,
+      enrollments,
+      enrollments: {programEnrollments},
+      enrollDialogError,
+      enrollDialogVisibility,
+      enrollSelectedProgram,
       currentProgramEnrollment,
+      setEnrollDialogError,
+      setEnrollDialogVisibility,
+      setEnrollSelectedProgram,
     } = this.props;
     let currentId;
     if (currentProgramEnrollment !== null) {
@@ -92,6 +109,17 @@ export default class ProgramSelector extends React.Component {
           placeholder={selected ? selected.title : ""}
           clearable={false}
           tabSelectsValue={false}
+        />
+        <NewEnrollmentDialog
+          addProgramEnrollment={addProgramEnrollment}
+          dashboard={dashboard}
+          enrollments={enrollments}
+          enrollDialogError={enrollDialogError}
+          enrollDialogVisibility={enrollDialogVisibility}
+          enrollSelectedProgram={enrollSelectedProgram}
+          setEnrollDialogError={setEnrollDialogError}
+          setEnrollDialogVisibility={setEnrollDialogVisibility}
+          setEnrollSelectedProgram={setEnrollSelectedProgram}
         />
       </div>;
     }

--- a/static/js/components/ProgramSelector_test.js
+++ b/static/js/components/ProgramSelector_test.js
@@ -97,12 +97,18 @@ describe('ProgramSelector', () => {
 
   it("shows the enrollment dialog when the 'Enroll in a new program' option is clicked", () => {
     let setEnrollDialogVisibility = sandbox.stub();
+    let setEnrollDialogError = sandbox.stub();
+    let setEnrollSelectedProgram = sandbox.stub();
     let wrapper = renderProgramSelector({
+      setEnrollDialogError,
       setEnrollDialogVisibility,
+      setEnrollSelectedProgram,
     });
     let onChange = wrapper.find(Select).props()['onChange'];
     onChange({value: 'enroll'});
-    assert(setEnrollDialogVisibility.calledWith(true), 'setEnrollDialogVisibility not called with true');
+    assert(setEnrollDialogVisibility.calledWith(true));
+    assert(setEnrollDialogError.calledWith(null));
+    assert(setEnrollSelectedProgram.calledWith(null));
   });
 
   it("switches to a new current enrollment when a new option is clicked", () => {

--- a/static/js/components/Toast.js
+++ b/static/js/components/Toast.js
@@ -1,0 +1,38 @@
+// @flow
+import React from 'react';
+
+export default class Toast extends React.Component {
+  props: {
+    open: boolean,
+    children: React.Element<*>,
+    timeout: number,
+    onTimeout: () => void,
+  };
+
+  static defaultProps = {
+    timeout: 5000
+  };
+
+  componentDidMount() {
+    const { onTimeout, open, timeout } = this.props;
+
+    if (open && onTimeout) {
+      setTimeout(onTimeout, timeout);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { onTimeout, timeout } = this.props;
+    if (!prevProps.open && this.props.open && onTimeout) {
+      setTimeout(onTimeout, timeout);
+    }
+  }
+
+  render() {
+    const { children, open } = this.props;
+
+    return <div className={`toast ${open ? 'open' : ''}`}>
+      {children}
+    </div>;
+  }
+}

--- a/static/js/components/Toast.js
+++ b/static/js/components/Toast.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 export default class Toast extends React.Component {
   props: {
+    children: any,
     open: boolean,
     timeout: number,
     onTimeout: () => void,

--- a/static/js/components/Toast.js
+++ b/static/js/components/Toast.js
@@ -1,10 +1,8 @@
-// @flow
 import React from 'react';
 
 export default class Toast extends React.Component {
   props: {
     open: boolean,
-    children: React.Element<*>,
     timeout: number,
     onTimeout: () => void,
   };
@@ -21,7 +19,7 @@ export default class Toast extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Object) {
     const { onTimeout, timeout } = this.props;
     if (!prevProps.open && this.props.open && onTimeout) {
       setTimeout(onTimeout, timeout);

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -146,7 +146,7 @@ class App extends React.Component {
     dispatch(addProgramEnrollment(programId));
   };
 
-  setEnrollDialogError = (error: string): void => {
+  setEnrollDialogError = (error: ?string): void => {
     const { dispatch } = this.props;
     dispatch(setEnrollDialogError(error));
   };
@@ -156,7 +156,7 @@ class App extends React.Component {
     dispatch(setEnrollDialogVisibility(visibility));
   };
 
-  setEnrollSelectedProgram = (programId: number): void => {
+  setEnrollSelectedProgram = (programId: ?number): void => {
     const { dispatch } = this.props;
     dispatch(setEnrollSelectedProgram(programId));
   };

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -1,12 +1,15 @@
 // @flow
 /* global SETTINGS: false */
 import React from 'react';
+import Icon from 'react-mdl/lib/Icon';
 import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
+import _ from 'lodash';
 
 import ErrorMessage from '../components/ErrorMessage';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
+import Toast from '../components/Toast';
 import {
   FETCH_SUCCESS,
   FETCH_FAILURE,
@@ -20,12 +23,15 @@ import {
   updateProfileValidation,
 } from '../actions/profile';
 import {
+  addProgramEnrollment,
   clearEnrollments,
   fetchProgramEnrollments,
   setCurrentProgramEnrollment,
 } from '../actions/enrollments';
 import {
+  setEnrollDialogError,
   setEnrollDialogVisibility,
+  setEnrollMessage,
   setEnrollSelectedProgram,
 } from '../actions/ui';
 import { clearUI, setProfileStep } from '../actions/ui';
@@ -135,6 +141,16 @@ class App extends React.Component {
     }
   }
 
+  addProgramEnrollment = (programId: number): void => {
+    const { dispatch } = this.props;
+    dispatch(addProgramEnrollment(programId));
+  };
+
+  setEnrollDialogError = (error: string): void => {
+    const { dispatch } = this.props;
+    dispatch(setEnrollDialogError(error));
+  };
+
   setEnrollDialogVisibility = (visibility: boolean): void => {
     const { dispatch } = this.props;
     dispatch(setEnrollDialogVisibility(visibility));
@@ -150,12 +166,19 @@ class App extends React.Component {
     dispatch(setCurrentProgramEnrollment(enrollment));
   };
 
+  clearMessage = (): void => {
+    const { dispatch } = this.props;
+    dispatch(setEnrollMessage(null));
+  };
+
   render() {
     const {
       currentProgramEnrollment,
       enrollments,
       ui: {
+        enrollDialogError,
         enrollDialogVisibility,
+        enrollMessage,
         enrollSelectedProgram,
       },
       location: { pathname },
@@ -171,18 +194,43 @@ class App extends React.Component {
       children = <ErrorMessage errorInfo={enrollments.getErrorInfo} />;
       empty = true;
     }
+
+    let open = false;
+    let message;
+    if (!_.isNil(enrollMessage)) {
+      open = true;
+
+      let icon;
+      if (enrollments.postStatus === FETCH_FAILURE) {
+        icon = <Icon name="error" key="icon "/>;
+      } else if (enrollments.postStatus === FETCH_SUCCESS) {
+        icon = <Icon name="done" key="icon" />;
+      }
+      message = [
+        icon,
+        " ",
+        enrollMessage,
+      ];
+    }
+
     return <div id="app">
       <Navbar
+        addProgramEnrollment={this.addProgramEnrollment}
         currentProgramEnrollment={currentProgramEnrollment}
         dashboard={dashboard}
         empty={empty}
+        enrollDialogError={enrollDialogError}
         enrollDialogVisibility={enrollDialogVisibility}
         enrollSelectedProgram={enrollSelectedProgram}
         enrollments={enrollments}
         setCurrentProgramEnrollment={this.setCurrentProgramEnrollment}
+        setEnrollDialogError={this.setEnrollDialogError}
         setEnrollDialogVisibility={this.setEnrollDialogVisibility}
         setEnrollSelectedProgram={this.setEnrollSelectedProgram}
       />
+      <Toast onTimeout={this.clearMessage} open={open}>
+        {message}
+      </Toast>
       <div className="page-content">
         { children }
       </div>

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -5,6 +5,7 @@ import type { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 import Loader from 'react-loader';
 import { Card, CardTitle } from 'react-mdl/lib/Card';
+import _ from 'lodash';
 
 import { FETCH_PROCESSING, checkout } from '../actions';
 import { createForm } from '../util/util';
@@ -48,12 +49,12 @@ class DashboardPage extends React.Component {
     let dashboardContent;
     // if there are no errors coming from the backend, simply show the dashboard
     let program;
-    if (currentProgramEnrollment !== null) {
+    if (!_.isNil(currentProgramEnrollment)) {
       program = dashboard.programs.find(program => program.id === currentProgramEnrollment.id);
     }
     if (dashboard.errorInfo !== undefined) {
       errorMessage = <ErrorMessage errorInfo={dashboard.errorInfo}/>;
-    } else if (program === null || program === undefined) {
+    } else if (_.isNil(program)) {
       errorMessage = <ErrorMessage errorInfo={{user_message: "No program enrollment is available."}} />;
     } else {
       dashboardContent = (

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -1,4 +1,3 @@
-// @flow
 /* global SETTINGS: false */
 import React from 'react';
 import type { Dispatch } from 'redux';

--- a/static/js/reducers/enrollments.js
+++ b/static/js/reducers/enrollments.js
@@ -66,6 +66,8 @@ export const currentProgramEnrollment = (state: any = null, action: Action) => {
       state = action.payload[0];
     }
     return state;
+  case RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS:
+    return action.payload;
   default:
     return state;
   }

--- a/static/js/reducers/enrollments.js
+++ b/static/js/reducers/enrollments.js
@@ -1,4 +1,6 @@
 // @flow
+import _ from 'lodash';
+
 import {
   REQUEST_GET_PROGRAM_ENROLLMENTS,
   RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
@@ -54,14 +56,14 @@ export const currentProgramEnrollment = (state: any = null, action: Action) => {
   case SET_CURRENT_PROGRAM_ENROLLMENT:
     return action.payload;
   case RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS:
-    if (state !== null) {
+    if (!_.isNil(state)) {
       let enrollment = action.payload.find(enrollment => enrollment.id === state.id);
       if (enrollment === undefined) {
         // current enrollment not found in list
         state = null;
       }
     }
-    if (state === null && action.payload.length > 0) {
+    if (_.isNil(state) && action.payload.length > 0) {
       // no current enrollment selected, pick first from list if there are any
       state = action.payload[0];
     }

--- a/static/js/reducers/enrollments_test.js
+++ b/static/js/reducers/enrollments_test.js
@@ -6,6 +6,9 @@ import {
   FETCH_SUCCESS,
   FETCH_FAILURE,
 } from '../actions';
+import {
+  SET_ENROLL_MESSAGE,
+} from '../actions/ui';
 import { PROGRAM_ENROLLMENTS } from '../constants';
 import {
   addProgramEnrollment,
@@ -92,14 +95,20 @@ describe('enrollments', () => {
       addProgramEnrollmentStub.returns(Promise.resolve(newEnrollment));
       store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
 
-      return dispatchThen(
-        addProgramEnrollment(newEnrollment.id),
-        [REQUEST_ADD_PROGRAM_ENROLLMENT, RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS]
-      ).then(enrollmentsState => {
+      return dispatchThen(addProgramEnrollment(newEnrollment.id), [
+        REQUEST_ADD_PROGRAM_ENROLLMENT,
+        RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS,
+        SET_ENROLL_MESSAGE,
+      ]).then(enrollmentsState => {
         assert.equal(enrollmentsState.postStatus, FETCH_SUCCESS);
         assert.deepEqual(enrollmentsState.programEnrollments, PROGRAM_ENROLLMENTS.concat(newEnrollment));
         assert.equal(addProgramEnrollmentStub.callCount, 1);
         assert.deepEqual(addProgramEnrollmentStub.args[0], [newEnrollment.id]);
+
+        assert.equal(
+          store.getState().ui.enrollMessage,
+          `You are now enrolled in the ${newEnrollment.title} MicroMasters`
+        );
       });
     });
 
@@ -107,15 +116,18 @@ describe('enrollments', () => {
       addProgramEnrollmentStub.returns(Promise.reject("addError"));
       store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
 
-      return dispatchThen(
-        addProgramEnrollment(newEnrollment.id),
-        [REQUEST_ADD_PROGRAM_ENROLLMENT, RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE]
-      ).then(enrollmentsState => {
+      return dispatchThen(addProgramEnrollment(newEnrollment.id), [
+        REQUEST_ADD_PROGRAM_ENROLLMENT,
+        RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE,
+        SET_ENROLL_MESSAGE,
+      ]).then(enrollmentsState => {
         assert.equal(enrollmentsState.postStatus, FETCH_FAILURE);
         assert.equal(enrollmentsState.postErrorInfo, "addError");
         assert.deepEqual(enrollmentsState.programEnrollments, PROGRAM_ENROLLMENTS);
         assert.equal(addProgramEnrollmentStub.callCount, 1);
         assert.deepEqual(addProgramEnrollmentStub.args[0], [newEnrollment.id]);
+
+        assert.equal(store.getState().ui.enrollMessage, "There was an error during enrollment");
       });
     });
 

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -36,6 +36,11 @@ import {
 import { PERSONAL_STEP } from '../constants';
 import type { Action } from '../flow/reduxTypes';
 
+export type UIDialog = {
+  title?: string;
+  text?: string;
+  visible?: boolean;
+};
 export type UIState = {
   workHistoryEdit:              boolean;
   workDialogVisibility:         boolean;
@@ -47,7 +52,7 @@ export type UIState = {
   showWorkDeleteDialog:         boolean;
   showEducationDeleteDialog:    boolean;
   deletionIndex:                ?number;
-  dialog:                       {};
+  dialog:                       UIDialog;
   showWorkDeleteAllDialog:      boolean;
   showEducationDeleteAllDialog: boolean;
   profileStep:                  string;

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -28,7 +28,9 @@ import {
 
   SET_EMAIL_DIALOG_VISIBILITY,
 
+  SET_ENROLL_DIALOG_ERROR,
   SET_ENROLL_DIALOG_VISIBILITY,
+  SET_ENROLL_MESSAGE,
   SET_ENROLL_SELECTED_PROGRAM,
 } from '../actions/ui';
 import { PERSONAL_STEP } from '../constants';
@@ -54,8 +56,10 @@ export type UIState = {
   searchFilterVisibility:       {[s: string]: boolean};
   tosDialogVisibility:          boolean;
   emailDialogVisibility:        boolean;
+  enrollDialogError:            ?string;
   enrollDialogVisibility:       boolean;
-  enrollSelectedProgram:       ?number;
+  enrollMessage:                ?string;
+  enrollSelectedProgram:        ?number;
 };
 
 export const INITIAL_UI_STATE: UIState = {
@@ -78,7 +82,9 @@ export const INITIAL_UI_STATE: UIState = {
   searchFilterVisibility: {},
   tosDialogVisibility: false,
   emailDialogVisibility: false,
+  enrollDialogError: null,
   enrollDialogVisibility: false,
+  enrollMessage: null,
   enrollSelectedProgram: null,
 };
 
@@ -181,6 +187,16 @@ export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
   case SET_EMAIL_DIALOG_VISIBILITY: {
     return Object.assign({}, state, {
       emailDialogVisibility: action.payload
+    });
+  }
+  case SET_ENROLL_DIALOG_ERROR: {
+    return Object.assign({}, state, {
+      enrollDialogError: action.payload
+    });
+  }
+  case SET_ENROLL_MESSAGE: {
+    return Object.assign({}, state, {
+      enrollMessage: action.payload
     });
   }
   case SET_ENROLL_SELECTED_PROGRAM: {

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -270,6 +270,20 @@ describe('ui reducers', () => {
   });
 
   describe('Enrollment', () => {
+    describe('enrollment message', () => {
+      it('should have a null default value', () => {
+        assert.equal(store.getState().ui.enrollMessage, null);
+      });
+
+      it('should let you set the message', () => {
+        return dispatchThen(setEnrollMessage("value"), [
+          SET_ENROLL_MESSAGE
+        ]).then(state => {
+          assert.equal(state.enrollMessage, "value");
+        });
+      });
+    });
+
     describe('enrollment dialog error', () => {
       it('should have a null default value', () => {
         assert.equal(store.getState().ui.enrollDialogError, null);

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -19,7 +19,9 @@ import {
   SET_USER_MENU_OPEN,
   SET_SEARCH_FILTER_VISIBILITY,
   SET_EMAIL_DIALOG_VISIBILITY,
+  SET_ENROLL_DIALOG_ERROR,
   SET_ENROLL_DIALOG_VISIBILITY,
+  SET_ENROLL_MESSAGE,
   SET_ENROLL_SELECTED_PROGRAM,
 
   clearUI,
@@ -41,7 +43,9 @@ import {
   setUserMenuOpen,
   setSearchFilterVisibility,
   setEmailDialogVisibility,
+  setEnrollDialogError,
   setEnrollDialogVisibility,
+  setEnrollMessage,
   setEnrollSelectedProgram,
 } from '../actions/ui';
 import { INITIAL_UI_STATE } from '../reducers/ui';
@@ -266,6 +270,34 @@ describe('ui reducers', () => {
   });
 
   describe('Enrollment', () => {
+    describe('enrollment dialog error', () => {
+      it('should have a null default value', () => {
+        assert.equal(store.getState().ui.enrollDialogError, null);
+      });
+
+      it('should let you set the dialog error', () => {
+        return dispatchThen(setEnrollDialogError("value"), [
+          SET_ENROLL_DIALOG_ERROR
+        ]).then(state => {
+          assert.equal(state.enrollDialogError, "value");
+        });
+      });
+    });
+
+    describe('enrollment success/failure message', () => {
+      it('should have a null default value', () => {
+        assert.equal(store.getState().ui.enrollMessage, null);
+      });
+
+      it('should let you toggle the program selector visibility', () => {
+        return dispatchThen(setEnrollMessage("value"), [
+          SET_ENROLL_DIALOG_VISIBILITY
+        ]).then(state => {
+          assert.equal(state.enrollMessage, "value");
+        });
+      });
+    });
+
     describe('enrollment dialog visibility', () => {
       it('should have a false default value', () => {
         assert.equal(store.getState().ui.enrollDialogVisibility, false);

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -48,12 +48,11 @@ describe('ui reducers', () => {
 
   afterEach(() => {
     sandbox.restore();
-
-    store = null;
-    dispatchThen = null;
   });
 
-  const assertReducerResultState = (action: Action, stateLookup: (ui: UIState) => any, defaultValue: any): void => {
+  const assertReducerResultState = (
+    action: () => Action, stateLookup: (ui: UIState) => any, defaultValue: any
+  ): void => {
     assert.deepEqual(defaultValue, stateLookup(store.getState().ui));
     for (let value of [true, null, false, 0, 3, 'x', {'a': 'b'}, {}, [3, 4, 5], [], '']) {
       let expected = value;
@@ -108,13 +107,6 @@ describe('ui reducers', () => {
   });
 
   describe('education reducers', () => {
-    it('has a default state', () => {
-      let state = store.getState().ui;
-      assert.deepEqual(state.educationDialogVisibility, false);
-      assert.deepEqual(state.educationDialogIndex, -1);
-      assert.deepEqual(state.educationDegreeLevel, '');
-    });
-
     it('should let you set education dialog visibility', () => {
       assertReducerResultState(setEducationDialogVisibility, ui => ui.educationDialogVisibility, false);
     });

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -305,7 +305,7 @@ describe('ui reducers', () => {
 
       it('should let you toggle the program selector visibility', () => {
         return dispatchThen(setEnrollMessage("value"), [
-          SET_ENROLL_DIALOG_VISIBILITY
+          SET_ENROLL_MESSAGE
         ]).then(state => {
           assert.equal(state.enrollMessage, "value");
         });

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -1,28 +1,7 @@
+// @flow
 /* global SETTINGS: false */
 import {
-  CLEAR_UI,
-  UPDATE_DIALOG_TEXT,
-  UPDATE_DIALOG_TITLE,
-  SET_DIALOG_VISIBILITY,
   SET_WORK_HISTORY_EDIT,
-  SET_WORK_DIALOG_VISIBILITY,
-  SET_WORK_DIALOG_INDEX,
-  SET_EDUCATION_DIALOG_VISIBILITY,
-  SET_EDUCATION_DIALOG_INDEX,
-  SET_EDUCATION_DEGREE_LEVEL,
-  SET_USER_PAGE_DIALOG_VISIBILITY,
-  SET_SHOW_EDUCATION_DELETE_DIALOG,
-  SET_SHOW_WORK_DELETE_DIALOG,
-  SET_DELETION_INDEX,
-  SET_SHOW_WORK_DELETE_ALL_DIALOG,
-  SET_PROFILE_STEP,
-  SET_USER_MENU_OPEN,
-  SET_SEARCH_FILTER_VISIBILITY,
-  SET_EMAIL_DIALOG_VISIBILITY,
-  SET_ENROLL_DIALOG_ERROR,
-  SET_ENROLL_DIALOG_VISIBILITY,
-  SET_ENROLL_MESSAGE,
-  SET_ENROLL_SELECTED_PROGRAM,
 
   clearUI,
   updateDialogText,
@@ -49,8 +28,10 @@ import {
   setEnrollSelectedProgram,
 } from '../actions/ui';
 import { INITIAL_UI_STATE } from '../reducers/ui';
-import { PROFILE_STEP_LABELS } from '../constants';
+import type { UIState } from '../reducers/ui';
+import { PERSONAL_STEP } from '../constants';
 import rootReducer from '../reducers';
+import type { Action } from '../flow/reduxTypes';
 
 import configureTestStore from 'redux-asserts';
 import { assert } from 'chai';
@@ -72,45 +53,46 @@ describe('ui reducers', () => {
     dispatchThen = null;
   });
 
+  const assertReducerResultState = (action: Action, stateLookup: (ui: UIState) => any, defaultValue: any): void => {
+    assert.deepEqual(defaultValue, stateLookup(store.getState().ui));
+    for (let value of [true, null, false, 0, 3, 'x', {'a': 'b'}, {}, [3, 4, 5], [], '']) {
+      let expected = value;
+      if (value === null) {
+        // redux-actions converts this to undefined
+        expected = undefined;
+      }
+      store.dispatch(action(value));
+      assert.deepEqual(expected, stateLookup(store.getState().ui));
+    }
+  };
+
   it('should clear the ui', () => {
-    return assert.eventually.deepEqual(
-      dispatchThen(clearUI(), [CLEAR_UI]),
-      INITIAL_UI_STATE
-    );
+    store.dispatch(clearUI());
+    assert.deepEqual(store.getState().ui, INITIAL_UI_STATE);
   });
 
   describe('dialog reducers', () => {
     it('should set a dialog title', () => {
-      return dispatchThen(updateDialogTitle('A title'), [UPDATE_DIALOG_TITLE]).then(state => {
-        assert.equal(state.dialog.title, 'A title');
-      });
+      assertReducerResultState(updateDialogTitle, ui => ui.dialog.title, undefined);
     });
 
     it('should set dialog text', () => {
-      return dispatchThen(updateDialogText('Some Text'), [UPDATE_DIALOG_TEXT]).then(state => {
-        assert.equal(state.dialog.text, 'Some Text');
-      });
+      assertReducerResultState(updateDialogText, ui => ui.dialog.text, undefined);
     });
 
     it('should set dialog visibility', () => {
-      return dispatchThen(setDialogVisibility(true), [SET_DIALOG_VISIBILITY]).then(state => {
-        assert.equal(state.dialog.visible, true);
-      });
+      assertReducerResultState(setDialogVisibility, ui => ui.dialog.visible, undefined);
     });
   });
 
   describe('work_history reducers', () => {
     it('should set the work history dialog visibility', () => {
-      return dispatchThen(setWorkDialogVisibility(true), [SET_WORK_DIALOG_VISIBILITY]).then(state => {
-        assert.equal(state.workDialogVisibility, true);
-
-        return dispatchThen(setWorkDialogVisibility(false), [SET_WORK_DIALOG_VISIBILITY]).then(state => {
-          assert.equal(state.workDialogVisibility, false);
-        });
-      });
+      assertReducerResultState(setWorkDialogVisibility, ui => ui.workDialogVisibility, false);
     });
 
     it('should set work history edit', () => {
+      assert.equal(store.getState().ui.workHistoryEdit, true);
+
       return dispatchThen(setWorkHistoryEdit(true), [SET_WORK_HISTORY_EDIT]).then(state => {
         assert.equal(state.workHistoryEdit, true);
 
@@ -121,223 +103,96 @@ describe('ui reducers', () => {
     });
 
     it('should set a work history dialog index', () => {
-      return dispatchThen(setWorkDialogIndex(2), [SET_WORK_DIALOG_INDEX]).then(state => {
-        assert.equal(state.workDialogIndex, 2);
-
-        return dispatchThen(setWorkDialogIndex(5), [SET_WORK_DIALOG_INDEX]).then(state => {
-          assert.equal(state.workDialogIndex, 5);
-        });
-      });
+      assertReducerResultState(setWorkDialogIndex, ui => ui.workDialogIndex, null);
     });
   });
 
   describe('education reducers', () => {
     it('has a default state', () => {
-      return dispatchThen({type: "undefined"}, []).then(state => {
-        assert.deepEqual(state.educationDialogVisibility, false);
-        assert.deepEqual(state.educationDialogIndex, -1);
-        assert.deepEqual(state.educationDegreeLevel, '');
-      });
+      let state = store.getState().ui;
+      assert.deepEqual(state.educationDialogVisibility, false);
+      assert.deepEqual(state.educationDialogIndex, -1);
+      assert.deepEqual(state.educationDegreeLevel, '');
     });
 
     it('should let you set education dialog visibility', () => {
-      return dispatchThen(setEducationDialogVisibility(true), [SET_EDUCATION_DIALOG_VISIBILITY]).then(state => {
-        assert.deepEqual(state.educationDialogVisibility, true);
-      });
+      assertReducerResultState(setEducationDialogVisibility, ui => ui.educationDialogVisibility, false);
     });
 
     it('should let you set education degree level', () => {
-      return dispatchThen(setEducationDegreeLevel('foobar'), [SET_EDUCATION_DEGREE_LEVEL]).then(state => {
-        assert.deepEqual(state.educationDegreeLevel, 'foobar');
-      });
+      assertReducerResultState(setEducationDegreeLevel, ui => ui.educationDegreeLevel, '');
     });
 
     it('should let you set education dialog index', () => {
-      return dispatchThen(setEducationDialogIndex(3), [SET_EDUCATION_DIALOG_INDEX]).then(state => {
-        assert.deepEqual(state.educationDialogIndex, 3);
-      });
+      assertReducerResultState(setEducationDialogIndex, ui => ui.educationDialogIndex, -1);
     });
   });
 
   describe('user page', () => {
-    [true, false].forEach(bool => {
-      it(`should let you set the user page dialog visibility to ${bool}`, () => {
-        return dispatchThen(setUserPageDialogVisibility(bool), [SET_USER_PAGE_DIALOG_VISIBILITY]).then(state => {
-          assert.deepEqual(state.userPageDialogVisibility, bool);
-        });
-      });
+    it(`should let you set the user page dialog visibility`, () => {
+      assertReducerResultState(setUserPageDialogVisibility, ui => ui.userPageDialogVisibility, false);
     });
   });
 
   describe('confirm delete dialog', () => {
-    [true, false].forEach( bool => {
-      it(`should let you set to show the education delete dialog to ${bool}`, () => {
-        return dispatchThen(setShowEducationDeleteDialog(bool), [SET_SHOW_EDUCATION_DELETE_DIALOG]).then(state => {
-          assert.deepEqual(state.showEducationDeleteDialog, bool);
-        });
-      });
+    it('should let you set to show the education delete dialog', () => {
+      assertReducerResultState(setShowEducationDeleteDialog, ui => ui.showEducationDeleteDialog, false);
     });
 
-    [true, false].forEach( bool => {
-      it(`should let you set to show the work delete dialog to ${bool}`, () => {
-        return dispatchThen(setShowWorkDeleteDialog(bool), [SET_SHOW_WORK_DELETE_DIALOG]).then(state => {
-          assert.deepEqual(state.showWorkDeleteDialog, bool);
-        });
-      });
+    it(`should let you set to show the work delete dialog`, () => {
+      assertReducerResultState(setShowWorkDeleteDialog, ui => ui.showWorkDeleteDialog, false);
     });
 
     it('should let you set a deletion index', () => {
-      return dispatchThen(setDeletionIndex(3), [SET_DELETION_INDEX]).then(state => {
-        assert.deepEqual(state.deletionIndex, 3);
-      });
+      assertReducerResultState(setDeletionIndex, ui => ui.deletionIndex, null);
     });
   });
 
   describe('confirm delete all dialog', () => {
-    let actionCreator = setShowWorkDeleteAllDialog,
-      action = SET_SHOW_WORK_DELETE_ALL_DIALOG,
-      accessor = s => s.showWorkDeleteAllDialog;
-
-    [true, false].forEach( bool => {
-      it(`should let you ${action} to ${bool}`, () => {
-        return dispatchThen(actionCreator(bool), [action]).then(state => {
-          assert.deepEqual(accessor(state), bool);
-        });
-      });
+    it(`should let you show work history delete all dialog`, () => {
+      assertReducerResultState(setShowWorkDeleteAllDialog, ui => ui.showWorkDeleteAllDialog, false);
     });
   });
 
   describe("profile step", () => {
-    PROFILE_STEP_LABELS.forEach((label, step) => {
-      it(`should let you set the profile step to ${label}`, () => {
-        return dispatchThen(setProfileStep(step), [SET_PROFILE_STEP]).then(state => {
-          assert.deepEqual(state.profileStep, step);
-        });
-      });
+    it(`should let you set the profile step`, () => {
+      assertReducerResultState(setProfileStep, ui => ui.profileStep, PERSONAL_STEP);
     });
   });
 
   describe("user menu", () => {
-    [true, false].forEach(bool => {
-      it(`should let you set the user menu open state to ${bool}`, () => {
-        return dispatchThen(setUserMenuOpen(bool), [SET_USER_MENU_OPEN]).then(state => {
-          assert.deepEqual(state.userMenuOpen, bool);
-        });
-      });
+    it('should let you set the user menu open state', () => {
+      assertReducerResultState(setUserMenuOpen, ui => ui.userMenuOpen, false);
     });
   });
 
   describe('search filter visibility', () => {
-    let filterName = 'my_filter';
-
-    [true, false].forEach(bool => {
-      let visibility = {[filterName]: bool};
-      it(`should let you set a new filter to ${bool}`, () => {
-        return dispatchThen(setSearchFilterVisibility(visibility), [
-          SET_SEARCH_FILTER_VISIBILITY
-        ]).then(state => {
-          assert.deepEqual(state.searchFilterVisibility, visibility);
-        });
-      });
-
-      it(`should let you change an existing filter from ${bool} to ${!bool}`, () => {
-        store.dispatch(setSearchFilterVisibility(visibility));
-        assert.deepEqual(
-          store.getState().ui.searchFilterVisibility,
-          visibility
-        );
-
-        let newVisibility = {[filterName]: !bool};
-        return dispatchThen(setSearchFilterVisibility(newVisibility), [
-          SET_SEARCH_FILTER_VISIBILITY
-        ]).then(state => {
-          assert.deepEqual(state.searchFilterVisibility, newVisibility);
-        });
-      });
+    it('should let you set the search filter visibility', () => {
+      assertReducerResultState(setSearchFilterVisibility, ui => ui.searchFilterVisibility, {});
     });
   });
 
   describe('Email dialog visibility', () => {
-    [true, false].forEach(bool => {
-      it(`should let you set email dialog visibility to ${bool}`, () => {
-        return dispatchThen(setEmailDialogVisibility(bool), [
-          SET_EMAIL_DIALOG_VISIBILITY
-        ]).then(state => {
-          assert.equal(state.emailDialogVisibility, bool);
-        });
-      });
+    it(`should let you set email dialog visibility`, () => {
+      assertReducerResultState(setEmailDialogVisibility, ui => ui.emailDialogVisibility, false);
     });
   });
 
   describe('Enrollment', () => {
-    describe('enrollment message', () => {
-      it('should have a null default value', () => {
-        assert.equal(store.getState().ui.enrollMessage, null);
-      });
-
-      it('should let you set the message', () => {
-        return dispatchThen(setEnrollMessage("value"), [
-          SET_ENROLL_MESSAGE
-        ]).then(state => {
-          assert.equal(state.enrollMessage, "value");
-        });
-      });
+    it('sets the enrollment message', () => {
+      assertReducerResultState(setEnrollMessage, ui => ui.enrollMessage, null);
     });
 
-    describe('enrollment dialog error', () => {
-      it('should have a null default value', () => {
-        assert.equal(store.getState().ui.enrollDialogError, null);
-      });
-
-      it('should let you set the dialog error', () => {
-        return dispatchThen(setEnrollDialogError("value"), [
-          SET_ENROLL_DIALOG_ERROR
-        ]).then(state => {
-          assert.equal(state.enrollDialogError, "value");
-        });
-      });
+    it('sets the enrollment dialog error', () => {
+      assertReducerResultState(setEnrollDialogError, ui => ui.enrollDialogError, null);
     });
 
-    describe('enrollment success/failure message', () => {
-      it('should have a null default value', () => {
-        assert.equal(store.getState().ui.enrollMessage, null);
-      });
-
-      it('should let you toggle the program selector visibility', () => {
-        return dispatchThen(setEnrollMessage("value"), [
-          SET_ENROLL_MESSAGE
-        ]).then(state => {
-          assert.equal(state.enrollMessage, "value");
-        });
-      });
+    it('sets the enrollment dialog visibility', () => {
+      assertReducerResultState(setEnrollDialogVisibility, ui => ui.enrollDialogVisibility, false);
     });
 
-    describe('enrollment dialog visibility', () => {
-      it('should have a false default value', () => {
-        assert.equal(store.getState().ui.enrollDialogVisibility, false);
-      });
-
-      it('should let you toggle the program selector visibility', () => {
-        return dispatchThen(setEnrollDialogVisibility("value"), [
-          SET_ENROLL_DIALOG_VISIBILITY
-        ]).then(state => {
-          assert.equal(state.enrollDialogVisibility, "value");
-        });
-      });
-    });
-
-    describe('enrollment dialog currently selected program', () => {
-      it('should have no default value', () => {
-        assert.equal(store.getState().ui.enrollSelectedProgram, undefined);
-      });
-
-      it('should let you toggle the program selector visibility', () => {
-        return dispatchThen(setEnrollSelectedProgram("value"), [
-          SET_ENROLL_SELECTED_PROGRAM
-        ]).then(state => {
-          assert.equal(state.enrollSelectedProgram, "value");
-        });
-      });
+    it('sets the enrollment dialog currently selected program', () => {
+      assertReducerResultState(setEnrollSelectedProgram, ui => ui.enrollSelectedProgram, null);
     });
   });
 });

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -57,4 +57,10 @@
     color: white;
     margin: 0 15px 15px 5px;
   }
+
+  &.enroll-button {
+    background-color: $dashboard-button-green;
+    color: white;
+    margin: 0 15px 15px 5px;
+  }
 }

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -13,6 +13,7 @@ $page-background: #efefef;
 $bg-light-green: #ccf0e5;
 $bg-light-blue: #d2e4f9;
 $bg-light-gray: #fbfbfb;
+$black-transparent: rgba(0, 0, 0, 0.9);
 
 //current colors - figure out what these all are
 $darkgrey: #696969;
@@ -27,6 +28,8 @@ $help-icon-blue: #1976e5;
 $dashboard-button-teal: #30bcd6;
 $border-color: #e4e4e4;
 $search-filter: #d2e4f9;
+$dashboard-button-green: $mm-brand-bg;
+$search-filter: #D2E4F9;
 $validation-red: #f44336;
 
 // other

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -29,7 +29,7 @@ $dashboard-button-teal: #30bcd6;
 $border-color: #e4e4e4;
 $search-filter: #d2e4f9;
 $dashboard-button-green: $mm-brand-bg;
-$search-filter: #D2E4F9;
+$search-filter: #d2e4f9;
 $validation-red: #f44336;
 
 // other

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -462,6 +462,31 @@ c.validation-wrapper {
   }
 }
 
+.toast {
+  display: none;
+  align-items: center;
+  flex-direction: row;
+  position: absolute;
+  background-color: $black-transparent;
+  color: #c5c5c5;
+  margin: 0 auto;
+  width: 500px;
+  padding: 20px;
+  left: 0;
+  right: 0;
+  z-index: 2;
+  font-size: 16px;
+
+  &.open {
+    display: flex;
+  }
+
+  .material-icons {
+    padding: 10px;
+    font-size: 40px;
+  }
+}
+
 // IE: make x's disappear for input items
 input::-ms-clear {
   display: none;


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #796 

#### What's this PR do?
Adds a dialog box which opens when the user clicks 'Enroll in a new program'. This dialog is used to add a new `ProgramEnrollment` for the user.

#### How should this be manually tested?
Make sure you are not enrolled in every live program. Then you should see the link in the program selector. Note that:

 - If you select the 'Enroll in a new program' option, it should not change the currently selected program displayed in the dropdown.
 - If you click 'Cancel' the dialog should close and nothing should change.
 - If you click 'Enroll' without a program selected you should get a validation warning. (The warning should disappear if you close and open the dialog again.)
 - You should see only programs you have not yet enrolled in.
 - When you select a program and click 'Enroll', it should close the dialog immediately and POST to the API. If it succeeds you should see a success message with a check mark like in the screenshot for #796. If it fails you should see an error icon with an error message. In both cases the toast will disappear after five seconds.
 - After a successful enrollment you will automatically be switched to the new program in the context.

#### Any background context you want to provide?
The click outside the dialog to close it is not supported due to complications with material-ui and react-select: https://github.com/JedWatson/react-select/issues/532
There may be some workaround for that, I haven't spent much time on it. Made an issue: #1002

Also, program page URLs are not available in the dashboard at the moment so they won't be displayed in the UI. Made an issue: #1003 

#### Screenshots (if appropriate)
![screenshot from 2016-09-09 12-39-58](https://cloud.githubusercontent.com/assets/863262/18395004/8b668360-768a-11e6-8452-ac41d04848d7.png)
