### PR TITLE
Added personalized pricing to the dashboard

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -133,6 +133,7 @@ def get_info_for_program(program, user, enrollments, certificates):
         "id": program.pk,
         "description": program.description,
         "title": program.title,
+        "financial_aid_availability": program.financial_aid_availability,
         "courses": []
     }
     for course in program.course_set.all():

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -821,7 +821,8 @@ class InfoProgramTest(ESTestCase):
             "id": self.program.pk,
             "description": self.program.description,
             "title": self.program.title,
-            "courses": [{'position_in_program': 1}, {'position_in_program': 1}]
+            "courses": [{'position_in_program': 1}, {'position_in_program': 1}],
+            "financial_aid_availability": self.program.financial_aid_availability,
         }
         self.assertEqual(res, expected_data)
 
@@ -835,7 +836,8 @@ class InfoProgramTest(ESTestCase):
             "id": self.program_no_courses.pk,
             "description": self.program_no_courses.description,
             "title": self.program_no_courses.title,
-            "courses": []
+            "courses": [],
+            "financial_aid_availability": self.program.financial_aid_availability,
         }
         self.assertEqual(res, expected_data)
 

--- a/profiles/management/realistic_program_data.json
+++ b/profiles/management/realistic_program_data.json
@@ -2,6 +2,7 @@
     {
         "description": "Learn stuff about digital learning.",
         "title": "Digital Learning",
+        "financial_aid_availability": true,
         "courses": [
             {
                 "position_in_program": 1,

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -3,9 +3,36 @@ import React from 'react';
 import moment from 'moment';
 import _ from 'lodash';
 import { Card, CardTitle } from 'react-mdl/lib/Card';
+import R from 'ramda';
 
 import type { Program } from '../../flow/programTypes';
 import CourseRow from './CourseRow';
+import { courseListToolTip } from './util';
+
+const ifPersonalizedPricing = R.curry((func, program) => (
+  program.financial_aid_availability ? func(program) : null
+));
+
+const price = price => <span className="price">{ price }</span>;
+
+const coursePriceRange = ifPersonalizedPricing(() => (
+  <div className="personalized-pricing">
+    <div className="heading">
+      How much does it cost?
+      { courseListToolTip('filler-text', 'course-price') }
+    </div>
+    <div className="explanation">
+      Courses cost varies between {price('$50')} and {price('$1000')} (full
+      price), depending on your income and ability to pay.
+    </div>
+    <button
+      className="mm-button dashboard-button"
+    >
+      Calculate your cost
+    </button>
+  </div>
+));
+
 
 export default class CourseListCard extends React.Component {
   props: {
@@ -26,7 +53,8 @@ export default class CourseListCard extends React.Component {
     );
 
     return <Card shadow={0} className="course-list">
-      <CardTitle>{program.title}</CardTitle>
+      <CardTitle>Your Courses</CardTitle>
+      { coursePriceRange(program) }
       {courseRows}
     </Card>;
   }

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 import { assert } from 'chai';
+import _ from 'lodash';
 
 import CourseListCard from './CourseListCard';
 import CourseRow from './CourseRow';
@@ -34,5 +35,19 @@ describe('CourseListCard', () => {
       // Each now must be exactly the same object
       assert(now === nows[0]);
     }
+  });
+
+  it("doesn't show the personalized pricing box for programs without it", () => {
+    const program = _.cloneDeep(DASHBOARD_RESPONSE[1]);
+    program.financial_aid_availability = false;
+    const wrapper = shallow(<CourseListCard program={program} checkout={() => null} />);
+    assert.equal(wrapper.find('.personalized-pricing').length, 0);
+  });
+
+  it("shows the personalized pricing box for programs that have it", () => {
+    const program = _.cloneDeep(DASHBOARD_RESPONSE[1]);
+    program.financial_aid_availability = true;
+    const wrapper = shallow(<CourseListCard program={program} checkout={() => null} />);
+    assert.equal(wrapper.find('.personalized-pricing').length, 1);
   });
 });

--- a/static/js/components/dashboard/CoursePrice.js
+++ b/static/js/components/dashboard/CoursePrice.js
@@ -1,8 +1,6 @@
 // @flow
 import React from 'react';
 import _ from 'lodash';
-import ReactTooltip from 'react-tooltip';
-import IconButton from 'react-mdl/lib/IconButton';
 
 import type {
   Course,
@@ -13,27 +11,12 @@ import {
   STATUS_OFFERED,
 } from '../../constants';
 import { formatPrice } from '../../util/util';
+import { courseListToolTip } from './util';
 
 export default class CoursePrice extends React.Component {
   props: {
     course: Course
   };
-
-  renderTooltip(text: string): React$Element<*>|void {
-    return (
-      <div>
-        <span className="tooltip-link"
-          data-tip
-          data-for='course-detail'>
-          <IconButton name="help" className="help"/>
-        </span>
-        <ReactTooltip id="course-detail" effect="solid"
-          event="click" globalEventOff="click" className="tooltip">
-          {text}
-        </ReactTooltip>
-      </div>
-    );
-  }
 
   courseTooltipText(courseStatus: string): string {
     if (courseStatus === STATUS_ENROLLED) {
@@ -72,7 +55,7 @@ export default class CoursePrice extends React.Component {
     }
 
     if (text) {
-      tooltipDisplay = this.renderTooltip(text);
+      tooltipDisplay = courseListToolTip(text, 'course-detail');
     }
 
     return (

--- a/static/js/components/dashboard/util.js
+++ b/static/js/components/dashboard/util.js
@@ -1,0 +1,18 @@
+// @flow
+import ReactTooltip from 'react-tooltip';
+import IconButton from 'react-mdl/lib/IconButton';
+import React from 'react';
+
+export const courseListToolTip = (text: string, id: string) => (
+  <div>
+    <span className="tooltip-link"
+      data-tip
+      data-for={ id }>
+      <IconButton name="help" className="help"/>
+    </span>
+    <ReactTooltip id={ id } effect="solid"
+      event="click" globalEventOff="click" className="tooltip">
+      { text }
+    </ReactTooltip>
+  </div>
+);

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -1,6 +1,7 @@
 export type Program = {
   courses: Array<Course>;
   id: number;
+  financial_aid_availability: boolean;
 };
 export type Course = {
   runs: Array<CourseRun>;

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -51,6 +51,19 @@
   cursor: pointer;
 }
 
+.dashboard-button {
+  background-color: $mm-brand-bg;
+  color: white;
+  text-align: center;
+  font-size: small;
+  min-height: 40px;
+  font-weight: 400;
+
+  &[disabled] {
+    background-color: adjust-color($dashboard-button-teal, $alpha: -0.5);
+  }
+}
+
 .disabled {
   opacity: 0.3;
 }

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -105,9 +105,9 @@ c.validation-wrapper {
 
       .mdl-card__supporting-text {
         padding: 0;
-        color: $font-gray-light;
+        color: $font-gray;
         font-size: 15px;
-        font-weight: 300;
+        font-weight: 400;
       }
 
       .mdl-card__title {
@@ -125,6 +125,36 @@ c.validation-wrapper {
 
   .course-list {
     padding: 20px 0 0 0;
+
+    .personalized-pricing {
+      margin: 0 25px 10px 25px;
+      padding: 30px;
+      background-color: $lightgrey;
+
+      .heading, .explanation {
+        margin-bottom: 17px;
+      }
+
+      .heading {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+
+        i {
+          color: $font-gray-light;
+          font-size: 20px;
+        }
+      }
+
+      .explanation {
+        font-size: 14px;
+        font-weight: 300;
+
+        .price {
+          font-weight: 600;
+        }
+      }
+    }
 
     .mdl-card__title {
       // align with course-row below which includes an extra 8px of grid cell padding
@@ -185,19 +215,6 @@ c.validation-wrapper {
           .material-icons {
             color: $mm-brand-fg;
             font-size: 28pt;
-          }
-
-          .dashboard-button {
-            background-color: $mm-brand-bg !important;
-            color: white;
-            text-align: center;
-            font-size: small;
-            min-height: 40px;
-            font-weight: 400;
-
-            &[disabled] {
-              background-color: adjust-color($dashboard-button-disable, $alpha: -0.2) !important;
-            }
           }
         }
 


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #937 

#### What's this PR do?

These things:

- new boolean field on `Program` (`personalized_pricing`) which represents whether a program has a personalized pricing scheme or not.

- some new functions in `CourseListCard.js` which will show the right UI if a program does have `personalized_pricing === true`.

- tests n stuff

- I also changed the program data in `realistic_program_data.json` to have `personalized_pricing = true` on the digital learning program

#### Where should the reviewer start?

#### How should this be manually tested?

Pull down the code and then do this:

1. blow away your search data:

```zsh
./manage.py delete_realistic_search_data
```

2. add new search data:

```zsh
./manage.py gen_realistic_search_data --staff-user ${username}
```

3. navigate to `/dashboard`. You should see the financial aid box when you have the `digital learning` program selected, but not when you have the `analog learning` program selected.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

![financial](https://cloud.githubusercontent.com/assets/6207644/18488192/619d3756-79c6-11e6-9867-1b041bb41bc2.png)


#### What GIF best describes this PR or how it makes you feel?

