### PR TITLE
Added pre-enroll dashboard course states

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -111,7 +111,7 @@ def create_unfulfilled_order(course_id, user):
     course_run = get_purchasable_course_run(course_id, user)
     enrollment = get_object_or_404(ProgramEnrollment, program=course_run.course.program, user=user)
     price_dict = get_formatted_course_price(enrollment)
-    price = price_dict['course_price']
+    price = price_dict['price']
     if price <= 0:
         log.warning(
             "Price to be charged for course run %s for user %s is less than or equal to zero: %s",

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -233,7 +233,7 @@ class PurchasableTests(ESTestCase):
         course_run, user = create_purchasable_course_run()
         discounted_price = round(course_run.courseprice_set.get(is_valid=True).price/2, 2)
         price_dict = {
-            "course_price": discounted_price
+            "price": discounted_price
         }
 
         with patch(

--- a/financialaid/api.py
+++ b/financialaid/api.py
@@ -90,7 +90,7 @@ def get_formatted_course_price(program_enrollment):
             whose price we're retrieving
     Returns:
         dict: {
-            "course_price": float - the course price
+            "price": float - the course price
             "financial_aid_adjustment": bool - if financial aid is approved and has been applied to this course price,
             "financial_aid_availability": bool - Program.financial_aid_availability,
             "has_financial_aid_request": bool - if has a financial aid request
@@ -121,7 +121,7 @@ def get_formatted_course_price(program_enrollment):
                 financial_aid_adjustment = True
     return {
         "program_id": program.id,
-        "course_price": course_price,
+        "price": course_price,
         "financial_aid_adjustment": financial_aid_adjustment,
         "financial_aid_availability": financial_aid_availability,
         "has_financial_aid_request": has_financial_aid_request

--- a/financialaid/api_test.py
+++ b/financialaid/api_test.py
@@ -279,7 +279,7 @@ class CoursePriceAPITests(FinancialAidBaseTestCase):
         enrollment = self.program_enrollment_ep1
         expected_response = {
             "program_id": enrollment.program.id,
-            "course_price": self.course_price.price - self.financialaid_approved.tier_program.discount_amount,
+            "price": self.course_price.price - self.financialaid_approved.tier_program.discount_amount,
             "financial_aid_adjustment": True,
             "financial_aid_availability": True,
             "has_financial_aid_request": True
@@ -296,7 +296,7 @@ class CoursePriceAPITests(FinancialAidBaseTestCase):
         enrollment = self.program_enrollment_ep2
         expected_response = {
             "program_id": enrollment.program.id,
-            "course_price": self.course_price.price,
+            "price": self.course_price.price,
             "financial_aid_adjustment": False,
             "financial_aid_availability": True,
             "has_financial_aid_request": True
@@ -314,7 +314,7 @@ class CoursePriceAPITests(FinancialAidBaseTestCase):
         # Enrolled and has no financial aid
         expected_response = {
             "program_id": enrollment.program.id,
-            "course_price": self.course_price.price,
+            "price": self.course_price.price,
             "financial_aid_adjustment": False,
             "financial_aid_availability": True,
             "has_financial_aid_request": False
@@ -333,7 +333,7 @@ class CoursePriceAPITests(FinancialAidBaseTestCase):
         self.program.save()
         expected_response = {
             "program_id": enrollment.program.id,
-            "course_price": self.course_price.price,
+            "price": self.course_price.price,
             "financial_aid_adjustment": False,
             "financial_aid_availability": False,
             "has_financial_aid_request": False

--- a/financialaid/views_test.py
+++ b/financialaid/views_test.py
@@ -585,7 +585,7 @@ class CoursePriceDetailViewTests(FinancialAidBaseTestCase, APIClient):
         expected_response = {
             "program_id": self.program.id,
             "has_financial_aid_request": True,
-            "course_price": self.course_price.price - self.financialaid_approved.tier_program.discount_amount,
+            "price": self.course_price.price - self.financialaid_approved.tier_program.discount_amount,
             "financial_aid_adjustment": True,
             "financial_aid_availability": True
         }
@@ -600,7 +600,7 @@ class CoursePriceDetailViewTests(FinancialAidBaseTestCase, APIClient):
         expected_response = {
             "program_id": self.program.id,
             "has_financial_aid_request": True,
-            "course_price": self.course_price.price,
+            "price": self.course_price.price,
             "financial_aid_adjustment": False,
             "financial_aid_availability": True
         }
@@ -615,7 +615,7 @@ class CoursePriceDetailViewTests(FinancialAidBaseTestCase, APIClient):
         expected_response = {
             "program_id": self.program.id,
             "has_financial_aid_request": False,
-            "course_price": self.course_price.price,
+            "price": self.course_price.price,
             "financial_aid_adjustment": False,
             "financial_aid_availability": True
         }
@@ -632,7 +632,7 @@ class CoursePriceDetailViewTests(FinancialAidBaseTestCase, APIClient):
         expected_response = {
             "program_id": self.program.id,
             "has_financial_aid_request": False,
-            "course_price": self.course_price.price,
+            "price": self.course_price.price,
             "financial_aid_adjustment": False,
             "financial_aid_availability": False
         }

--- a/mail/api.py
+++ b/mail/api.py
@@ -188,7 +188,7 @@ def generate_financial_aid_email(financial_aid):
         )
         message = FINANCIAL_AID_APPROVAL_MESSAGE.format(
             program_name=financial_aid.tier_program.program.title,
-            price=get_formatted_course_price(program_enrollment)["course_price"]
+            price=get_formatted_course_price(program_enrollment)["price"]
         )
         subject = FINANCIAL_AID_APPROVAL_SUBJECT.format(program_name=financial_aid.tier_program.program.title)
     elif financial_aid.status == FinancialAidStatus.PENDING_MANUAL_APPROVAL:

--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -257,7 +257,7 @@ class FinancialAidMailAPITests(TestCase):
             first_name=self.financial_aid.user.profile.first_name,
             message=FINANCIAL_AID_APPROVAL_MESSAGE.format(
                 program_name=self.financial_aid.tier_program.program.title,
-                price=get_formatted_course_price(self.program_enrollment)["course_price"]
+                price=get_formatted_course_price(self.program_enrollment)["price"]
             ),
             program_name=self.financial_aid.tier_program.program.title
         )

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -4,7 +4,8 @@ import React from 'react';
 import moment from 'moment';
 import Button from 'react-mdl/lib/Button';
 
-import type { Course, CourseRun } from '../../flow/programTypes';
+import type { Course, CourseRun, FinancialAidUserInfo } from '../../flow/programTypes';
+import type { CoursePrice } from '../../flow/dashboardTypes';
 import {
   STATUS_NOT_PASSED,
   STATUS_PASSED,
@@ -12,39 +13,88 @@ import {
   STATUS_CURRENTLY_ENROLLED,
   STATUS_OFFERED,
   DASHBOARD_FORMAT,
+  FA_PENDING_STATUSES,
+  FA_STATUS_SKIPPED
 } from '../../constants';
+import { formatPrice } from '../../util/util';
 
 export default class CourseAction extends React.Component {
   props: {
     checkout: Function,
     course: Course,
+    coursePrice: CoursePrice,
+    financialAid: FinancialAidUserInfo,
+    hasFinancialAid: boolean,
+    openFinancialAidCalculator: () => void,
     now: moment$Moment,
   };
 
-  makeEnrollButton = (text: string, run: CourseRun, disabled: boolean) => {
-    const { checkout } = this.props;
+  getCoursePrice(): string {
+    const { coursePrice } = this.props;
+    return formatPrice(coursePrice.price);
+  }
+
+  isCurrentlyEnrollable(enrollmentStartDate: ?Object): boolean {
+    const { now } = this.props;
+    return enrollmentStartDate !== null &&
+      enrollmentStartDate !== undefined &&
+      enrollmentStartDate.isSameOrBefore(now, 'day');
+  }
+
+  needsPriceCalculation(): boolean {
+    const { financialAid, hasFinancialAid } = this.props;
+    return hasFinancialAid &&
+      !financialAid.has_user_applied &&
+      financialAid.application_status !== FA_STATUS_SKIPPED;
+  }
+
+  hasPendingFinancialAid(): boolean {
+    const { financialAid, hasFinancialAid } = this.props;
+    return hasFinancialAid && FA_PENDING_STATUSES.includes(financialAid.application_status);
+  }
+
+  renderEnrollButton(run: CourseRun): React$Element<*> {
+    const {
+      checkout,
+      openFinancialAidCalculator
+    } = this.props;
+    let text = '';
+    let needsPriceCalculation = this.needsPriceCalculation();
     let buttonProps = {};
 
-    if (!disabled) {
-      buttonProps.onClick = () => {
-        checkout(run.course_id);
-      };
+    if (needsPriceCalculation) {
+      text = 'Calculate Cost';
     } else {
+      text = `Pay Now - ${this.getCoursePrice()}`;
+    }
+
+    if (this.hasPendingFinancialAid()) {
       buttonProps.disabled = true;
+    } else {
+      if (needsPriceCalculation) {
+        buttonProps.onClick = openFinancialAidCalculator;
+      } else {
+        buttonProps.onClick = () => {
+          checkout(run.course_id);
+        };
+      }
     }
 
     return (
-      <span>
-        <Button className="dashboard-button" {...buttonProps}>
-          {text}
-        </Button>
-        <span className="sr-only"> in {run.title}</span>
-      </span>
+      <Button className="dashboard-button" {...buttonProps}>
+        {text}
+      </Button>
     );
-  };
+  }
+
+  renderPayLaterLink(): React$Element<*> {
+    return (
+      <a href="#">Enroll and pay later</a>
+    );
+  }
 
   render() {
-    const { course, now } = this.props;
+    const { course } = this.props;
     let firstRun: CourseRun = {};
     if (course.runs.length > 0) {
       firstRun = course.runs[0];
@@ -57,34 +107,30 @@ export default class CourseAction extends React.Component {
       action = <i className="material-icons">done</i>;
       break;
     case STATUS_CAN_UPGRADE: {
-      action = this.makeEnrollButton("Upgrade", firstRun, false);
+      let formattedUpgradeDate = moment(firstRun.course_upgrade_deadline).format(DASHBOARD_FORMAT);
+      action = this.renderEnrollButton(firstRun);
+      description = `Payment due: ${formattedUpgradeDate}`;
       break;
     }
     case STATUS_OFFERED: {
-      let disabled = false;
-      if (!firstRun.enrollment_start_date && firstRun.fuzzy_enrollment_start_date) {
-        disabled = true;
-        description = `Enrollment begins ${firstRun.fuzzy_enrollment_start_date}`;
-      } else if (firstRun.enrollment_start_date) {
-        let enrollmentStartDate = moment(firstRun.enrollment_start_date);
-        if (enrollmentStartDate.isAfter(now, 'day')) {
-          disabled = true;
-          let formattedDate = enrollmentStartDate.format(DASHBOARD_FORMAT);
-          description = `Enrollment begins ${formattedDate}`;
+      let enrollmentStartDate = firstRun.enrollment_start_date ? moment(firstRun.enrollment_start_date) : null;
+      if (this.isCurrentlyEnrollable(enrollmentStartDate)) {
+        action = this.renderEnrollButton(firstRun);
+        description = this.renderPayLaterLink();
+      } else {
+        if (enrollmentStartDate) {
+          let formattedEnrollDate = enrollmentStartDate.format(DASHBOARD_FORMAT);
+          description = `Enrollment begins ${formattedEnrollDate}`;
+        } else if (firstRun.fuzzy_enrollment_start_date) {
+          description = `Enrollment begins ${firstRun.fuzzy_enrollment_start_date}`;
         }
       }
-
-      action = this.makeEnrollButton("Enroll", firstRun, disabled);
       break;
     }
     case STATUS_NOT_PASSED:
     case STATUS_CURRENTLY_ENROLLED:
       // do nothing;
       break;
-    default: {
-      // there are no runs
-      action = this.makeEnrollButton("Enroll", firstRun, true);
-    }
     }
 
     return <div className="course-action">

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -5,34 +5,67 @@ import { shallow } from 'enzyme';
 import moment from 'moment';
 import { assert } from 'chai';
 import sinon from 'sinon';
+import _ from 'lodash';
 
 import CourseAction from './CourseAction';
 import {
   DASHBOARD_FORMAT,
+  COURSE_PRICES_RESPONSE,
+  FINANCIAL_AID_PARTIAL_RESPONSE,
   STATUS_PASSED,
   STATUS_NOT_PASSED,
   STATUS_OFFERED,
   STATUS_CAN_UPGRADE,
   STATUS_CURRENTLY_ENROLLED,
+  FA_PENDING_STATUSES,
+  FA_STATUS_SKIPPED
 } from '../../constants';
-import { findCourse } from './CourseDescription_test';
+import { findCourse, findAndCloneCourse } from '../../util/test_utils';
 
 describe('CourseAction', () => {
   const now = moment();
-  let sandbox, checkoutStub;
+  let sandbox, checkoutStub, coursePrice, defaultParams, defaultParamsNow;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     checkoutStub = sandbox.stub();
+    coursePrice = COURSE_PRICES_RESPONSE[1];
+    defaultParams = {
+      checkout: checkoutStub,
+      coursePrice: coursePrice,
+      hasFinancialAid: false,
+      financialAid: {}
+    };
+    defaultParamsNow = Object.assign({}, defaultParams, { now: now });
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
+  let getElements = (renderedComponent) => {
+    let buttonContainer = renderedComponent.find(".course-action-action");
+    let button = buttonContainer.find(".dashboard-button");
+    let buttonText;
+    if (!_.isNil(button) && button.children().length > 0) {
+      buttonText = button.children().text();
+    }
+    let description = renderedComponent.find(".course-action-description");
+    return {
+      buttonContainer: buttonContainer,
+      button: button,
+      buttonText: buttonText,
+      description: description
+    };
+  };
+
+  let alterFirstRun = (course, overrideObject) => {
+    course.runs[0] = Object.assign({}, course.runs[0], overrideObject);
+  };
+
   let assertCheckoutButton = (button, courseId) => {
     button.simulate('click');
-    assert.equal(checkoutStub.callCount, 1);
+    assert.isAbove(checkoutStub.callCount, 0);
     assert.deepEqual(checkoutStub.args[0], [courseId]);
   };
 
@@ -41,7 +74,7 @@ describe('CourseAction', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_PASSED
     ));
-    const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
+    const wrapper = shallow(<CourseAction course={course} {...defaultParamsNow} />);
     assert.equal(wrapper.find(".material-icons").text(), 'done');
   });
 
@@ -50,7 +83,7 @@ describe('CourseAction', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_NOT_PASSED
     ));
-    const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
+    const wrapper = shallow(<CourseAction course={course} {...defaultParamsNow} />);
     assert.equal(wrapper.text(), '');
   });
 
@@ -59,21 +92,44 @@ describe('CourseAction', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_CURRENTLY_ENROLLED
     ));
-    const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
+    const wrapper = shallow(<CourseAction course={course} {...defaultParamsNow} />);
     assert.equal(wrapper.text(), '');
   });
 
-  [STATUS_OFFERED, STATUS_CAN_UPGRADE].forEach((status) => {
-    it(`shows the enroll button followed by course title when status is ${status}`, () => {
-      let course = findCourse(course => (
-        course.runs.length > 0 &&
-        course.runs[0].status === status
-      ));
-      let firstRun = course.runs[0];
-      const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
-      let buttonContainer = wrapper.find(".course-action-action");
+  it('shows a button to enroll and pay, and a link to enroll and pay later', () => {
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED
+    ));
+    const wrapper = shallow(<CourseAction course={course} {...defaultParamsNow} />);
+    let firstRun = course.runs[0];
+    let elements = getElements(wrapper);
 
-      assert.include(buttonContainer.text(), `<Button /> in ${firstRun.title}`);
+    assert.isUndefined(elements.button.props().disabled);
+    assert.include(elements.buttonText, 'Pay Now');
+    assert.equal(elements.description.text(), 'Enroll and pay later');
+    assertCheckoutButton(elements.button, firstRun.course_id);
+  });
+
+  it('shows an enroll button if user is not enrolled and enrollment starts today or earlier', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED &&
+      course.runs[0].enrollment_start_date !== undefined
+    ));
+    let nowString = now.toISOString();
+    let pastString = moment(now).add(-10, 'days').toISOString();
+
+    [nowString, pastString].forEach(dateString => {
+      alterFirstRun(course, {enrollment_start_date: dateString});
+      const wrapper = shallow(<CourseAction course={course} {...defaultParamsNow} />);
+      let firstRun = course.runs[0];
+      let elements = getElements(wrapper);
+
+      assert.isUndefined(elements.button.props().disabled);
+      assert.include(elements.buttonText, 'Pay Now');
+      assert.equal(elements.description.text(), 'Enroll and pay later');
+      assertCheckoutButton(elements.button, firstRun.course_id);
     });
   });
 
@@ -82,111 +138,115 @@ describe('CourseAction', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_CAN_UPGRADE
     ));
-    const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
-    let buttonContainer = wrapper.find(".course-action-action");
-    let button = buttonContainer.find(".dashboard-button");
-    let buttonText = button.children().text();
-    let description = wrapper.find(".course-action-description");
+    const wrapper = shallow(<CourseAction course={course} {...defaultParamsNow} />);
     let firstRun = course.runs[0];
+    let elements = getElements(wrapper);
+    let formattedUpgradeDate = moment(firstRun.course_upgrade_deadline).format(DASHBOARD_FORMAT);
 
-    assert.isUndefined(button.props().disabled);
-    assert.equal(buttonText, 'Upgrade');
-    assert.equal(description.text(), "");
-    assertCheckoutButton(button, firstRun.course_id);
+    assert.isUndefined(elements.button.props().disabled);
+    assert.include(elements.buttonText, 'Pay Now');
+    assert.equal(elements.description.text(), `Payment due: ${formattedUpgradeDate}`);
+    assertCheckoutButton(elements.button, firstRun.course_id);
   });
 
-  it('shows a disabled enroll button if user is not enrolled and there is no enrollment date', () => {
-    // there should also be text below the button
-    let course = findCourse(course => (
+  it('shows a message if a user is not enrolled and the course has a future enrollment start date', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED
+    ));
+    let enrollmentStartDate = moment(now).add(10, 'days').toISOString();
+    alterFirstRun(course, {enrollment_start_date: enrollmentStartDate});
+    const wrapper = shallow(<CourseAction course={course} {...defaultParamsNow} />);
+    let firstRun = course.runs[0];
+    let elements = getElements(wrapper);
+
+    assert.include(elements.buttonContainer.text(), '');
+    let formattedDate = moment(firstRun.enrollment_start_date).format(DASHBOARD_FORMAT);
+    assert.equal(elements.description.text(), `Enrollment begins ${formattedDate}`);
+  });
+
+  it('shows a message if a user is not enrolled and the course has a fuzzy enrollment date', () => {
+    let course = findAndCloneCourse(course => (
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_OFFERED &&
       course.runs[0].enrollment_start_date === undefined
     ));
-    const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
-    let buttonContainer = wrapper.find(".course-action-action");
-    let button = buttonContainer.find(".dashboard-button");
-    let buttonText = button.children().text();
-    let description = wrapper.find(".course-action-description");
-    let firstRun = course.runs[0];
+    alterFirstRun(course, {fuzzy_enrollment_start_date: 'whenever'});
+    const wrapper = shallow(<CourseAction course={course} {...defaultParamsNow} />);
+    let elements = getElements(wrapper);
 
-    assert.isTrue(button.props().disabled);
-    assert.equal(buttonText, 'Enroll');
-    assert.equal(description.text(), `Enrollment begins ${firstRun.fuzzy_enrollment_start_date}`);
+    assert.include(elements.buttonContainer.text(), '');
+    assert.equal(elements.description.text(), 'Enrollment begins whenever');
   });
 
-  it('shows a disabled enroll button if user is not enrolled and enrollment starts in future', () => {
-    // there should also be text below the button
-    let course = findCourse(course => (
-      course.runs.length > 0 &&
-      course.runs[0].status === STATUS_OFFERED &&
-      course.runs[0].enrollment_start_date !== undefined
-    ));
-    let firstRun = course.runs[0];
-    let yesterday = moment(firstRun.enrollment_start_date).add(-1, 'days');
-    const wrapper = shallow(<CourseAction course={course} now={yesterday} checkout={checkoutStub}/>);
-    let buttonContainer = wrapper.find(".course-action-action");
-    let button = buttonContainer.find(".dashboard-button");
-    let buttonText = button.children().text();
-    let description = wrapper.find(".course-action-description");
+  describe('with financial aid', () => {
+    let course, aidParams;
 
-    assert.isTrue(button.props().disabled);
-    assert.equal(buttonText, 'Enroll');
-    let formattedDate = moment(firstRun.enrollment_start_date).format(DASHBOARD_FORMAT);
-    assert.equal(description.text(), `Enrollment begins ${formattedDate}`);
-  });
+    beforeEach(() => {
+      course = findAndCloneCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === STATUS_OFFERED
+      ));
+      aidParams = Object.assign({}, {
+        financialAid: _.cloneDeep(FINANCIAL_AID_PARTIAL_RESPONSE),
+        hasFinancialAid: true
+      });
+    });
 
-  it('shows an enroll button if user is not enrolled and enrollment starts today', () => {
-    let course = findCourse(course => (
-      course.runs.length > 0 &&
-      course.runs[0].status === STATUS_OFFERED &&
-      course.runs[0].enrollment_start_date !== undefined
-    ));
-    let firstRun = course.runs[0];
-    let today = moment(firstRun.enrollment_start_date);
-    const wrapper = shallow(<CourseAction course={course} now={today} checkout={checkoutStub}/>);
-    let buttonContainer = wrapper.find(".course-action-action");
-    let button = buttonContainer.find(".dashboard-button");
-    let buttonText = button.children().text();
-    let description = wrapper.find(".course-action-description");
+    it('indicates that a user must calculate the course price', () => {
+      alterFirstRun(course, {
+        enrollment_start_date: now.toISOString(),
+      });
+      aidParams.financialAid.has_user_applied = false;
 
-    assert.isUndefined(button.props().disabled);
-    assert.equal(buttonText, 'Enroll');
-    assert.equal(description.text(), ``);
-    assertCheckoutButton(button, firstRun.course_id);
-  });
+      let params = Object.assign({}, defaultParamsNow, aidParams);
+      const wrapper = shallow(
+        <CourseAction course={course} {...params} />
+      );
+      let elements = getElements(wrapper);
 
-  it('shows an enroll button if user is not enrolled and enrollment started already', () => {
-    let course = findCourse(course => (
-      course.runs.length > 0 &&
-      course.runs[0].status === STATUS_OFFERED &&
-      course.runs[0].enrollment_start_date !== undefined
-    ));
-    let firstRun = course.runs[0];
-    let tomorrow = moment(firstRun.enrollment_start_date).add(1, 'days');
-    const wrapper = shallow(<CourseAction course={course} now={tomorrow} checkout={checkoutStub}/>);
-    let buttonContainer = wrapper.find(".course-action-action");
-    let button = buttonContainer.find(".dashboard-button");
-    let buttonText = button.children().text();
-    let description = wrapper.find(".course-action-description");
+      assert.isUndefined(elements.button.props().disabled);
+      assert.equal(elements.buttonText, 'Calculate Cost');
+      assert.equal(elements.description.text(), 'Enroll and pay later');
+    });
 
-    assert.isUndefined(button.props().disabled);
-    assert.equal(buttonText, 'Enroll');
-    assert.equal(description.text(), ``);
-    assertCheckoutButton(button, firstRun.course_id);
-  });
+    it('shows an enroll/pay button if a user has skipped financial aid', () => {
+      alterFirstRun(course, {
+        enrollment_start_date: now.toISOString(),
+      });
+      aidParams.financialAid.has_user_applied = false;
+      aidParams.financialAid.application_status = FA_STATUS_SKIPPED;
 
-  it('is not an offered course and user has not failed', () => {
-    let course = findCourse(course => (
-      course.runs.length === 0
-    ));
-    const wrapper = shallow(<CourseAction course={course} now={now} checkout={checkoutStub}/>);
-    let buttonContainer = wrapper.find(".course-action-action");
-    let description = wrapper.find(".course-action-description");
-    let button = buttonContainer.find(".dashboard-button");
-    let buttonText = button.children().text();
+      let params = Object.assign({}, defaultParamsNow, aidParams);
+      const wrapper = shallow(
+        <CourseAction course={course} {...params} />
+      );
+      let elements = getElements(wrapper);
 
-    assert(button.props().disabled);
-    assert.equal(buttonText, 'Enroll');
-    assert.equal(description.text(), '');
+      assert.isUndefined(elements.button.props().disabled);
+      assert.include(elements.buttonText, 'Pay Now');
+      assert.equal(elements.description.text(), 'Enroll and pay later');
+    });
+
+    it('shows a disabled enroll/pay button if a user is pending approval', () => {
+      alterFirstRun(course, {
+        enrollment_start_date: now.toISOString(),
+      });
+      aidParams.financialAid.has_user_applied = true;
+
+      FA_PENDING_STATUSES.forEach(pendingStatus => {
+        aidParams.financialAid.application_status = pendingStatus;
+
+        let params = Object.assign({}, defaultParamsNow, aidParams);
+        const wrapper = shallow(
+          <CourseAction course={course} {...params} />
+        );
+        let elements = getElements(wrapper);
+
+        assert.isTrue(elements.button.props().disabled);
+        assert.include(elements.buttonText, 'Pay Now');
+        assert.equal(elements.description.text(), 'Enroll and pay later');
+      });
+    });
   });
 });

--- a/static/js/components/dashboard/CourseDescription_test.js
+++ b/static/js/components/dashboard/CourseDescription_test.js
@@ -3,14 +3,10 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 import { assert } from 'chai';
-import type {
-  Course,
-  Program
-} from '../../flow/programTypes';
 
 import CourseDescription from './CourseDescription';
+import { findCourse } from '../../util/test_utils';
 import {
-  DASHBOARD_RESPONSE,
   DASHBOARD_FORMAT,
   STATUS_PASSED,
   STATUS_NOT_PASSED,
@@ -19,18 +15,6 @@ import {
   STATUS_OFFERED,
   ALL_COURSE_STATUSES,
 } from '../../constants';
-
-
-export function findCourse(courseSelector: (course: Course, program: Program) => boolean): Course {
-  for (let program of DASHBOARD_RESPONSE) {
-    for (let course of program.courses) {
-      if (courseSelector(course, program)) {
-        return course;
-      }
-    }
-  }
-  throw "Unable to find course";
-}
 
 describe('CourseDescription', () => {
   it('shows the course title', () => {

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -5,22 +5,26 @@ import _ from 'lodash';
 import { Card, CardTitle } from 'react-mdl/lib/Card';
 
 import type { Program } from '../../flow/programTypes';
+import type { CoursePrice } from '../../flow/dashboardTypes';
 import CourseRow from './CourseRow';
 import FinancialAidCalculator from '../../containers/FinancialAidCalculator';
-
 
 export default class CourseListCard extends React.Component {
   props: {
     checkout:                   Function,
     program:                    Program,
+    coursePrice:                CoursePrice,
+    openFinancialAidCalculator: () => void,
     now?:                       Object,
   };
 
   render() {
     let {
       program,
+      coursePrice,
       now,
       checkout,
+      openFinancialAidCalculator,
     } = this.props;
     if (now === undefined) {
       now = moment();
@@ -28,13 +32,22 @@ export default class CourseListCard extends React.Component {
 
     let sortedCourses = _.orderBy(program.courses, 'position_in_program');
     let courseRows = sortedCourses.map(course =>
-      <CourseRow course={course} now={now} key={course.id} checkout={checkout} />
+      <CourseRow
+        hasFinancialAid={program.financial_aid_availability}
+        financialAid={program.financial_aid_user_info}
+        course={course}
+        coursePrice={coursePrice}
+        key={course.id}
+        checkout={checkout}
+        openFinancialAidCalculator={openFinancialAidCalculator}
+        now={now}
+      />
     );
 
     return <Card shadow={0} className="course-list">
       <FinancialAidCalculator />
       <CardTitle>Required Courses</CardTitle>
-      {courseRows}
+      { courseRows }
     </Card>;
   }
 }

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -7,28 +7,27 @@ import _ from 'lodash';
 
 import CourseListCard from './CourseListCard';
 import CourseRow from './CourseRow';
-import { DASHBOARD_RESPONSE } from '../../constants';
+import { DASHBOARD_RESPONSE, COURSE_PRICES_RESPONSE } from '../../constants';
 
 describe('CourseListCard', () => {
+  let defaultCardParams = {
+    coursePrice: _.cloneDeep(COURSE_PRICES_RESPONSE[0]),
+    checkout: () => null
+  };
+
   it('creates a CourseRow for each course', () => {
     const program = DASHBOARD_RESPONSE[1];
     assert(program.courses.length > 0);
     let now = moment();
-    const checkout = () => null;
     const wrapper = shallow(
-      <CourseListCard
-        program={program}
-        now={now}
-        checkout={checkout}
-        openFinancialAidCalculator={() => undefined}
-      />
+      <CourseListCard program={program} now={now} {...defaultCardParams} />
     );
     assert.equal(wrapper.find(CourseRow).length, program.courses.length);
     wrapper.find(CourseRow).forEach((courseRow, i) => {
       const props = courseRow.props();
       assert.equal(props.now, now);
       assert.equal(props.course, program.courses[i]);
-      assert.equal(props.checkout, checkout);
+      assert.equal(props.checkout, defaultCardParams.checkout);
     });
   });
 
@@ -36,7 +35,7 @@ describe('CourseListCard', () => {
     const program = DASHBOARD_RESPONSE[1];
     assert(program.courses.length > 0);
     const wrapper = shallow(
-      <CourseListCard program={program} checkout={() => null} openFinancialAidCalculator={() => undefined} />
+      <CourseListCard program={program} {...defaultCardParams} />
     );
     let nows = wrapper.find(CourseRow).map(courseRow => courseRow.props().now);
     assert(nows.length > 0);
@@ -50,7 +49,7 @@ describe('CourseListCard', () => {
     const program = _.cloneDeep(DASHBOARD_RESPONSE[1]);
     program.financial_aid_availability = false;
     const wrapper = shallow(
-      <CourseListCard program={program} checkout={() => null} openFinancialAidCalculator={() => undefined} />
+      <CourseListCard program={program} {...defaultCardParams} />
     );
     assert.equal(wrapper.find('.personalized-pricing').length, 0);
   });

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -5,27 +5,48 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 import CourseAction from './CourseAction';
 import CourseStatus from './CourseStatus';
 import CourseDescription from './CourseDescription';
-import type { Course } from '../../flow/programTypes';
+import type { Course, FinancialAidUserInfo } from '../../flow/programTypes';
+import type { CoursePrice } from '../../flow/dashboardTypes';
 
 export default class CourseRow extends React.Component {
   props: {
     checkout: Function,
     course: Course,
+    coursePrice: CoursePrice,
+    financialAid: FinancialAidUserInfo,
+    hasFinancialAid: boolean,
+    openFinancialAidCalculator: () => void,
     now: moment$Moment,
   };
 
   render() {
-    const { course, now, checkout } = this.props;
+    const {
+      course,
+      coursePrice,
+      financialAid,
+      hasFinancialAid,
+      checkout,
+      openFinancialAidCalculator,
+      now
+    } = this.props;
 
     return <Grid className="course-row">
-      <Cell col={6}>
+      <Cell col={5}>
         <CourseDescription course={course} />
       </Cell>
       <Cell col={3}>
         <CourseStatus course={course}/>
       </Cell>
-      <Cell col={3}>
-        <CourseAction course={course} now={now} checkout={checkout} />
+      <Cell col={4}>
+        <CourseAction
+          course={course}
+          coursePrice={coursePrice}
+          hasFinancialAid={hasFinancialAid}
+          financialAid={financialAid}
+          checkout={checkout}
+          openFinancialAidCalculator={openFinancialAidCalculator}
+          now={now}
+        />
       </Cell>
     </Grid>;
   }

--- a/static/js/components/dashboard/CourseRow_test.js
+++ b/static/js/components/dashboard/CourseRow_test.js
@@ -8,18 +8,40 @@ import CourseRow from './CourseRow';
 import CourseAction from './CourseAction';
 import CourseDescription from './CourseDescription';
 import CourseStatus from './CourseStatus';
-import { DASHBOARD_RESPONSE } from '../../constants';
+import {
+  DASHBOARD_RESPONSE,
+  COURSE_PRICES_RESPONSE,
+  FINANCIAL_AID_PARTIAL_RESPONSE
+} from '../../constants';
 
 describe('CourseRow', () => {
   it('forwards the appropriate props', () => {
     const course = DASHBOARD_RESPONSE[1].courses[0];
+    const hasFinancialAid = true;
+    const financialAid = FINANCIAL_AID_PARTIAL_RESPONSE;
+    const coursePrice = COURSE_PRICES_RESPONSE[0];
+    const openFinancialAidCalculator = () => {};
     const now = moment();
     const checkout = () => null;
-    const wrapper = shallow(<CourseRow course={course} now={now} checkout={checkout} />);
+    const wrapper = shallow(
+      <CourseRow
+        course={course}
+        hasFinancialAid={hasFinancialAid}
+        financialAid={financialAid}
+        coursePrice={coursePrice}
+        now={now}
+        checkout={checkout}
+        openFinancialAidCalculator={openFinancialAidCalculator}
+      />
+    );
     assert.deepEqual(wrapper.find(CourseAction).props(), {
       now,
+      hasFinancialAid,
+      financialAid,
+      coursePrice,
       course,
       checkout,
+      openFinancialAidCalculator,
     });
     assert.deepEqual(wrapper.find(CourseDescription).props(), {
       course,

--- a/static/js/components/dashboard/CourseStatus.js
+++ b/static/js/components/dashboard/CourseStatus.js
@@ -1,62 +1,14 @@
 // @flow
 import React from 'react';
-import _ from 'lodash';
 
-import type {
-  Course,
-  CourseRun
-} from '../../flow/programTypes';
-import {
-  STATUS_CAN_UPGRADE,
-  STATUS_OFFERED,
-} from '../../constants';
-import { formatPrice } from '../../util/util';
-import { courseListToolTip } from './util';
+import type { Course } from '../../flow/programTypes';
 
 export default class CourseStatus extends React.Component {
   props: {
     course: Course
   };
 
-  coursePrice(firstRun: CourseRun): string {
-    let courseHasPrice = (
-      !_.isNil(firstRun.price) &&
-      (firstRun.status === STATUS_OFFERED || firstRun.status === STATUS_CAN_UPGRADE)
-    );
-
-    if (courseHasPrice) {
-      return formatPrice(firstRun.price);
-    }
-
-    return '';
-  }
-
   render() {
-    const { course } = this.props;
-    let firstRun: CourseRun = {};
-    let priceDisplay;
-    let tooltipDisplay;
-
-    if (course.runs.length > 0) {
-      firstRun = course.runs[0];
-    }
-    const price = this.coursePrice(firstRun);
-
-    if (price) {
-      priceDisplay = <span className="price">{price}</span>;
-    }
-
-    if (firstRun.status === STATUS_CAN_UPGRADE) {
-      tooltipDisplay = courseListToolTip(
-        "You need to enroll in the Verified Course to get MicroMasters credit.",
-        `course-detail${course.id}`,
-      );
-    }
-
-    return (
-      <div className="course-status">
-        {priceDisplay} {tooltipDisplay}
-      </div>
-    );
+    return null;
   }
 }

--- a/static/js/components/dashboard/CourseStatus_test.js
+++ b/static/js/components/dashboard/CourseStatus_test.js
@@ -4,74 +4,10 @@ import { shallow } from 'enzyme';
 import { assert } from 'chai';
 
 import CourseStatus from './CourseStatus';
-import {
-  STATUS_PASSED,
-  STATUS_CAN_UPGRADE,
-  STATUS_CURRENTLY_ENROLLED,
-  STATUS_OFFERED,
-  STATUS_NOT_PASSED,
-} from '../../constants';
 
-import { findCourse } from './CourseDescription_test';
+import { findCourse } from '../../util/test_utils';
 
 describe('CourseStatus', () => {
-  it('shows price of course with status offered', () => {
-    let course = findCourse(course => (
-      course.runs.length > 0 &&
-      course.runs[0].status === STATUS_OFFERED
-    ));
-    assert.equal(course.runs[0].price, 50.00);
-
-    const wrapper = shallow(<CourseStatus course={course}/>);
-    assert.equal(wrapper.find(".price").text(), "$50");
-  });
-
-  it('shows price of course with status enrolled', () => {
-    let course = findCourse(course => (
-      course.runs.length > 0 &&
-      course.runs[0].status === STATUS_CAN_UPGRADE
-    ));
-    assert.equal(course.runs[0].price, 50.00);
-
-    const wrapper = shallow(<CourseStatus course={course}/>);
-    assert.equal(wrapper.find(".price").text(), "$50");
-  });
-
-  for (let status of [STATUS_PASSED, STATUS_NOT_PASSED, STATUS_CURRENTLY_ENROLLED]) {
-    it(`doesn't show the price of course with status ${status}`, () => {
-      let course = findCourse(course => (
-        course.runs.length > 0 &&
-        course.runs[0].status === status
-      ));
-      assert.isNotOk(course.runs[0].price);
-
-      const wrapper = shallow(<CourseStatus course={course}/>);
-      assert.equal(wrapper.find(".price").length, 0);
-    });
-  }
-
-  it('shows the tooltip for status enrolled', () => {
-    let course = findCourse(course => (
-      course.runs.length > 0 &&
-      course.runs[0].status === STATUS_CAN_UPGRADE
-    ));
-    const wrapper = shallow(<CourseStatus course={course}/>);
-    let tooltip = wrapper.find(".help");
-    assert.equal(tooltip.length, 1);
-  });
-
-  for (let status of [STATUS_OFFERED, STATUS_CURRENTLY_ENROLLED, STATUS_NOT_PASSED, STATUS_PASSED]) {
-    it(`doesn't show any tooltip for status ${status}`, () => {
-      let course = findCourse(course => (
-        course.runs.length > 0 &&
-        course.runs[0].status === status
-      ));
-      const wrapper = shallow(<CourseStatus course={course}/>);
-      let tooltip = wrapper.find(".help");
-      assert.equal(tooltip.length, 0);
-    });
-  }
-
   it("doesn't show anything if there are no runs", () => {
     let course = findCourse(course => course.runs.length === 0);
     const wrapper = shallow(<CourseStatus course={course}/>);

--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -119,7 +119,7 @@ export default class FinancialAidCard extends React.Component {
     case FA_STATUS_SKIPPED:
       return <Grid className="financial-aid-box">
         <Cell col={12}>
-          Your cost is <b>{price(coursePrice.course_price)} per course</b>.
+          Your cost is <b>{price(coursePrice.price)} per course</b>.
         </Cell>
       </Grid>;
     case FA_STATUS_PENDING_MANUAL_APPROVAL:
@@ -128,7 +128,7 @@ export default class FinancialAidCard extends React.Component {
       return <div>
         <Grid>
           <Cell col={12}>
-            Your cost is {price(coursePrice.course_price)} per course.
+            Your cost is {price(coursePrice.price)} per course.
           </Cell>
         </Grid>
 

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -47,13 +47,20 @@ export const ALL_COURSE_STATUSES = [
 
 // financial aid statuses
 export const FA_STATUS_CREATED = 'created';
-export const FA_STATUS_AUTO_APPROVED = 'auto-approved';
 export const FA_STATUS_PENDING_DOCS = 'pending-docs';
+export const FA_STATUS_DOCS_SENT = 'docs-sent';
 export const FA_STATUS_PENDING_MANUAL_APPROVAL = 'pending-manual-approval';
 export const FA_STATUS_APPROVED = 'approved';
+export const FA_STATUS_AUTO_APPROVED = 'auto-approved';
 export const FA_STATUS_REJECTED = 'rejected';
-export const FA_STATUS_DOCS_SENT = 'docs-sent';
 export const FA_STATUS_SKIPPED = 'skipped';
+
+export const FA_PENDING_STATUSES = [
+  FA_STATUS_PENDING_DOCS,
+  FA_STATUS_DOCS_SENT,
+  FA_STATUS_PENDING_MANUAL_APPROVAL
+];
+export const FA_APPROVED_STATUSES = [FA_STATUS_APPROVED, FA_STATUS_AUTO_APPROVED];
 
 export const TOAST_SUCCESS = 'success';
 export const TOAST_FAILURE = 'failure';
@@ -342,6 +349,7 @@ export const DASHBOARD_RESPONSE = [
         "id": 4
       }
     ],
+    "financial_aid_availability": false,
     "id": 3
   },
   {
@@ -413,6 +421,7 @@ export const DASHBOARD_RESPONSE = [
             "course_start_date": "2016-08-22T11:48:27Z",
             "fuzzy_start_date": "Fall 2017",
             "course_end_date": "2016-09-09T10:20:10Z",
+            "course_upgrade_deadline": "2016-08-20T11:48:27Z",
           }
         ],
         "description": null,
@@ -499,6 +508,7 @@ export const DASHBOARD_RESPONSE = [
     ],
     "title": "Master Program",
     "description": null,
+    "financial_aid_availability": false,
     "id": 4
   },
   {
@@ -525,6 +535,7 @@ export const DASHBOARD_RESPONSE = [
         "prerequisites": ""
       },
     ],
+    "financial_aid_availability": false,
     "id": 5
   },
 ];
@@ -540,11 +551,24 @@ export const PROGRAM_ENROLLMENTS = [
   },
 ];
 
+export const FINANCIAL_AID_PARTIAL_RESPONSE = {
+  application_status: null,
+  has_user_applied: false,
+  max_possible_cost: 1000,
+  min_possible_cost: 1000
+};
+
 export const COURSE_PRICES_RESPONSE = [{
   program_id: DASHBOARD_RESPONSE[1].id,
-  course_price: 100.00,
+  price: 100.00,
   financial_aid_adjustment: false,
-  financial_aid_availability: true,
+  financial_aid_availability: false,
+  has_financial_aid_request: false
+}, {
+  program_id: DASHBOARD_RESPONSE[2].id,
+  price: 200.00,
+  financial_aid_adjustment: false,
+  financial_aid_availability: false,
   has_financial_aid_request: false
 }];
 

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -59,7 +59,7 @@ class App extends React.Component {
     currentProgramEnrollment: ProgramEnrollment,
     dispatch:                 Dispatch,
     dashboard:                DashboardState,
-    coursePrices:             CoursePricesState,
+    prices:                   CoursePricesState,
     enrollments:              ProgramEnrollmentsState,
     history:                  Object,
     ui:                       UIState,
@@ -111,8 +111,8 @@ class App extends React.Component {
   }
 
   fetchCoursePrices() {
-    const { coursePrices, dispatch } = this.props;
-    if (coursePrices.fetchStatus === undefined) {
+    const { prices, dispatch } = this.props;
+    if (prices.fetchStatus === undefined) {
       dispatch(fetchCoursePrices());
     }
   }
@@ -198,7 +198,7 @@ class App extends React.Component {
         enrollSelectedProgram,
       },
       location: { pathname },
-      dashboard,
+      dashboard
     } = this.props;
     let { children } = this.props;
     let empty = false;
@@ -265,7 +265,7 @@ const mapStateToProps = (state) => {
   return {
     userProfile:              profile,
     dashboard:                state.dashboard,
-    coursePrices:             state.coursePrices,
+    prices:                   state.prices,
     ui:                       state.ui,
     currentProgramEnrollment: state.currentProgramEnrollment,
     enrollments:              state.enrollments,

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -36,10 +36,10 @@ class DashboardPage extends React.Component {
   };
 
   props: {
-    coursePrices:             CoursePricesState,
     profile:                  ProfileGetResult,
     currentProgramEnrollment: ProgramEnrollment,
     dashboard:                DashboardState,
+    prices:                   CoursePricesState,
     dispatch:                 Dispatch,
     setCalculatorVisibility:  (b: boolean) => void,
     ui:                       UIState,
@@ -120,25 +120,25 @@ class DashboardPage extends React.Component {
 
   render() {
     const {
-      coursePrices,
       dashboard,
+      prices,
       profile: { profile },
       documents: { documentSentDate },
       currentProgramEnrollment,
     } = this.props;
-    const loaded = dashboard.fetchStatus !== FETCH_PROCESSING;
+    const loaded = dashboard.fetchStatus !== FETCH_PROCESSING && prices.fetchStatus !== FETCH_PROCESSING;
     let errorMessage;
     let dashboardContent;
     // if there are no errors coming from the backend, simply show the dashboard
     let program, coursePrice;
     if (!_.isNil(currentProgramEnrollment)) {
       program = dashboard.programs.find(program => program.id === currentProgramEnrollment.id);
-      coursePrice = coursePrices.coursePrices.find(prices => prices.program_id === currentProgramEnrollment.id);
+      coursePrice = prices.coursePrices.find(coursePrice => coursePrice.program_id === currentProgramEnrollment.id);
     }
     if (dashboard.errorInfo !== undefined) {
       errorMessage = <ErrorMessage errorInfo={dashboard.errorInfo}/>;
-    } else if (coursePrices.errorInfo !== undefined) {
-      errorMessage = <ErrorMessage errorInfo={coursePrices.errorInfo} />;
+    } else if (prices.errorInfo !== undefined) {
+      errorMessage = <ErrorMessage errorInfo={prices.errorInfo} />;
     } else if (_.isNil(program) || _.isNil(coursePrice)) {
       errorMessage = <ErrorMessage errorInfo={{user_message: "No program enrollment is available."}} />;
     } else {
@@ -160,8 +160,10 @@ class DashboardPage extends React.Component {
             {financialAidCard}
             <CourseListCard
               program={program}
+              coursePrice={coursePrice}
               key={program.id}
               checkout={this.dispatchCheckout}
+              openFinancialAidCalculator={this.openFinancialAidCalculator}
             />
           </div>
           <div className="second-column">
@@ -194,8 +196,8 @@ const mapStateToProps = (state) => {
 
   return {
     profile: profile,
-    coursePrices: state.coursePrices,
     dashboard: state.dashboard,
+    prices: state.prices,
     currentProgramEnrollment: state.currentProgramEnrollment,
     ui: state.ui,
     documents: state.documents,

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -15,7 +15,7 @@ import {
   TOAST_FAILURE,
   TOAST_SUCCESS,
 } from '../constants';
-import { findCourse } from '../components/dashboard/CourseDescription_test';
+import { findCourse } from '../util/test_utils';
 
 describe('DashboardPage', () => {
   let renderComponent, helper;

--- a/static/js/flow/dashboardTypes.js
+++ b/static/js/flow/dashboardTypes.js
@@ -9,7 +9,7 @@ export type DashboardState = {
 
 export type CoursePrice = {
   program_id: number,
-  course_price: number,
+  price: number,
   financial_aid_adjustment: boolean,
   financial_aid_availability: boolean,
   has_financial_aid_request: boolean

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -25,9 +25,15 @@ export type CourseRun = {
   fuzzy_start_date?: string;
   course_start_date?: string;
   course_end_date?: string;
+  course_upgrade_deadline?: string;
   price?: number;
 };
-
+export type FinancialAid = {
+  application_status: string;
+  has_user_applied: boolean;
+  max_possible_cost: number;
+  min_possible_cost: number;
+};
 export type UserProgram = {
   grade_average: number
 };

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -199,7 +199,7 @@ export const checkout = (state: CheckoutState = INITIAL_CHECKOUT_STATE, action: 
 const INITIAL_COURSE_PRICES_STATE: CoursePricesState = {
   coursePrices: []
 };
-export const coursePrices = (state: CoursePricesState = INITIAL_COURSE_PRICES_STATE, action: Action) => {
+export const prices = (state: CoursePricesState = INITIAL_COURSE_PRICES_STATE, action: Action) => {
   switch (action.type) {
   case REQUEST_COURSE_PRICES:
     return Object.assign({}, state, {
@@ -228,7 +228,7 @@ export default combineReducers({
   ui,
   email,
   checkout,
-  coursePrices,
+  prices,
   enrollments,
   currentProgramEnrollment,
   signupDialog,

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -1,6 +1,28 @@
 import TestUtils from 'react-addons-test-utils';
 import { assert } from 'chai';
 import sinon from 'sinon';
+import _ from 'lodash';
+
+import { DASHBOARD_RESPONSE } from '../constants';
+import type {
+  Course,
+  Program
+} from '../../flow/programTypes';
+
+export function findCourse(courseSelector: (course: Course, program: Program) => boolean): Course {
+  for (let program of DASHBOARD_RESPONSE) {
+    for (let course of program.courses) {
+      if (courseSelector(course, program)) {
+        return course;
+      }
+    }
+  }
+  throw "Unable to find course";
+}
+
+export function findAndCloneCourse(courseSelector: (course: Course, program: Program) => boolean): Course {
+  return _.cloneDeep(findCourse(courseSelector));
+}
 
 export const modifyTextField = (field, text) => {
   field.value = text;

--- a/static/js/util/validation_test.js
+++ b/static/js/util/validation_test.js
@@ -508,7 +508,7 @@ describe('Email validation', () => {
   });
 });
 
-describe('financial aid validation', () => {
+describe('Financial aid validation', () => {
   let financialAid;
 
   beforeEach(() => {

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -245,6 +245,8 @@ c.validation-wrapper {
         text-align: center;
 
         .course-action-action {
+          padding-bottom: 3px;
+
           .material-icons {
             color: $mm-brand-fg;
             font-size: 28pt;
@@ -254,6 +256,11 @@ c.validation-wrapper {
         .course-action-description {
           color: $darkgrey;
           font-size: 10pt;
+        }
+
+        .mdl-button[disabled] {
+          background-color: $lightgrey;
+          color: #ffffff;
         }
       }
     }


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #1102 

#### What's this PR do?

- handles financial aid and course price information coming from our APIs
- covers the pre-enroll states outlined in #1102 (full invision design [here](https://projects.invisionapp.com/share/NB7VM1GSG#/screens/185611170))

#### Where should the reviewer start?

static/js/components/dashboard/CourseAction.js

#### How should this be manually tested?

FYI: I have a few code snippets that create the states needed for this. If you'd like to use them, let me know and I'll tidy them up and send them over

First you'll need to set up some data:

1. CoursePrice records for any programs you intend to test
1. No previous enrollments in the CourseRuns you want to test for your user
1. For any CourseRun you want to test, set it to have a future start_date and enrollment_start_date

Second, you'll need to satisfy the following conditions to test the 3 states in #1102:

1. Program with no financial aid
1. Program with financial aid, FinancialAid record with null status
1. Program with financial aid, FinancialAid record with a pending status (`FinancialAidStatus.PENDING_DOCS` or `FinancialAidStatus.PENDING_MANUAL_APPROVAL`)

#### Screenshots (if appropriate)


