### PR TITLE
Removed course status

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -29,25 +29,24 @@ REFRESH_ENROLLMENT_CACHE_MINUTES = 5
 
 class CourseStatus:
     """
-    Possible statuses for a course for a user
+    Possible statuses for a course for a user. These are the course run statuses used in the dashboard API.
     """
     PASSED = 'passed'
     NOT_PASSED = 'not-passed'
     CURRENT_GRADE = 'verified'
     UPGRADE = 'enrolled'
-    NOT_OFFERED = 'not-offered'
     OFFERED = 'offered'
 
     @classmethod
     def all_statuses(cls):
         """Helper to get all the statuses"""
         return [cls.PASSED, cls.NOT_PASSED, cls.CURRENT_GRADE,
-                cls.UPGRADE, cls.NOT_OFFERED, cls.OFFERED]
+                cls.UPGRADE, cls.OFFERED]
 
 
 class CourseRunStatus:
     """
-    Possible statuses for a course run for a user
+    Possible statuses for a course run for a user. These are used internally.
     """
     NOT_ENROLLED = 'not-enrolled'
     GRADE = 'grade'
@@ -115,13 +114,12 @@ class CourseRunUserStatus:
         )
 
 
-def get_info_for_program(program, user, enrollments, certificates):
+def get_info_for_program(program, enrollments, certificates):
     """
     Helper function that formats a program with all the courses and runs
 
     Args:
         program (Program): a program
-        user (User): an user object
         enrollments (Enrollments): the user enrollments object
         certificates (Certificates): the user certificates objects
 
@@ -138,18 +136,17 @@ def get_info_for_program(program, user, enrollments, certificates):
     }
     for course in program.course_set.all():
         data['courses'].append(
-            get_info_for_course(user, course, enrollments, certificates)
+            get_info_for_course(course, enrollments, certificates)
         )
     data['courses'].sort(key=lambda x: x['position_in_program'])
     return data
 
 
-def get_info_for_course(user, course, user_enrollments, user_certificates):
+def get_info_for_course(course, user_enrollments, user_certificates):
     """
     Checks the status of a course given the status of all its runs
 
     Args:
-        user (User): an user object
         course (Course): a course object
         user_enrollments (Enrollments): the user enrollments object
         user_certificates (Certificates): the user certificates objects
@@ -166,11 +163,9 @@ def get_info_for_course(user, course, user_enrollments, user_certificates):
         "description": course.description,
         "prerequisites": course.prerequisites,
         "runs": [],
-        "status": None,
     }
     with transaction.atomic():
         if not course.courserun_set.count():
-            course_data['status'] = CourseStatus.NOT_OFFERED
             return course_data
         # get all the run statuses
         run_statuses = [get_status_for_courserun(course_run, user_enrollments)
@@ -187,96 +182,48 @@ def get_info_for_course(user, course, user_enrollments, user_certificates):
     # remove the picked run_status from the list
     run_statuses.remove(run_status)
 
-    if run_status.status == CourseRunStatus.NOT_ENROLLED:
-        next_run = course.get_next_run()
-        status = CourseStatus.OFFERED if next_run is not None else CourseStatus.NOT_OFFERED
-        course_data['status'] = status
-        if next_run is not None:
-            course_data['runs'].append(
-                format_courserun_for_dashboard(next_run, status, position=len(course_data['runs'])+1))
-    elif run_status.status == CourseRunStatus.NOT_PASSED:
-        next_run = course.get_next_run()
-        status = CourseStatus.OFFERED if next_run is not None else CourseStatus.NOT_OFFERED
-        course_data['status'] = status
-        if next_run is not None:
-            course_data['runs'].append(
-                format_courserun_for_dashboard(next_run, status, position=len(course_data['runs'])+1))
-        if next_run is None or run_status.course_run.pk != next_run.pk:
-            course_data['runs'].append(
-                format_courserun_for_dashboard(
-                    run_status.course_run, CourseStatus.NOT_PASSED, position=len(course_data['runs'])+1)
-            )
-    elif run_status.status == CourseRunStatus.GRADE:
-        course_data['status'] = CourseStatus.CURRENT_GRADE
+    def add_run(next_run, status, certificate=None):
+        """Helper function to add a course run to the status dictionary"""
         course_data['runs'].append(
             format_courserun_for_dashboard(
-                run_status.course_run, CourseStatus.CURRENT_GRADE, position=len(course_data['runs'])+1)
+                next_run,
+                status,
+                certificate=certificate,
+                position=len(course_data['runs']) + 1
+            )
         )
