### PR TITLE
Set "Place of Birth" facet to accept multiple values

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -129,6 +129,7 @@ export default class LearnerSearch extends SearchkitComponent {
                   id="birth_location"
                   title="Place of Birth"
                   field="profile.birth_country"
+                  operator="OR"
                   itemComponent={CountryRefinementOption}
                 />
               </FilterVisibilityToggle>


### PR DESCRIPTION
#### What are the relevant tickets?

closes #986 

#### What's this PR do?

Allows a user to select multiple values for the "Place of Birth" facet. Those values are treated in an 'OR' fashion - any user that matches any one of the values selected will be in the search results

#### How should this be manually tested?

Run the app and navigate to the learner's search page. Test with multiple values for Place of Birth

#### Any background context you want to provide?

Due to some searchkit limitations, we've decided not to pursue the same change for Current Location (see issue comments for details)

