### PR TITLE
Display courses with enrollment status on ProgramPage

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -1,0 +1,37 @@
+
+"""
+apis for program page
+"""
+
+
+def get_course_enrollment_text(course):
+    """
+    Return text that contains start and enrollment
+    information about the course.
+    """
+    course_run = course.get_next_run()
+    text = 'Not available'
+
+    if course_run:
+        if course_run.is_current:
+            text = 'Ongoing - '
+            if course_run.enrollment_end:
+                text += 'Enrollment Ends {:%D}'.format(
+                    course_run.enrollment_end
+                )
+            else:
+                text += 'Enrollment Open'
+        elif course_run.is_future:
+            text = 'Starts {:%D}'.format(course_run.start_date)
+            if course_run.is_future_enrollment_open:
+                text += ' - Enrollment Open'
+            elif course_run.enrollment_start:
+                text += ' - Enrollment {:%m/%Y}'.format(
+                    course_run.enrollment_start
+                )
+    else:
+        course_run = course.get_promised_run()
+        if course_run:
+            text = 'Coming ' + course_run.fuzzy_start_date
+
+    return text

--- a/cms/api_test.py
+++ b/cms/api_test.py
@@ -1,0 +1,116 @@
+"""
+Tests for the program page api functions
+"""
+from datetime import datetime, timedelta
+import pytz
+
+from search.base import ESTestCase
+from courses.factories import (
+    CourseFactory,
+    CourseRunFactory,
+)
+from cms.api import get_course_enrollment_text
+
+
+# pylint: disable=no-self-use
+class CourseEnrollmentInfoTest(ESTestCase):
+    """Test for get_course_enrollment_text"""
+
+    def setUp(self):
+        super(CourseEnrollmentInfoTest, self).setUp()
+        self.now = datetime.now(pytz.utc)
+
+    def test_future_course_enr_future(self):
+        """Test Course that starts in the future, enrollment in future"""
+        course = CourseFactory.create(title="Course in the future")
+        future_date = self.now + timedelta(weeks=1)
+        start_date = 'Starts {:%D} - '.format(future_date)
+        enr_start = 'Enrollment {:%m/%Y}'.format(future_date)
+        # create a run that starts soon, enrollment_start in the future
+        CourseRunFactory.create(
+            course=course,
+            start_date=future_date,
+            end_date=self.now + timedelta(weeks=10),
+            enrollment_start=future_date,
+            enrollment_end=self.now + timedelta(weeks=2),
+        )
+        assert get_course_enrollment_text(course) == start_date + enr_start
+
+    def test_future_course_enr_open(self):
+        """Test course in the future, enrollment open"""
+        future_date = self.now + timedelta(weeks=1)
+        start_date = 'Starts {:%D} - Enrollment Open'.format(future_date)
+        course = CourseFactory.create(title="Starts soon, Enrollment open")
+        # and a run is about to start and enrollment is open
+        CourseRunFactory.create(
+            course=course,
+            start_date=future_date,
+            end_date=self.now + timedelta(weeks=10),
+            enrollment_start=self.now - timedelta(weeks=1),
+            enrollment_end=self.now + timedelta(weeks=10),
+        )
+        assert get_course_enrollment_text(course) == start_date
+
+    def test_future_course_no_enr_end(self):
+        """Test course in the future, enrollment_end is None"""
+        future_date = self.now + timedelta(weeks=1)
+        text = 'Starts {:%D} - Enrollment Open'.format(future_date)
+        course = CourseFactory.create(title="Starts soon, no enr_end date")
+        CourseRunFactory.create(
+            course=course,
+            start_date=future_date,
+            end_date=self.now + timedelta(weeks=10),
+            enrollment_start=self.now - timedelta(weeks=1),
+            enrollment_end=None
+        )
+        assert get_course_enrollment_text(course) == text
+
+    def test_current_course(self):
+        """Test current course, enrollment ends soon"""
+        course = CourseFactory.create(title="Ongoing, Enrollment ends")
+        text = 'Ongoing - Enrollment Ends {:%D}'.format(self.now + timedelta(weeks=10))
+        CourseRunFactory.create(
+            course=course,
+            start_date=self.now - timedelta(weeks=1),
+            end_date=self.now + timedelta(weeks=10),
+            enrollment_start=self.now - timedelta(weeks=1),
+            enrollment_end=self.now + timedelta(weeks=10),
+        )
+        assert get_course_enrollment_text(course) == text
+
+    def test_current_course_no_enr_end(self):
+        """Test current course, enrollment open"""
+        course = CourseFactory.create(title="Ongoing, Enrollment open")
+        CourseRunFactory.create(
+            course=course,
+            start_date=self.now - timedelta(weeks=1),
+            end_date=None,
+            enrollment_start=self.now - timedelta(weeks=1),
+            enrollment_end=None,
+        )
+        assert get_course_enrollment_text(course) == 'Ongoing - Enrollment Open'
+
+    def test_course_fuzzy_start_date(self):
+        """Test course with promised course run"""
+        course = CourseFactory.create(title="Promised in the future")
+        CourseRunFactory.create(
+            course=course,
+            fuzzy_start_date="Fall 2017",
+            start_date=None,
+            end_date=None,
+            enrollment_start=None,
+            enrollment_end=None,
+        )
+        assert get_course_enrollment_text(course) == 'Coming Fall 2017'
+
+    def test_current_course_enr_closed(self):
+        """Test current course, enrollment closed"""
+        course = CourseFactory.create(title="Starts soon, Enrollment closed")
+        CourseRunFactory.create(
+            course=course,
+            start_date=self.now - timedelta(weeks=1),
+            end_date=self.now + timedelta(weeks=10),
+            enrollment_start=self.now - timedelta(weeks=2),
+            enrollment_end=self.now - timedelta(weeks=1),
+        )
+        assert get_course_enrollment_text(course) == 'Not available'

