### PR TITLE
Added course price API call to front end

### DIFF
--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -138,7 +138,10 @@ class FinancialAidMailAPITests(TestCase):
             cls.staff_user_profile = ProfileFactory.create()
         cls.financial_aid = FinancialAidFactory.create()
 
-    @override_settings(MAILGUN_FROM_EMAIL='mailgun_from_email@example.com', MAILGUN_RECIPIENT_OVERRIDE=None)
+    @override_settings(
+        MAILGUN_FROM_EMAIL='mailgun_from_email@example.com',
+        MAILGUN_RECIPIENT_OVERRIDE=None
+    )
     def test_financial_aid_email(self, mock_post):
         """
         Test that MailgunClient.send_financial_aid_email() sends an individual message
@@ -174,7 +177,10 @@ class FinancialAidMailAPITests(TestCase):
         assert audit.email_subject == 'email subject'
         assert audit.email_body == 'email body'
 
-    @override_settings(MAILGUN_FROM_EMAIL='mailgun_from_email@example.com', MAILGUN_RECIPIENT_OVERRIDE=None)
+    @override_settings(
+        MAILGUN_FROM_EMAIL='mailgun_from_email@example.com',
+        MAILGUN_RECIPIENT_OVERRIDE=None
+    )
     def test_financial_aid_email_with_blank_subject_and_body(self, mock_post):
         """
         Test that MailgunClient.send_financial_aid_email() sends an individual message

