### PR TITLE
Refactored checkout API to work with non-financial aid programs

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -22,7 +22,7 @@ from ecommerce.exceptions import EcommerceModelException
 
 class Order(Model):
     """
-    An order made
+    An order for financial aid programs
     """
     FULFILLED = 'fulfilled'
     FAILED = 'failed'
@@ -48,7 +48,7 @@ class Order(Model):
 
 class Line(Model):
     """
-    A line in an order
+    A line in an order. This contains information about a specific item to be purchased.
     """
     course_key = TextField()
     order = ForeignKey(Order)

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -1,18 +1,22 @@
 """Views from ecommerce"""
 import logging
+from urllib.parse import urljoin
 
 from django.conf import settings
+from django.shortcuts import get_object_or_404
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
+from courses.models import CourseRun
 from ecommerce.api import (
     create_unfulfilled_order,
     enroll_user_on_success,
     generate_cybersource_sa_payload,
     get_new_order_by_reference_number,
+    get_purchasable_course_run,
 )
 from ecommerce.models import (
     Order,
@@ -33,20 +37,37 @@ class CheckoutView(APIView):
 
     def post(self, request, *args, **kwargs):
         """
-        Creates a new unfulfilled Order and returns information used to submit to CyberSource
+        If the course run is part of a financial aid program, create a new unfulfilled Order
+        and return information used to submit to CyberSource.
+
+        If the program does not have financial aid, this will return a URL to let the user
+        pay for the course on edX.
         """
         try:
             course_id = request.data['course_id']
         except KeyError:
             raise ValidationError("Missing course_id")
 
-        order = create_unfulfilled_order(course_id, request.user)
-        dashboard_url = request.build_absolute_uri('/dashboard/')
-        payload = generate_cybersource_sa_payload(order, dashboard_url)
+        course_run = get_object_or_404(
+            CourseRun,
+            course__program__live=True,
+            edx_course_key=course_id,
+        )
+        if course_run.course.program.financial_aid_availability:
+            order = create_unfulfilled_order(course_id, request.user)
+            dashboard_url = request.build_absolute_uri('/dashboard/')
+            payload = generate_cybersource_sa_payload(order, dashboard_url)
+            url = settings.CYBERSOURCE_SECURE_ACCEPTANCE_URL
+            method = 'POST'
+        else:
+            payload = {}
+            url = urljoin(settings.EDXORG_BASE_URL, '/course_modes/choose/{}/'.format(course_id))
+            method = 'GET'
 
         return Response({
             'payload': payload,
-            'url': settings.CYBERSOURCE_SECURE_ACCEPTANCE_URL,
+            'url': url,
+            'method': method,
         })
 
 

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -16,7 +16,6 @@ from ecommerce.api import (
     enroll_user_on_success,
     generate_cybersource_sa_payload,
     get_new_order_by_reference_number,
-    get_purchasable_course_run,
 )
 from ecommerce.models import (
     Order,

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -521,7 +521,7 @@ export const PROFILE_STEP_LABELS = new Map([
 export const DEFAULT_OPTION_LIMIT_COUNT = 10;
 
 /* eslint-disable max-len */
-export const CHECKOUT_RESPONSE = {
+export const CHECKOUT_RESPONSE_CYBERSOURCE = {
   "payload": {
     "access_key": "access_key",
     "amount": "123.45",
@@ -539,7 +539,13 @@ export const CHECKOUT_RESPONSE = {
     "transaction_uuid": "uuid",
     "unsigned_field_names": ""
   },
-  "url": "https://testsecureacceptance.cybersource.com/pay"
+  "url": "https://testsecureacceptance.cybersource.com/pay",
+  "method": "POST"
+};
+export const CHECKOUT_RESPONSE_EDX = {
+  "payload": {},
+  "url": "http://edx.org",
+  "method": "GET"
 };
 /* eslint-enable max-len */
 

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -88,12 +88,16 @@ class DashboardPage extends React.Component {
     const { dispatch } = this.props;
 
     return dispatch(checkout(courseId)).then(result => {
-      const { payload, url } = result;
+      const { payload, url, method } = result;
 
-      const form = createForm(url, payload);
-      const body = document.querySelector("body");
-      body.appendChild(form);
-      form.submit();
+      if (method === 'POST') {
+        const form = createForm(url, payload);
+        const body = document.querySelector("body");
+        body.appendChild(form);
+        form.submit();
+      } else {
+        window.location = url;
+      }
     });
   };
 

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -40,7 +40,7 @@ import * as api from '../util/api';
 import {
   DASHBOARD_RESPONSE,
   USER_PROFILE_RESPONSE,
-  CHECKOUT_RESPONSE,
+  CHECKOUT_RESPONSE_CYBERSOURCE,
 } from '../constants';
 import configureTestStore from 'redux-asserts';
 import rootReducer, { INITIAL_PROFILES_STATE } from '../reducers';
@@ -302,7 +302,7 @@ describe('reducers', () => {
     });
 
     it('should POST a checkout successfully', () => {
-      checkoutStub.returns(Promise.resolve(CHECKOUT_RESPONSE));
+      checkoutStub.returns(Promise.resolve(CHECKOUT_RESPONSE_CYBERSOURCE));
 
       return dispatchThen(checkout('course_id'), [REQUEST_CHECKOUT, RECEIVE_CHECKOUT_SUCCESS]).then(checkoutState => {
         assert.equal(checkoutState.fetchStatus, FETCH_SUCCESS);

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -33,7 +33,7 @@ import {
   DOCTORATE,
   MASTERS,
   PROFILE_STEP_LABELS,
-  CHECKOUT_RESPONSE,
+  CHECKOUT_RESPONSE_CYBERSOURCE,
 } from '../constants';
 import { assertMaybeEquality, assertIsNothing } from './sanctuary_test';
 import { program } from '../components/ProgressWidget_test';
@@ -391,7 +391,7 @@ describe('utility functions', () => {
 
   describe('createForm', () => {
     it('creates a form with hidden values corresponding to the payload', () => {
-      const { url, payload } = CHECKOUT_RESPONSE;
+      const { url, payload } = CHECKOUT_RESPONSE_CYBERSOURCE;
       const form = createForm(url, payload);
 
       let clone = _.clone(payload);


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1058 

#### What's this PR do?
The checkout API is changed to create a new order for financial aid programs, and to return a URL to edX for non-financial aid programs. 


#### How should this be manually tested?
Set one program to have financial aid and one to not have it. Have one course run in each to be enrollable. Click enroll on the financial aid program's course and verify that you're directed to Cybersource. Click enroll on the non-financial aid program's course and verify that you're directed to edX, to the relevant course page.

#### What GIF best describes this PR or how it makes you feel?
![](https://pbs.twimg.com/media/CtA0hX_UIAAN3Yx.jpg)
