### PR TITLE
Only one role per User can be assigned

### DIFF
--- a/roles/models.py
+++ b/roles/models.py
@@ -3,7 +3,8 @@ General models for the micromasters app
 """
 
 from django.contrib.auth.models import User
-from django.db import models
+from django.core.exceptions import ValidationError
+from django.db import models, transaction
 
 from courses.models import Program
 from roles.roles import Staff, Instructor
@@ -31,3 +32,29 @@ class Role(models.Model):
 
     class Meta:
         unique_together = ('user', 'program', 'role',)
+
+    @transaction.atomic
+    def save(self, *args, **kwargs):
+        """
+        Overridden method to run a preventive validation before saving the object.
+        """
+        self.full_clean()
+        super(Role, self).save(*args, **kwargs)
+
+    def full_clean(self, *args, **kwargs):
+        """
+        Overridden method to run a preventive validation.
+        """
+        # try to get all the roles different from the current one
+        existing_role_queryset = Role.objects.filter(user=self.user).exclude(role=self.role)
+        # exclude the current object in case it going to be modified
+        if self.pk is not None:
+            existing_role_queryset = existing_role_queryset.exclude(pk=self.pk)
+        if existing_role_queryset.exists():
+            raise ValidationError(
+                'The user has the role "{0}" assigned at the moment and cannot have a second one. '
+                'This is a technical limitation planned to be solved in the future.'.format(
+                    existing_role_queryset.first().role
+                )
+            )
+        super(Role, self).full_clean(*args, **kwargs)

--- a/roles/models_test.py
+++ b/roles/models_test.py
@@ -1,21 +1,91 @@
 """
 Tests for models
 """
+from django.core.exceptions import ValidationError
 
-from unittest import TestCase
-
-from roles.models import Role
+from courses.factories import ProgramFactory
+from profiles.factories import UserFactory
 from roles import roles
+from roles.models import Role
+from search.base import ESTestCase
+
+# pylint: disable=no-self-use
 
 
-class MicroMastersRoleTest(TestCase):
+class MicroMastersRoleTest(ESTestCase):
     """
     Tests for the MicroMastersRole model
     """
 
-    def test_role_available(self):  # pylint: disable=no-self-use
+    @classmethod
+    def setUpTestData(cls):
+        super(MicroMastersRoleTest, cls).setUpTestData()
+        cls.user = UserFactory.create()
+        cls.program1 = ProgramFactory.create()
+        cls.program2 = ProgramFactory.create()
+
+    def tearDown(self):
+        super(MicroMastersRoleTest, self).tearDown()
+        Role.objects.all().delete()
+
+    def test_role_available(self):
         """
         Simple test for all the roles available
         """
         for role_key in Role.ASSIGNABLE_ROLES:
             assert role_key in (roles.Staff.ROLE_ID, roles.Instructor.ROLE_ID, )
+
+    def test_one_role_in_program(self):
+        """
+        The same user cannot have different roles in the same program
+        """
+        Role.objects.create(
+            user=self.user,
+            program=self.program1,
+            role=roles.Staff.ROLE_ID
+        )
+        with self.assertRaises(ValidationError):
+            Role.objects.create(
+                user=self.user,
+                program=self.program1,
+                role=roles.Instructor.ROLE_ID
+            )
+
+    def test_one_role_in_multiple_program(self):
+        """
+        The same user cannot have different roles even in different programs
+        """
+        Role.objects.create(
+            user=self.user,
+            program=self.program1,
+            role=roles.Staff.ROLE_ID
+        )
+        with self.assertRaises(ValidationError):
+            Role.objects.create(
+                user=self.user,
+                program=self.program2,
+                role=roles.Instructor.ROLE_ID
+            )
+
+    def test_role_modification(self):
+        """
+        The role for a user can be modified if there is not another same role for another program
+        """
+        role = Role.objects.create(
+            user=self.user,
+            program=self.program1,
+            role=roles.Staff.ROLE_ID
+        )
+        # role can be modified
+        role.role = roles.Instructor.ROLE_ID
+        role.save()
+        # crete a second role for the user in another program
+        Role.objects.create(
+            user=self.user,
+            program=self.program2,
+            role=roles.Instructor.ROLE_ID
+        )
+        # the role cannot be modified any more
+        with self.assertRaises(ValidationError):
+            role.role = roles.Staff.ROLE_ID
+            role.save()

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -196,12 +196,11 @@ class DashboardTests(ViewsTests):
         """
         profile = self.create_and_login_user()
 
-        for role in Role.ASSIGNABLE_ROLES:
-            Role.objects.create(
-                program=ProgramFactory.create(),
-                user=profile.user,
-                role=role,
-            )
+        Role.objects.create(
+            program=ProgramFactory.create(),
+            user=profile.user,
+            role=Role.DEFAULT_ROLE,
+        )
 
         resp = self.client.get(DASHBOARD_URL)
         js_settings = json.loads(resp.context['js_settings_json'])


### PR DESCRIPTION
#### What are the relevant tickets?
closes #1034

#### What's this PR do?
Enforces the existence of only one role type per user

#### Where should the reviewer start?
`roles/models.py`

#### How should this be manually tested?
try to assign `Staff` and `Admin` to the same user in the django Admin

#### Any background context you want to provide?
This is a limitation of the library we are using and given that there are thoughts to create a new `reviewer` role, it makes sense to be sure there is not confusion on this front.

There is a known issue with this code: even if in the Admin you get an error, there will still be a confirmation message. AFAIK this cannot be removed because the confirmation message is generated after the error message. I do not think this is a problem given that only people who access the Admin can see it.
![screen shot 2016-09-14 at 4 36 01 pm](https://cloud.githubusercontent.com/assets/1005204/18529010/5efec162-7a99-11e6-9df0-606932ebb960.png)