--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -21,7 +21,8 @@ from ecommerce.views import (
 from financialaid.views import (
     FinancialAidRequestView,
     FinancialAidActionView,
-    GetLearnerPriceForCourseView
+    CoursePriceListView,
+    CoursePriceDetailView
 )
 from profiles.views import ProfileViewSet
 from search.views import ElasticProxyView
@@ -50,8 +51,9 @@ urlpatterns = [
     url(r'^api/v0/financial_aid_request/$', FinancialAidRequestView.as_view(), name='financial_aid_request'),
     url(r'^api/v0/financial_aid_action/(?P<financial_aid_id>[\d]+)/$', FinancialAidActionView.as_view(),
         name='financial_aid_action'),
-    url(r'^api/v0/financial_aid_course_price/(?P<program_id>[\d]+)/$',
-        GetLearnerPriceForCourseView.as_view(), name='financial_aid_course_price'),
+    url(r'^api/v0/course_prices/$', CoursePriceListView.as_view(), name='course_price_list'),
+    url(r'^api/v0/course_prices/(?P<program_id>[\d]+)/$',
+        CoursePriceDetailView.as_view(), name='course_price_detail'),
     url(r'^api/v0/order_fulfillment/$', OrderFulfillmentView.as_view(), name='order-fulfillment'),
     url(r'^status/', include('server_status.urls')),
     url(r'^financial_aid/', include('financialaid.urls')),

--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -1,11 +1,12 @@
 // @flow
 import type { Dispatch } from 'redux';
+import { createAction } from 'redux-actions';
 
 import * as api from '../util/api';
 import type { CheckoutResponse } from '../flow/checkoutTypes';
 import type { APIErrorInfo } from '../flow/generalTypes';
 import type { Action, Dispatcher } from '../flow/reduxTypes';
-import type { Dashboard } from '../flow/dashboardTypes';
+import type { Dashboard, CoursePrices } from '../flow/dashboardTypes';
 
 // constants for fetch status (these are not action types)
 export const FETCH_FAILURE = 'FETCH_FAILURE';
@@ -73,3 +74,28 @@ export const receiveCheckoutFailure = (errorInfo: APIErrorInfo): Action => ({
   type: RECEIVE_CHECKOUT_FAILURE,
   payload: { errorInfo }
 });
+
+// course price actions
+export const REQUEST_COURSE_PRICES = 'REQUEST_COURSE_PRICES';
+const requestCoursePrices = createAction(REQUEST_COURSE_PRICES);
+
+export const RECEIVE_COURSE_PRICES_SUCCESS = 'RECEIVE_COURSE_PRICES_SUCCESS';
+const receiveCoursePricesSuccess = createAction(RECEIVE_COURSE_PRICES_SUCCESS);
+
+export const RECEIVE_COURSE_PRICES_FAILURE = 'RECEIVE_COURSE_PRICES_FAILURE';
+const receiveCoursePricesFailure = createAction(RECEIVE_COURSE_PRICES_FAILURE);
+
+export const CLEAR_COURSE_PRICES = 'CLEAR_COURSE_PRICES';
+export const clearCoursePrices = createAction(CLEAR_COURSE_PRICES);
+
+export function fetchCoursePrices(): Dispatcher<CoursePrices> {
+  return (dispatch: Dispatch) => {
+    dispatch(requestCoursePrices());
+    return api.getCoursePrices().
+      then(coursePrices => dispatch(receiveCoursePricesSuccess(coursePrices))).
+      catch(error => {
+        dispatch(receiveCoursePricesFailure(error));
+        // the exception is assumed handled and will not be propagated
+      });
+  };
+}

--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import {
   RECEIVE_DASHBOARD_FAILURE,
   RECEIVE_DASHBOARD_SUCCESS,
+  RECEIVE_COURSE_PRICES_SUCCESS,
 } from '../actions';
 import { SET_USER_PAGE_DIALOG_VISIBILITY } from '../actions/ui';
 import {
@@ -91,6 +92,7 @@ describe("ErrorMessage", () => {
 
       dashboardErrorActions = [
         RECEIVE_DASHBOARD_FAILURE,
+        RECEIVE_COURSE_PRICES_SUCCESS,
         RECEIVE_GET_USER_PROFILE_SUCCESS,
         RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
       ];
@@ -173,6 +175,7 @@ describe("ErrorMessage", () => {
 
         const types = [
           RECEIVE_DASHBOARD_SUCCESS,
+          RECEIVE_COURSE_PRICES_SUCCESS,
           RECEIVE_GET_USER_PROFILE_FAILURE,
           RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
         ];
@@ -198,6 +201,7 @@ describe("ErrorMessage", () => {
         let actions = [
           REQUEST_GET_USER_PROFILE,
           RECEIVE_DASHBOARD_SUCCESS,
+          RECEIVE_COURSE_PRICES_SUCCESS,
           RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
           RECEIVE_GET_USER_PROFILE_FAILURE,
         ];
@@ -215,6 +219,7 @@ describe("ErrorMessage", () => {
         let userPageActions = [
           REQUEST_GET_USER_PROFILE,
           RECEIVE_DASHBOARD_SUCCESS,
+          RECEIVE_COURSE_PRICES_SUCCESS,
           RECEIVE_GET_USER_PROFILE_SUCCESS,
           RECEIVE_GET_USER_PROFILE_SUCCESS,
         ];

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -5,6 +5,49 @@ export const BACHELORS = 'b';
 export const MASTERS = 'm';
 export const DOCTORATE = 'p';
 
+export const ISO_8601_FORMAT = 'YYYY-MM-DD';
+export const DASHBOARD_FORMAT = 'M/D/Y';
+
+// NOTE: this is in order of attainment
+export const EDUCATION_LEVELS = [
+  {value: HIGH_SCHOOL, label: "High school"},
+  {value: ASSOCIATE, label: 'Associate degree'},
+  {value: BACHELORS, label: "Bachelor's degree"},
+  {value: MASTERS, label: "Master's or professional degree"},
+  {value: DOCTORATE, label: "Doctorate"}
+];
+
+export const PERSONAL_STEP = 'personal';
+export const EMPLOYMENT_STEP = 'employment';
+export const EDUCATION_STEP = 'education';
+
+export const PROFILE_STEP_LABELS = new Map([
+  [PERSONAL_STEP, "Personal"],
+  [EDUCATION_STEP, "Education"],
+  [EMPLOYMENT_STEP, "Professional"]
+]);
+
+export const DEFAULT_OPTION_LIMIT_COUNT = 10;
+
+export const SEARCH_FILTER_DEFAULT_VISIBILITY = true;
+
+export const STATUS_PASSED = 'passed';
+export const STATUS_NOT_PASSED = 'not-passed';
+export const STATUS_CURRENTLY_ENROLLED = 'currently-enrolled';
+export const STATUS_CAN_UPGRADE = 'can-upgrade';
+export const STATUS_OFFERED = 'offered';
+
+export const ALL_COURSE_STATUSES = [
+  STATUS_PASSED,
+  STATUS_NOT_PASSED,
+  STATUS_OFFERED,
+  STATUS_CAN_UPGRADE,
+  STATUS_CURRENTLY_ENROLLED,
+];
+
+export const TOAST_SUCCESS = 'success';
+export const TOAST_FAILURE = 'failure';
+
 export const ELASTICSEARCH_RESPONSE = {
   "took": 22,
   "timed_out": false,
@@ -210,20 +253,6 @@ export const USER_PROFILE_RESPONSE = {
 export const USER_PROGRAM_RESPONSE = {
   "grade_average": 83
 };
-
-export const STATUS_PASSED = 'passed';
-export const STATUS_NOT_PASSED = 'not-passed';
-export const STATUS_CURRENTLY_ENROLLED = 'currently-enrolled';
-export const STATUS_CAN_UPGRADE = 'can-upgrade';
-export const STATUS_OFFERED = 'offered';
-
-export const ALL_COURSE_STATUSES = [
-  STATUS_PASSED,
-  STATUS_NOT_PASSED,
-  STATUS_OFFERED,
-  STATUS_CAN_UPGRADE,
-  STATUS_CURRENTLY_ENROLLED,
-];
 
 export const DASHBOARD_RESPONSE = [
   {
@@ -490,35 +519,30 @@ export const DASHBOARD_RESPONSE = [
   },
 ];
 
+export const PROGRAM_ENROLLMENTS = [
+  {
+    id: DASHBOARD_RESPONSE[1].id,
+    title: DASHBOARD_RESPONSE[1].title
+  },
+  {
+    id: DASHBOARD_RESPONSE[2].id,
+    title: DASHBOARD_RESPONSE[2].title
+  },
+];
+
+export const COURSE_PRICES_RESPONSE = [{
+  program_id: DASHBOARD_RESPONSE[1].id,
+  course_price: 100.00,
+  financial_aid_adjustment: false,
+  financial_aid_availability: true,
+  has_financial_aid_request: false
+}];
+
 export const ERROR_RESPONSE = {
   "errorStatusCode": 500,
   "error_code": "AB123",
   "user_message": "custom error message for the user."
 };
-
-export const ISO_8601_FORMAT = 'YYYY-MM-DD';
-export const DASHBOARD_FORMAT = 'M/D/Y';
-
-// NOTE: this is in order of attainment
-export const EDUCATION_LEVELS = [
-  {value: HIGH_SCHOOL, label: "High school"},
-  {value: ASSOCIATE, label: 'Associate degree'},
-  {value: BACHELORS, label: "Bachelor's degree"},
-  {value: MASTERS, label: "Master's or professional degree"},
-  {value: DOCTORATE, label: "Doctorate"}
-];
-
-export const PERSONAL_STEP = 'personal';
-export const EMPLOYMENT_STEP = 'employment';
-export const EDUCATION_STEP = 'education';
-
-export const PROFILE_STEP_LABELS = new Map([
-  [PERSONAL_STEP, "Personal"],
-  [EDUCATION_STEP, "Education"],
-  [EMPLOYMENT_STEP, "Professional"]
-]);
-
-export const DEFAULT_OPTION_LIMIT_COUNT = 10;
 
 /* eslint-disable max-len */
 export const CHECKOUT_RESPONSE_CYBERSOURCE = {
@@ -548,19 +572,3 @@ export const CHECKOUT_RESPONSE_EDX = {
   "method": "GET"
 };
 /* eslint-enable max-len */
-
-export const PROGRAM_ENROLLMENTS = [
-  {
-    id: DASHBOARD_RESPONSE[1].id,
-    title: DASHBOARD_RESPONSE[1].title
-  },
-  {
-    id: DASHBOARD_RESPONSE[2].id,
-    title: DASHBOARD_RESPONSE[2].title
-  },
-];
-
-export const SEARCH_FILTER_DEFAULT_VISIBILITY = true;
-
-export const TOAST_SUCCESS = 'success';
-export const TOAST_FAILURE = 'failure';

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -18,6 +18,8 @@ import {
   FETCH_FAILURE,
   fetchDashboard,
   clearDashboard,
+  fetchCoursePrices,
+  clearCoursePrices,
 } from '../actions';
 import {
   fetchUserProfile,
@@ -39,7 +41,7 @@ import {
 } from '../actions/ui';
 import { clearUI, setProfileStep } from '../actions/ui';
 import { validateProfileComplete } from '../util/validation';
-import type { DashboardState } from '../flow/dashboardTypes';
+import type { DashboardState, CoursePricesState } from '../flow/dashboardTypes';
 import type {
   ProgramEnrollment,
   ProgramEnrollmentsState,
@@ -57,6 +59,7 @@ class App extends React.Component {
     currentProgramEnrollment: ProgramEnrollment,
     dispatch:                 Dispatch,
     dashboard:                DashboardState,
+    coursePrices:             CoursePricesState,
     enrollments:              ProgramEnrollmentsState,
     history:                  Object,
     ui:                       UIState,
@@ -70,6 +73,7 @@ class App extends React.Component {
   updateRequirements() {
     this.fetchUserProfile(SETTINGS.username);
     this.fetchDashboard();
+    this.fetchCoursePrices();
     this.fetchEnrollments();
     this.requireProfileFilledOut();
     this.requireCompleteProfile();
@@ -87,6 +91,7 @@ class App extends React.Component {
     const { dispatch } = this.props;
     dispatch(clearProfile(SETTINGS.username));
     dispatch(clearDashboard());
+    dispatch(clearCoursePrices());
     dispatch(clearUI());
     dispatch(clearEnrollments());
   }
@@ -102,6 +107,13 @@ class App extends React.Component {
     const { dashboard, dispatch } = this.props;
     if (dashboard.fetchStatus === undefined) {
       dispatch(fetchDashboard());
+    }
+  }
+
+  fetchCoursePrices() {
+    const { coursePrices, dispatch } = this.props;
+    if (coursePrices.fetchStatus === undefined) {
+      dispatch(fetchCoursePrices());
     }
   }
 
@@ -253,6 +265,7 @@ const mapStateToProps = (state) => {
   return {
     userProfile:              profile,
     dashboard:                state.dashboard,
+    coursePrices:             state.coursePrices,
     ui:                       state.ui,
     currentProgramEnrollment: state.currentProgramEnrollment,
     enrollments:              state.enrollments,

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -6,9 +6,11 @@ import { assert } from 'chai';
 import _ from 'lodash';
 
 import Navbar from '../components/Navbar';
-import { CLEAR_DASHBOARD } from '../actions';
 import {
+  CLEAR_DASHBOARD,
+  CLEAR_COURSE_PRICES,
   RECEIVE_DASHBOARD_SUCCESS,
+  RECEIVE_COURSE_PRICES_SUCCESS,
 } from '../actions';
 import {
   RECEIVE_GET_USER_PROFILE_SUCCESS,
@@ -55,7 +57,13 @@ describe('App', () => {
 
   it('clears profile, ui, enrollments, and dashboard after unmounting', () => {
     return renderComponent("/dashboard").then(([, div]) => {
-      return listenForActions([CLEAR_DASHBOARD, CLEAR_PROFILE, CLEAR_UI, CLEAR_ENROLLMENTS], () => {
+      return listenForActions([
+        CLEAR_DASHBOARD,
+        CLEAR_COURSE_PRICES,
+        CLEAR_PROFILE,
+        CLEAR_UI,
+        CLEAR_ENROLLMENTS
+      ], () => {
         ReactDOM.unmountComponentAtNode(div);
       });
     });
@@ -115,6 +123,7 @@ describe('App', () => {
       helper.enrollmentsGetStub.returns(Promise.reject());
       let types = [
         RECEIVE_DASHBOARD_SUCCESS,
+        RECEIVE_COURSE_PRICES_SUCCESS,
         RECEIVE_GET_USER_PROFILE_SUCCESS,
         RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE,
       ];

--- a/static/js/flow/dashboardTypes.js
+++ b/static/js/flow/dashboardTypes.js
@@ -6,3 +6,16 @@ export type DashboardState = {
   programs:     Dashboard,
   fetchStatus?: string,
 };
+
+export type CoursePrice = {
+  program_id: number,
+  course_price: number,
+  financial_aid_adjustment: boolean,
+  financial_aid_availability: boolean,
+  has_financial_aid_request: boolean
+};
+export type CoursePrices = Array<CoursePrice>;
+export type CoursePricesState = {
+  coursePrices: CoursePrices,
+  fetchStatus?: string,
+}

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -24,6 +24,11 @@ import {
   RECEIVE_CHECKOUT_SUCCESS,
   RECEIVE_CHECKOUT_FAILURE,
 
+  REQUEST_COURSE_PRICES,
+  RECEIVE_COURSE_PRICES_SUCCESS,
+  RECEIVE_COURSE_PRICES_FAILURE,
+  CLEAR_COURSE_PRICES,
+
   FETCH_FAILURE,
   FETCH_PROCESSING,
   FETCH_SUCCESS,
@@ -34,7 +39,7 @@ import {
   currentProgramEnrollment,
   enrollments,
 } from './enrollments';
-import type { DashboardState } from '../flow/dashboardTypes';
+import type { DashboardState, CoursePricesState } from '../flow/dashboardTypes';
 import type { Action } from '../flow/reduxTypes';
 import type {
   ProfileGetResult,
@@ -190,6 +195,31 @@ export const checkout = (state: CheckoutState = INITIAL_CHECKOUT_STATE, action: 
   }
 };
 
+const INITIAL_COURSE_PRICES_STATE: CoursePricesState = {
+  coursePrices: []
+};
+export const coursePrices = (state: CoursePricesState = INITIAL_COURSE_PRICES_STATE, action: Action) => {
+  switch (action.type) {
+  case REQUEST_COURSE_PRICES:
+    return Object.assign({}, state, {
+      fetchStatus: FETCH_PROCESSING
+    });
+  case RECEIVE_COURSE_PRICES_SUCCESS:
+    return Object.assign({}, state, {
+      fetchStatus: FETCH_SUCCESS,
+      coursePrices: action.payload
+    });
+  case RECEIVE_COURSE_PRICES_FAILURE:
+    return Object.assign({}, state, {
+      fetchStatus: FETCH_FAILURE,
+      errorInfo: action.payload
+    });
+  case CLEAR_COURSE_PRICES:
+    return INITIAL_COURSE_PRICES_STATE;
+  default:
+    return state;
+  }
+};
 
 export default combineReducers({
   profiles,
@@ -197,6 +227,7 @@ export default combineReducers({
   ui,
   email,
   checkout,
+  coursePrices,
   enrollments,
   currentProgramEnrollment,
   signupDialog,

--- a/static/js/util/api.js
+++ b/static/js/util/api.js
@@ -206,3 +206,7 @@ export function addFinancialAid(income: number, currency: string, programId: num
     })
   });
 }
+
+export function getCoursePrices(): Promise<*> {
+  return mockableFetchJSONWithCSRF('/api/v0/course_prices/', {});
+}

--- a/static/js/util/api_test.js
+++ b/static/js/util/api_test.js
@@ -6,6 +6,7 @@ import {
   getUserProfile,
   patchUserProfile,
   getDashboard,
+  getCoursePrices,
   getCookie,
   fetchJSONWithCSRF,
   fetchWithCSRF,
@@ -21,6 +22,7 @@ import * as api from './api';
 import {
   CHECKOUT_RESPONSE,
   DASHBOARD_RESPONSE,
+  COURSE_PRICES_RESPONSE,
   USER_PROFILE_RESPONSE,
   PROGRAM_ENROLLMENTS,
 } from '../constants';
@@ -144,6 +146,14 @@ describe('api', function() {
 
       return assert.isRejected(getDashboard()).then(() => {
         assert.ok(fetchJSONStub.calledWith('/api/v0/dashboard/', {}, true));
+      });
+    });
+
+    it('gets course prices', () => {
+      fetchJSONStub.returns(Promise.resolve(COURSE_PRICES_RESPONSE));
+      return getCoursePrices().then(coursePrices => {
+        assert.ok(fetchJSONStub.calledWith(`/api/v0/course_prices/`, {}));
+        assert.deepEqual(coursePrices, COURSE_PRICES_RESPONSE);
       });
     });
 

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -8,12 +8,15 @@ import { compose } from 'redux';
 import * as api from '../util/api';
 import {
   DASHBOARD_RESPONSE,
+  COURSE_PRICES_RESPONSE,
   PROGRAM_ENROLLMENTS,
   USER_PROFILE_RESPONSE,
 } from '../constants';
 import {
   REQUEST_DASHBOARD,
   RECEIVE_DASHBOARD_SUCCESS,
+  REQUEST_COURSE_PRICES,
+  RECEIVE_COURSE_PRICES_SUCCESS,
 } from '../actions';
 import {
   REQUEST_GET_USER_PROFILE,
@@ -29,7 +32,6 @@ import { localStorageMock } from '../util/test_utils';
 import { configureMainTestStore } from '../store/configureStore';
 
 class IntegrationTestHelper {
-
   constructor() {
     if ( ! window.localStorage ) {
       window.localStorage = localStorageMock();
@@ -49,6 +51,8 @@ class IntegrationTestHelper {
 
     this.dashboardStub = this.sandbox.stub(api, 'getDashboard');
     this.dashboardStub.returns(Promise.resolve(DASHBOARD_RESPONSE));
+    this.coursePricesStub = this.sandbox.stub(api, 'getCoursePrices');
+    this.coursePricesStub.returns(Promise.resolve(COURSE_PRICES_RESPONSE));
     this.profileGetStub = this.sandbox.stub(api, 'getUserProfile');
     this.profileGetStub.returns(Promise.resolve(USER_PROFILE_RESPONSE));
     this.enrollmentsGetStub = this.sandbox.stub(api, 'getProgramEnrollments');
@@ -68,12 +72,14 @@ class IntegrationTestHelper {
   renderComponent(url = "/", extraTypesToAssert = [], isSuccessExpected = true) {
     let expectedTypes = [
       REQUEST_DASHBOARD,
+      REQUEST_COURSE_PRICES,
       REQUEST_GET_USER_PROFILE,
       REQUEST_GET_PROGRAM_ENROLLMENTS,
     ];
     let expectedSuccessTypes = [
       RECEIVE_DASHBOARD_SUCCESS,
       RECEIVE_GET_USER_PROFILE_SUCCESS,
+      RECEIVE_COURSE_PRICES_SUCCESS,
       RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
     ];
 


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #1151 

#### What's this PR do?

- Adds a new API view to get course prices for _all_ of a user's enrolled programs
- Adds a call to that API at the app level on the front end; this puts course price info in the application state (a la dashboard data)

#### Where should the reviewer start?

Probably static/js/containers/App.js and financialaid/views.py

#### How should this be manually tested?

1. Remove staff permissions for 1 or more programs for your user
1. Make sure you have relevant course price information in your data (I did this simply by adding a relevant `CoursePrice` record)
1. Run the app and check your network tab to make sure the `course_prices` endpoint is being called and the response contains relevant data

#### Any background context you want to provide?

Note that this data isn't being used anywhere on the front end yet. That's for later issues

