### PR TITLE
Changed names and values for course statuses

### DIFF
--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -180,9 +180,9 @@ class DashboardTest(APITestCase):
                 if len(course_data['runs']) == 1:
                     assert 'course_id' in course_data['runs'][0]
                     if course_data['runs'][0]['course_id'] == "course-v1:edX+DemoX+Demo_Course":
-                        assert course_data['runs'][0]['status'] == CourseStatus.CURRENT_GRADE
+                        assert course_data['runs'][0]['status'] == CourseStatus.CURRENTLY_ENROLLED
                     if course_data['runs'][0]['course_id'] == "course-v1:MITx+8.MechCX+2014_T1":
-                        assert course_data['runs'][0]['status'] == CourseStatus.UPGRADE
+                        assert course_data['runs'][0]['status'] == CourseStatus.CAN_UPGRADE
 
     @patch('backends.utils.refresh_user_token', autospec=True)
     def test_certificates_enrollments(self, mocked_refresh):

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -8,8 +8,8 @@ import type { Course, CourseRun } from '../../flow/programTypes';
 import {
   STATUS_NOT_PASSED,
   STATUS_PASSED,
-  STATUS_ENROLLED,
-  STATUS_VERIFIED,
+  STATUS_CAN_UPGRADE,
+  STATUS_CURRENTLY_ENROLLED,
   STATUS_OFFERED,
   DASHBOARD_FORMAT,
 } from '../../constants';
