### PR TITLE
Set default staff page to learner search

### DIFF
--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -3,12 +3,17 @@ APIs for extending the python social auth pipeline
 """
 import logging
 from datetime import datetime
+from rolepermissions.verifications import has_role
 from urllib.parse import urljoin
 
 from backends.edxorg import EdxOrgOAuth2
 from profiles.api import get_social_username
 from profiles.models import Profile
 from profiles.util import split_name
+from roles.models import (
+    Instructor,
+    Staff,
+)
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +35,15 @@ def update_profile_from_edx(backend, user, response, is_new, *args, **kwargs):  
 
     # this function is completely skipped if the backend is not edx or
     # the user has not created now
-    if backend.name != EdxOrgOAuth2.name or not is_new:
+    if backend.name != EdxOrgOAuth2.name:
+        return
+
+    if has_role(user, [Staff.ROLE_ID, Instructor.ROLE_ID]):
+        backend.strategy.session_set('next', '/learners')
+    else:
+        backend.strategy.session_set('next', '/dashboard')
+
+    if not is_new:
         return
 
     access_token = response.get('access_token')

--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -3,8 +3,9 @@ APIs for extending the python social auth pipeline
 """
 import logging
 from datetime import datetime
-from rolepermissions.verifications import has_role
 from urllib.parse import urljoin
+
+from rolepermissions.verifications import has_role
 
 from backends.edxorg import EdxOrgOAuth2
 from profiles.api import get_social_username

--- a/backends/pipeline_api_test.py
+++ b/backends/pipeline_api_test.py
@@ -8,10 +8,16 @@ import mock
 
 from backends import pipeline_api, edxorg
 from backends.pipeline_api import update_from_linkedin
+from courses.factories import ProgramFactory
 from profiles.api import get_social_username
 from profiles.models import Profile
 from profiles.factories import UserFactory
 from profiles.util import split_name
+from roles.models import (
+    Instructor,
+    Role,
+    Staff,
+)
 from search.base import ESTestCase
 
 
