### PR TITLE
Fixed settings page styling

### DIFF
--- a/static/js/components/PrivacyForm.js
+++ b/static/js/components/PrivacyForm.js
@@ -1,6 +1,7 @@
 // @flow
 /* global SETTINGS: false */
 import React from 'react';
+import { Card } from 'react-mdl/lib/Card';
 
 import ProfileFormFields from '../util/ProfileFormFields';
 import type { Profile, ValidationErrors, UpdateProfileFunc } from '../flow/profileTypes';
@@ -21,10 +22,18 @@ class PrivacyForm extends ProfileFormFields {
     ];
     return (
       <div>
-        <h4 className="privacy-form-heading">Who can see your profile?</h4>
-        { this.boundRadioGroupField(['account_privacy'], '', this.privacyOptions) }
-        <h4 className="privacy-form-heading">Email Preferences</h4>
-        { this.boundRadioGroupField(['email_optin'], '', emailOptions) }
+        <Card shadow={1} className="profile-form">
+          <h4 className="privacy-form-heading">Who can see your profile?</h4>
+          <div className="profile-form-row">
+            { this.boundRadioGroupField(['account_privacy'], '', this.privacyOptions) }
+          </div>
+        </Card>
+        <Card shadow={1} className="profile-form">
+          <h4 className="privacy-form-heading">Email Preferences</h4>
+          <div className="profile-form-row">
+            { this.boundRadioGroupField(['email_optin'], '', emailOptions) }
+          </div>
+        </Card>
       </div>
     );
   }

--- a/static/js/containers/SettingsPage.js
+++ b/static/js/containers/SettingsPage.js
@@ -3,16 +3,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Loader from 'react-loader';
-import Grid, { Cell } from 'react-mdl/lib/Grid';
 
-import Jumbotron from '../components/Jumbotron';
 import { startProfileEdit } from '../actions/profile';
 import { FETCH_PROCESSING } from '../actions/index';
 import ProfileFormContainer from './ProfileFormContainer';
 import PrivacyForm from '../components/PrivacyForm';
 import ProfileProgressControls from '../components/ProfileProgressControls';
 import { privacyValidation } from '../util/validation';
-import { getPreferredName } from '../util/util';
 
 class SettingsPage extends ProfileFormContainer {
   componentWillMount() {
@@ -32,7 +29,6 @@ class SettingsPage extends ProfileFormContainer {
     });
     let loaded = false;
     let username = SETTINGS.username;
-    let preferredName = getPreferredName(props.profile);
 
     if (profiles[username] !== undefined) {
       let profileFromStore = profiles[username];
@@ -41,23 +37,16 @@ class SettingsPage extends ProfileFormContainer {
 
     return (
       <Loader loaded={loaded}>
-        <Jumbotron {...props} text={preferredName}>
-          <div className="card-copy">
-            <Grid className="profile-tab-grid privacy-form">
-              <Cell col={12}>
-                <PrivacyForm {...props} />
-              </Cell>
-              <Cell col={12}>
-                <ProfileProgressControls
-                  nextBtnLabel="Save"
-                  {...props}
-                  isLastTab={true}
-                  validator={privacyValidation}
-                />
-              </Cell>
-            </Grid>
-          </div>
-        </Jumbotron>
+        <div className="single-column privacy-form">
+          <h4 className="privacy-form-heading">Settings</h4>
+          <PrivacyForm {...props} />
+          <ProfileProgressControls
+            nextBtnLabel="Save"
+            {...props}
+            isLastTab={true}
+            validator={privacyValidation}
+          />
+        </div>
       </Loader>
     );
   }

--- a/static/js/containers/SettingsPage_test.js
+++ b/static/js/containers/SettingsPage_test.js
@@ -67,10 +67,13 @@ describe("SettingsPage", function() {
 
     it('shows the privacy form', () => {
       return renderComponent("/settings", userActions).then(([, div]) => {
-        let question = div.getElementsByClassName('privacy-form-heading')[0];
+        let pageHeading = div.getElementsByClassName('privacy-form-heading')[0];
+        assert.equal(pageHeading.textContent, 'Settings');
+
+        let question = div.getElementsByClassName('privacy-form-heading')[1];
         assert.equal(question.textContent, 'Who can see your profile?');
 
-        let emailPrefHeading = div.getElementsByClassName('privacy-form-heading')[1];
+        let emailPrefHeading = div.getElementsByClassName('privacy-form-heading')[2];
         assert.equal(emailPrefHeading.textContent, 'Email Preferences');
       });
     });

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -35,6 +35,7 @@ export function boundRadioGroupField(keySet: string[], label: string, options: O
   const styles = {
     labelStyle: {
       left: -10,
+      width: '100%'
     }
   };
 

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -30,6 +30,10 @@
     background-image: -webkit-linear-gradient(top, #f8f8f8   0%, #f1f1f1   100%);
     background-image: linear-gradient(to bottom, #f8f8f8   0%, #f1f1f1   100%);
   }
+
+  &.next {
+    margin-left: -21px;
+  }
 }
 
 .mm-minor-action {

--- a/static/scss/profile.scss
+++ b/static/scss/profile.scss
@@ -37,6 +37,8 @@
   }
 
   .profile-radio-switch, .profile-radio-group {
+    font-size: 14px;
+
     svg:last-child {
       fill: $mm-brand-blue !important;
     }
@@ -163,6 +165,11 @@
   }
 }
 
+.privacy-form-heading {
+  font-size: 20px;
+  font-weight: 500;
+  margin-top: 0;
+}
 
 // for the Why we ask this tooltip
 // TODO: where should this go?


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/micromasters/issues/936

#### What's this PR do?
- [x] remove tab navigation
- [x] remove avatar header
- [x] separate content into two distinct cards

#### Where should the reviewer start?
- See settingpage.js 

#### How should this be manually tested?
- From menu go to settings page

@aliceriot @pdpinch @gsidebo 

#### Screenshots (if appropriate)
<img width="1279" alt="screen shot 2016-09-13 at 6 21 28 pm" src="https://cloud.githubusercontent.com/assets/10431250/18475714/efb6d58c-79e0-11e6-9c65-6daaf63b751e.png">



