### PR TITLE
Added order receipt and cancellation UI

### DIFF
--- a/courses/factories.py
+++ b/courses/factories.py
@@ -47,7 +47,8 @@ class CourseRunFactory(DjangoModelFactory):
     """Factory for CourseRuns"""
     title = fuzzy.FuzzyText(prefix="CourseRun ")
     course = factory.SubFactory(CourseFactory)
-    edx_course_key = fuzzy.FuzzyText()
+    # Try to make sure we escape this correctly
+    edx_course_key = fuzzy.FuzzyText(prefix="course:/()+&/")
     enrollment_start = fuzzy.FuzzyDateTime(datetime(1980, 1, 1, tzinfo=pytz.utc))
     start_date = fuzzy.FuzzyDateTime(datetime(1980, 1, 1, tzinfo=pytz.utc))
     enrollment_end = fuzzy.FuzzyDateTime(datetime(1980, 1, 1, tzinfo=pytz.utc))

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -5,12 +5,12 @@ from base64 import b64encode
 from datetime import datetime
 import hashlib
 import hmac
+from urllib.parse import quote_plus
+
 from mock import (
     MagicMock,
     patch,
 )
-from urllib.parse import quote_plus
-
 from django.http.response import Http404
 from django.test import override_settings
 from rest_framework.exceptions import ValidationError

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -9,6 +9,7 @@ from mock import (
     MagicMock,
     patch,
 )
+from urllib.parse import quote_plus
 
 from django.http.response import Http404
 from django.test import override_settings
@@ -173,11 +174,12 @@ class CybersourceTests(ESTestCase):
         with patch('ecommerce.api.get_social_username', autospec=True, return_value=username):
             with patch('ecommerce.api.datetime', autospec=True, utcnow=MagicMock(return_value=now)):
                 with patch('ecommerce.api.uuid.uuid4', autospec=True, return_value=MagicMock(hex=transaction_uuid)):
-                    payload = generate_cybersource_sa_payload(order)
+                    payload = generate_cybersource_sa_payload(order, 'dashboard_url')
         signature = payload.pop('signature')
         assert generate_cybersource_sa_signature(payload) == signature
         signed_field_names = payload['signed_field_names'].split(',')
         assert signed_field_names == sorted(payload.keys())
