### PR TITLE
Overrode save method on FinancialAid to ensure uniqueness between Use…

### DIFF
--- a/financialaid/models.py
+++ b/financialaid/models.py
@@ -3,6 +3,7 @@ Models for the Financial Aid App
 """
 import datetime
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.db import (
     models,
     transaction,
@@ -137,7 +138,7 @@ class FinancialAid(TimestampedModel):
                 user=self.user,
                 tier_program__program=self.tier_program.program
         ).exclude(id=self.id).exists():
-            raise Exception("Cannot have multiple FinancialAid objects for the same User and Program.")
+            raise ValidationError("Cannot have multiple FinancialAid objects for the same User and Program.")
         super().save(*args, **kwargs)
 
 

--- a/financialaid/models.py
+++ b/financialaid/models.py
@@ -134,7 +134,7 @@ class FinancialAid(TimestampedModel):
         """
         Override save to make sure only one FinancialAid object exists for a User and the associated Program
         """
-        if self.__class__.objects.filter(
+        if FinancialAid.objects.filter(
                 user=self.user,
                 tier_program__program=self.tier_program.program
         ).exclude(id=self.id).exists():

--- a/financialaid/models.py
+++ b/financialaid/models.py
@@ -128,6 +128,18 @@ class FinancialAid(TimestampedModel):
     country_of_income = models.CharField(null=True, max_length=100)
     date_exchange_rate = models.DateTimeField(null=True)
 
+    @transaction.atomic
+    def save(self, *args, **kwargs):
+        """
+        Override save to make sure only one FinancialAid object exists for a User and the associated Program
+        """
+        if self.__class__.objects.filter(
+            user=self.user,
+            tier_program__program=self.tier_program.program
+        ).exclude(id=self.id).exists():
+            raise Exception("Cannot have multiple FinancialAid objects for the same User and Program.")
+        super().save(*args, **kwargs)
+
 
 class FinancialAidAudit(TimestampedModel):
     """

--- a/financialaid/models.py
+++ b/financialaid/models.py
@@ -134,8 +134,8 @@ class FinancialAid(TimestampedModel):
         Override save to make sure only one FinancialAid object exists for a User and the associated Program
         """
         if self.__class__.objects.filter(
-            user=self.user,
-            tier_program__program=self.tier_program.program
+                user=self.user,
+                tier_program__program=self.tier_program.program
         ).exclude(id=self.id).exists():
             raise Exception("Cannot have multiple FinancialAid objects for the same User and Program.")
         super().save(*args, **kwargs)

--- a/financialaid/models_test.py
+++ b/financialaid/models_test.py
@@ -30,12 +30,13 @@ class FinancialAidModelsTests(ESTestCase):
         Tests that FinancialAid objects are unique per User and Program
         """
         financial_aid = FinancialAidFactory.create()
-        try:
-            # Test creation of FinancialAid that isn't unique_together with "user" and "tier_program__program"
-            FinancialAidFactory.create(user=financial_aid.user)
-            FinancialAidFactory.create(tier_program=financial_aid.tier_program)
-        except ValidationError:
-            self.fail("Creation of FinancialAid objects should have been successful")
+        # Test creation of FinancialAid that isn't unique_together with "user" and "tier_program__program"
+        FinancialAidFactory.create(user=financial_aid.user)
+        FinancialAidFactory.create(tier_program=financial_aid.tier_program)
+        # Test updating the original FinancialAid doesn't raise ValidationError
+        financial_aid.income_usd = 100
+        financial_aid.save()
+        # Test creation should fail for FinancialAid already existing with the same "user" and "tier_program__program"
         with self.assertRaises(ValidationError):
             FinancialAidFactory.create(
                 user=financial_aid.user,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1091 

#### What's this PR do?
Adds a uniqueness constraint on `FinancialAid `objects between User and Program so that learners cannot have multiple financial aid applications per program.  This is done by overriding `FinancialAid.save`.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?
After 10/15, we'll most likely be allowing learners to apply multiple times, so this will eventually change, but for now will protect against bugs in other parts of the codebase.

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