+
+    if run_status.status == CourseRunStatus.NOT_ENROLLED:
+        next_run = course.get_next_run()
+        if next_run is not None:
+            add_run(next_run, CourseStatus.OFFERED)
+    elif run_status.status == CourseRunStatus.NOT_PASSED:
+        next_run = course.get_next_run()
+        if next_run is not None:
+            add_run(next_run, CourseStatus.OFFERED)
+        if next_run is None or run_status.course_run.pk != next_run.pk:
+            add_run(run_status.course_run, CourseStatus.NOT_PASSED)
+    elif run_status.status == CourseRunStatus.GRADE:
+        add_run(run_status.course_run, CourseStatus.CURRENT_GRADE)
     # check if we need to check the certificate
     elif run_status.status == CourseRunStatus.READ_CERT:
         # if there is no certificate for the user, the user never passed
         # the course, so she needs to enroll in the next one
         if not user_certificates.has_verified_cert(run_status.course_run.edx_course_key):
             next_run = course.get_next_run()
-            status = CourseStatus.OFFERED if next_run is not None else CourseStatus.NOT_OFFERED
-            course_data['status'] = status
             if next_run is not None:
-                course_data['runs'].append(
-                    format_courserun_for_dashboard(next_run, status, position=len(course_data['runs'])+1)
-                )
+                add_run(next_run, CourseStatus.OFFERED)
             # add the run of the status anyway if the next run is different from the one just added
             if next_run is None or run_status.course_run.pk != next_run.pk:
-                course_data['runs'].append(
-                    format_courserun_for_dashboard(
-                        run_status.course_run, CourseStatus.NOT_PASSED, position=len(course_data['runs'])+1)
-                )
+                add_run(run_status.course_run, CourseStatus.NOT_PASSED)
         else:
             # pull the verified certificate for course
             cert = user_certificates.get_verified_cert(run_status.course_run.edx_course_key)
-            course_data['status'] = CourseStatus.PASSED
-            course_data['runs'].append(
-                format_courserun_for_dashboard(
-                    run_status.course_run,
-                    CourseStatus.PASSED,
-                    cert,
-                    position=len(course_data['runs'])+1
-                )
-            )
+            add_run(run_status.course_run, CourseStatus.PASSED, certificate=cert)
     elif run_status.status == CourseRunStatus.WILL_ATTEND:
-        course_data['status'] = CourseStatus.CURRENT_GRADE
-        course_data['runs'].append(
-            format_courserun_for_dashboard(
-                run_status.course_run, CourseStatus.CURRENT_GRADE, position=len(course_data['runs'])+1)
-            )
+        add_run(run_status.course_run, CourseStatus.CURRENT_GRADE)
     elif run_status.status == CourseRunStatus.UPGRADE:
-        course_data['status'] = CourseStatus.UPGRADE
-        course_data['runs'].append(
-            format_courserun_for_dashboard(
-                run_status.course_run, CourseStatus.UPGRADE, position=len(course_data['runs'])+1)
-            )
-
-    # final check before returning the data
-    if course_data['status'] is None:
-        # this should never happen, but put a default behavior just in case
-        log.critical(
-            'course %s for user %s has status %s',
-            run_status.course_run.edx_course_key,
-            user.username,
-            run_status.status
-        )
-        next_run = course.get_next_run()
-        status = CourseStatus.OFFERED if next_run is not None else CourseStatus.NOT_OFFERED
-        course_data['status'] = status
-        if next_run is not None:
-            course_data['runs'].append(
-                format_courserun_for_dashboard(next_run, status, position=len(course_data['runs'])+1)
-            )
-        # add the run of the status anyway if the next run is different from the one just added
-        if next_run is None or run_status.course_run.pk != next_run.pk:
-            course_data['runs'].append(
-                format_courserun_for_dashboard(
-                    run_status.course_run, CourseStatus.NOT_PASSED, position=len(course_data['runs'])+1)
-            )
+        add_run(run_status.course_run, CourseStatus.UPGRADE)
 
     # add all the other runs with status != NOT_ENROLLED
     # the first one (or two in some cases) has been added with the logic before
@@ -286,23 +233,10 @@ def get_info_for_course(user, course, user_enrollments, user_certificates):
                     user_certificates.has_verified_cert(run_status.course_run.edx_course_key)):
                 # in this case the user might have passed the course also in the past
                 cert = user_certificates.get_verified_cert(run_status.course_run.edx_course_key)