@@ -122,7 +128,7 @@ class EdxPipelineApiTest(ESTestCase):
         """
         self.check_empty_profile(self.user_profile)
         pipeline_api.update_profile_from_edx(
-            edxorg.EdxOrgOAuth2, self.user, {'access_token': 'foo'}, False)
+            edxorg.EdxOrgOAuth2(strategy=mock.Mock()), self.user, {'access_token': 'foo'}, False)
 
         self.user_profile.refresh_from_db()
         self.check_empty_profile(self.user_profile)
@@ -134,7 +140,7 @@ class EdxPipelineApiTest(ESTestCase):
         self.check_empty_profile(self.user_profile)
 
         pipeline_api.update_profile_from_edx(
-            edxorg.EdxOrgOAuth2, self.user, {'access_token': ''}, True)
+            edxorg.EdxOrgOAuth2(strategy=mock.Mock()), self.user, {'access_token': ''}, True)
 
         self.user_profile.refresh_from_db()
         self.check_empty_profile(self.user_profile)
@@ -150,7 +156,7 @@ class EdxPipelineApiTest(ESTestCase):
 
         # just checking that nothing raises an exception
         pipeline_api.update_profile_from_edx(
-            edxorg.EdxOrgOAuth2, self.user, {'access_token': 'foo_token'}, True)
+            edxorg.EdxOrgOAuth2(strategy=mock.Mock()), self.user, {'access_token': 'foo_token'}, True)
 
         # verify that a profile has not been created
         with self.assertRaises(Profile.DoesNotExist):
@@ -164,7 +170,7 @@ class EdxPipelineApiTest(ESTestCase):
         mocked_content = self.mocked_edx_profile
         mocked_get_json.return_value = mocked_content
         pipeline_api.update_profile_from_edx(
-            edxorg.EdxOrgOAuth2, self.user, {'access_token': 'foo_token'}, True)
+            edxorg.EdxOrgOAuth2(strategy=mock.Mock()), self.user, {'access_token': 'foo_token'}, True)
         mocked_get_json.assert_called_once_with(
             urljoin(
                 edxorg.EdxOrgOAuth2.EDXORG_BASE_URL,
@@ -209,11 +215,33 @@ class EdxPipelineApiTest(ESTestCase):
             mocked_content['language_proficiencies'] = proficiencies
             mocked_get_json.return_value = mocked_content
             pipeline_api.update_profile_from_edx(
-                edxorg.EdxOrgOAuth2, self.user, {'access_token': 'foo_token'}, True)
+                edxorg.EdxOrgOAuth2(strategy=mock.Mock()), self.user, {'access_token': 'foo_token'}, True)
 
             self.user_profile.refresh_from_db()
             assert self.user_profile.preferred_language is None
             assert self.user_profile.edx_language_proficiencies == proficiencies
+
+    def test_login_redirect_dashboard(self):
+        """
+        A student should be directed to /dashboard
+        """
+        student = UserFactory.create()
+        session_set = mock.Mock()
+        backend = edxorg.EdxOrgOAuth2(strategy=mock.Mock(session_set=session_set))
+        pipeline_api.update_profile_from_edx(backend, student, {}, False)
+        session_set.assert_called_with('next', '/dashboard')
+
+    def test_login_redirect_learners(self):
+        """
+        Staff or instructors should be directed to /learners
+        """
+        for role in [Staff.ROLE_ID, Instructor.ROLE_ID]:
+            user = UserFactory.create()
+            Role.objects.create(user=user, role=role, program=ProgramFactory.create())
+            session_set = mock.Mock()
+            backend = edxorg.EdxOrgOAuth2(strategy=mock.Mock(session_set=session_set))
+            pipeline_api.update_profile_from_edx(backend, user, {}, False)
+            session_set.assert_called_with('next', '/learners')
 
 
 class LinkedInPipelineTests(ESTestCase):

--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import React from 'react';
 import { Link } from 'react-router';
 import { Header, HeaderRow } from 'react-mdl';
@@ -48,16 +49,21 @@ export default class Navbar extends React.Component {
       setEnrollSelectedProgram,
     } = this.props;
 
+    let link = '/dashboard';
+    if (SETTINGS.roles.find(role => role.role === 'staff' || role.role === 'instructor')) {
+      link = '/learners';
+    }
+
     return (
       <div className="micromasters-navbar">
         <Header className="micromasters-nav">
           <HeaderRow className="micromasters-header">
             <div className="micromasters-title">
-              <Link to='/dashboard/'>
+              <Link to={link}>
                 <img src="/static/images/mit-logo-transparent.svg" alt="MIT" />
               </Link>
               <span className="mdl-layout-title">
-                <Link to='/dashboard/'>
+                <Link to={link}>
                   MicroMasters
                 </Link>
               </span>

--- a/static/js/components/Navbar_test.js
+++ b/static/js/components/Navbar_test.js
@@ -1,0 +1,27 @@
+/* global SETTINGS: false */
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+import Link from 'react-router/lib/Link';
+
+import Navbar from './Navbar';
+
+
+describe('Navbar', () => {
+  it('has a link to the dashboard if the user has no roles', () => {
+    let wrapper = shallow(<Navbar />);
+    wrapper.find(Link).forEach(link => {
+      assert.equal(link.props()['to'], "/dashboard");
+    });
+  });
+
+  it('has a link to the learner page if the user is staff or instructor', () => {
+    for (let role of ['staff', 'instructor']) {
+      SETTINGS.roles = [{ role }];
+      let wrapper = shallow(<Navbar />);
+      wrapper.find(Link).forEach(link => {
+        assert.equal(link.props()['to'], "/learners");
+      });
+    }
+  });
+});

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -1,10 +1,12 @@
 // Define globals we would usually get from Django
-global.SETTINGS = {
+const settings = {
   authenticated: true,
   name: "full name",
   username: "jane",
-  edx_base_url: "/edx/"
+  edx_base_url: "/edx/",
+  roles: []
 };
+global.SETTINGS = Object.assign({}, settings);
 
 // polyfill for Object.entries
 import entries from 'object.entries';
@@ -15,9 +17,10 @@ if (!Object.entries) {
 // Make sure window and document are available for testing
 require('jsdom-global')();
 
-// cleanup document after each test run
+// cleanup after each test run
 afterEach(function (){
   document.body.innerHTML = '';
+  global.SETTINGS = Object.assign({}, settings);
 });
 
 // required for interacting with react-mdl components


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #903

#### What's this PR do?
 - The Micromasters link in the navbar now points to either /dashboard or /learners depending on if you have a Instructor or Staff role
 - When the user logs in they are directed to /dashboard or /learners depending on if they have an instructor or staff role

#### How should this be manually tested?
Log in and out as a staff and a student and verify that the new page matches the expected one based on the description above. Also click the image on the upper left to test that the link is updated too.
