### PR TITLE
Add social meta tags

### DIFF
--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -16,6 +16,26 @@
 {% endblock %}
 {% block keywords %}micromasters, MIT, online masters, online courses, MOOC{% endblock %}
 
+{% block social %}
+  <meta property="og:site:name" content="MIT MicroMasters">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://micromasters.mit.edu/">
+  <meta property="og:title" content="MIT MicroMasters">
+  <meta property="og:description" content="The MicroMasters is a
+    new digital credential for online learners. The MicroMasters
+    credential will be granted to learners who complete an
+    integrated set of graduate-level online courses. With the MicroMasters
+    credentials, learners can apply for an accelerated master's degree
+    program on campus, at MIT or other top universities.">
+  <meta property="og:image" content="{{ request.build_absolute_uri }}static/images/lp_hero2.jpg">
+  <meta property="og:image:secure_url" content="{{ request.build_absolute_uri }}static/images/lp_hero2.jpg">
+  <meta property="og:image:type" content="image/jpeg">
+  <meta property="og:image:width" content="948">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="@MITxonedX">
+{% endblock %}
+
 {% block content %}
 
 

--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -8,6 +8,20 @@
 {% block description %}{% if page.program.description %}{{ page.program.description }}{% endif %}{% endblock %}
 {% block keywords %}micromasters, MIT, {{ page.program.title }}, online masters, online courses, MOOC{% endblock %}
 
+{% block social %}
+  <meta property="og:site:name" content="{{ page.title }} MicroMasters">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  <meta property="og:title" content="{{ page.title }} MicroMasters">
+  <meta property="og:description" content="{% if page.program.description %}{{ page.program.description }}{% endif %}">
+  <meta property="og:image" content="{{ page.background_image.file.url|safe }}">
+  <meta property="og:image:secure_url" content="{{ page.background_image.file.url|safe }}">
+  <meta property="og:image:type" content="image/jpeg">
+  <meta property="og:image:width" content="{{ page.background_image.width }}">
+  <meta property="og:image:height" content="{{ page.background_image.height }}">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="@MITxonedX">
+{% endblock %}
 
 {% block body_class %}template-programpage{% endblock %}
 {% block content %}

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -209,6 +209,7 @@ TEMPLATES = [
 TEMPLATE_CONTEXT_PROCESSORS = (
     'social.apps.django_app.context_processors.backends',
     'social.apps.django_app.context_processors.login_redirect',
+    'django.core.context_processors.request'
 )
 
 WSGI_APPLICATION = 'micromasters.wsgi.application'

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -18,6 +18,7 @@
     <title>{% block title %}{% endblock %}</title>
     <meta name="description" content="{% block description%}{% endblock %}">
     <meta name="keywords" content="{% block keywords%}{% endblock %}">
+    {% block social %}{% endblock %}
     {% block extrahead %}
     {% endblock %}
     <!-- Google Analytics -->


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #1112

#### What's this PR do?
Added meta tags for Facebook Open Graph and Twitter Cards. Twitter Card requires a property `twitter:site` which is `@username for the website used in the card footer`. This requires an account for the website, so this is left as `@site_account`.
Note: Some Twitter card tags are not present because:
```When the Twitter card processor looks for tags on your page, it first checks for the Twitter property, and if not present, falls back to the supported Open Graph property.```

https://micromasters-ci-pr-1134.herokuapp.com/
