### PR TITLE
Fixed learners layout

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -64,11 +64,6 @@
       "from": "amdefine@>=0.0.4",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
-    "animate.css": {
-      "version": "3.5.2",
-      "from": "animate.css@latest",
-      "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-3.5.2.tgz"
-    },
     "ansi-escapes": {
       "version": "1.4.0",
       "from": "ansi-escapes@>=1.1.0 <2.0.0",
@@ -4106,6 +4101,11 @@
       "from": "react-select@latest",
       "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.1.tgz"
     },
+    "react-sticky": {
+      "version": "5.0.5",
+      "from": "react-sticky@latest",
+      "resolved": "https://registry.npmjs.org/react-sticky/-/react-sticky-5.0.5.tgz"
+    },
     "react-tap-event-plugin": {
       "version": "1.0.0",
       "from": "react-tap-event-plugin@1.0.0",
@@ -5268,11 +5268,6 @@
       "version": "1.0.0",
       "from": "wordwrap@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-    },
-    "wowjs": {
-      "version": "1.1.3",
-      "from": "wowjs@1.1.3",
-      "resolved": "https://registry.npmjs.org/wowjs/-/wowjs-1.1.3.tgz"
     },
     "wrap-ansi": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-router": "2.4.0",
     "react-router-bootstrap": "0.23.0",
     "react-select": "^1.0.0-rc.1",
+    "react-sticky": "^5.0.5",
     "react-tap-event-plugin": "1.0.0",
     "react-tooltip": "^3.1.6",
     "react-virtualized": "^7.7.1",

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -16,10 +16,15 @@ import {
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Card from 'react-mdl/lib/Card/Card';
 import iso3166 from 'iso-3166-2';
+import { StickyContainer, Sticky } from 'react-sticky';
 
 import ProgramFilter from './ProgramFilter';
 import LearnerResult from './search/LearnerResult';
 import CountryRefinementOption from './search/CountryRefinementOption';
+import CustomPaginationDisplay from './search/CustomPaginationDisplay';
+import CustomResetFiltersDisplay from './search/CustomResetFiltersDisplay';
+
+import CustomSortingSelect from './search/CustomSortingSelect';
 import FilterVisibilityToggle from './search/FilterVisibilityToggle';
 import HitsCount from './search/HitsCount';
 import EmailCompositionDialog from './EmailCompositionDialog';
@@ -105,6 +110,7 @@ export default class LearnerSearch extends SearchkitComponent {
       openEmailComposer,
       currentProgramEnrollment,
     } = this.props;
+
     return (
       <div className="learners-search">
         <ProgramFilter
@@ -118,79 +124,82 @@ export default class LearnerSearch extends SearchkitComponent {
           sendEmail={sendEmail}
           searchkit={this.searchkit}
         />
-        <Grid className="search-grid">
-          <Cell col={3} className="search-sidebar">
-            <Card className="fullwidth" shadow={1}>
-              <FilterVisibilityToggle
-                {...this.props}
-                filterName="birth-location"
-              >
-                <RefinementListFilter
-                  id="birth_location"
-                  title="Place of Birth"
-                  field="profile.birth_country"
-                  operator="OR"
-                  itemComponent={CountryRefinementOption}
-                />
-              </FilterVisibilityToggle>
-              <FilterVisibilityToggle
-                {...this.props}
-                filterName="residence-country"
-              >
-                <HierarchicalMenuFilter
-                  fields={["profile.country", "profile.state_or_territory"]}
-                  title="Current Location"
-                  id="country"
-                  translations={this.searchkitTranslations}
-                />
-              </FilterVisibilityToggle>
-              <FilterVisibilityToggle
-                {...this.props}
-                filterName="grade-average"
-              >
-                <RangeFilter
-                  field="program.grade_average"
-                  id="grade-average"
-                  min={0}
-                  max={100}
-                  showHistogram={true}
-                  title="Program Avg. Grade"
-                />
-              </FilterVisibilityToggle>
-            </Card>
-          </Cell>
-          <Cell col={9}>
-            <Card className="fullwidth" shadow={1}>
-              <Grid className="search-header">
-                <Cell col={6} className="result-info">
-                  <button
-                    id="email-selected"
-                    className="mm-button minor-action"
-                    onClick={() => openEmailComposer(this.searchkit)}
+        <StickyContainer>
+          <Grid className="search-grid">
+            <Cell col={3} className="search-sidebar">
+              <Sticky>
+                <Card className="fullwidth" shadow={1}>
+                  <FilterVisibilityToggle
+                    {...this.props}
+                    filterName="birth-location"
                   >
-                    Email Selected
-                  </button>
-                  <HitsStats component={HitsCount} />
-                </Cell>
-                <Cell col={2} />
-                <Cell col={4} className="pagination-sort">
-                  <SortingSelector options={sortOptions} />
-                  <Pagination />
-                </Cell>
-                <Cell col={12}>
-                  <SelectedFilters />
-                  <ResetFilters />
-                </Cell>
-              </Grid>
-              <Hits 
-                className="learner-results"
-                hitsPerPage={50}
-                itemComponent={LearnerResult}
-              />
-              <NoHits />
-            </Card>
-          </Cell>
-        </Grid>
+                    <RefinementListFilter
+                      id="birth_location"
+                      title="Country of Birth"
+                      field="profile.birth_country"
+                      operator="OR"
+                      itemComponent={CountryRefinementOption}
+                    />
+                  </FilterVisibilityToggle>
+                  <FilterVisibilityToggle
+                    {...this.props}
+                    filterName="residence-country"
+                  >
+                    <HierarchicalMenuFilter
+                      fields={["profile.country", "profile.state_or_territory"]}
+                      title="Current Residence"
+                      id="country"
+                      translations={this.searchkitTranslations}
+                    />
+                  </FilterVisibilityToggle>
+                  <FilterVisibilityToggle
+                    {...this.props}
+                    filterName="grade-average"
+                  >
+                    <RangeFilter
+                      field="program.grade_average"
+                      id="grade-average"
+                      min={0}
+                      max={100}
+                      showHistogram={true}
+                      title="Program Avg. Grade"
+                    />
+                  </FilterVisibilityToggle>
+                </Card>
+              </Sticky>
+            </Cell>
+            <Cell col={9}>
+              <Card className="fullwidth" shadow={1}>
+                <Grid className="search-header">
+                  <Cell col={6} className="result-info">
+                    <button
+                      id="email-selected"
+                      className="mm-button minor-action"
+                      onClick={() => openEmailComposer(this.searchkit)}
+                    >
+                      Email These Learners
+                    </button>
+                    <HitsStats component={HitsCount} />
+                  </Cell>
+                  <Cell col={2} />
+                  <Cell col={4} className="pagination-sort">
+                    <SortingSelector options={sortOptions} listComponent={CustomSortingSelect} />
+                    <Pagination showText={false} listComponent={CustomPaginationDisplay} />
+                  </Cell>
+                  <Cell col={12}>
+                    <SelectedFilters />
+                    <ResetFilters component={CustomResetFiltersDisplay}/>
+                  </Cell>
+                </Grid>
+                <Hits
+                  className="learner-results"
+                  hitsPerPage={50}
+                  itemComponent={LearnerResult} />
+                <NoHits />
+              </Card>
+            </Cell>
+          </Grid>
+        </StickyContainer>
       </div>
     );
   }

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -23,7 +23,6 @@ import LearnerResult from './search/LearnerResult';
 import CountryRefinementOption from './search/CountryRefinementOption';
 import CustomPaginationDisplay from './search/CustomPaginationDisplay';
 import CustomResetFiltersDisplay from './search/CustomResetFiltersDisplay';
-
 import CustomSortingSelect from './search/CustomSortingSelect';
 import FilterVisibilityToggle from './search/FilterVisibilityToggle';
 import HitsCount from './search/HitsCount';

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -186,7 +186,7 @@ export default class LearnerSearch extends SearchkitComponent {
                     <SortingSelector options={sortOptions} listComponent={CustomSortingSelect} />
                     <Pagination showText={false} listComponent={CustomPaginationDisplay} />
                   </Cell>
-                  <Cell col={12}>
+                  <Cell col={12} className="mm-filters">
                     <SelectedFilters />
                     <ResetFilters component={CustomResetFiltersDisplay}/>
                   </Cell>

--- a/static/js/components/search/CustomPaginationDisplay.js
+++ b/static/js/components/search/CustomPaginationDisplay.js
@@ -1,0 +1,44 @@
+// @flow
+import React from 'react';
+import Icon from 'react-mdl/lib/Icon';
+import type { Event, EventTarget } from '../../flow/eventType';
+
+export default class CustomPaginationDisplay extends React.Component {
+  props: {
+    disabled:   boolean,
+    toggleItem: Function,
+  };
+
+  onClick(toggleItem: Function, evt: Event): void {
+    evt.preventDefault();
+    let target: EventTarget = evt.target;
+    let key = target.getAttribute("data-key");
+    toggleItem(key);
+  }
+
+  render() {
+    const { toggleItem, disabled } = this.props;
+    let optionsNext, optionsPrev;
+
+    if (!disabled) {
+      optionsPrev = (
+        <div className="sk-toggle-option sk-toggle__item sk-pagination-option"
+          data-qa="option" data-key="previous" onClick={this.onClick.bind(null, toggleItem)}>
+          <Icon name="navigate_before" data-key="previous" />
+        </div>
+      );
+      optionsNext = (
+        <div className="sk-toggle-option sk-toggle__item sk-pagination-option"
+          data-qa="option" data-key="next" onClick={this.onClick.bind(null, toggleItem)}>
+          <Icon name="navigate_next" data-key="next" />
+        </div>
+      );
+    }
+
+    return (
+      <div data-qa="options" className="sk-toggle sk-toggle-height">
+        {optionsPrev}{optionsNext}
+      </div>
+    );
+  }
+}

--- a/static/js/components/search/CustomPaginationDisplay.js
+++ b/static/js/components/search/CustomPaginationDisplay.js
@@ -22,14 +22,22 @@ export default class CustomPaginationDisplay extends React.Component {
 
     if (!disabled) {
       optionsPrev = (
-        <div className="sk-toggle-option sk-toggle__item sk-pagination-option"
-          data-qa="option" data-key="previous" onClick={this.onClick.bind(null, toggleItem)}>
+        <div
+          className="sk-toggle-option sk-toggle__item sk-pagination-option"
+          data-qa="option"
+          data-key="previous"
+          onClick={this.onClick.bind(null, toggleItem)}
+        >
           <Icon name="navigate_before" data-key="previous" />
         </div>
       );
       optionsNext = (
-        <div className="sk-toggle-option sk-toggle__item sk-pagination-option"
-          data-qa="option" data-key="next" onClick={this.onClick.bind(null, toggleItem)}>
+        <div
+          className="sk-toggle-option sk-toggle__item sk-pagination-option"
+          data-qa="option"
+          data-key="next"
+          onClick={this.onClick.bind(null, toggleItem)}
+        >
           <Icon name="navigate_next" data-key="next" />
         </div>
       );

--- a/static/js/components/search/CustomPaginationDisplay_test.js
+++ b/static/js/components/search/CustomPaginationDisplay_test.js
@@ -1,0 +1,54 @@
+// @flow
+import React from 'react';
+import { shallow } from 'enzyme';
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+import CustomPaginationDisplay from './CustomPaginationDisplay';
+
+describe('CustomPaginationDisplay', () => {
+  let toggleItemStub = sinon.stub();
+  let props = {
+    disabled: false,
+    toggleItem: toggleItemStub
+  };
+
+  it('renders custom pagination buttons', () => {
+    const wrapper = shallow(<CustomPaginationDisplay {...props}/>);
+    const previousOption = wrapper.find('[data-key="previous"]');
+    const nextOption = wrapper.find('[data-key="next"]');
+
+    assert.isAbove(previousOption.length, 0);
+    assert.isAbove(nextOption.length, 0);
+    assert.equal(previousOption.first().text(), '<Icon />');
+    assert.equal(nextOption.first().text(), '<Icon />');
+  });
+
+  it('toggleItem called on previous option click', () => {
+    const wrapper = shallow(<CustomPaginationDisplay {...props}/>);
+    const previousOption = wrapper.find('[data-key="previous"]');
+    let event = {
+      preventDefault: (): void => {},
+      target: {
+        getAttribute: (): string => { return 'previous'; }
+      }
+    };
+
+    previousOption.at(0).simulate('click', event, toggleItemStub);
+    assert(toggleItemStub.called, "toggleItem handler wasn't called");
+  });
+
+  it('toggleItem called on next option click', () => {
+    const wrapper = shallow(<CustomPaginationDisplay {...props}/>);
+    const nextOption = wrapper.find('[data-key="next"]');
+    let event = {
+      preventDefault: (): void => {},
+      target: {
+        getAttribute: (): string => { return 'next'; }
+      }
+    };
+
+    nextOption.at(0).simulate('click', event, toggleItemStub);
+    assert(toggleItemStub.called, "toggleItem handler wasn't called");
+  });
+});

--- a/static/js/components/search/CustomPaginationDisplay_test.js
+++ b/static/js/components/search/CustomPaginationDisplay_test.js
@@ -13,6 +13,10 @@ describe('CustomPaginationDisplay', () => {
     toggleItem: toggleItemStub
   };
 
+  afterEach(() => {
+    toggleItemStub.reset();
+  });
+
   it('renders custom pagination buttons', () => {
     const wrapper = shallow(<CustomPaginationDisplay {...props}/>);
     const previousOption = wrapper.find('[data-key="previous"]');

--- a/static/js/components/search/CustomResetFiltersDisplay.js
+++ b/static/js/components/search/CustomResetFiltersDisplay.js
@@ -1,0 +1,32 @@
+// @flow
+import React from 'react';
+import {
+  ResetFiltersDisplay,
+  FastClick
+} from 'searchkit';
+
+export default class CustomResetFiltersDisplay extends ResetFiltersDisplay {
+  props: {
+    bemBlock:      any,
+    hasFilters:    boolean,
+    resetFilters:  Function,
+    clearAllLabel: string,
+  };
+
+  render(){
+    const {bemBlock, hasFilters, resetFilters, clearAllLabel} = this.props;
+    let clearFilterLink;
+
+    if (hasFilters) {
+      return (
+        <div>
+          <FastClick handler={resetFilters}>
+            <div className={bemBlock().state({disabled:!hasFilters})}>
+              <div className={bemBlock("reset")}>{clearAllLabel}</div>
+            </div>
+          </FastClick>
+        </div>
+      );
+    }
+  }
+}

--- a/static/js/components/search/CustomResetFiltersDisplay.js
+++ b/static/js/components/search/CustomResetFiltersDisplay.js
@@ -32,7 +32,6 @@ export default class CustomResetFiltersDisplay extends ResetFiltersDisplay {
         </div>
       );
     }
-
     return null;
   }
 }

--- a/static/js/components/search/CustomResetFiltersDisplay.js
+++ b/static/js/components/search/CustomResetFiltersDisplay.js
@@ -18,15 +18,18 @@ export default class CustomResetFiltersDisplay extends ResetFiltersDisplay {
     let clearFilterLink;
 
     if (hasFilters) {
-      return (
-        <div>
-          <FastClick handler={resetFilters}>
-            <div className={bemBlock().state({disabled:!hasFilters})}>
-              <div className={bemBlock("reset")}>{clearAllLabel}</div>
-            </div>
-          </FastClick>
-        </div>
+      clearFilterLink = (
+        <FastClick handler={resetFilters}>
+					<div className={bemBlock().state({disabled:!hasFilters})}>
+						<div className={bemBlock("reset")}>{clearAllLabel}</div>
+					</div>
+				</FastClick>
       );
     }
+    return (
+      <div>
+        {clearFilterLink}
+      </div>
+    );
   }
 }

--- a/static/js/components/search/CustomResetFiltersDisplay.js
+++ b/static/js/components/search/CustomResetFiltersDisplay.js
@@ -14,7 +14,12 @@ export default class CustomResetFiltersDisplay extends ResetFiltersDisplay {
   };
 
   render(){
-    const {bemBlock, hasFilters, resetFilters, clearAllLabel} = this.props;
+    const {
+      bemBlock,
+      hasFilters,
+      resetFilters,
+      clearAllLabel
+    } = this.props;
 
     if (hasFilters) {
       return (

--- a/static/js/components/search/CustomResetFiltersDisplay.js
+++ b/static/js/components/search/CustomResetFiltersDisplay.js
@@ -15,21 +15,19 @@ export default class CustomResetFiltersDisplay extends ResetFiltersDisplay {
 
   render(){
     const {bemBlock, hasFilters, resetFilters, clearAllLabel} = this.props;
-    let clearFilterLink;
 
     if (hasFilters) {
-      clearFilterLink = (
-        <FastClick handler={resetFilters}>
-					<div className={bemBlock().state({disabled:!hasFilters})}>
-						<div className={bemBlock("reset")}>{clearAllLabel}</div>
-					</div>
-				</FastClick>
+      return (
+        <div>
+          <FastClick handler={resetFilters}>
+            <div className={bemBlock().state({disabled:!hasFilters})}>
+              <div className={bemBlock("reset")}>{clearAllLabel}</div>
+            </div>
+          </FastClick>
+        </div>
       );
     }
-    return (
-      <div>
-        {clearFilterLink}
-      </div>
-    );
+
+    return null;
   }
 }

--- a/static/js/components/search/CustomResetFiltersDisplay_test.js
+++ b/static/js/components/search/CustomResetFiltersDisplay_test.js
@@ -24,7 +24,7 @@ describe('CustomResetFiltersDisplay', () => {
     assert.equal(wrapper.children().children().text(), 'Clear all filters');
   });
 
-  it('assert reset filter link does not render', () => {
+  it('reset filter link does not render when hasFilters is false', () => {
     let noFilterProps = _.clone(props);
     noFilterProps.hasFilters = false;
     const wrapper = shallow(<CustomResetFiltersDisplay {...noFilterProps}/>);

--- a/static/js/components/search/CustomResetFiltersDisplay_test.js
+++ b/static/js/components/search/CustomResetFiltersDisplay_test.js
@@ -1,0 +1,34 @@
+// @flow
+import React from 'react';
+import _ from 'lodash';
+import { shallow } from 'enzyme';
+import { assert } from 'chai';
+
+import CustomResetFiltersDisplay from './CustomResetFiltersDisplay';
+
+describe('CustomResetFiltersDisplay', () => {
+  let props = {
+    clearAllLabel: "Clear all filters",
+    hasFilters: true,
+    resetFilters: () => {},
+    bemBlock: (): Object => {
+      return {
+        state: (): void => {}
+      };
+    }
+  };
+
+  it('renders reset filters link', () => {
+    const wrapper = shallow(<CustomResetFiltersDisplay {...props}/>);
+
+    assert.equal(wrapper.children().children().text(), 'Clear all filters');
+  });
+
+  it('assert reset filter link does not render', () => {
+    let noFilterProps = _.clone(props);
+    noFilterProps.hasFilters = false;
+    const wrapper = shallow(<CustomResetFiltersDisplay {...noFilterProps}/>);
+
+    assert.equal(wrapper.children().length, 0);
+  });
+});

--- a/static/js/components/search/CustomSortingSelect.js
+++ b/static/js/components/search/CustomSortingSelect.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Select } from 'searchkit';
+import _ from 'lodash';
+import block from 'bem-cn';
+
+import type { Event } from '../../flow/eventType';
+
+export default class CustomSortingSelect extends Select {
+
+  showDropdown(sortSelectField: string, clickEvent: Event): void {
+    clickEvent.preventDefault();
+    let event: Event = document.createEvent('MouseEvents');
+    event.initMouseEvent('mousedown', true, true, window);
+    ReactDOM.findDOMNode(sortSelectField).dispatchEvent(event);
+  }
+
+  render() {
+    const {
+      mod, className, items, disabled, showCount, translate, countFormatter
+    } = this.props;
+    const bemBlocks = { container: block(mod) };
+
+    return (
+      <div className={bemBlocks.container().mix(className).state({ disabled }) }>
+        <span className="label-before-selected"
+          onClick={this.showDropdown.bind(null, this.refs.sortSelectField)}>
+          Sort by:
+        </span>
+        <select onChange={this.onChange} value={this.getSelectedValue()} ref="sortSelectField">
+          {_.map(items, ({key, label, title, disabled, docCount}) => {
+            let text = translate(label || title || key);
+
+            if (showCount && docCount !== undefined) {
+              text += ` (${countFormatter(docCount)})`;
+            }
+
+            return (
+              <option key={key} value={key} disabled={disabled}>
+                {text}
+              </option>
+            );
+          })};
+        </select>
+      </div>
+    );
+  }
+}

--- a/static/js/components/search/CustomSortingSelect.js
+++ b/static/js/components/search/CustomSortingSelect.js
@@ -15,6 +15,20 @@ export default class CustomSortingSelect extends Select {
     ReactDOM.findDOMNode(sortSelectField).dispatchEvent(event);
   }
 
+  optionText(
+    label: string,
+    showCount: number,
+    docCount: number,
+    countFormatter: Function,
+  ): string {
+    let text = label;
+
+    if (showCount && docCount !== undefined) {
+      text += ` (${countFormatter(docCount)})`;
+    }
+    return text;
+  }
+
   render() {
     const {
       mod, className, items, disabled, showCount, translate, countFormatter
@@ -29,15 +43,14 @@ export default class CustomSortingSelect extends Select {
         </span>
         <select onChange={this.onChange} value={this.getSelectedValue()} ref="sortSelectField">
           {_.map(items, ({key, label, title, disabled, docCount}) => {
-            let text = translate(label || title || key);
-
-            if (showCount && docCount !== undefined) {
-              text += ` (${countFormatter(docCount)})`;
-            }
-
             return (
               <option key={key} value={key} disabled={disabled}>
-                {text}
+                {this.optionText(
+                  translate(label || title || key),
+                  showCount,
+                  docCount,
+                  countFormatter
+                )}
               </option>
             );
           })};

--- a/static/js/components/search/CustomSortingSelect.js
+++ b/static/js/components/search/CustomSortingSelect.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Select } from 'searchkit';
-import _ from 'lodash';
 import block from 'bem-cn';
 
 import type { Event } from '../../flow/eventType';
@@ -14,23 +13,33 @@ export default class CustomSortingSelect extends Select {
     ReactDOM.findDOMNode(sortSelectField).dispatchEvent(event);
   }
 
-  optionText(
+  renderOptions(
     translate: Function,
     showCount: number,
     countFormatter: Function,
-    item: Object
-  ): string {
-    let text = translate(item.label || item.title || item.key);
+    items: Array<Object>
+  ): Array<React$Element<*>> {
+    return items.map(item => {
+      let text = translate(item.label || item.title || item.key);
+      if (showCount && item.docCount !== undefined) {
+        text += ` (${countFormatter(item.docCount)})`;
+      }
 
-    if (showCount && item.docCount !== undefined) {
-      text += ` (${countFormatter(item.docCount)})`;
-    }
-    return text;
+      return <option key={item.key} value={item.key} disable={item.disabled}>
+        { text }
+      </option>;
+    });
   }
 
   render() {
     const {
-      mod, className, items, disabled, showCount, translate, countFormatter
+      mod,
+      className,
+      items,
+      disabled,
+      showCount,
+      translate,
+      countFormatter
     } = this.props;
     const bemBlocks = { container: block(mod) };
 
@@ -41,13 +50,7 @@ export default class CustomSortingSelect extends Select {
           Sort by:
         </span>
         <select onChange={this.onChange} value={this.getSelectedValue()} ref="sortSelectField">
-          {_.map(items, (item) => {
-            return (
-              <option key={item.key} value={item.key} disabled={item.disabled}>
-                {this.optionText(translate, showCount, countFormatter, item)}
-              </option>
-            );
-          })};
+          {this.renderOptions(translate, showCount, countFormatter, items)}
         </select>
       </div>
     );

--- a/static/js/components/search/CustomSortingSelect.js
+++ b/static/js/components/search/CustomSortingSelect.js
@@ -7,7 +7,6 @@ import block from 'bem-cn';
 import type { Event } from '../../flow/eventType';
 
 export default class CustomSortingSelect extends Select {
-
   showDropdown(sortSelectField: string, clickEvent: Event): void {
     clickEvent.preventDefault();
     let event: Event = document.createEvent('MouseEvents');
@@ -16,15 +15,15 @@ export default class CustomSortingSelect extends Select {
   }
 
   optionText(
-    label: string,
+    translate: Function,
     showCount: number,
-    docCount: number,
     countFormatter: Function,
+    item: Object
   ): string {
-    let text = label;
+    let text = translate(item.label || item.title || item.key);
 
-    if (showCount && docCount !== undefined) {
-      text += ` (${countFormatter(docCount)})`;
+    if (showCount && item.docCount !== undefined) {
+      text += ` (${countFormatter(item.docCount)})`;
     }
     return text;
   }
@@ -42,15 +41,10 @@ export default class CustomSortingSelect extends Select {
           Sort by:
         </span>
         <select onChange={this.onChange} value={this.getSelectedValue()} ref="sortSelectField">
-          {_.map(items, ({key, label, title, disabled, docCount}) => {
+          {_.map(items, (item) => {
             return (
-              <option key={key} value={key} disabled={disabled}>
-                {this.optionText(
-                  translate(label || title || key),
-                  showCount,
-                  docCount,
-                  countFormatter
-                )}
+              <option key={item.key} value={item.key} disabled={item.disabled}>
+                {this.optionText(translate, showCount, countFormatter, item)}
               </option>
             );
           })};

--- a/static/js/components/search/CustomSortingSelect_test.js
+++ b/static/js/components/search/CustomSortingSelect_test.js
@@ -1,0 +1,60 @@
+// @flow
+import React from 'react';
+import { shallow } from 'enzyme';
+import { assert } from 'chai';
+
+import CustomSortingSelect from './CustomSortingSelect';
+
+describe('CustomSortingSelect', () => {
+  const options = [
+    {
+      key: 'Last Name A-Z',
+      label: 'Last Name A-Z',
+      title: 'Last Name A-Z',
+      disabled: false,
+      docCount: false
+    },
+    {
+      key: 'Last Name Z-A',
+      label: 'Last Name Z-A',
+      title: 'Last Name Z-A',
+      disabled: false,
+      docCount: false
+    },
+    {
+      key: 'Grade Hight-to-low',
+      label: 'Grade Hight-to-low',
+      title: 'Grade Hight-to-low',
+      disabled: false,
+      docCount: false
+    },
+    {
+      key: 'Grade Low-to-high',
+      label: 'Grade Low-to-high',
+      title: 'Grade Low-to-high',
+      disabled: false,
+      docCount: false
+    },
+  ];
+
+  let props = {
+    mod: "sk-select",
+    className: "sk-select",
+    items: options,
+    disabled: false,
+    showCount: false,
+    translate: (text): string => { return text; },
+    countFormatter: (): void => {}
+  };
+
+  it('renders dropdown', () => {
+    const wrapper = shallow(<CustomSortingSelect {...props}/>);
+    const optionList = wrapper.find("option");
+
+    assert.equal(wrapper.find("span").text(), "Sort by:");
+    assert.equal(optionList.at(0).text(), "Last Name A-Z");
+    assert.equal(optionList.at(1).text(), "Last Name Z-A");
+    assert.equal(optionList.at(2).text(), "Grade Hight-to-low");
+    assert.equal(optionList.at(3).text(), "Grade Low-to-high");
+  });
+});

--- a/static/js/components/search/LearnerResult.js
+++ b/static/js/components/search/LearnerResult.js
@@ -31,7 +31,7 @@ export default class LearnerResult extends React.Component {
         </Cell>
         <Cell col={4} className="centered learner-location">
           <span>
-            { getLocation(profile) }
+            { getLocation(profile, false) }
           </span>
         </Cell>
         <Cell col={3} className="learner-grade">

--- a/static/js/components/search/LearnerResult_test.js
+++ b/static/js/components/search/LearnerResult_test.js
@@ -29,7 +29,6 @@ describe('LearnerResult', () => {
   it("should include the user's location", () => {
     let result = renderLearnerResult(elasticHit);
     assert.include(result, USER_PROFILE_RESPONSE.city);
-    assert.include(result, USER_PROFILE_RESPONSE.state_or_territory);
     assert.include(result, USER_PROFILE_RESPONSE.country);
   });
 

--- a/static/js/flow/eventType.js
+++ b/static/js/flow/eventType.js
@@ -1,0 +1,11 @@
+// @flow
+
+export type Event = {
+  preventDefault: Function;
+  target:         EventTarget;
+  initMouseEvent: Function;
+};
+
+export type EventTarget = {
+  getAttribute: Function;
+};

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -266,12 +266,16 @@ export function getPreferredName(profile: Profile, last: boolean = true): string
 /**
  * returns the users location
  */
-export function getLocation(profile: Profile): string {
+export function getLocation(profile: Profile, showState: boolean = true): string {
   let { country, state_or_territory, city } = profile;
   let subCountryLocation, countryLocation;
   if ( country === 'US' ) {
     let state = state_or_territory.replace(/^\D{2}-/, '');
-    subCountryLocation = `${city}, ${state}`;
+    if (showState) {
+      subCountryLocation = `${city}, ${state}`;
+    } else {
+      subCountryLocation = city;
+    }
     countryLocation = 'US';
   } else {
     subCountryLocation = city;

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -271,11 +271,7 @@ export function getLocation(profile: Profile, showState: boolean = true): string
   let subCountryLocation, countryLocation;
   if ( country === 'US' ) {
     let state = state_or_territory.replace(/^\D{2}-/, '');
-    if (showState) {
-      subCountryLocation = `${city}, ${state}`;
-    } else {
-      subCountryLocation = city;
-    }
+    subCountryLocation = showState ? `${city}, ${state}` : city;
     countryLocation = 'US';
   } else {
     subCountryLocation = city;

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -188,6 +188,8 @@ describe('utility functions', () => {
         city: 'Portland'
       };
       assert.equal(getLocation(us), 'Portland, ME, US');
+      // assert hide state
+      assert.equal(getLocation(us, false), 'Portland, US');
     });
   });
 

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -184,6 +184,18 @@
         font-size: 14px;
         font-weight: normal;
         color: rgba(0,0,0,0.8);
+
+        &.sk-toggle-height {
+          text-align: center;
+          vertical-align: middle;
+          max-height: 30px !important;
+        }
+
+        .sk-pagination-option * {
+          font-size: 20px;
+          font-weight: 400;
+          padding: 0 0 !important;
+        }
       }
     }
 
@@ -214,10 +226,6 @@
       padding: 4px;
       position: relative;
       bottom: 5px;
-    }
-
-    .sk-reset-filters.is-disabled {
-      color: rgba(0,0,0,0);
     }
 
     .mdl-cell {
@@ -317,9 +325,26 @@
 }
 
 .sk-select {
+  display: flex;
+  flex-flow: row;
+  border-radius: 3px;
+  border: 1px solid #e4e4e4;
+  max-height: 30px !important;
+
   > select {
     background-color: $fg-grey;
-    border-color: $border-color;
+    border: 0;
+    padding: 6px 30px 6px 0;
+  }
+
+  .label-before-selected {
+    width: 70px;
+    background-color: $fg-grey;
+    margin-right: -13px;
+    padding: 5px 0 5px 5px;
+    font-size: 14px;
+    font-weight: normal;
+    color: rgba(0,0,0,0.8);
   }
 
   select, option {

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -147,6 +147,10 @@
     }
   }
 
+  .mm-filters:empty {
+    display: none !important;
+  }
+
   .search-header {
     min-height: 100px;
     padding-left: 5px;

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -192,11 +192,11 @@
         &.sk-toggle-height {
           text-align: center;
           vertical-align: middle;
-          max-height: 30px !important;
+          height: 30px !important;
         }
 
         .sk-pagination-option * {
-          font-size: 20px;
+          font-size: 21px;
           font-weight: 400;
           padding: 0 0 !important;
         }
@@ -333,12 +333,12 @@
   flex-flow: row;
   border-radius: 3px;
   border: 1px solid #e4e4e4;
-  max-height: 30px !important;
+  height: 35px !important;
 
   > select {
     background-color: $fg-grey;
     border: 0;
-    padding: 6px 30px 6px 0;
+    padding: 5px 30px 5px 0;
   }
 
   .label-before-selected {


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes https://github.com/mitodl/micromasters/issues/934
- #851
- #854

#### What's this PR do?
- [x] Change "Email Selected" button label to "Email These Learners"
- [x] Remove US states from search results
- [x] Change "Place of Birth" facet label to "Country of Birth" (#851)
- [x] Change "Current Location" facet label to "Current Residence" (#854)
- [x] highlight (in green) the area between the handles in histogram facets (Done by @roberthouse54 )
- [x] Change the Pagination to arrows instead of "Next\Previous"
- [x] Add "Sort by:" to the sort filter only on the current selection.
- [x] The "Clear Filters" link should be hidden when no filters are selected, and the entire line that the filters live on should also be hidden. 
- [x] Also, when the page scrolls, it would be nice to dock the left nav to the top of the browser window, so it does not scroll when the results scrolls.

#### Where should the reviewer start?
- /learners/

#### How should this be manually tested?
- run ./webpack_dev_server.sh --install
- See LearnerSearch.js

@aliceriot @pdpinch @gsidebo 
#### Screenshots (if appropriate)
<img width="1251" alt="screen shot 2016-09-14 at 6 18 14 pm" src="https://cloud.githubusercontent.com/assets/10431250/18513619/a382b506-7aa7-11e6-9aae-129ba0853b8d.png">