--- a/cms/models.py
+++ b/cms/models.py
@@ -3,6 +3,7 @@ Page models for the CMS
 """
 import json
 
+from collections import OrderedDict
 from django.conf import settings
 from django.db import models
 from modelcluster.fields import ParentalKey
@@ -17,6 +18,7 @@ from courses.serializers import ProgramSerializer
 from micromasters.utils import webpack_dev_server_host
 from profiles.api import get_social_username
 from ui.views import get_bundle_url
+from cms.api import get_course_enrollment_text
 
 
 def programs_for_sign_up(programs):
@@ -145,6 +147,12 @@ class ProgramPage(Page):
         username = get_social_username(request.user)
         context = super(ProgramPage, self).get_context(request)
 
+        courses_info = OrderedDict()
+        for course in self.program.course_set.all().order_by(
+                'position_in_program'
+        ):
+            courses_info[course] = get_course_enrollment_text(course)
+
         context["style_src"] = get_bundle_url(request, "style.js")
         context["public_src"] = get_bundle_url(request, "public.js")
         context["style_public_src"] = get_bundle_url(request, "style_public.js")
@@ -153,6 +161,7 @@ class ProgramPage(Page):
         context["username"] = username
         context["js_settings_json"] = json.dumps(js_settings)
         context["title"] = self.title
+        context["courses_info"] = courses_info
 
         return context
 

--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -50,13 +50,13 @@
             <div class="title">
               Courses
             </div>
-            {% for course in page.program.course_set.all %}
+            {% for course, status in courses_info.items %}
             <div class="course-details">
               <div class="title">
                 {{ course.title }}
               </div>
               <div class="description">
-                {{ course.description|richtext }}
+                {{ status }}
               </div>
             </div>
             {% endfor %}

--- a/courses/models.py
+++ b/courses/models.py
@@ -63,6 +63,15 @@ class Course(models.Model):
         next_run_set = next_run_set.order_by('start_date')
         return next_run_set[0]
 
+    def get_promised_run(self):
+        """
+        Get a run that does not have start_date,
+        only fuzzy_start_date
+        """
+        return self.courserun_set.filter(
+            models.Q(start_date=None) & models.Q(fuzzy_start_date__isnull=False)
+        ).first()
+
 
 class CourseRun(models.Model):
     """
@@ -116,6 +125,22 @@ class CourseRun(models.Model):
         if not self.start_date:
             return False
         return self.start_date > datetime.now(pytz.utc)
