### PR TITLE
Disabled SanctuaryJS run-time type checking in production

### DIFF
--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -5,7 +5,8 @@ import _ from 'lodash';
 import TextField from 'material-ui/TextField';
 import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
 import Checkbox from 'material-ui/Checkbox';
-import S, { Maybe } from 'sanctuary';
+import { S } from './sanctuary';
+const { Maybe } = S;
 import R from 'ramda';
 
 import { ISO_8601_FORMAT } from '../constants';

--- a/static/js/util/sanctuary.js
+++ b/static/js/util/sanctuary.js
@@ -1,12 +1,15 @@
 // @flow
 import R from 'ramda';
-import S, { Maybe, Just, Nothing } from 'sanctuary';
+import { create, env } from 'sanctuary';
+
+const checkTypes = process.env.NODE_ENV !== 'production';
+export const S = create({ checkTypes: checkTypes, env: env });
 
 /*
  * returns Just(items) if all items are Just, else Nothing
  */
-export const allJust = R.curry((items: Maybe[]) => (
-  R.all(S.isJust)(items) ? Just(items) : Nothing()
+export const allJust = R.curry((items: S.Maybe[]) => (
+  R.all(S.isJust)(items) ? S.Just(items) : S.Nothing()
 ));
 
 /*

--- a/static/js/util/sanctuary_test.js
+++ b/static/js/util/sanctuary_test.js
@@ -1,8 +1,8 @@
 // @flow
-import S, { Maybe, Just, Nothing } from 'sanctuary';
 import { assert } from 'chai';
 
-import { allJust, mstr } from './sanctuary';
+import { S, allJust, mstr } from './sanctuary';
+const { Maybe, Just, Nothing } = S;
 
 export const assertMaybeEquality = (m1: Maybe, m2: Maybe) => {
   assert(m1.equals(m2), "Maybe's should be equal");

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -6,7 +6,8 @@ import ga from 'react-ga';
 import striptags from 'striptags';
 import _ from 'lodash';
 import iso3166 from 'iso-3166-2';
-import { Maybe, Just, Nothing } from 'sanctuary';
+import { S } from './sanctuary';
+const { Maybe, Just, Nothing } = S;
 
 import {
   EDUCATION_LEVELS,

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -1,9 +1,10 @@
 /* global SETTINGS: false */
 import { assert } from 'chai';
 import React from 'react';
-import { Just } from 'sanctuary';
 import R from 'ramda';
 import _ from 'lodash';
+import { S } from './sanctuary';
+const { Just } = S;
 
 import {
   makeStrippedHtml,

--- a/static/js/util/validation.js
+++ b/static/js/util/validation.js
@@ -1,7 +1,6 @@
 // @flow
 import _ from 'lodash';
 import moment from 'moment';
-import { Maybe, Nothing } from 'sanctuary';
 
 import type {
   Profile,
@@ -18,6 +17,8 @@ import {
   EMPLOYMENT_STEP,
   PRIVACY_STEP,
 } from '../constants';
+import { S } from './sanctuary';
+const { Maybe, Nothing } = S;
 
 let handleNestedValidation = (profile: Profile, keys, nestedKey: string) => {
   let nestedFields = index => (

--- a/static/js/util/validation_test.js
+++ b/static/js/util/validation_test.js
@@ -2,7 +2,8 @@ import { assert } from 'chai';
 import _ from 'lodash';
 import sinon from 'sinon';
 import moment from 'moment';
-import { Just } from 'sanctuary';
+import { S } from './sanctuary';
+const { Just } = S;
 
 import {
   personalValidation,


### PR DESCRIPTION
#### What are the relevant tickets?

closes #985 

#### What's this PR do?

This PR disables the runtime type checking (see [this](https://github.com/sanctuary-js/sanctuary-def)) for Sanctuary in production. Optionally, it could be disabled in development as well, by editing a file. This significantly speeds up the date fields (which are using sanctuary's `Maybe` type constructor).

I think we want to keep the runtime type-checking in development, because if you're using the sanctuary stuff at all it's actually super helpful. However, it's pretty slow, so I think we should definitely turn it off for production.

#### Where should the reviewer start?

Make sure the changes look legit. I was following along with what the sanctuary repo recommends here: https://github.com/sanctuary-js/sanctuary#type-checking

#### How should this be manually tested?

Pull down the code. Go to a profile editing page (either `/users` or `/profile`) and edit a date field. Observe how slow it is (it's really slow).

Then, open `util/sanctuary.js`. Change line 6 from this:

```js
export const S = create({ checkTypes: checkTypes, env: env });
```

to this:

```js
export const S = create({ checkTypes: false, env: env });
```

Reload the app. editing date fields should be significantly faster now. This is how the date field should behave in production.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