@@ -56,7 +56,7 @@ export default class CourseAction extends React.Component {
     case STATUS_PASSED:
       action = <i className="material-icons">done</i>;
       break;
-    case STATUS_ENROLLED: {
+    case STATUS_CAN_UPGRADE: {
       action = this.makeEnrollButton("Upgrade", firstRun, false);
       break;
     }
@@ -78,7 +78,7 @@ export default class CourseAction extends React.Component {
       break;
     }
     case STATUS_NOT_PASSED:
-    case STATUS_VERIFIED:
+    case STATUS_CURRENTLY_ENROLLED:
       // do nothing;
       break;
     default: {

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -12,8 +12,8 @@ import {
   STATUS_PASSED,
   STATUS_NOT_PASSED,
   STATUS_OFFERED,
-  STATUS_ENROLLED,
-  STATUS_VERIFIED,
+  STATUS_CAN_UPGRADE,
+  STATUS_CURRENTLY_ENROLLED,
 } from '../../constants';
 import { findCourse } from './CourseDescription_test';
 
@@ -57,13 +57,13 @@ describe('CourseAction', () => {
   it('shows nothing for a verified course', () => {
     let course = findCourse(course => (
       course.runs.length > 0 &&
-      course.runs[0].status === STATUS_VERIFIED
+      course.runs[0].status === STATUS_CURRENTLY_ENROLLED
     ));
     const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
     assert.equal(wrapper.text(), '');
   });
 
-  [STATUS_OFFERED, STATUS_ENROLLED].forEach((status) => {
+  [STATUS_OFFERED, STATUS_CAN_UPGRADE].forEach((status) => {
     it(`shows the enroll button followed by course title when status is ${status}`, () => {
       let course = findCourse(course => (
         course.runs.length > 0 &&
@@ -80,7 +80,7 @@ describe('CourseAction', () => {
   it('shows an upgrade button if user is not verified but is enrolled', () => {
     let course = findCourse(course => (
       course.runs.length > 0 &&
-      course.runs[0].status === STATUS_ENROLLED
+      course.runs[0].status === STATUS_CAN_UPGRADE
     ));
     const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
     let buttonContainer = wrapper.find(".course-action-action");

--- a/static/js/components/dashboard/CourseDescription.js
+++ b/static/js/components/dashboard/CourseDescription.js
@@ -7,8 +7,8 @@ import type { Course, CourseRun } from '../../flow/programTypes';
 import {
   STATUS_PASSED,
   STATUS_NOT_PASSED,
-  STATUS_ENROLLED,
-  STATUS_VERIFIED,
+  STATUS_CAN_UPGRADE,
+  STATUS_CURRENTLY_ENROLLED,
   STATUS_OFFERED,
   DASHBOARD_FORMAT,
 } from '../../constants';
@@ -39,8 +39,8 @@ export default class CourseDescription extends React.Component {
         return `Coming ${firstRun.fuzzy_start_date}`;
       }
       break;
-    case STATUS_ENROLLED:
-    case STATUS_VERIFIED:
+    case STATUS_CAN_UPGRADE:
+    case STATUS_CURRENTLY_ENROLLED:
     case STATUS_OFFERED:
       if (firstRun.course_start_date) {
         let courseStartDate = moment(firstRun.course_start_date);

--- a/static/js/components/dashboard/CourseDescription_test.js
+++ b/static/js/components/dashboard/CourseDescription_test.js
@@ -14,8 +14,8 @@ import {
   DASHBOARD_FORMAT,
   STATUS_PASSED,
   STATUS_NOT_PASSED,
-  STATUS_ENROLLED,
-  STATUS_VERIFIED,
+  STATUS_CAN_UPGRADE,
+  STATUS_CURRENTLY_ENROLLED,
   STATUS_OFFERED,
   ALL_COURSE_STATUSES,
 } from '../../constants';
@@ -84,7 +84,7 @@ describe('CourseDescription', () => {
   it(`does show date with status verified`, () => {
     let course = findCourse(course => (
       course.runs.length > 0 &&
-      course.runs[0].status === STATUS_VERIFIED
+      course.runs[0].status === STATUS_CURRENTLY_ENROLLED
     ));
     const wrapper = shallow(<CourseDescription course={course} />);
     let firstRun = course.runs[0];
@@ -97,7 +97,7 @@ describe('CourseDescription', () => {
   it(`does show date with status enrolled`, () => {
     let course = findCourse(course => (
       course.runs.length > 0 &&
-      course.runs[0].status === STATUS_ENROLLED
+      course.runs[0].status === STATUS_CAN_UPGRADE
     ));
     const wrapper = shallow(<CourseDescription course={course} />);
     let firstRun = course.runs[0];

--- a/static/js/components/dashboard/CourseStatus.js
+++ b/static/js/components/dashboard/CourseStatus.js
@@ -7,7 +7,7 @@ import type {
   CourseRun
 } from '../../flow/programTypes';
 import {
-  STATUS_ENROLLED,
+  STATUS_CAN_UPGRADE,
   STATUS_OFFERED,
 } from '../../constants';
 import { formatPrice } from '../../util/util';
@@ -21,7 +21,7 @@ export default class CourseStatus extends React.Component {
   coursePrice(firstRun: CourseRun): string {
     let courseHasPrice = (
       !_.isNil(firstRun.price) &&
-      (firstRun.status === STATUS_OFFERED || firstRun.status === STATUS_ENROLLED)
+      (firstRun.status === STATUS_OFFERED || firstRun.status === STATUS_CAN_UPGRADE)
     );
 
     if (courseHasPrice) {
@@ -46,7 +46,7 @@ export default class CourseStatus extends React.Component {
       priceDisplay = <span className="price">{price}</span>;
     }
 
-    if (firstRun.status === STATUS_ENROLLED) {
+    if (firstRun.status === STATUS_CAN_UPGRADE) {
       tooltipDisplay = courseListToolTip(
         "You need to enroll in the Verified Course to get MicroMasters credit.",
         `course-detail${course.id}`,

--- a/static/js/components/dashboard/CourseStatus_test.js
+++ b/static/js/components/dashboard/CourseStatus_test.js
@@ -6,8 +6,8 @@ import { assert } from 'chai';
 import CourseStatus from './CourseStatus';
 import {
   STATUS_PASSED,
-  STATUS_ENROLLED,
-  STATUS_VERIFIED,
+  STATUS_CAN_UPGRADE,
+  STATUS_CURRENTLY_ENROLLED,
   STATUS_OFFERED,
   STATUS_NOT_PASSED,
 } from '../../constants';
@@ -29,7 +29,7 @@ describe('CourseStatus', () => {
   it('shows price of course with status enrolled', () => {
     let course = findCourse(course => (
       course.runs.length > 0 &&
-      course.runs[0].status === STATUS_ENROLLED
+      course.runs[0].status === STATUS_CAN_UPGRADE
     ));
     assert.equal(course.runs[0].price, 50.00);
 
@@ -37,7 +37,7 @@ describe('CourseStatus', () => {
     assert.equal(wrapper.find(".price").text(), "$50");
   });
 
-  for (let status of [STATUS_PASSED, STATUS_NOT_PASSED, STATUS_VERIFIED]) {
+  for (let status of [STATUS_PASSED, STATUS_NOT_PASSED, STATUS_CURRENTLY_ENROLLED]) {
     it(`doesn't show the price of course with status ${status}`, () => {
       let course = findCourse(course => (
         course.runs.length > 0 &&
@@ -53,14 +53,14 @@ describe('CourseStatus', () => {
   it('shows the tooltip for status enrolled', () => {
     let course = findCourse(course => (
       course.runs.length > 0 &&
-      course.runs[0].status === STATUS_ENROLLED
+      course.runs[0].status === STATUS_CAN_UPGRADE
     ));
     const wrapper = shallow(<CourseStatus course={course}/>);
     let tooltip = wrapper.find(".help");
     assert.equal(tooltip.length, 1);
   });
 
-  for (let status of [STATUS_OFFERED, STATUS_VERIFIED, STATUS_NOT_PASSED, STATUS_PASSED]) {
+  for (let status of [STATUS_OFFERED, STATUS_CURRENTLY_ENROLLED, STATUS_NOT_PASSED, STATUS_PASSED]) {
     it(`doesn't show any tooltip for status ${status}`, () => {
       let course = findCourse(course => (
         course.runs.length > 0 &&

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -213,16 +213,16 @@ export const USER_PROGRAM_RESPONSE = {
 
 export const STATUS_PASSED = 'passed';
 export const STATUS_NOT_PASSED = 'not-passed';
-export const STATUS_VERIFIED = 'verified';
-export const STATUS_ENROLLED = "enrolled";
-export const STATUS_OFFERED = "offered";
+export const STATUS_CURRENTLY_ENROLLED = 'currently-enrolled';
+export const STATUS_CAN_UPGRADE = 'can-upgrade';
+export const STATUS_OFFERED = 'offered';
 
 export const ALL_COURSE_STATUSES = [
   STATUS_PASSED,
   STATUS_NOT_PASSED,
   STATUS_OFFERED,
-  STATUS_ENROLLED,
-  STATUS_VERIFIED,
+  STATUS_CAN_UPGRADE,
+  STATUS_CURRENTLY_ENROLLED,
 ];
 
 export const DASHBOARD_RESPONSE = [
@@ -366,7 +366,7 @@ export const DASHBOARD_RESPONSE = [
         "runs": [
           {
             "id": 7,
-            "status": STATUS_ENROLLED,
+            "status": STATUS_CAN_UPGRADE,
             "title": "Not verified run",
             "course_id": "not-verified",
             "position": 0,
@@ -426,7 +426,7 @@ export const DASHBOARD_RESPONSE = [
         "runs": [
           {
             "id": 13,
-            "status": STATUS_VERIFIED,
+            "status": STATUS_CURRENTLY_ENROLLED,
             "course_start_date": "8765-03-21",
             "title": "First run",
             "position": 0,
@@ -474,7 +474,7 @@ export const DASHBOARD_RESPONSE = [
           {
             "course_id": "course-v1:edX+DemoX+Demo_Course2",
             "id": 6,
-            "status": STATUS_VERIFIED,
+            "status": STATUS_CURRENTLY_ENROLLED,
             "title": "Course run for last program",
             "position": 0,
             "course_start_date": "2016-01-01",


### PR DESCRIPTION
#### What are the relevant tickets?

No ticket

#### What's this PR do?

Renames misleading course statuses and matches the values to the names

#### How should this be manually tested?

Make sure the dashboard works
