### PR TITLE
Add back terms of service link in dialog, and change Log in link to act the same as signup

### DIFF
--- a/static/js/containers/SignupDialog.js
+++ b/static/js/containers/SignupDialog.js
@@ -36,7 +36,7 @@ const SignupDialog = ({
         <img src="/static/images/mit_logo_grey_red.png" />
       </div>
       <span>
-        The MIT MicroMasters program is powered by edX.
+        All MITx MicroMasters courses are delivered on edX.
         To sign up for a MIT MicroMasters program you need an edX account.
       </span>
 

--- a/static/js/containers/SignupDialog.js
+++ b/static/js/containers/SignupDialog.js
@@ -43,6 +43,14 @@ const SignupDialog = ({
       <a className="mm-button signup" href="/login/edxorg">
         Continue with edX
       </a>
+      <div className="terms-of-service-text">
+        By clicking "Continue with edX" I certify that I agree with <a href="/terms_of_service" target="_blank">
+          MIT MicroMasters Terms of Service.
+        </a> Read our <a
+          href="http://web.mit.edu/referencepubs/nondiscrimination/index.html"
+          target="_blank"
+        >Nondiscrimination Policy.</a>
+      </div>
     </div>
   </Dialog>;
 };

--- a/static/scss/signup-dialog.scss
+++ b/static/scss/signup-dialog.scss
@@ -23,4 +23,19 @@
     color: #555;
     line-height: 1.5em;
   }
+
+  .program-select {
+    font-weight: 400;
+    font-size: 16px;
+    margin-bottom: 28px;
+  }
+
+  .terms-of-service-text {
+    font-size: 12px;
+    max-width: 96%;
+    margin: 28px auto 0;
+    font-weight: 300;
+    line-height: 1.4em;
+    color: #616161;
+  }
 }

--- a/ui/templates/header.html
+++ b/ui/templates/header.html
@@ -12,7 +12,7 @@
             Sign Out
           </a>
           {% else %}
-          <a class="members-login btn ghost upper-case" href="{% url 'social:begin' 'edxorg' %}">Log In</a>
+          <a class="members-login btn ghost open-signup-dialog upper-case">Log In</a>
           <a class="btn btn-login white-button open-signup-dialog upper-case">
           Sign Up
           </a>


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1113

#### What's this PR do?
Changes the login link to act the same as sign up, and the dialog box will contain a link to the terms of service again