### PR TITLE
Implemented personal pricing for ecommerce

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -21,6 +21,7 @@ from rest_framework.exceptions import ValidationError
 from backends.edxorg import EdxOrgOAuth2
 from courses.models import CourseRun
 from dashboard.api import update_cached_enrollment
+from dashboard.models import ProgramEnrollment
 from ecommerce.exceptions import (
     EcommerceEdxApiException,
     EcommerceException,
@@ -30,7 +31,7 @@ from ecommerce.models import (
     Line,
     Order,
 )
-from financialaid.api import get_course_price_for_learner
+from financialaid.api import get_formatted_course_price
 from financialaid.models import (
     FinancialAid,
     FinancialAidStatus,
@@ -108,8 +109,8 @@ def create_unfulfilled_order(course_id, user):
         Order: A newly created Order for the CourseRun with the given course_id
     """
     course_run = get_purchasable_course_run(course_id, user)
-
-    price_dict = get_course_price_for_learner(user, course_run.course.program)
+    enrollment = get_object_or_404(ProgramEnrollment, program=course_run.course.program, user=user)
+    price_dict = get_formatted_course_price(enrollment)
     price = price_dict['course_price']
     if price <= 0:
         log.warning(

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -68,8 +68,8 @@ def get_purchasable_course_run(course_key, user):
         raise
 
     if not FinancialAid.objects.filter(
-        tier_program__current=True,
-        tier_program__program__course__courserun=course_run,
+            tier_program__current=True,
+            tier_program__program__course__courserun=course_run,
     ).exists():
         log.warning("Course run %s has no attached financial aid")
         raise ValidationError("Course run {} does not have an attached financial aid application".format(course_key))

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -69,7 +69,7 @@ def get_purchasable_course_run(course_key, user):
 
     if not FinancialAid.objects.filter(
         tier_program__current=True,
-        tier_program__program__course__course_run=course_run,
+        tier_program__program__course__courserun=course_run,
     ).exists():
         log.warning("Course run %s has no attached financial aid")
         raise ValidationError("Course run {} does not have an attached financial aid application".format(course_key))

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -98,7 +98,7 @@ def create_unfulfilled_order(course_id, user):
     price = price_dict['course_price']
     if price <= 0:
         log.warning(
-            "Price to be charged for course run {} for user {} is less than or equal to zero: %s",
+            "Price to be charged for course run %s for user %s is less than or equal to zero: %s",
             course_id,
             get_social_username(user),
             price,

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -178,6 +178,17 @@ class PurchasableTests(ESTestCase):
         with self.assertRaises(Http404):
             get_purchasable_course_run(course_run.edx_course_key, user)
 
+    def test_no_program_enrollment(self):
+        """
+        For a user to purchase a course run they must already be enrolled in the program
+        """
+        course_run, user = create_purchasable_course_run()
+        ProgramEnrollment.objects.filter(program=course_run.course.program, user=user).delete()
+        try:
+            create_unfulfilled_order(course_run.edx_course_key, user)
+        except Http404:
+            pass
+
     def test_already_purchased(self):
         """
         Purchasable course runs must not be already purchased
@@ -230,7 +241,7 @@ class PurchasableTests(ESTestCase):
             autospec=True,
             return_value=course_run,
         ) as get_purchasable, patch(
-            'ecommerce.api.get_course_price_for_learner',
+            'ecommerce.api.get_formatted_course_price',
             autospec=True,
             return_value=price_dict,
         ) as get_price:

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -136,7 +136,7 @@ class PurchasableTests(ESTestCase):
         course_run, user = create_purchasable_course_run()
         price_obj = course_run.courseprice_set.get(is_valid=True)
 
-        for invalid_price in (0, -1.23):
+        for invalid_price in (0, -1.23,):
             price_obj.price = invalid_price
             price_obj.save()
 

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -7,18 +7,22 @@ import hashlib
 import hmac
 from urllib.parse import quote_plus
 
+from django.core.exceptions import ImproperlyConfigured
+from django.http.response import Http404
+from django.test import override_settings
 from mock import (
     MagicMock,
     patch,
 )
-from django.http.response import Http404
-from django.test import override_settings
 from rest_framework.exceptions import ValidationError
 from edx_api.enrollments import Enrollment
 
 from backends.pipeline_api import EdxOrgOAuth2
 from courses.factories import CourseRunFactory
-from dashboard.models import CachedEnrollment
+from dashboard.models import (
+    CachedEnrollment,
+    ProgramEnrollment,
+)
 from ecommerce.api import (
     create_unfulfilled_order,
     enroll_user_on_success,
@@ -49,20 +53,25 @@ def create_purchasable_course_run():
     """
     Creates a purchasable course run and an associated user
     """
-    course_run = CourseRunFactory.create(course__program__live=True)
+    course_run = CourseRunFactory.create(
+        course__program__live=True,
+        course__program__financial_aid_availability=True,
+    )
     CoursePriceFactory.create(course_run=course_run, is_valid=True)
     user = UserFactory.create()
+    ProgramEnrollment.objects.create(user=user, program=course_run.course.program)
     return course_run, user
 
 
 class PurchasableTests(ESTestCase):
     """
-    Tests for get_purchasable_courses and create_unfilfilled_order
+    Tests for get_purchasable_courses and create_unfulfilled_order
     """
 
     def test_success(self):
         """
-        A course run which is live, and has a price, was not already purchased, and should be purchasable
+        A course run which is live, has financial aid,
+        has a price, and was not already purchased, should be purchasable
         """
         course_run, user = create_purchasable_course_run()
         assert get_purchasable_course_run(course_run.edx_course_key, user) == course_run
@@ -74,6 +83,18 @@ class PurchasableTests(ESTestCase):
         course_run, user = create_purchasable_course_run()
         program = course_run.course.program
         program.live = False
+        program.save()
+
+        with self.assertRaises(Http404):
+            get_purchasable_course_run(course_run.edx_course_key, user)
+
+    def test_no_financial_aid(self):
+        """
+        Purchasable course runs must have financial aid
+        """
+        course_run, user = create_purchasable_course_run()
+        program = course_run.course.program
+        program.financial_aid_availability = False
         program.save()
 
         with self.assertRaises(Http404):
@@ -108,28 +129,61 @@ class PurchasableTests(ESTestCase):
 
         assert ex.exception.args[0] == 'Course run {} is already purchased'.format(course_run.edx_course_key)
 
+    def test_less_or_equal_to_zero(self):
+        """
+        An order may not have a negative or zero price
+        """
+        course_run, user = create_purchasable_course_run()
+        price_obj = course_run.courseprice_set.get(is_valid=True)
+
+        for invalid_price in (0, -1.23):
+            price_obj.price = invalid_price
+            price_obj.save()
+
+            with patch('ecommerce.api.get_purchasable_course_run', autospec=True, return_value=course_run) as mocked:
+                with self.assertRaises(ImproperlyConfigured) as ex:
+                    create_unfulfilled_order(course_run.edx_course_key, user)
+                assert ex.exception.args[0] == "Price to be charged is less than or equal to zero"
+            assert mocked.call_count == 1
+            assert mocked.call_args[0] == (course_run.edx_course_key, user)
+
+            assert Order.objects.count() == 0
+
     def test_create_order(self):
         """
         Create Order from a purchasable course
         """
         course_run, user = create_purchasable_course_run()
-        price = course_run.courseprice_set.get(is_valid=True).price
+        discounted_price = round(course_run.courseprice_set.get(is_valid=True).price/2, 2)
+        price_dict = {
+            "course_price": discounted_price
+        }
 
-        with patch('ecommerce.api.get_purchasable_course_run', autospec=True, return_value=course_run) as mocked:
+        with patch(
+            'ecommerce.api.get_purchasable_course_run',
+            autospec=True,
+            return_value=course_run,
+        ) as get_purchasable, patch(
+            'ecommerce.api.get_course_price_for_learner',
+            autospec=True,
+            return_value=price_dict,
+        ) as get_price:
             order = create_unfulfilled_order(course_run.edx_course_key, user)
-        assert mocked.call_count == 1
-        assert mocked.call_args[0] == (course_run.edx_course_key, user)
+        assert get_purchasable.call_count == 1
+        assert get_purchasable.call_args[0] == (course_run.edx_course_key, user)
+        assert get_price.call_count == 1
+        assert get_price.call_args[0] == (user, course_run.course.program)
 
         assert Order.objects.count() == 1
         assert order.status == Order.CREATED
-        assert order.total_price_paid == price
+        assert order.total_price_paid == discounted_price
         assert order.user == user
 
         assert order.line_set.count() == 1
         line = order.line_set.first()
         assert line.course_key == course_run.edx_course_key
         assert line.description == 'Seat for {}'.format(course_run.title)
-        assert line.price == price
+        assert line.price == discounted_price
 
 
 CYBERSOURCE_ACCESS_KEY = 'access'

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -249,7 +249,9 @@ class PurchasableTests(ESTestCase):
         assert get_purchasable.call_count == 1
         assert get_purchasable.call_args[0] == (course_run.edx_course_key, user)
         assert get_price.call_count == 1
-        assert get_price.call_args[0] == (user, course_run.course.program)
+        assert get_price.call_args[0] == (
+            ProgramEnrollment.objects.get(user=user, program=course_run.course.program),
+        )
 
         assert Order.objects.count() == 1
         assert order.status == Order.CREATED

--- a/financialaid/models.py
+++ b/financialaid/models.py
@@ -107,6 +107,7 @@ class FinancialAidStatus:
     REJECTED = 'rejected'
 
     ALL_STATUSES = [CREATED, APPROVED, AUTO_APPROVED, REJECTED, PENDING_DOCS, PENDING_MANUAL_APPROVAL]
+    TERMINAL_STATUSES = [APPROVED, AUTO_APPROVED, REJECTED]
     STATUS_MESSAGES_DICT = {
         CREATED: "Created Applications",
         AUTO_APPROVED: "Auto-approved Applications",


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1058 

#### What's this PR do?
Uses personal price when charging user.

#### How should this be manually tested?
Talk to me first to set up the Cybersource test environment variables

- Create a `TierProgram` for some program with some discount amount if you don't have one already. 
- Create a `FinancialAid` with status `approved` referencing that `TierProgram`.
-  Create a `CoursePrice` on some `CourseRun` which has `is_valid=True`. Make sure that the price is more than the discount you set. Set up `CourseRun` such that the enroll button shows up in the dashboard (soon to be replaced with a Pay button)
 - Click the enroll button. You should be directed to Cybersource. The total being requested should be equal to the price in `CoursePrice` minus the discount amount.
 - Go into the Django shell and verify that an `Order` is created for this course run, that it has `total_price_paid` equal to the discounted price, and that there is one `Line` in the `Order` whose `price` is also equal to the discounted price.

Then, test that negative or zero prices are rejected:
- Delete the `Order` that was created in the Django shell.
 - Set `CoursePrice.price` to a value lower or equal to the discount amount
 - Click the enroll button again. You should get a 500 error, and an `ImproperlyConfigured` exception in the Django console

#### What GIF best describes this PR or how it makes you feel?
![7ktihtl](https://cloud.githubusercontent.com/assets/863262/18928744/67a1d5a6-858f-11e6-8117-c9c618bc5145.png)
