### PR TITLE
Added financial aid calculator

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1166,6 +1166,11 @@
       "from": "cssstyle@>=0.2.34 <0.3.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.36.tgz"
     },
+    "currency-codes": {
+      "version": "1.1.2",
+      "from": "currency-codes@latest",
+      "resolved": "https://registry.npmjs.org/currency-codes/-/currency-codes-1.1.2.tgz"
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "from": "currently-unhandled@>=0.4.1 <0.5.0",
@@ -1883,6 +1888,11 @@
       "version": "1.0.0",
       "from": "first-chunk-stream@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+    },
+    "first-match": {
+      "version": "0.0.1",
+      "from": "first-match@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/first-match/-/first-match-0.0.1.tgz"
     },
     "flat-cache": {
       "version": "1.0.10",
@@ -3394,6 +3404,11 @@
       "version": "1.0.1",
       "from": "nth-check@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
+    },
+    "nub": {
+      "version": "0.0.0",
+      "from": "nub@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/nub/-/nub-0.0.0.tgz"
     },
     "num2fraction": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "css-loader": "0.23.1",
+    "currency-codes": "^1.1.2",
     "enzyme": "^2.4.1",
     "eslint": "^2.13.1",
     "eslint-config-defaults": "9.0.0",

--- a/static/js/actions/financial_aid.js
+++ b/static/js/actions/financial_aid.js
@@ -1,0 +1,42 @@
+// @flow
+import type { Dispatch } from 'redux';
+import { createAction } from 'redux-actions';
+
+import type { Dispatcher } from '../flow/reduxTypes';
+import * as api from '../util/api';
+
+export const START_CALCULATOR_EDIT = 'START_CALCULATOR_EDIT';
+export const startCalculatorEdit = createAction(START_CALCULATOR_EDIT);
+
+export const CLEAR_CALCULATOR_EDIT = 'CLEAR_CALCULATOR_EDIT';
+export const clearCalculatorEdit = createAction(CLEAR_CALCULATOR_EDIT);
+
+export const UPDATE_CALCULATOR_EDIT = 'UPDATE_CALCULATOR_EDIT';
+export const updateCalculatorEdit = createAction(UPDATE_CALCULATOR_EDIT);
+
+export const UPDATE_CALCULATOR_VALIDATION = 'UPDATE_PROFILE_VALIDATION';
+export const updateCalculatorValidation = createAction(UPDATE_CALCULATOR_VALIDATION);
+
+export const REQUEST_ADD_FINANCIAL_AID = 'REQUEST_ADD_FINANCIAL_AID';
+export const requestAddFinancialAid = createAction(REQUEST_ADD_FINANCIAL_AID);
+
+export const RECEIVE_ADD_FINANCIAL_AID_SUCCESS = 'RECEIVE_ADD_FINANCIAL_AID_SUCCESS';
+export const receiveAddFinancialAidSuccess = createAction(RECEIVE_ADD_FINANCIAL_AID_SUCCESS);
+
+export const RECEIVE_ADD_FINANCIAL_AID_FAILURE = 'RECEIVE_ADD_FINANCIAL_AID_FAILURE';
+export const receiveAddFinancialAidFailure = createAction(RECEIVE_ADD_FINANCIAL_AID_FAILURE);
+
+export const addFinancialAid = (income: number, currency: string, programId: number): Dispatcher<*> => {
+  return (dispatch: Dispatch) => {
+    dispatch(requestAddFinancialAid());
+    return api.addFinancialAid(income, currency, programId).then(
+      () => {
+        dispatch(receiveAddFinancialAidSuccess());
+        return Promise.resolve();
+      },
+      () => {
+        dispatch(receiveAddFinancialAidFailure());
+        return Promise.reject();
+      });
+  };
+};

--- a/static/js/actions/financial_aid_test.js
+++ b/static/js/actions/financial_aid_test.js
@@ -1,0 +1,32 @@
+// @flow
+import {
+  START_CALCULATOR_EDIT,
+  startCalculatorEdit,
+  CLEAR_CALCULATOR_EDIT,
+  clearCalculatorEdit,
+  UPDATE_CALCULATOR_EDIT,
+  updateCalculatorEdit,
+  UPDATE_CALCULATOR_VALIDATION,
+  updateCalculatorValidation,
+  REQUEST_ADD_FINANCIAL_AID,
+  requestAddFinancialAid,
+  RECEIVE_ADD_FINANCIAL_AID_SUCCESS,
+  receiveAddFinancialAidSuccess,
+  RECEIVE_ADD_FINANCIAL_AID_FAILURE,
+  receiveAddFinancialAidFailure,
+} from './financial_aid';
+import { assertCreatedActionHelper } from './util';
+
+describe('financial aid actions', () => {
+  it('should create all action creators', () => {
+    [
+      [startCalculatorEdit, START_CALCULATOR_EDIT],
+      [clearCalculatorEdit, CLEAR_CALCULATOR_EDIT],
+      [updateCalculatorEdit, UPDATE_CALCULATOR_EDIT],
+      [updateCalculatorValidation, UPDATE_CALCULATOR_VALIDATION],
+      [requestAddFinancialAid, REQUEST_ADD_FINANCIAL_AID],
+      [receiveAddFinancialAidSuccess, RECEIVE_ADD_FINANCIAL_AID_SUCCESS],
+      [receiveAddFinancialAidFailure, RECEIVE_ADD_FINANCIAL_AID_FAILURE],
+    ].forEach(assertCreatedActionHelper);
+  });
+});

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -88,3 +88,6 @@ export const setEnrollSelectedProgram = createAction(SET_ENROLL_SELECTED_PROGRAM
 
 export const SET_PHOTO_DIALOG_VISIBILITY = 'SET_PHOTO_DIALOG_VISIBILITY';
 export const setPhotoDialogVisibility = createAction(SET_PHOTO_DIALOG_VISIBILITY);
+
+export const SET_CALCULATOR_DIALOG_VISIBILITY = 'SET_CALCULATOR_DIALOG_VISIBILITY';
+export const setCalculatorDialogVisibility = createAction(SET_CALCULATOR_DIALOG_VISIBILITY);

--- a/static/js/actions/ui_test.js
+++ b/static/js/actions/ui_test.js
@@ -21,6 +21,7 @@ import {
   SET_TOAST_MESSAGE,
   SET_ENROLL_SELECTED_PROGRAM,
   SET_PHOTO_DIALOG_VISIBILITY,
+  SET_CALCULATOR_DIALOG_VISIBILITY,
 
   clearUI,
   updateDialogText,
@@ -44,6 +45,7 @@ import {
   setToastMessage,
   setEnrollSelectedProgram,
   setPhotoDialogVisibility,
+  setCalculatorDialogVisibility,
 } from '../actions/ui';
 import { assertCreatedActionHelper } from './util';
 
@@ -72,6 +74,7 @@ describe('generated UI action helpers', () => {
       [setToastMessage, SET_TOAST_MESSAGE],
       [setEnrollSelectedProgram, SET_ENROLL_SELECTED_PROGRAM],
       [setPhotoDialogVisibility, SET_PHOTO_DIALOG_VISIBILITY],
+      [setCalculatorDialogVisibility, SET_CALCULATOR_DIALOG_VISIBILITY],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -8,14 +8,15 @@ import R from 'ramda';
 import type { Program } from '../../flow/programTypes';
 import CourseRow from './CourseRow';
 import { courseListToolTip } from './util';
+import FinancialAidCalculator from '../../containers/FinancialAidCalculator';
 
-const ifPersonalizedPricing = R.curry((func, program) => (
-  program.financial_aid_availability ? func(program) : null
+const ifPersonalizedPricing = R.curry((func, program, callback) => (
+  program.financial_aid_availability ? func(callback) : null
 ));
 
 const price = price => <span className="price">{ price }</span>;
 
-const coursePriceRange = ifPersonalizedPricing(() => (
+const coursePriceRange = ifPersonalizedPricing(openDialog => (
   <div className="personalized-pricing">
     <div className="heading">
       How much does it cost?
@@ -27,6 +28,7 @@ const coursePriceRange = ifPersonalizedPricing(() => (
     </div>
     <button
       className="mm-button dashboard-button"
+      onClick={openDialog}
     >
       Calculate your cost
     </button>
@@ -36,13 +38,19 @@ const coursePriceRange = ifPersonalizedPricing(() => (
 
 export default class CourseListCard extends React.Component {
   props: {
-    checkout: Function,
-    program: Program,
-    now?: Object,
+    checkout:                   Function,
+    program:                    Program,
+    now?:                       Object,
+    openFinancialAidCalculator: () => void,
   };
 
   render() {
-    let { program, now, checkout } = this.props;
+    let {
+      program,
+      now,
+      checkout,
+      openFinancialAidCalculator,
+    } = this.props;
     if (now === undefined) {
       now = moment();
     }
@@ -53,8 +61,9 @@ export default class CourseListCard extends React.Component {
     );
 
     return <Card shadow={0} className="course-list">
+      <FinancialAidCalculator />
       <CardTitle>Your Courses</CardTitle>
-      { coursePriceRange(program) }
+      { coursePriceRange(program, openFinancialAidCalculator) }
       {courseRows}
     </Card>;
   }

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -15,7 +15,14 @@ describe('CourseListCard', () => {
     assert(program.courses.length > 0);
     let now = moment();
     const checkout = () => null;
-    const wrapper = shallow(<CourseListCard program={program} now={now} checkout={checkout} />);
+    const wrapper = shallow(
+      <CourseListCard
+        program={program}
+        now={now}
+        checkout={checkout}
+        openFinancialAidCalculator={() => undefined}
+      />
+    );
     assert.equal(wrapper.find(CourseRow).length, program.courses.length);
     wrapper.find(CourseRow).forEach((courseRow, i) => {
       const props = courseRow.props();
@@ -28,7 +35,9 @@ describe('CourseListCard', () => {
   it("fills in now if it's missing in the props", () => {
     const program = DASHBOARD_RESPONSE[1];
     assert(program.courses.length > 0);
-    const wrapper = shallow(<CourseListCard program={program} checkout={() => null} />);
+    const wrapper = shallow(
+      <CourseListCard program={program} checkout={() => null} openFinancialAidCalculator={() => undefined} />
+    );
     let nows = wrapper.find(CourseRow).map(courseRow => courseRow.props().now);
     assert(nows.length > 0);
     for (let now of nows) {
@@ -40,14 +49,18 @@ describe('CourseListCard', () => {
   it("doesn't show the personalized pricing box for programs without it", () => {
     const program = _.cloneDeep(DASHBOARD_RESPONSE[1]);
     program.financial_aid_availability = false;
-    const wrapper = shallow(<CourseListCard program={program} checkout={() => null} />);
+    const wrapper = shallow(
+      <CourseListCard program={program} checkout={() => null} openFinancialAidCalculator={() => undefined} />
+    );
     assert.equal(wrapper.find('.personalized-pricing').length, 0);
   });
 
   it("shows the personalized pricing box for programs that have it", () => {
     const program = _.cloneDeep(DASHBOARD_RESPONSE[1]);
     program.financial_aid_availability = true;
-    const wrapper = shallow(<CourseListCard program={program} checkout={() => null} />);
+    const wrapper = shallow(
+      <CourseListCard program={program} checkout={() => null} openFinancialAidCalculator={() => undefined} />
+    );
     assert.equal(wrapper.find('.personalized-pricing').length, 1);
   });
 });

--- a/static/js/components/inputs/SelectField.js
+++ b/static/js/components/inputs/SelectField.js
@@ -22,6 +22,7 @@ class SelectField extends React.Component {
   editKeySet: string[];
 
   props: {
+    id?:                      string,
     profile:                  Profile,
     autocompleteStyleProps:   Object,
     autocompleteBehaviors:    Array<any>,
@@ -159,9 +160,10 @@ class SelectField extends React.Component {
   };
   
   render() {
-    const { errors, keySet } = this.props;
+    const { errors, keySet, id } = this.props;
     return (
       <AutoComplete
+        id={id}
         className={validationErrorSelector(errors, keySet)}
         searchText={this.getSearchText()}
         {...this.getAutocompleteProps()}

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -21,6 +21,8 @@ import CourseListCard from '../components/dashboard/CourseListCard';
 import DashboardUserCard from '../components/dashboard/DashboardUserCard';
 import ErrorMessage from '../components/ErrorMessage';
 import ProgressWidget from '../components/ProgressWidget';
+import { setCalculatorDialogVisibility } from '../actions/ui';
+import { startCalculatorEdit } from '../actions/financial_aid';
 import type { DashboardState } from '../flow/dashboardTypes';
 import type { ProgramEnrollment } from '../flow/enrollmentTypes';
 import type { ProfileGetResult } from '../flow/profileTypes';
@@ -35,6 +37,7 @@ class DashboardPage extends React.Component {
     currentProgramEnrollment: ProgramEnrollment,
     dashboard:                DashboardState,
     dispatch:                 Dispatch,
+    setCalculatorVisibility:  (b: boolean) => void,
   };
 
   componentDidMount() {
@@ -94,6 +97,12 @@ class DashboardPage extends React.Component {
     });
   };
 
+  openFinancialAidCalculator = () => {
+    const { dispatch, currentProgramEnrollment } = this.props;
+    dispatch(setCalculatorDialogVisibility(true));
+    dispatch(startCalculatorEdit(currentProgramEnrollment.id));
+  };
+
   render() {
     const {
       dashboard,
@@ -121,6 +130,7 @@ class DashboardPage extends React.Component {
               program={program}
               key={program.id}
               checkout={this.dispatchCheckout}
+              openFinancialAidCalculator={this.openFinancialAidCalculator}
             />
           </div>
           <div className="second-column">

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -1,0 +1,212 @@
+import React from 'react';
+import Dialog from 'material-ui/Dialog';
+import { connect } from 'react-redux';
+import R from 'ramda';
+import Button from 'react-mdl/lib/Button';
+import TextField from 'material-ui/TextField';
+import Checkbox from 'react-mdl/lib/Checkbox';
+
+import {
+  updateCalculatorEdit,
+  clearCalculatorEdit,
+  addFinancialAid,
+  updateCalculatorValidation,
+} from '../actions/financial_aid';
+import { setCalculatorDialogVisibility } from '../actions/ui';
+import { createSimpleActionHelpers } from '../util/redux';
+import SelectField from '../components/inputs/SelectField';
+import { currencyOptions } from '../util/currency';
+import {
+  validateFinancialAid,
+  sanitizeNumberString
+} from '../util/validation';
+import type { ProgramEnrollment } from '../flow/enrollmentTypes';
+import type {
+  FinancialAidState,
+  FinancialAidValidation,
+} from '../reducers/financial_aid';
+
+const currencySelect = (update, current) => (
+  <SelectField
+    options={currencyOptions}
+    keySet={['currency']}
+    profile={current}
+    onChange={update}
+    updateProfile={update}
+    name="currency"
+    id="currency-select"
+  />
+);
+
+const salaryUpdate = R.curry((update, current, e) => {
+  let newEdit = R.clone(current);
+  newEdit.income = sanitizeNumberString(e.target.value, 20);
+  update(newEdit);
+});
+
+const salaryField = (update, current) => (
+  <TextField
+    name="salary"
+    id="user-salary-input"
+    className="salary-field"
+    value={current.income}
+    fullWidth={true}
+    onChange={salaryUpdate(update, current)}
+  />
+);
+
+const checkboxText = `I testify that the income I reported is true and accurate.
+I am aware that I may be asked to verify my income with documentation.`;
+
+const checkboxUpdate = (update, current, bool) => {
+  let newEdit = R.clone(current);
+  newEdit.checkBox = bool;
+  update(newEdit);
+};
+
+const checkBox = (update, current) => (
+  <Checkbox
+    checked={current.checkBox}
+    label={checkboxText}
+    onChange={() => checkboxUpdate(update, current, !current.checkBox)}
+  />
+);
+
+const actionButtons = R.map(({ name, onClick, label}) => (
+  <Button
+    type='button'
+    className={`${name}-button mm-button`}
+    key={name}
+    onClick={onClick}>
+    { label }
+  </Button>
+));
+
+const calculatorActions = (cancel, save) => {
+  const buttonManifest = [
+    { name: 'cancel', onClick: cancel, label: 'Cancel' },
+    { name: 'main-action save', onClick: save, label: 'Calculate' },
+  ];
+
+  return <div className="actions">
+    <a className="full-price">
+      Skip this and Pay Full Price
+    </a>
+    <div className="buttons">
+      { actionButtons(buttonManifest) }
+    </div>
+  </div>;
+};
+
+const validationMessage = (key, errors) => {
+  if ( errors === undefined || R.isNil(errors[key]) ) {
+    return null;
+  }
+  return <div className="validation-message">
+    { errors[key] }
+  </div>;
+};
+
+type CalculatorProps = {
+  calculatorDialogVisibility: boolean,
+  closeDialogAndCancel:       () => void,
+  financialAid:               FinancialAidState,
+  validation:                 FinancialAidValidation,
+  saveFinancialAid:           (f: FinancialAidState) => void,
+  updateCalculatorEdit:       (f: FinancialAidState) => void,
+  currentProgramEnrollment:   ProgramEnrollment,
+};
+
+const FinancialAidCalculator = ({
+  calculatorDialogVisibility,
+  closeDialogAndCancel,
+  financialAid,
+  financialAid: { validation },
+  saveFinancialAid,
+  updateCalculatorEdit,
+  currentProgramEnrollment: { title },
+}: CalculatorProps) => (
+  <Dialog
+    open={calculatorDialogVisibility}
+    contentClassName="financial-aid-calculator"
+    bodyClassName="financial-aid-calculator-body"
+    onRequestClose={closeDialogAndCancel}
+    autoScrollBodyContent={true}
+    actions={calculatorActions(closeDialogAndCancel, () => saveFinancialAid(financialAid))}
+    title="Cost Calculator"
+  >
+    <div className="copy">
+      { `The cost of courses in the ${title} Micromasters varies between $50 and $1000,
+      based on your income and ability to pay.`}
+    </div>
+    <div className="salary-input">
+      <div className="income">
+        <div>
+          Income (yearly)
+        </div>
+        { salaryField(updateCalculatorEdit, financialAid) }
+        { validationMessage('income', validation) }
+      </div>
+      <div className="currency">
+        <div>
+          Currency
+        </div>
+        { currencySelect(updateCalculatorEdit, financialAid) }
+        { validationMessage('currency', validation) }
+      </div>
+    </div>
+    <div className="checkbox">
+      { checkBox(updateCalculatorEdit, financialAid) }
+    </div>
+    <div className="checkbox-alert">
+      { validationMessage('checkBox', validation) }
+    </div>
+  </Dialog>
+);
+
+const closeDialogAndCancel = dispatch => (
+  () => {
+    dispatch(setCalculatorDialogVisibility(false));
+    dispatch(clearCalculatorEdit());
+  }
+);
+
+const saveFinancialAid = R.curry((dispatch, current) => {
+  const { income, currency, programId } = current;
+  let errors = validateFinancialAid(current);
+  if ( ! R.isEmpty(errors) ) {
+    dispatch(updateCalculatorValidation(errors));
+  } else {
+    dispatch(addFinancialAid(income, currency, programId)).then(() => {
+      dispatch(clearCalculatorEdit());
+      dispatch(setCalculatorDialogVisibility(false));
+    });
+  }
+});
+
+const mapStateToProps = state => {
+  const {
+    ui: { calculatorDialogVisibility },
+    financialAid,
+    currentProgramEnrollment,
+  } = state;
+
+  return {
+    calculatorDialogVisibility,
+    financialAid,
+    currentProgramEnrollment,
+  };
+};
+
+const mapDispatchToProps = dispatch => {
+  return {
+    closeDialogAndCancel: closeDialogAndCancel(dispatch),
+    saveFinancialAid: saveFinancialAid(dispatch),
+    ...createSimpleActionHelpers(dispatch, [
+      ['clearCalculatorEdit', clearCalculatorEdit],
+      ['updateCalculatorEdit', updateCalculatorEdit],
+    ]),
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(FinancialAidCalculator);

--- a/static/js/reducers/financial_aid.js
+++ b/static/js/reducers/financial_aid.js
@@ -1,0 +1,63 @@
+// @flow
+import {
+  START_CALCULATOR_EDIT,
+  CLEAR_CALCULATOR_EDIT,
+  UPDATE_CALCULATOR_EDIT,
+  UPDATE_CALCULATOR_VALIDATION,
+  REQUEST_ADD_FINANCIAL_AID,
+  RECEIVE_ADD_FINANCIAL_AID_SUCCESS,
+  RECEIVE_ADD_FINANCIAL_AID_FAILURE
+} from '../actions/financial_aid';
+import {
+  FETCH_FAILURE,
+  FETCH_PROCESSING,
+  FETCH_SUCCESS,
+} from '../actions';
+import type { Action } from '../flow/reduxTypes';
+
+export const INITIAL_FINANCIAL_AID_STATE = {};
+
+export const FINANCIAL_AID_EDIT = {
+  income:       "",
+  currency:     "",
+  checkBox:     false,
+  fetchStatus:  null,
+  programId:    null,
+  validation:   {},
+};
+
+export type FinancialAidValidation = {
+  income?: string,
+  currency?: string,
+  checkBox?: string,
+};
+
+export type FinancialAidState = {
+  income?:      string,
+  currency?:    string,
+  checkBox?:    boolean,
+  fetchStatus?: string,
+  programId?:   number,
+  validation?:  FinancialAidValidation,
+};
+
+export const financialAid = (state: FinancialAidState = INITIAL_FINANCIAL_AID_STATE, action: Action) => {
+  switch (action.type) {
+  case START_CALCULATOR_EDIT:
+    return { ...FINANCIAL_AID_EDIT, programId: action.payload };
+  case CLEAR_CALCULATOR_EDIT:
+    return INITIAL_FINANCIAL_AID_STATE;
+  case UPDATE_CALCULATOR_EDIT:
+    return { ...state, ...action.payload };
+  case UPDATE_CALCULATOR_VALIDATION:
+    return { ...state, validation: action.payload };
+  case REQUEST_ADD_FINANCIAL_AID:
+    return { ...state, fetchStatus: FETCH_PROCESSING };
+  case RECEIVE_ADD_FINANCIAL_AID_SUCCESS:
+    return { ...state, fetchStatus: FETCH_SUCCESS };
+  case RECEIVE_ADD_FINANCIAL_AID_FAILURE:
+    return { ...state, fetchStatus: FETCH_FAILURE };
+  default:
+    return state;
+  }
+};

--- a/static/js/reducers/financial_aid_test.js
+++ b/static/js/reducers/financial_aid_test.js
@@ -1,0 +1,125 @@
+// @flow
+import configureTestStore from 'redux-asserts';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import R from 'ramda';
+
+import {
+  START_CALCULATOR_EDIT,
+  startCalculatorEdit,
+  CLEAR_CALCULATOR_EDIT,
+  clearCalculatorEdit,
+  UPDATE_CALCULATOR_EDIT,
+  updateCalculatorEdit,
+  UPDATE_CALCULATOR_VALIDATION,
+  updateCalculatorValidation,
+  REQUEST_ADD_FINANCIAL_AID,
+  requestAddFinancialAid,
+  RECEIVE_ADD_FINANCIAL_AID_SUCCESS,
+  RECEIVE_ADD_FINANCIAL_AID_FAILURE,
+  addFinancialAid,
+} from '../actions/financial_aid';
+import {
+  FETCH_FAILURE,
+  FETCH_PROCESSING,
+  FETCH_SUCCESS,
+} from '../actions';
+import { setCurrentProgramEnrollment } from '../actions/enrollments';
+import {
+  FINANCIAL_AID_EDIT,
+  INITIAL_FINANCIAL_AID_STATE,
+} from './financial_aid';
+import rootReducer from '../reducers';
+import * as api from '../util/api';
+
+describe('financial aid reducers', () => {
+  let sandbox, store, dispatchThen;
+  let addFinancialAidStub;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    store = configureTestStore(rootReducer);
+    dispatchThen = store.createDispatchThen(state => state.financialAid);
+    store.dispatch(setCurrentProgramEnrollment(1));
+    addFinancialAidStub = sandbox.stub(api, 'addFinancialAid');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should let you start editing', () => {
+    return dispatchThen(startCalculatorEdit(1), [START_CALCULATOR_EDIT]).then(state => {
+      let expectation = Object.assign({}, FINANCIAL_AID_EDIT, {
+        programId: 1
+      });
+      assert.deepEqual(state, expectation);
+    });
+  });
+
+
+  it('should let you clear edits', () => {
+    store.dispatch(startCalculatorEdit(1));
+    return dispatchThen(clearCalculatorEdit(), [CLEAR_CALCULATOR_EDIT]).then(state => {
+      assert.deepEqual(state, INITIAL_FINANCIAL_AID_STATE);
+    });
+  });
+
+  it('should let you update an edit in progress', () => {
+    store.dispatch(startCalculatorEdit(1));
+    let update = R.clone(store.getState().financialAid);
+    update.income = '1000000';
+    return dispatchThen(updateCalculatorEdit(update), [UPDATE_CALCULATOR_EDIT]).then(state => {
+      assert.deepEqual(state, update);
+    });
+  });
+
+  it('should let you update the validation', () => {
+    store.dispatch(startCalculatorEdit(1));
+    let validation = { some: 'error' };
+    return dispatchThen(updateCalculatorValidation(validation), [
+      UPDATE_CALCULATOR_VALIDATION
+    ]).then(state => {
+      assert.deepEqual(state.validation, validation);
+    });
+  });
+
+  it('should process adding a financial aid object', () => {
+    store.dispatch(startCalculatorEdit(1));
+    return dispatchThen(requestAddFinancialAid(100000, 'USD', 1), [
+      REQUEST_ADD_FINANCIAL_AID
+    ]).then(state => {
+      assert.equal(state.fetchStatus, FETCH_PROCESSING);
+    });
+  });
+
+  it('should let you add financial aid', () => {
+    addFinancialAidStub.returns(Promise.resolve());
+    store.dispatch(startCalculatorEdit(1));
+    return dispatchThen(addFinancialAid(100000, 'USD', 1), [
+      REQUEST_ADD_FINANCIAL_AID,
+      RECEIVE_ADD_FINANCIAL_AID_SUCCESS,
+    ]).then(state => {
+      let expectation = Object.assign({}, FINANCIAL_AID_EDIT, {
+        programId: 1,
+        fetchStatus: FETCH_SUCCESS
+      });
+      assert.deepEqual(state, expectation);
+    });
+  });
+
+  it('should fail to add a financial aid', () => {
+    addFinancialAidStub.returns(Promise.reject());
+    store.dispatch(startCalculatorEdit(1));
+    return dispatchThen(addFinancialAid(100000, 'USD', 1), [
+      REQUEST_ADD_FINANCIAL_AID,
+      RECEIVE_ADD_FINANCIAL_AID_FAILURE,
+    ]).then(state => {
+      let expectation = Object.assign({}, FINANCIAL_AID_EDIT, {
+        programId: 1,
+        fetchStatus: FETCH_FAILURE
+      });
+      assert.deepEqual(state, expectation);
+    });
+  });
+});

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -42,6 +42,7 @@ import type {
 } from '../flow/profileTypes';
 import { signupDialog } from './signup_dialog';
 import { imageUpload } from './image_upload';
+import { financialAid } from './financial_aid';
 
 export const INITIAL_PROFILES_STATE = {};
 export const profiles = (state: Profiles = INITIAL_PROFILES_STATE, action: Action) => {
@@ -200,4 +201,5 @@ export default combineReducers({
   currentProgramEnrollment,
   signupDialog,
   imageUpload,
+  financialAid,
 });

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -34,6 +34,7 @@ import {
   SET_ENROLL_SELECTED_PROGRAM,
 
   SET_PHOTO_DIALOG_VISIBILITY,
+  SET_CALCULATOR_DIALOG_VISIBILITY,
 } from '../actions/ui';
 import { PERSONAL_STEP } from '../constants';
 import type { ToastMessage } from '../flow/generalTypes';
@@ -68,6 +69,7 @@ export type UIState = {
   toastMessage:                 ?ToastMessage;
   enrollSelectedProgram:        ?number;
   photoDialogVisibility:        boolean;
+  calculatorDialogVisibility:   boolean;
 };
 
 export const INITIAL_UI_STATE: UIState = {
@@ -94,6 +96,7 @@ export const INITIAL_UI_STATE: UIState = {
   toastMessage: null,
   enrollSelectedProgram: null,
   photoDialogVisibility: false,
+  calculatorDialogVisibility: false,
 };
 
 export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
@@ -218,6 +221,8 @@ export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
   }
   case SET_PHOTO_DIALOG_VISIBILITY:
     return { ...state, photoDialogVisibility: action.payload };
+  case SET_CALCULATOR_DIALOG_VISIBILITY:
+    return { ...state, calculatorDialogVisibility: action.payload };
   default:
     return state;
   }

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -26,6 +26,7 @@ import {
   setToastMessage,
   setEnrollSelectedProgram,
   setPhotoDialogVisibility,
+  setCalculatorDialogVisibility,
 } from '../actions/ui';
 import { INITIAL_UI_STATE } from '../reducers/ui';
 import type { UIState } from '../reducers/ui';
@@ -185,6 +186,12 @@ describe('ui reducers', () => {
 
     it('sets the enrollment dialog currently selected program', () => {
       assertReducerResultState(setEnrollSelectedProgram, ui => ui.enrollSelectedProgram, null);
+    });
+  });
+
+  describe('Calculator visibility', () => {
+    it('should let you set calculator visibility', () => {
+      assertReducerResultState(setCalculatorDialogVisibility, ui => ui.calculatorDialogVisibility, false);
     });
   });
 });

--- a/static/js/util/api.js
+++ b/static/js/util/api.js
@@ -195,3 +195,14 @@ export function updateProfileImage(username: string, image: Blob, name: string):
     body: formData
   });
 }
+
+export function addFinancialAid(income: number, currency: string, programId: number): Promise<*> {
+  return mockableFetchJSONWithCSRF('/api/v0/financial_aid_request/', {
+    method: 'POST',
+    body: JSON.stringify({
+      original_income: income,
+      original_currency: currency,
+      program_id: programId
+    })
+  });
+}

--- a/static/js/util/api_test.js
+++ b/static/js/util/api_test.js
@@ -15,6 +15,7 @@ import {
   getProgramEnrollments,
   addProgramEnrollment,
   updateProfileImage,
+  addFinancialAid,
 } from './api';
 import * as api from './api';
 import {
@@ -241,6 +242,45 @@ describe('api', function() {
           assert.ok(fetchJSONStub.calledWith('/api/v0/enrolledprograms/', {
             method: 'POST',
             body: JSON.stringify({program_id: enrollment.id})
+          }));
+        });
+      });
+    });
+
+    describe('for adding financial aid', () => {
+      it('add financial aid successfully', () => {
+        let programId = PROGRAM_ENROLLMENTS[0].id;
+        fetchJSONStub.returns(Promise.resolve());
+
+        fetchMock.mock('/api/v0/financial_aid_request', () => {
+          return { status: 200 };
+        });
+
+        return addFinancialAid(10000, 'USD', programId).then(() => {
+          assert.ok(fetchJSONStub.calledWith('/api/v0/financial_aid_request/', {
+            method: 'POST',
+            body: JSON.stringify({
+              original_income: 10000,
+              original_currency: 'USD',
+              program_id: 3
+            })
+          }));
+        });
+      });
+
+      it('fails to add financial aid', () => {
+        fetchJSONStub.returns(Promise.reject());
+
+        let programId = PROGRAM_ENROLLMENTS[0].id;
+
+        return assert.isRejected(addFinancialAid(10000, 'USD', programId)).then(() => {
+          assert.ok(fetchJSONStub.calledWith('/api/v0/financial_aid_request/', {
+            method: 'POST',
+            body: JSON.stringify({
+              original_income: 10000,
+              original_currency: 'USD',
+              program_id: 3
+            })
           }));
         });
       });

--- a/static/js/util/currency.js
+++ b/static/js/util/currency.js
@@ -1,0 +1,17 @@
+// @flow
+import cc from 'currency-codes';
+import R from 'ramda';
+
+const codeToOption = code => (
+  { value: code, label: cc.code(code).currency }
+);
+
+const labelSort = R.sortBy(R.compose(R.toLower, R.prop('label')));
+
+const excludeUnusedCodes = R.reject(R.flip(R.contains)(['USS', 'USN']));
+
+const codesToOptions = R.compose(
+  labelSort, R.map(codeToOption), excludeUnusedCodes
+);
+
+export const currencyOptions = codesToOptions(cc.codes());

--- a/static/js/util/redux.js
+++ b/static/js/util/redux.js
@@ -20,7 +20,7 @@ export function createActionHelper(dispatch: Dispatch, actionCreator: Function):
  * returns an array of simple (synchronous) action helpers when passed the
  * dispatch function and an array of synchronous action creators
  */
-export type ActionHelpers = Array<{[k: string]: (...args: any) => void}>;
+export type ActionHelpers = {[k: string]: (...args: any) => void};
 export type ActionManifest = Array<[string, ActionCreator]>;
 export function createSimpleActionHelpers(dispatch: Dispatch, actionList: ActionManifest): ActionHelpers {
   return R.fromPairs(

--- a/static/js/util/validation.js
+++ b/static/js/util/validation.js
@@ -9,6 +9,10 @@ import type {
 } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 import type { Email } from '../flow/emailTypes';
+import type {
+  FinancialAidState,
+  FinancialAidValidation,
+} from '../reducers/financial_aid';
 import { filterPositiveInt } from './util';
 import {
   HIGH_SCHOOL,
@@ -30,7 +34,7 @@ let isNilOrEmptyString = (val: any): boolean => (
   val === null || val === undefined || val === ""
 );
 
-let checkFieldPresence = (profile, requiredFields, messages: any): ValidationErrors => {
+let checkFieldPresence = (profile, requiredFields, messages: any) => {
   let errors = {};
 
   for (let keySet of requiredFields) {
@@ -221,7 +225,7 @@ export function validateProfileComplete(profile: Profile): ProfileComplete {
  * Validate a day of month
  */
 export function validateDay(input: string): Maybe<number> {
-  let sanitized = sanitizeDate(input, 2);
+  let sanitized = sanitizeNumberString(input, 2);
   let date = filterPositiveInt(sanitized);
   if (date === undefined) {
     return Nothing();
@@ -236,7 +240,7 @@ export function validateDay(input: string): Maybe<number> {
 /**
  * Removes non-numeric characters and truncates output string
  */
-export function sanitizeDate(input: string|number, length: number): string {
+export function sanitizeNumberString(input: string|number, length: number): string {
   if ( typeof input === 'string' ) {
     let out = input.replace(/[^\d]+/g, '');
     if ( out.match(/^0+/) ) {
@@ -256,7 +260,7 @@ export function sanitizeDate(input: string|number, length: number): string {
  * Validate a month number
  */
 export function validateMonth(input: string|number): Maybe<number> {
-  let sanitized = sanitizeDate(input, 2);
+  let sanitized = sanitizeNumberString(input, 2);
   let month = filterPositiveInt(sanitized);
   if (month === undefined) {
     return Nothing();
@@ -274,7 +278,7 @@ export function validateYear(input: string|number|null): Maybe<number> {
   if ( input === null ) {
     return Nothing();
   }
-  let sanitized = sanitizeDate(input, 4);
+  let sanitized = sanitizeNumberString(input, 4);
   let year = filterPositiveInt(sanitized);
   if (year === undefined) {
     return Nothing();
@@ -298,4 +302,17 @@ export function combineValidators(...validators: Array<Function>): Function {
   return (...args) => _.merge({}, ...validators.map(
     validator => validator(...args)
   ));
+}
+
+export function validateFinancialAid(edit: FinancialAidState): FinancialAidValidation {
+  let messages = {
+    'income': 'Income is required',
+    'currency': 'Please select a currency',
+  };
+  let required = Object.keys(messages).map(k => [k]);
+  let errors: FinancialAidValidation = checkFieldPresence(edit, required, messages);
+  if ( !edit.checkBox ) {
+    errors['checkBox'] = 'You must agree to these terms';
+  }
+  return errors;
 }

--- a/static/js/util/validation_test.js
+++ b/static/js/util/validation_test.js
@@ -15,8 +15,9 @@ import {
   validateMonth,
   validateYear,
   combineValidators,
-  sanitizeDate,
+  sanitizeNumberString,
   emailValidation,
+  validateFinancialAid,
 } from './validation';
 import {
   USER_PROFILE_RESPONSE,
@@ -274,7 +275,7 @@ describe('Profile validation functions', () => {
     });
   });
 
-  describe('sanitizeDate', () => {
+  describe('sanitizeNumberString', () => {
     describe('string input', () => {
       it('should remove any non-numerical characters', () => {
         [
@@ -284,7 +285,7 @@ describe('Profile validation functions', () => {
           ['A(*@$%!@#$100', 2, '10'],
           ['eggplant 1X00 hey', 10, '100']
         ].forEach(([input, length, expectation]) => {
-          assert.deepEqual(sanitizeDate(input, length), expectation);
+          assert.deepEqual(sanitizeNumberString(input, length), expectation);
         });
       });
 
@@ -297,22 +298,22 @@ describe('Profile validation functions', () => {
           ['TESTS', 25, ''],
           ['1991', 0, '']
         ].forEach(([input, length, expectation]) => {
-          assert.deepEqual(sanitizeDate(input, length), expectation);
+          assert.deepEqual(sanitizeNumberString(input, length), expectation);
         });
       });
 
       it('should leave leading zeros when under the length', () => {
-        assert.equal(sanitizeDate('09', 2), '09');
+        assert.equal(sanitizeNumberString('09', 2), '09');
       });
 
       it('should remove leading zeros when over the length', () => {
-        assert.equal(sanitizeDate('01999', 4), '1999');
+        assert.equal(sanitizeNumberString('01999', 4), '1999');
       });
     });
 
     describe('numerical input', () => {
       it('should return a string', () => {
-        assert.deepEqual(sanitizeDate(3, 1), '3');
+        assert.deepEqual(sanitizeNumberString(3, 1), '3');
       });
 
       it('should trim a number down to the correct number of places', () => {
@@ -321,7 +322,7 @@ describe('Profile validation functions', () => {
           [1999, 2, '19'],
           [112341234, 1, '1']
         ].forEach(([input, length, expectation]) => {
-          assert.deepEqual(sanitizeDate(input, length), expectation);
+          assert.deepEqual(sanitizeNumberString(input, length), expectation);
         });
       });
     });
@@ -504,5 +505,41 @@ describe('Email validation', () => {
   it('should return no errors if all fields are filled out', () => {
     let errors = emailValidation(email);
     assert.deepEqual(errors, {});
+  });
+});
+
+describe('financial aid validation', () => {
+  let financialAid;
+
+  beforeEach(() => {
+    financialAid = {
+      income: '1000000',
+      currency: 'JPY',
+      checkBox: true
+    };
+  });
+
+  it('should complain if income is empty', () => {
+    financialAid.income = undefined;
+    let errors = validateFinancialAid(financialAid);
+    assert.deepEqual(errors, {
+      income: 'Income is required'
+    });
+  });
+
+  it('should complain if currency is empty', () => {
+    financialAid.currency = undefined;
+    let errors = validateFinancialAid(financialAid);
+    assert.deepEqual(errors, {
+      currency: 'Please select a currency'
+    });
+  });
+
+  it('should complain if the checkBox is false', () => {
+    financialAid.checkBox = false;
+    let errors = validateFinancialAid(financialAid);
+    assert.deepEqual(errors, {
+      checkBox: 'You must agree to these terms'
+    });
   });
 });

--- a/static/scss/calculator.scss
+++ b/static/scss/calculator.scss
@@ -1,0 +1,68 @@
+.financial-aid-calculator {
+  div {
+    border-top: none !important;
+  }
+
+  .mm-button {
+    padding-top: 1px;
+  }
+
+  .validation-message {
+    font-size: 12px;
+    color: $validation-red;
+  }
+
+  h3 {
+    border-bottom: none !important;
+    padding: 40px 40px 20px !important;
+  }
+
+  .financial-aid-calculator-body {
+    padding: 0 40px 20px !important;
+  }
+
+  .salary-input, .salary-input > div {
+    display:  flex;
+  }
+
+  .salary-input {
+    background-color: $lightgrey;
+    padding: 30px;
+    margin-top: 25px;
+    flex-direction: row;
+    justify-content: space-between;
+
+    > div {
+      flex-direction: column;
+      width: 48%;
+
+      > .title {
+        font-weight: 600;
+      }
+    }
+  }
+
+  .checkbox {
+    padding: 15px;
+    font-size: 14px;
+    line-height: 10px;
+    font-weight: 300;
+  }
+
+  .checkbox-alert {
+    margin-left: 38px;
+    margin-top: 7px;
+  }
+
+  .actions {
+    width: 100%;
+    padding: 0 20px 20px 40px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+
+    .buttons {
+      display: flex;
+    }
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -25,6 +25,7 @@
 @import "footer";
 @import "profile-image";
 @import "profile-image-uploader";
+@import "calculator";
 
 .selected {
   font-weight: bold;


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1097 

#### What's this PR do?

This adds the financial aid calculator. This comprises:

- function to hit the REST API
- new reducer for financial aid stuff (and actions)
- UI components to render the calculator
- validation code for the calculator form
- a little bit of code to deal with countries -> currencies


#### Where should the reviewer start?

Read over the changes?

#### How should this be manually tested?

You should be able to go `/dashboard` and click 'Calculate your cost' to open the calculator. Fill in a salary amount and select `USD` ('United States Dollars') from the currency list. Then submitting the form should create a financial aid object for your user and program combo.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

![calculator](https://cloud.githubusercontent.com/assets/6207644/18918367/8e4f9a66-8568-11e6-9613-1b90eb9f49e5.png)

#### What GIF best describes this PR or how it makes you feel?