-                course_data['runs'].append(
-                    format_courserun_for_dashboard(
-                        run_status.course_run,
-                        CourseStatus.PASSED,
-                        cert,
-                        position=len(course_data['runs'])+1
-                    )
-                )
+                add_run(run_status.course_run, CourseStatus.PASSED, certificate=cert)
             else:
                 # any other status means that the student never passed the course run
-                course_data['runs'].append(
-                    format_courserun_for_dashboard(
-                        run_status.course_run,
-                        CourseStatus.NOT_PASSED,
-                        position=len(course_data['runs'])+1
-                    )
-                )
+                add_run(run_status.course_run, CourseStatus.NOT_PASSED)
 
     return course_data
 
@@ -350,6 +284,7 @@ def format_courserun_for_dashboard(course_run, status_for_user, certificate=None
         status_for_user (str): a string representing the status of a course for the user
         certificate (Certificate): an object representing the
             certificate of the user for this run
+        position (int): The position of the course run within the list
 
     Returns:
         dict: a dictionary containing information about the course

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -142,11 +142,11 @@ def get_info_for_program(program, enrollments, certificates):
     return data
 
 
-def _add_run(course_data, next_run, status, certificate=None):
+def _add_run(course_data, run, status, certificate=None):
     """Helper function to add a course run to the status dictionary"""
     course_data['runs'].append(
         format_courserun_for_dashboard(
-            next_run,
+            run,
             status,
             certificate=certificate,
             position=len(course_data['runs']) + 1

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -60,5 +60,5 @@ class UserDashboard(APIView):
 
         response_data = []
         for program in Program.objects.filter(live=True):
-            response_data.append(get_info_for_program(program, request.user, enrollments, certificates))
+            response_data.append(get_info_for_program(program, enrollments, certificates))
         return Response(response_data)

--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -145,7 +145,7 @@ class DashboardTest(APITestCase):
             assert 'courses' in program
             assert len(program['courses']) == 2
             for course in program['courses']:
-                assert course['status'] == CourseStatus.NOT_OFFERED
+                assert len(course['runs']) == 0
 
     @patch('backends.utils.refresh_user_token', autospec=True)
     def test_with_runs(self, mocked_refresh):
@@ -176,7 +176,6 @@ class DashboardTest(APITestCase):
             assert 'courses' in program
             assert len(program['courses']) == 2
             for course_data in program['courses']:
-                assert 'status' in course_data
                 assert 'runs' in course_data
                 if len(course_data['runs']) == 1:
                     assert 'course_id' in course_data['runs'][0]

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -6,8 +6,10 @@ import Button from 'react-mdl/lib/Button';
 
 import type { Course, CourseRun } from '../../flow/programTypes';
 import {
+  STATUS_NOT_PASSED,
   STATUS_PASSED,
   STATUS_ENROLLED,
+  STATUS_VERIFIED,
   STATUS_OFFERED,
   DASHBOARD_FORMAT,
 } from '../../constants';
@@ -43,14 +45,14 @@ export default class CourseAction extends React.Component {
 
   render() {
     const { course, now } = this.props;
-    let firstRun = {};
+    let firstRun: CourseRun = {};
     if (course.runs.length > 0) {
       firstRun = course.runs[0];
     }
 
     let action = "", description = "";
 
-    switch (course.status) {
+    switch (firstRun.status) {
     case STATUS_PASSED:
       action = <i className="material-icons">done</i>;
       break;
@@ -73,6 +75,15 @@ export default class CourseAction extends React.Component {
       }
 
       action = this.makeEnrollButton("Enroll", firstRun, disabled);
+      break;
+    }
+    case STATUS_NOT_PASSED:
+    case STATUS_VERIFIED:
+      // do nothing;
+      break;
+    default: {
+      // there are no runs
+      action = this.makeEnrollButton("Enroll", firstRun, true);
       break;
     }
     }

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -84,7 +84,6 @@ export default class CourseAction extends React.Component {
     default: {
       // there are no runs
       action = this.makeEnrollButton("Enroll", firstRun, true);
-      break;
     }
     }
 

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -14,7 +14,6 @@ import {
   STATUS_OFFERED,
   STATUS_ENROLLED,
   STATUS_VERIFIED,
-  STATUS_NOT_OFFERED,
 } from '../../constants';
 import { findCourse } from './CourseDescription_test';
 
@@ -38,14 +37,17 @@ describe('CourseAction', () => {
   };
 
   it('shows a check mark for a passed course', () => {
-    let course = findCourse(course => course.status === STATUS_PASSED);
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_PASSED
+    ));
     const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
     assert.equal(wrapper.find(".material-icons").text(), 'done');
   });
 
   it('shows nothing for a failed course', () => {
     let course = findCourse(course => (
-      course.status === STATUS_NOT_OFFERED &&
+      course.runs.length > 0 &&
       course.runs[0].status === STATUS_NOT_PASSED
     ));
     const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
@@ -53,14 +55,20 @@ describe('CourseAction', () => {
   });
 
   it('shows nothing for a verified course', () => {
-    let course = findCourse(course => course.status === STATUS_VERIFIED);
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_VERIFIED
+    ));
     const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
     assert.equal(wrapper.text(), '');
   });
 
   [STATUS_OFFERED, STATUS_ENROLLED].forEach((status) => {
     it(`shows the enroll button followed by course title when status is ${status}`, () => {
-      let course = findCourse(course => course.status === status);
+      let course = findCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
       let firstRun = course.runs[0];
       const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
       let buttonContainer = wrapper.find(".course-action-action");
@@ -70,7 +78,10 @@ describe('CourseAction', () => {
   });
 
   it('shows an upgrade button if user is not verified but is enrolled', () => {
-    let course = findCourse(course => course.status === STATUS_ENROLLED);
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_ENROLLED
+    ));
     const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
     let buttonContainer = wrapper.find(".course-action-action");
     let button = buttonContainer.find(".dashboard-button");
@@ -87,7 +98,8 @@ describe('CourseAction', () => {
   it('shows a disabled enroll button if user is not enrolled and there is no enrollment date', () => {
     // there should also be text below the button
     let course = findCourse(course => (
-      course.status === STATUS_OFFERED &&
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED &&
       course.runs[0].enrollment_start_date === undefined
     ));
     const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
@@ -105,7 +117,8 @@ describe('CourseAction', () => {
   it('shows a disabled enroll button if user is not enrolled and enrollment starts in future', () => {
     // there should also be text below the button
     let course = findCourse(course => (
-      course.status === STATUS_OFFERED &&
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED &&
       course.runs[0].enrollment_start_date !== undefined
     ));
     let firstRun = course.runs[0];
@@ -124,7 +137,8 @@ describe('CourseAction', () => {
 
   it('shows an enroll button if user is not enrolled and enrollment starts today', () => {
     let course = findCourse(course => (
-      course.status === STATUS_OFFERED &&
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED &&
       course.runs[0].enrollment_start_date !== undefined
     ));
     let firstRun = course.runs[0];
@@ -143,7 +157,8 @@ describe('CourseAction', () => {
 
   it('shows an enroll button if user is not enrolled and enrollment started already', () => {
     let course = findCourse(course => (
-      course.status === STATUS_OFFERED &&
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED &&
       course.runs[0].enrollment_start_date !== undefined
     ));
     let firstRun = course.runs[0];
@@ -162,14 +177,16 @@ describe('CourseAction', () => {
 
   it('is not an offered course and user has not failed', () => {
     let course = findCourse(course => (
-      course.status === STATUS_NOT_OFFERED &&
       course.runs.length === 0
     ));
     const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
     let buttonContainer = wrapper.find(".course-action-action");
     let description = wrapper.find(".course-action-description");
+    let button = buttonContainer.find(".dashboard-button");
+    let buttonText = button.children().text();
 
-    assert.equal(buttonContainer.text(), '');
+    assert(button.props().disabled);
+    assert.equal(buttonText, 'Enroll');
     assert.equal(description.text(), '');
   });
 });

--- a/static/js/components/dashboard/CourseDescription.js
+++ b/static/js/components/dashboard/CourseDescription.js
@@ -5,7 +5,6 @@ import moment from 'moment';
 
 import type { Course, CourseRun } from '../../flow/programTypes';
 import {
-  STATUS_NOT_OFFERED,
   STATUS_PASSED,
   STATUS_NOT_PASSED,
   STATUS_ENROLLED,
@@ -24,26 +23,20 @@ export default class CourseDescription extends React.Component {
     return `${label}: ${formattedDate}`;
   }
 
-  courseDateMessage(courseStatus: string, firstRun: CourseRun): string {
-    if (!firstRun) {
-      return '';
-    }
-
-    let text = "";
-
-    switch (courseStatus) {
+  courseDateMessage = (firstRun: CourseRun): any => {
+    switch (firstRun.status) {
     case STATUS_PASSED:
       if (firstRun.course_end_date) {
         let courseEndDate = moment(firstRun.course_end_date);
-        text = this.courseDate('Ended', courseEndDate);
+        return this.courseDate('Ended', courseEndDate);
       }
       break;
-    case STATUS_NOT_OFFERED:
-      if (firstRun.status === STATUS_NOT_PASSED && firstRun.course_end_date) {
+    case STATUS_NOT_PASSED:
+      if (firstRun.course_end_date) {
         let courseEndDate = moment(firstRun.course_end_date);
-        text = this.courseDate('Ended', courseEndDate);
+        return this.courseDate('Ended', courseEndDate);
       } else if (!_.isNil(firstRun.fuzzy_start_date)) {
-        text = `Coming ${firstRun.fuzzy_start_date}`;
+        return `Coming ${firstRun.fuzzy_start_date}`;
       }
       break;
     case STATUS_ENROLLED:
@@ -51,13 +44,16 @@ export default class CourseDescription extends React.Component {
     case STATUS_OFFERED:
       if (firstRun.course_start_date) {
         let courseStartDate = moment(firstRun.course_start_date);
-        text = this.courseDate('Start date', courseStartDate);
+        return this.courseDate('Start date', courseStartDate);
       }
       break;
+    default:
+      // no runs in this course
+      return <span className="no-runs">Coming soon...</span>;
     }
 
-    return text;
-  }
+    return '';
+  };
 
   render() {
     const { course } = this.props;
@@ -72,7 +68,7 @@ export default class CourseDescription extends React.Component {
         {course.title}
       </span> <br />
       <span className="course-description-result">
-        {this.courseDateMessage(course.status, firstRun)}
+        {this.courseDateMessage(firstRun)}
       </span>
     </div>;
   }

--- a/static/js/components/dashboard/CourseDescription_test.js
+++ b/static/js/components/dashboard/CourseDescription_test.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import _ from 'lodash';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 import { assert } from 'chai';
@@ -18,7 +17,6 @@ import {
   STATUS_ENROLLED,
   STATUS_VERIFIED,
   STATUS_OFFERED,
-  STATUS_NOT_OFFERED,
   ALL_COURSE_STATUSES,
 } from '../../constants';
 
@@ -35,22 +33,12 @@ export function findCourse(courseSelector: (course: Course, program: Program) =>
 }
 
 describe('CourseDescription', () => {
-  let createCourseRun = (status: string) => {
-    return Object.assign({
-      "position": 1,
-      "title": "title",
-      "course_id": "course-v1:odl+GIO101+FALL14",
-      "status": status,
-      "id": 1,
-      "fuzzy_start_date": "Fall 2017",
-      "course_start_date": '2016-01-09T10:20:10Z',
-      "course_end_date": '2016-03-01T10:20:10Z'
-    });
-  };
-
   it('shows the course title', () => {
     for (let status of ALL_COURSE_STATUSES) {
-      let course = findCourse(course => course.status === status);
+      let course = findCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
       const wrapper = shallow(<CourseDescription course={course}/>);
 
       assert(course.title.length > 0);
@@ -59,8 +47,10 @@ describe('CourseDescription', () => {
   });
 
   it(`does show date with status passed`, () => {
-    let course = _.cloneDeep(findCourse(course => course.status === STATUS_PASSED));
-    course.runs = [ createCourseRun(STATUS_PASSED) ];
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_PASSED
+    ));
     const wrapper = shallow(<CourseDescription course={course} />);
     let firstRun = course.runs[0];
     let courseEndDate = moment(firstRun.course_end_date);
@@ -69,9 +59,11 @@ describe('CourseDescription', () => {
     assert.equal(wrapper.find(".course-description-result").text(), `Ended: ${formattedDate}`);
   });
 
-  it(`does show date with status not-offered and firstRun status not-passed`, () => {
-    let course = _.cloneDeep(findCourse(course => course.status === STATUS_NOT_OFFERED));
-    course.runs = [ createCourseRun(STATUS_NOT_PASSED) ];
+  it(`does show date with status not-passed`, () => {
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_NOT_PASSED
+    ));
     const wrapper = shallow(<CourseDescription course={course} />);
     let firstRun = course.runs[0];
     let courseEndDate = moment(firstRun.course_end_date);
@@ -80,29 +72,20 @@ describe('CourseDescription', () => {
     assert.equal(wrapper.find(".course-description-result").text(), `Ended: ${formattedDate}`);
   });
 
-  it(`does show date with status not-offered and firstRun status not-offered`, () => {
-    let course = _.cloneDeep(findCourse(course => course.status === STATUS_NOT_OFFERED));
-    course.runs = [ createCourseRun(STATUS_NOT_OFFERED) ];
+  it(`does not show anything when there are no runs for a course`, () => {
+    let course = findCourse(course => (
+      course.runs.length === 0
+    ));
     const wrapper = shallow(<CourseDescription course={course} />);
-    let firstRun = course.runs[0];
 
-    assert.equal(wrapper.find(".course-description-result").text(), `Coming ${firstRun.fuzzy_start_date}`);
+    assert.equal(wrapper.find(".course-description-result").text(), 'Coming soon...');
   });
 
-  it(`does show date with status verified-not-completed`, () => {
-    let course = _.cloneDeep(findCourse(course => course.status === STATUS_VERIFIED));
-    course.runs = [ createCourseRun(STATUS_VERIFIED) ];
-    const wrapper = shallow(<CourseDescription course={course} />);
-    let firstRun = course.runs[0];
-    let courseStartDate = moment(firstRun.course_start_date);
-    let formattedDate = courseStartDate.format(DASHBOARD_FORMAT);
-
-    assert.equal(wrapper.find(".course-description-result").text(), `Start date: ${formattedDate}`);
-  });
-
-  it(`does show date with status enrolled-not-verified`, () => {
-    let course = _.cloneDeep(findCourse(course => course.status === STATUS_ENROLLED));
-    course.runs = [ createCourseRun(STATUS_ENROLLED) ];
+  it(`does show date with status verified`, () => {
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_VERIFIED
+    ));
     const wrapper = shallow(<CourseDescription course={course} />);
     let firstRun = course.runs[0];
     let courseStartDate = moment(firstRun.course_start_date);
@@ -111,9 +94,24 @@ describe('CourseDescription', () => {
     assert.equal(wrapper.find(".course-description-result").text(), `Start date: ${formattedDate}`);
   });
 
-  it(`does show date with status offered-not-enrolled`, () => {
-    let course = _.cloneDeep(findCourse(course => course.status === STATUS_OFFERED));
-    course.runs = [ createCourseRun(STATUS_OFFERED) ];
+  it(`does show date with status enrolled`, () => {
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_ENROLLED
+    ));
+    const wrapper = shallow(<CourseDescription course={course} />);
+    let firstRun = course.runs[0];
+    let courseStartDate = moment(firstRun.course_start_date);
+    let formattedDate = courseStartDate.format(DASHBOARD_FORMAT);
+
+    assert.equal(wrapper.find(".course-description-result").text(), `Start date: ${formattedDate}`);
+  });
+
+  it(`does show date with status offered`, () => {
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED
+    ));
     const wrapper = shallow(<CourseDescription course={course} />);
     let firstRun = course.runs[0];
     let courseStartDate = moment(firstRun.course_start_date);

--- a/static/js/components/dashboard/CoursePrice.js
+++ b/static/js/components/dashboard/CoursePrice.js
@@ -18,17 +18,10 @@ export default class CoursePrice extends React.Component {
     course: Course
   };
 
-  courseTooltipText(courseStatus: string): string {
-    if (courseStatus === STATUS_ENROLLED) {
-      return "You need to enroll in the Verified Course to get MicroMasters credit.";
-    }
-    return '';
-  }
-
-  coursePrice(firstRun: CourseRun, courseStatus: string): string {
+  coursePrice(firstRun: CourseRun): string {
     let courseHasPrice = (
       !_.isNil(firstRun.price) &&
-      (courseStatus === STATUS_OFFERED || courseStatus === STATUS_ENROLLED)
+      (firstRun.status === STATUS_OFFERED || firstRun.status === STATUS_ENROLLED)
     );
 
     if (courseHasPrice) {
@@ -40,22 +33,24 @@ export default class CoursePrice extends React.Component {
 
   render() {
     const { course } = this.props;
-    let firstRun = {};
+    let firstRun: CourseRun = {};
     let priceDisplay;
     let tooltipDisplay;
-    const text = this.courseTooltipText(course.status);
 
     if (course.runs.length > 0) {
       firstRun = course.runs[0];
     }
-    const price = this.coursePrice(firstRun, course.status);
+    const price = this.coursePrice(firstRun);
 
     if (price) {
       priceDisplay = <span className="course-price-display">{price}</span>;
     }
 
-    if (text) {
-      tooltipDisplay = courseListToolTip(text, 'course-detail');
+    if (firstRun.status === STATUS_ENROLLED) {
+      tooltipDisplay = courseListToolTip(
+        "You need to enroll in the Verified Course to get MicroMasters credit.",
+        'course-detail',
+      );
     }
 
     return (

--- a/static/js/components/dashboard/CoursePrice_test.js
+++ b/static/js/components/dashboard/CoursePrice_test.js
@@ -9,43 +9,72 @@ import {
   STATUS_ENROLLED,
   STATUS_VERIFIED,
   STATUS_OFFERED,
-  STATUS_NOT_OFFERED
+  STATUS_NOT_PASSED,
 } from '../../constants';
 
 import { findCourse } from './CourseDescription_test';
 
 describe('CoursePrice', () => {
-  it('shows price of course with status offered-not-enrolled', () => {
-    let course = findCourse(course => course.status === STATUS_OFFERED);
+  it('shows price of course with status offered', () => {
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED
+    ));
     assert.equal(course.runs[0].price, 50.00);
 
     const wrapper = shallow(<CoursePrice course={course}/>);
     assert.equal(wrapper.find(".course-price-display").text(), "$50");
   });
 
-  it('shows price of course with status enrolled-not-verified', () => {
-    let course = findCourse(course => course.status === STATUS_ENROLLED);
+  it('shows price of course with status enrolled', () => {
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_ENROLLED
+    ));
     assert.equal(course.runs[0].price, 50.00);
 
-    const wrapper = shallow(<CoursePrice course={course}  />);
+    const wrapper = shallow(<CoursePrice course={course}/>);
     assert.equal(wrapper.find(".course-price-display").text(), "$50");
   });
 
-  for (let status of [STATUS_PASSED, STATUS_NOT_OFFERED, STATUS_VERIFIED]) {
+  for (let status of [STATUS_PASSED, STATUS_NOT_PASSED, STATUS_VERIFIED]) {
     it(`doesn't show the price of course with status ${status}`, () => {
-      let course = findCourse(course => course.status === status);
+      let course = findCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
       assert.isNotOk(course.runs[0].price);
 
-      const wrapper = shallow(<CoursePrice course={course} />);
+      const wrapper = shallow(<CoursePrice course={course}/>);
       assert.equal(wrapper.find(".course-price-display").length, 0);
     });
   }
 
-  it('tooltip display for status enrolled-not-verified', () => {
-    let course = findCourse(course => course.status === STATUS_ENROLLED);
-    const wrapper = shallow(<CoursePrice course={course} />);
+  it('shows the tooltip for status enrolled', () => {
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_ENROLLED
+    ));
+    const wrapper = shallow(<CoursePrice course={course}/>);
     let tooltip = wrapper.find(".help");
     assert.equal(tooltip.length, 1);
   });
 
+  for (let status of [STATUS_OFFERED, STATUS_VERIFIED, STATUS_NOT_PASSED, STATUS_PASSED]) {
+    it(`doesn't show any tooltip for status ${status}`, () => {
+      let course = findCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
+      const wrapper = shallow(<CoursePrice course={course}/>);
+      let tooltip = wrapper.find(".help");
+      assert.equal(tooltip.length, 0);
+    });
+  }
+
+  it("doesn't show anything if there are no runs", () => {
+    let course = findCourse(course => course.runs.length === 0);
+    const wrapper = shallow(<CoursePrice course={course}/>);
+    assert.equal(wrapper.text().trim(), "");
+  });
 });

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -216,11 +216,10 @@ export const STATUS_NOT_PASSED = 'not-passed';
 export const STATUS_VERIFIED = 'verified';
 export const STATUS_ENROLLED = "enrolled";
 export const STATUS_OFFERED = "offered";
-export const STATUS_NOT_OFFERED = 'not-offered';
 
 export const ALL_COURSE_STATUSES = [
-  STATUS_NOT_OFFERED,
   STATUS_PASSED,
+  STATUS_NOT_PASSED,
   STATUS_OFFERED,
   STATUS_ENROLLED,
   STATUS_VERIFIED,
@@ -276,7 +275,6 @@ export const DASHBOARD_RESPONSE = [
         ],
         "position_in_program": 0,
         "title": "Gio Course - failed, no grade",
-        "status": STATUS_NOT_OFFERED,
         "description": "",
         "id": 1
       },
@@ -285,7 +283,6 @@ export const DASHBOARD_RESPONSE = [
         "runs": [],
         "position_in_program": 1,
         "title": "8.MechCx Advanced Introductory Classical Mechanics",
-        "status": STATUS_NOT_OFFERED,
         "description": "",
         "id": 2
       },
@@ -294,7 +291,6 @@ export const DASHBOARD_RESPONSE = [
         "runs": [],
         "position_in_program": 2,
         "title": "EDX Demo course",
-        "status": STATUS_NOT_OFFERED,
         "description": "",
         "id": 3
       },
@@ -303,7 +299,6 @@ export const DASHBOARD_RESPONSE = [
         "runs": [],
         "position_in_program": 3,
         "title": "Peter Course",
-        "status": STATUS_NOT_OFFERED,
         "description": "",
         "id": 4
       }
@@ -314,7 +309,6 @@ export const DASHBOARD_RESPONSE = [
     "courses": [
       {
         "id": 5,
-        "status": STATUS_OFFERED,
         "position_in_program": 1,
         "title": "Supply Chain and Logistics Fundamentals - enroll button",
         "runs": [
@@ -337,7 +331,6 @@ export const DASHBOARD_RESPONSE = [
       },
       {
         "id": 6,
-        "status": STATUS_PASSED,
         "position_in_program": 5,
         "title": "Passed course - check mark, grade is 88%",
         "runs": [
@@ -359,7 +352,6 @@ export const DASHBOARD_RESPONSE = [
       },
       {
         "id": 7,
-        "status": STATUS_NOT_OFFERED,
         "position_in_program": 2,
         "title": "Empty course - no status text",
         "runs": [
@@ -369,7 +361,6 @@ export const DASHBOARD_RESPONSE = [
       },
       {
         "id": 8,
-        "status": STATUS_ENROLLED,
         "position_in_program": 3,
         "title": "Not verified course - upgrade button",
         "runs": [
@@ -390,7 +381,6 @@ export const DASHBOARD_RESPONSE = [
       },
       {
         "id": 10,
-        "status": STATUS_OFFERED,
         "position_in_program": 4,
         "title": "Enrollment starting course - disabled enroll button, text says Enrollment begins 3/3/2106",
         "runs": [
@@ -413,7 +403,6 @@ export const DASHBOARD_RESPONSE = [
       },
       {
         "id": 12,
-        "status": STATUS_PASSED,
         "title": "Passed course missing grade - check mark, no grade",
         "position_in_program": 6,
         "runs": [
@@ -434,7 +423,6 @@ export const DASHBOARD_RESPONSE = [
         "id": 15,
         "position_in_program": 9,
         "title": "verified not completed, course starts in future - action text is Course starting",
-        "status": STATUS_VERIFIED,
         "runs": [
           {
             "id": 13,
@@ -449,7 +437,6 @@ export const DASHBOARD_RESPONSE = [
       },
       {
         "id": 11,
-        "status": STATUS_OFFERED,
         "position_in_program": 0,
         "title": "Fuzzy enrollment starting course - First in program, action text is enrollment begins soonish",
         "runs": [
@@ -480,7 +467,6 @@ export const DASHBOARD_RESPONSE = [
     "courses": [
       {
         "id": 9,
-        "status": STATUS_VERIFIED,
         "position_in_program": 0,
         "title": "Course for last program in progress - no grade, action or description",
         "runs": [

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -5,15 +5,14 @@ export type Program = {
 };
 export type Course = {
   runs: Array<CourseRun>;
-  status?: string;
   id: number;
 };
 export type CourseRun = {
   grade?: number|null;
-  course_id?: number|string;
-  title?: string;
+  course_id: string;
+  title: string;
   fuzzy_enrollment_start_date?: string;
-  status?: string;
+  status: string;
   enrollment_start_date?: string;
   fuzzy_start_date?: string;
   course_start_date?: string;

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -183,6 +183,10 @@ c.validation-wrapper {
           font-size: 10pt;
           color: $darkgrey;
           padding: 10px 0;
+
+          .no-runs {
+            color: black;
+          }
         }
 
         .course-description-enrolled {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1032

#### What's this PR do?
 - Removes the course status from the dashboard API. From now on the first run will have the appropriate status. If there are no runs 'Coming soon...' will be displayed, from [this mockup](https://projects.invisionapp.com/share/NB7VM1GSG#/screens/185611170)
 - The `not-offered` status is removed because it was only used with the course status, not the run status.
 - Handle case where there are no runs to display

#### How should this be manually tested?
If there are no future course runs for a given course (this is the default for the realistic fake data we have) then you should now see 'Coming soon...' similar to the screenshot. Otherwise all data should be the same as before.

#### Screenshots (if appropriate)
![screenshot from 2016-09-14 15-18-40](https://cloud.githubusercontent.com/assets/863262/18526668/71facd2e-7a8f-11e6-8ce3-21d045d2113b.png)