+
+    @property
+    def is_future_enrollment_open(self):
+        """
+        Checks if the course will run in the future and
+        enrollment is currently open
+        """
+        if self.is_future:
+            if self.enrollment_start:
+                now = datetime.now(pytz.utc)
+                if self.enrollment_end:
+                    return self.enrollment_start <= now <= self.enrollment_end
+                else:
+                    return self.enrollment_start <= now
+
+        return False
 
     @property
     def is_upgradable(self):

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -343,6 +343,49 @@ class CourseRunTests(CourseModelTests):
         )
         assert course_run.is_future is False
 
+    def test_is_future_enrollment_open(self):
+        """Test for is_future_enrollment_open property"""
+        # with no start date
+        course_run = self.create_run()
+        assert course_run.is_future_enrollment_open is False
+
+        # with start in the future, no enrollment_start
+        course_run = self.create_run(
+            start=self.now + timedelta(weeks=2)
+        )
+        assert course_run.is_future_enrollment_open is False
+
+        # enrollment_start in the past, no enrollment_end
+        course_run = self.create_run(
+            start=self.now + timedelta(weeks=2),
+            enr_start=self.now - timedelta(weeks=3),
+            enr_end=None
+        )
+        assert course_run.is_future_enrollment_open is True
+
+        # enrollment_start in the past, enrollment_end in the past
+        course_run = self.create_run(
+            start=self.now + timedelta(weeks=2),
+            enr_start=self.now - timedelta(weeks=3),
+            enr_end=self.now - timedelta(weeks=1)
+        )
+        assert course_run.is_future_enrollment_open is False
+
+        # enrollment_start in the past, enrollment_end in the future
+        course_run = self.create_run(
+            start=self.now + timedelta(weeks=2),
+            enr_start=self.now - timedelta(weeks=3),
+            enr_end=self.now + timedelta(weeks=3)
+        )
+        assert course_run.is_future_enrollment_open is True
+
+        # enrollment_start in the future
+        course_run = self.create_run(
+            start=self.now + timedelta(weeks=2),
+            enr_start=self.now + timedelta(weeks=1)
+        )
+        assert course_run.is_future_enrollment_open is False
+
     def test_is_upgradable(self):
         """Test for is_upgradable property"""
         # with no upgrade_deadline

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -15,7 +15,7 @@ from wagtail.wagtailimages.tests.utils import get_test_image_file
 
 from cms.models import HomePage, ProgramPage
 from courses.models import Program
-from courses.factories import ProgramFactory
+from courses.factories import ProgramFactory, CourseFactory
 from backends.edxorg import EdxOrgOAuth2
 from profiles.api import get_social_username
 from profiles.factories import ProfileFactory
@@ -360,6 +360,26 @@ class TestProgramPage(ViewsTests):
 
         resp = self.client.get('/')
         self.assertContains(resp, image.get_rendition('fill-345x265').url)
+
+    def test_courses_enrollment_text(self):
+        """
+        Verify get_course_enrollment_test is called with
+        each course in the program
+        """
+        for i in range(5):
+            course = CourseFactory(
+                program=self.program_page.program,
+                position_in_program=i)
+            course.save()
+        with patch('cms.models.get_course_enrollment_text') as get_enrollment_text:
+            get_enrollment_text.return_value = 'some text'
+            response = self.client.get(self.program_page.url)
+            self.assertContains(response, 'some text')
+            courses = self.program_page.program.course_set.all().order_by(
+                'position_in_program'
+            )
+            for i, course in enumerate(courses):
+                assert get_enrollment_text.call_args_list[i][0][0] == course
 
 
 class TestUsersPage(ViewsTests):


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #922 
#### What's this PR do?
Update the courses widget on program page to display start/end date, and enrollment information.
#### Where should the reviewer start?
Create a program with few courses. For each course create a course run with the following possible parameters:
1. start date in the future, enrollment start date in the future
2. start date in the future, enrollment start date has past, enrollment end date in the future
etc.

![screen shot 2016-09-20 at 5 37 38 pm](https://cloud.githubusercontent.com/assets/7574259/18689725/99d73ef4-7f58-11e6-9bab-0c62cebea3de.png)
