### PR TITLE
Implemented enrollment after course purchase

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -336,6 +336,38 @@ def format_courserun_for_dashboard(course_run, status_for_user, certificate=None
     return formatted_run
 
 
+def update_cached_enrollment(user, enrollment, course_id, now):
+    """
+    Updates the cached enrollment based on an Enrollment object
+
+    Args:
+        user (User): A user
+        enrollment (Enrollment):
+            An Enrollment object from edx_api_client
+        course_id (str): A course key
+        now (datetime.datetime): The datetime value used as now
+
+    Returns:
+        None
+    """
+    # get the certificate data or None
+    # None means we will cache the fact that the student
+    # does not have an enrollment for the given course
+    enrollment_data = enrollment.json if enrollment is not None else None
+    course_run = CourseRun.objects.get(edx_course_key=course_id)
+    updated_values = {
+        'user': user,
+        'course_run': course_run,
+        'data': enrollment_data,
+        'last_request': now,
+    }
+    models.CachedEnrollment.objects.update_or_create(
+        user=user,
+        course_run=course_run,
+        defaults=updated_values
+    )
+
+
 def _check_if_refresh(user, cached_model, refresh_delta):
     """
     Helper function to check if cached data in a model need to be refreshed.
@@ -398,22 +430,7 @@ def get_student_enrollments(user, edx_client):
     with transaction.atomic():
         for course_id in course_ids:
             enrollment = enrollments.get_enrollment_for_course(course_id)
-            # get the certificate data or None
-            # None means we will cache the fact that the student
-            # does not have an enrollment for the given course
-            enrollment_data = enrollment.json if enrollment is not None else None
-            course_run = CourseRun.objects.get(edx_course_key=course_id)
-            updated_values = {
-                'user': user,
-                'course_run': course_run,
-                'data': enrollment_data,
-                'last_request': now,
-            }
-            models.CachedEnrollment.objects.update_or_create(
-                user=user,
-                course_run=course_run,
-                defaults=updated_values
-            )
+            update_cached_enrollment(user, enrollment, course_id, now)
 
     return enrollments
 

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -337,7 +337,7 @@ def format_courserun_for_dashboard(course_run, status_for_user, certificate=None
 
 
 @transaction.atomic
-def update_cached_enrollment(user, enrollment, now):
+def update_cached_enrollment(user, enrollment, course_id, now):
     """
     Updates the cached enrollment based on an Enrollment object
 
@@ -345,6 +345,7 @@ def update_cached_enrollment(user, enrollment, now):
         user (User): A user
         enrollment (Enrollment):
             An Enrollment object from edx_api_client
+        course_id (str): A course key
         now (datetime.datetime): The datetime value used as now
 
     Returns:
@@ -354,7 +355,7 @@ def update_cached_enrollment(user, enrollment, now):
     # None means we will cache the fact that the student
     # does not have an enrollment for the given course
     enrollment_data = enrollment.json if enrollment is not None else None
-    course_run = CourseRun.objects.get(edx_course_key=enrollment.course_id)
+    course_run = CourseRun.objects.get(edx_course_key=course_id)
     updated_values = {
         'user': user,
         'course_run': course_run,
@@ -430,7 +431,7 @@ def get_student_enrollments(user, edx_client):
     with transaction.atomic():
         for course_id in course_ids:
             enrollment = enrollments.get_enrollment_for_course(course_id)
-            update_cached_enrollment(user, enrollment, now)
+            update_cached_enrollment(user, enrollment, course_id, now)
 
     return enrollments
 

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -337,7 +337,7 @@ def format_courserun_for_dashboard(course_run, status_for_user, certificate=None
 
 
 @transaction.atomic
-def update_cached_enrollment(user, enrollment, course_id, now):
+def update_cached_enrollment(user, enrollment, now):
     """
     Updates the cached enrollment based on an Enrollment object
 
@@ -345,7 +345,6 @@ def update_cached_enrollment(user, enrollment, course_id, now):
         user (User): A user
         enrollment (Enrollment):
             An Enrollment object from edx_api_client
-        course_id (str): A course key
         now (datetime.datetime): The datetime value used as now
 
     Returns:
@@ -355,7 +354,7 @@ def update_cached_enrollment(user, enrollment, course_id, now):
     # None means we will cache the fact that the student
     # does not have an enrollment for the given course
     enrollment_data = enrollment.json if enrollment is not None else None
-    course_run = CourseRun.objects.get(edx_course_key=course_id)
+    course_run = CourseRun.objects.get(edx_course_key=enrollment.course_id)
     updated_values = {
         'user': user,
         'course_run': course_run,
@@ -431,7 +430,7 @@ def get_student_enrollments(user, edx_client):
     with transaction.atomic():
         for course_id in course_ids:
             enrollment = enrollments.get_enrollment_for_course(course_id)
-            update_cached_enrollment(user, enrollment, course_id, now)
+            update_cached_enrollment(user, enrollment, now)
 
     return enrollments
 

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -336,6 +336,7 @@ def format_courserun_for_dashboard(course_run, status_for_user, certificate=None
     return formatted_run
 
 
+@transaction.atomic
 def update_cached_enrollment(user, enrollment, course_id, now):
     """
     Updates the cached enrollment based on an Enrollment object

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -350,7 +350,7 @@ def update_cached_enrollment(user, enrollment, now):
     Returns:
         None
     """
-    # get the certificate data or None
+    # get the enrollment data or None
     # None means we will cache the fact that the student
     # does not have an enrollment for the given course
     enrollment_data = enrollment.json if enrollment is not None else None

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -253,7 +253,7 @@ def enroll_user_on_success(order):
             exceptions.append(ex)
 
     now = datetime.now(pytz.UTC)
-    for enrollment in enrollments():
+    for enrollment in enrollments:
         update_cached_enrollment(order.user, enrollment, now)
 
     if exceptions:

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -239,11 +239,11 @@ def enroll_user(order):
     enrollments_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL).enrollments
 
     exceptions = []
-    enrollments = {}
+    enrollments = []
     for line in order.line_set.all():
         course_key = line.course_key
         try:
-            enrollments[course_key] = enrollments_client.create_audit_student_enrollment(course_key)
+            enrollments.append(enrollments_client.create_audit_student_enrollment(course_key))
         except Exception as ex:  # pylint: disable=broad-except
             log.error(
                 "Error creating audit enrollment for course key %s for user %s",
@@ -253,8 +253,8 @@ def enroll_user(order):
             exceptions.append(ex)
 
     now = datetime.now(pytz.UTC)
-    for course_key, enrollment in enrollments.items():
-        update_cached_enrollment(order.user, enrollment, course_key, now)
+    for enrollment in enrollments():
+        update_cached_enrollment(order.user, enrollment, now)
 
     if len(exceptions) > 0:
         raise EcommerceEdxApiException(exceptions)

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -256,5 +256,5 @@ def enroll_user(order):
     for enrollment in enrollments():
         update_cached_enrollment(order.user, enrollment, now)
 
-    if len(exceptions) > 0:
+    if exceptions:
         raise EcommerceEdxApiException(exceptions)

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -239,11 +239,11 @@ def enroll_user_on_success(order):
     enrollments_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL).enrollments
 
     exceptions = []
-    enrollments = {}
+    enrollments = []
     for line in order.line_set.all():
         course_key = line.course_key
         try:
-            enrollments[course_key] = enrollments_client.create_audit_student_enrollment(course_key)
+            enrollments.append(enrollments_client.create_audit_student_enrollment(course_key))
         except Exception as ex:  # pylint: disable=broad-except
             log.error(
                 "Error creating audit enrollment for course key %s for user %s",

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -13,10 +13,15 @@ from django.conf import settings
 from django.db import transaction
 from django.http.response import Http404
 from django.shortcuts import get_object_or_404
+from edx_api.client import EdxApi
+import pytz
 from rest_framework.exceptions import ValidationError
 
+from backends.edxorg import EdxOrgOAuth2
 from courses.models import CourseRun
+from dashboard.api import update_cached_enrollment
 from ecommerce.exceptions import (
+    EcommerceEdxApiException,
     EcommerceException,
     ParseException,
 )
@@ -218,3 +223,38 @@ def get_new_order_by_reference_number(reference_number):
         return Order.objects.get(id=order_id, status=Order.CREATED)
     except Order.DoesNotExist:
         raise EcommerceException("Order {} is expected to have status 'created'".format(order_id))
+
+
+def enroll_user(order):
+    """
+    Enroll user after they made a successful purchase.
+
+    Args:
+        order (Order): An order to be fulfilled
+
+    Returns:
+         None
+    """
+    user_social = order.user.social_auth.get(provider=EdxOrgOAuth2.name)
+    enrollments_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL).enrollments
+
+    exceptions = []
+    enrollments = {}
+    for line in order.line_set.all():
+        course_key = line.course_key
+        try:
+            enrollments[course_key] = enrollments_client.create_audit_student_enrollment(course_key)
+        except Exception as ex:
+            log.error(
+                "Error creating audit enrollment for course key %s for user %s",
+                course_key,
+                get_social_username(order.user),
+            )
+            exceptions.append(ex)
+
+    now = datetime.now(pytz.UTC)
+    for course_key, enrollment in enrollments.items():
+        update_cached_enrollment(order.user, enrollment, course_key, now)
+
+    if len(exceptions) > 0:
+        raise EcommerceEdxApiException(exceptions)

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -239,11 +239,11 @@ def enroll_user_on_success(order):
     enrollments_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL).enrollments
 
     exceptions = []
-    enrollments = []
+    enrollments = {}
     for line in order.line_set.all():
         course_key = line.course_key
         try:
-            enrollments.append(enrollments_client.create_audit_student_enrollment(course_key))
+            enrollments[course_key] = enrollments_client.create_audit_student_enrollment(course_key)
         except Exception as ex:  # pylint: disable=broad-except
             log.error(
                 "Error creating audit enrollment for course key %s for user %s",
@@ -254,7 +254,7 @@ def enroll_user_on_success(order):
 
     now = datetime.now(pytz.UTC)
     for enrollment in enrollments:
-        update_cached_enrollment(order.user, enrollment, now)
+        update_cached_enrollment(order.user, enrollment, enrollment.course_id, now)
 
     if exceptions:
         raise EcommerceEdxApiException(exceptions)

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -244,7 +244,7 @@ def enroll_user(order):
         course_key = line.course_key
         try:
             enrollments[course_key] = enrollments_client.create_audit_student_enrollment(course_key)
-        except Exception as ex:
+        except Exception as ex:  # pylint: disable=broad-except
             log.error(
                 "Error creating audit enrollment for course key %s for user %s",
                 course_key,

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -225,7 +225,7 @@ def get_new_order_by_reference_number(reference_number):
         raise EcommerceException("Order {} is expected to have status 'created'".format(order_id))
 
 
-def enroll_user(order):
+def enroll_user_on_success(order):
     """
     Enroll user after they made a successful purchase.
 

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -21,7 +21,7 @@ from courses.factories import CourseRunFactory
 from dashboard.models import CachedEnrollment
 from ecommerce.api import (
     create_unfulfilled_order,
-    enroll_user,
+    enroll_user_on_success,
     generate_cybersource_sa_payload,
     generate_cybersource_sa_signature,
     get_purchasable_course_run,
@@ -303,7 +303,7 @@ class EnrollUserTests(ESTestCase):
         enrollments_mock = MagicMock(create_audit_student_enrollment=create_audit_mock)
         edx_api_mock = MagicMock(enrollments=enrollments_mock)
         with patch('ecommerce.api.EdxApi', return_value=edx_api_mock):
-            enroll_user(self.order)
+            enroll_user_on_success(self.order)
 
         assert len(create_audit_mock.call_args_list) == self.order.line_set.count()
         for i, line in enumerate(self.order.line_set.all()):
@@ -334,7 +334,7 @@ class EnrollUserTests(ESTestCase):
         edx_api_mock = MagicMock(enrollments=enrollments_mock)
         with patch('ecommerce.api.EdxApi', return_value=edx_api_mock):
             with self.assertRaises(EcommerceEdxApiException) as ex:
-                enroll_user(self.order)
+                enroll_user_on_success(self.order)
             assert len(ex.exception.args[0]) == 1
             assert ex.exception.args[0][0].args[0] == 'fatal error {}'.format(self.line1.course_key)
 

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -13,11 +13,15 @@ from mock import (
 )
 from django.http.response import Http404
 from django.test import override_settings
+from edx_api.enrollments import Enrollment
 from rest_framework.exceptions import ValidationError
 
+from backends.pipeline_api import EdxOrgOAuth2
 from courses.factories import CourseRunFactory
+from dashboard.models import CachedEnrollment
 from ecommerce.api import (
     create_unfulfilled_order,
+    enroll_user,
     generate_cybersource_sa_payload,
     generate_cybersource_sa_signature,
     get_purchasable_course_run,
@@ -29,7 +33,11 @@ from ecommerce.exceptions import (
     EcommerceException,
     ParseException,
 )
-from ecommerce.factories import CoursePriceFactory
+from ecommerce.factories import (
+    CoursePriceFactory,
+    LineFactory,
+    OrderFactory,
+)
 from ecommerce.models import Order
 from profiles.factories import UserFactory
 from search.base import ESTestCase
@@ -256,3 +264,58 @@ class ReferenceNumberTests(ESTestCase):
             with self.assertRaises(EcommerceException) as ex:
                 get_new_order_by_reference_number(make_reference_id(order))
             assert ex.exception.args[0] == "Order {} is expected to have status 'created'".format(order.id)
+
+
+class EnrollUserTests(ESTestCase):
+    """
+    Tests for enroll_user
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = UserFactory()
+        cls.user.social_auth.create(
+            provider='not_edx',
+        )
+        cls.user.social_auth.create(
+            provider=EdxOrgOAuth2.name,
+            uid="{}_edx".format(cls.user.username),
+        )
+        cls.order = OrderFactory.create(status=Order.CREATED, user=cls.user)
+        cls.line1 = LineFactory.create(order=cls.order)
+        cls.line2 = LineFactory.create(order=cls.order)
+        cls.course_run1 = CourseRunFactory.create(edx_course_key=cls.line1.course_key)
+        CoursePriceFactory.create(course_run=cls.course_run1, is_valid=True)
+        cls.course_run2 = CourseRunFactory.create(edx_course_key=cls.line2.course_key)
+        CoursePriceFactory.create(course_run=cls.course_run2, is_valid=True)
+
+    def test_enroll(self):
+        """
+        Test that an enrollment is made for each course key attached to the order
+        and that the CachedEnrollments are produced.
+        """
+        fake_enrollment = Enrollment({"some": "text"})
+
+        create_audit_mock = MagicMock(return_value=fake_enrollment)
+        enrollments_mock = MagicMock(create_audit_student_enrollment=create_audit_mock)
+        edx_api_mock = MagicMock(enrollments=enrollments_mock)
+        with patch('ecommerce.api.EdxApi', return_value=edx_api_mock):
+            enroll_user(self.order)
+
+        for i, line in enumerate(self.order.line_set.all()):
+            assert create_audit_mock.call_args_list[i][0] == (line.course_key, )
+        assert CachedEnrollment.objects.count() == self.order.line_set.count()
+
+        for line in self.order.line_set.all():
+            enrollment = CachedEnrollment.objects.get(
+                user=self.order.user,
+                course_run__edx_course_key=line.course_key,
+            )
+            assert enrollment.data == fake_enrollment.json
+
+    def test_failed(self):
+        """
+        Test that an exception is raised containing a list of exceptions of the failed enrollments
+        """

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -299,7 +299,7 @@ class EnrollUserTests(ESTestCase):
         """
         def create_audit(course_key):
             """Helper function to create a fake enrollment"""
-            return Enrollment({"course_details": {"course_id": "id"}})
+            return Enrollment({"course_details": {"course_id": course_key}})
 
         create_audit_mock = MagicMock(side_effect=create_audit)
         enrollments_mock = MagicMock(create_audit_student_enrollment=create_audit_mock)
@@ -327,7 +327,7 @@ class EnrollUserTests(ESTestCase):
             """Fail for first course key"""
             if course_key == self.line1.course_key:
                 raise Exception("fatal error {}".format(course_key))
-            return Enrollment({"course_details": {"course_id": "id"}})
+            return Enrollment({"course_details": {"course_id": course_key}})
 
         create_audit_mock = MagicMock(side_effect=create_audit)
         enrollments_mock = MagicMock(create_audit_student_enrollment=create_audit_mock)

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -347,4 +347,4 @@ class EnrollUserTests(ESTestCase):
             user=self.order.user,
             course_run__edx_course_key=self.line2.course_key,
         )
-        assert enrollment.data == create_audit(self.line1.course_key).json
+        assert enrollment.data == create_audit(self.line2.course_key).json

--- a/ecommerce/exceptions.py
+++ b/ecommerce/exceptions.py
@@ -9,6 +9,12 @@ class EcommerceException(Exception):
     """
 
 
+class EcommerceEdxApiException(Exception):
+    """
+    Exception regarding edx
+    """
+
+
 class EcommerceModelException(Exception):
     """
     Exception regarding ecommerce models

--- a/ecommerce/exceptions.py
+++ b/ecommerce/exceptions.py
@@ -11,7 +11,7 @@ class EcommerceException(Exception):
 
 class EcommerceEdxApiException(Exception):
     """
-    Exception regarding edx
+    Exception regarding edx_api_client
     """
 
 

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 
 from ecommerce.api import (
     create_unfulfilled_order,
-    enroll_user,
+    enroll_user_on_success,
     generate_cybersource_sa_payload,
     get_new_order_by_reference_number,
 )
@@ -80,7 +80,7 @@ class OrderFulfillmentView(APIView):
             else:
                 # Do the verified enrollment with edX here
                 order.status = Order.FULFILLED
-                enroll_user(order)
+                enroll_user_on_success(order)
             order.save()
         except:
             order.status = Order.FAILED

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -106,7 +106,7 @@ class OrderFulfillmentView(APIView):
 
                 now = datetime.datetime.now(pytz.UTC)
                 for course_key, enrollment in enrollments.items():
-                    update_cached_enrollment(request.user, enrollment, course_key, now)
+                    update_cached_enrollment(order.user, enrollment, course_key, now)
 
                 if len(exceptions) > 0:
                     raise EcommerceEdxApiException(exceptions)

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -87,7 +87,7 @@ class OrderFulfillmentView(APIView):
                 # Do the verified enrollment with edX here
                 order.status = Order.FULFILLED
 
-                user_social = request.user.social_auth.get(provider=EdxOrgOAuth2.name)
+                user_social = order.user.social_auth.get(provider=EdxOrgOAuth2.name)
                 enrollments_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL).enrollments
 
                 exceptions = []
@@ -100,7 +100,7 @@ class OrderFulfillmentView(APIView):
                         log.error(
                             "Error creating audit enrollment for course key %s for user %s",
                             course_key,
-                            get_social_username(request.user),
+                            get_social_username(order.user),
                         )
                         exceptions.append(ex)
 

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -1,30 +1,24 @@
 """Views from ecommerce"""
-import datetime
 import logging
 
 from django.conf import settings
-from edx_api.client import EdxApi
-import pytz
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
-from backends.edxorg import EdxOrgOAuth2
-from dashboard.api import update_cached_enrollment
 from ecommerce.api import (
     create_unfulfilled_order,
+    enroll_user,
     generate_cybersource_sa_payload,
     get_new_order_by_reference_number,
 )
-from ecommerce.exceptions import EcommerceEdxApiException
 from ecommerce.models import (
     Order,
     Receipt,
 )
 from ecommerce.permissions import IsSignedByCyberSource
-from profiles.api import get_social_username
 
 log = logging.getLogger(__name__)
 
@@ -86,31 +80,7 @@ class OrderFulfillmentView(APIView):
             else:
                 # Do the verified enrollment with edX here
                 order.status = Order.FULFILLED
-
-                user_social = order.user.social_auth.get(provider=EdxOrgOAuth2.name)
-                enrollments_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL).enrollments
-
-                exceptions = []
-                enrollments = {}
-                for line in order.line_set.all():
-                    course_key = line.course_key
-                    try:
-                        enrollments[course_key] = enrollments_client.create_audit_student_enrollment(course_key)
-                    except Exception as ex:
-                        log.error(
-                            "Error creating audit enrollment for course key %s for user %s",
-                            course_key,
-                            get_social_username(order.user),
-                        )
-                        exceptions.append(ex)
-
-                now = datetime.datetime.now(pytz.UTC)
-                for course_key, enrollment in enrollments.items():
-                    update_cached_enrollment(order.user, enrollment, course_key, now)
-
-                if len(exceptions) > 0:
-                    raise EcommerceEdxApiException(exceptions)
-
+                enroll_user(order)
             order.save()
         except:
             order.status = Order.FAILED

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -155,6 +155,16 @@ class OrderFulfillmentViewTests(ESTestCase):
         assert Receipt.objects.count() == 1
         assert Receipt.objects.first().data == data
 
+    def test_failed_enroll(self):
+        """
+        If we fail to enroll in edX, the order status should be failed
+        """
+        with patch('ecommerce.views.enroll_user', side_effect=KeyError):
+            self.client.post(reverse('order-fulfillment'))
+
+        assert Order.objects.count() == 1
+        assert Order.objects.first().status == Order.FAILED
+
     def test_not_accept(self):
         """
         If the decision is not ACCEPT then the order should be marked as failed

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -121,7 +121,7 @@ class OrderFulfillmentViewTests(ESTestCase):
         data['decision'] = 'ACCEPT'
 
         with patch('ecommerce.views.IsSignedByCyberSource.has_permission', return_value=True), patch(
-            'ecommerce.views.enroll_user'
+            'ecommerce.views.enroll_user_on_success'
         ) as enroll_user:
             resp = self.client.post(reverse('order-fulfillment'), data=data)
 
@@ -170,7 +170,7 @@ class OrderFulfillmentViewTests(ESTestCase):
         data['decision'] = 'ACCEPT'
 
         with patch('ecommerce.views.IsSignedByCyberSource.has_permission', return_value=True), patch(
-            'ecommerce.views.enroll_user', side_effect=KeyError
+            'ecommerce.views.enroll_user_on_success', side_effect=KeyError
         ):
             with self.assertRaises(KeyError):
                 self.client.post(reverse('order-fulfillment'), data=data)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #918 

#### What's this PR do?
After a successful course purchase, the user is enrolled in the audit track for that course on edX. We also update `CachedEnrollment` locally so the user sees the new state in the dashboard.

#### How should this be manually tested?
Talk to me, we will need to use the PR build here. Also we should test and merge #1085 first so that we can verify that the dashboard button updates are immediate.
