### PR TITLE
Realistic user fixes for social username and program enrollments

### DIFF
--- a/profiles/management/commands/delete_realistic_search_data.py
+++ b/profiles/management/commands/delete_realistic_search_data.py
@@ -1,9 +1,12 @@
 """
 Deletes a set of realistic users/programs that were added to help us test search functionality
 """
+from factory.django import mute_signals
 from django.core.management import BaseCommand
+from django.db.models.signals import post_delete
 from django.contrib.auth.models import User
 from courses.models import Program
+from dashboard.models import CachedEnrollment, CachedCertificate
 from profiles.management.commands.gen_realistic_search_data import FAKE_PROGRAM_DESC_PREFIX, FAKE_USER_USERNAME_PREFIX
 
 
@@ -14,5 +17,10 @@ class Command(BaseCommand):
     help = "Deletes a set of realistic users and programs/courses that were generated to help us test search"
 
     def handle(self, *args, **options):
+        fake_program_ids = \
+            Program.objects.filter(description__startswith=FAKE_PROGRAM_DESC_PREFIX).values_list('id', flat=True)
+        with mute_signals(post_delete):
+            for model_cls in [CachedEnrollment, CachedCertificate]:
+                model_cls.objects.filter(course_run__course__program__id__in=fake_program_ids).delete()
+        Program.objects.filter(id__in=fake_program_ids).delete()
         User.objects.filter(username__startswith=FAKE_USER_USERNAME_PREFIX).delete()
-        Program.objects.filter(description__startswith=FAKE_PROGRAM_DESC_PREFIX).delete()


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #1038 
Fixes #1073 

#### What's this PR do?

As stated above, closes #1038 and applies a few other fixes. For example, ProgramEnrollment creation changed fundamentally since this script was written and this PR adjusts for that

#### How should this be manually tested?

Run `delete_realistic_search_data`, then `gen_realistic_search_data`. I'd recommend you run `gen_realistic_search_data` with a `--staff-user` argument to set up your own user with the proper enrollments and permissions (run `gen_realistic_search_data --help` for details)