+        quoted_course_key = quote_plus(course_run.edx_course_key)
 
         assert payload == {
             'access_key': CYBERSOURCE_ACCESS_KEY,
@@ -185,8 +187,8 @@ class CybersourceTests(ESTestCase):
             'consumer_id': username,
             'currency': 'USD',
             'locale': 'en-us',
-            'override_custom_cancel_page': 'https://micromasters.mit.edu?cancel',
-            'override_custom_receipt_page': "https://micromasters.mit.edu?receipt",
+            'override_custom_cancel_page': 'dashboard_url?status=cancel&course_key={}'.format(quoted_course_key),
+            'override_custom_receipt_page': "dashboard_url?status=receipt&course_key={}".format(quoted_course_key),
             'reference_number': make_reference_id(order),
             'profile_id': CYBERSOURCE_PROFILE_ID,
             'signed_date_time': now.strftime(ISO_8601_FORMAT),

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -2,6 +2,7 @@
 import logging
 
 from django.conf import settings
+from django.core.urlresolvers import reverse
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
@@ -40,7 +41,8 @@ class CheckoutView(APIView):
             raise ValidationError("Missing course_id")
 
         order = create_unfulfilled_order(course_id, request.user)
-        payload = generate_cybersource_sa_payload(order)
+        dashboard_url = request.build_absolute_uri('/dashboard/')
+        payload = generate_cybersource_sa_payload(order, dashboard_url)
 
         return Response({
             'payload': payload,

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -2,7 +2,6 @@
 import logging
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -385,7 +385,7 @@ export const DASHBOARD_RESPONSE = [
         "title": "Enrollment starting course - disabled enroll button, text says Enrollment begins 3/3/2106",
         "runs": [
           {
-            "course_id": "course-v1:supply+chain",
+            "course_id": "course-v1:supply+chain2",
             "id": 8,
             "status": STATUS_OFFERED,
             "fuzzy_enrollment_start_date": null,
@@ -432,6 +432,7 @@ export const DASHBOARD_RESPONSE = [
             "position": 0,
             "fuzzy_start_date": "Fall 2017",
             "course_end_date": "2016-09-09T10:20:10Z",
+            "course_id": "verified",
           }
         ]
       },
@@ -441,7 +442,7 @@ export const DASHBOARD_RESPONSE = [
         "title": "Fuzzy enrollment starting course - First in program, action text is enrollment begins soonish",
         "runs": [
           {
-            "course_id": "course-v1:supply+chain",
+            "course_id": "course-v1:supply+chain3",
             "id": 9,
             "status": STATUS_OFFERED,
             "fuzzy_enrollment_start_date": "soonish",
@@ -471,7 +472,7 @@ export const DASHBOARD_RESPONSE = [
         "title": "Course for last program in progress - no grade, action or description",
         "runs": [
           {
-            "course_id": "course-v1:edX+DemoX+Demo_Course",
+            "course_id": "course-v1:edX+DemoX+Demo_Course2",
             "id": 6,
             "status": STATUS_VERIFIED,
             "title": "Course run for last program",

--- a/static/js/constants_test.js
+++ b/static/js/constants_test.js
@@ -8,6 +8,7 @@ describe('constants', () => {
     let programIds : Set<number> = new Set();
     let courseIds : Set<number> = new Set();
     let runIds : Set<number> = new Set();
+    let courseKeys : Set<string> = new Set();
     for (let program of DASHBOARD_RESPONSE) {
       assert(!_.isNil(program.id), 'Missing program id');
       assert(!programIds.has(program.id), `Duplicate program id ${program.id}`);
@@ -33,6 +34,9 @@ describe('constants', () => {
           assert(!_.isNil(run.position), `Missing position for run ${run.id}`);
           assert(!positionInCourse.has(run.position), `Duplicate position for run ${run.id}`);
           positionInCourse.add(run.position);
+          assert(run.course_id, `Missing course_id for run ${run.id}`);
+          assert(!courseKeys.has(run.course_id), `Duplicate course key ${run.course_id}`);
+          courseKeys.add(run.course_id);
         }
       }
     }

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -231,21 +231,17 @@ class App extends React.Component {
     }
 
     let open = false;
-    let message;
+    let message, title, icon;
     if (toastMessage) {
       open = true;
 
-      let icon = "";
       if (toastMessage.icon === TOAST_FAILURE) {
         icon = <Icon name="error" key="icon "/>;
       } else if (toastMessage.icon === TOAST_SUCCESS) {
         icon = <Icon name="done" key="icon" />;
       }
-      message = [
-        icon,
-        " ",
-        toastMessage.message,
-      ];
+      title = toastMessage.title;
+      message = toastMessage.message;
     }
 
     return <div id="app">
@@ -264,7 +260,11 @@ class App extends React.Component {
         setEnrollSelectedProgram={this.setEnrollSelectedProgram}
       />
       <Toast onTimeout={this.clearMessage} open={open}>
-        {message}
+        {icon}
+        <div className="body">
+          <span className="title">{title}</span>
+          <span className="message">{message}</span>
+        </div>
       </Toast>
       <div className="page-content">
         { children }

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -7,8 +7,14 @@ import CourseAction from '../components/dashboard/CourseAction';
 import IntegrationTestHelper from '../util/integration_test_helper';
 import { REQUEST_DASHBOARD } from '../actions';
 import * as actions from '../actions';
+import { SET_TOAST_MESSAGE } from '../actions/ui';
 import * as util from '../util/util';
-import { CHECKOUT_RESPONSE } from '../constants';
+import {
+  CHECKOUT_RESPONSE,
+  TOAST_FAILURE,
+  TOAST_SUCCESS,
+} from '../constants';
+import { findCourse } from '../components/dashboard/CourseDescription_test';
 
 describe('DashboardPage', () => {
   let renderComponent, helper;
@@ -64,6 +70,28 @@ describe('DashboardPage', () => {
         assert(document.body.querySelector(".fake-form"), 'fake form not found in body');
         assert.equal(submitStub.callCount, 1);
         assert.deepEqual(submitStub.args[0], []);
+      });
+    });
+  });
+
+  it('shows the order status toast when the query param is set for a cancellation', () => {
+    return renderComponent('/dashboard?status=cancel', [SET_TOAST_MESSAGE]).then(() => {
+      assert.deepEqual(helper.store.getState().ui.toastMessage, {
+        message: "Order was cancelled",
+        icon: TOAST_FAILURE
+      });
+    });
+  });
+
+  it('shows the order status toast when the query param is set for a success', () => {
+    let course = findCourse(course => course.runs.length > 0);
+    let run = course.runs[0];
+    let encodedKey = encodeURIComponent(run.course_id);
+    return renderComponent(`/dashboard?status=receipt&course_key=${encodedKey}`, [SET_TOAST_MESSAGE]).then(() => {
+      assert.deepEqual(helper.store.getState().ui.toastMessage, {
+        title: "Order Complete!",
+        message: `You are now enrolled in ${course.title}`,
+        icon: TOAST_SUCCESS
       });
     });
   });

--- a/static/js/flow/generalTypes.js
+++ b/static/js/flow/generalTypes.js
@@ -24,5 +24,6 @@ export type APIErrorInfo = {
 
 export type ToastMessage = {
   message: string,
+  title?: string,
   icon?: string,
 };

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -511,6 +511,15 @@ c.validation-wrapper {
     padding: 10px;
     font-size: 40px;
   }
+
+  .body {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .title {
+    font-size: 18px;
+  }
 }
 
 // IE: make x's disappear for input items

--- a/ui/views.py
+++ b/ui/views.py
@@ -8,8 +8,10 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.urlresolvers import reverse
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from django.shortcuts import (
+    redirect,
     render,
     Http404,
 )
@@ -83,9 +85,14 @@ class ReactView(View):  # pylint: disable=unused-argument
             }
         )
 
+    def post(self, request, *args, **kwargs):
+        """Redirect to GET. This assumes there's never any good reason to POST to these views."""
+        return redirect(request.build_absolute_uri())
+
 
 @method_decorator(require_mandatory_urls, name='dispatch')
 @method_decorator(login_required, name='dispatch')
+@method_decorator(csrf_exempt, name='dispatch')
 class DashboardView(ReactView):
     """
     Wrapper for dashboard view which asserts certain logged in requirements


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #904 
Fixes #905 

#### What's this PR do?
Handles showing the user a temporary toast message to indicate a successful order or a cancellation.

This deviates from the mockup a bit in that there's no link to the course page in the toast.


#### How should this be manually tested?
Ask me for the test credentials for Cybersource and go through the order process

#### Screenshots (if appropriate)
![screenshot from 2016-09-22 10-18-13](https://cloud.githubusercontent.com/assets/863262/18751694/e94ccaac-80ad-11e6-8a12-cd6390666edd.png)


