### PR TITLE
Removed filter on program enrollments in dashboard API

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -15,14 +15,13 @@ from edx_api.client import EdxApi
 
 from backends import utils
 from backends.edxorg import EdxOrgOAuth2
-
+from courses.models import Program
 from dashboard.api import (
     get_info_for_program,
     get_student_certificates,
     get_student_current_grades,
     get_student_enrollments,
 )
-from dashboard.models import ProgramEnrollment
 from dashboard.utils import MMTrack
 
 
@@ -62,10 +61,10 @@ class UserDashboard(APIView):
         current_grades = get_student_current_grades(request.user, edx_client)
 
         response_data = []
-        for program_enrollment in ProgramEnrollment.objects.filter(user=request.user, program__live=True):
+        for program in Program.objects.filter(live=True):
             mmtrack_info = MMTrack(
                 request.user,
-                program_enrollment.program,
+                program,
                 enrollments,
                 current_grades,
                 certificates

--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -94,11 +94,11 @@ class DashboardTest(APITestCase):
 
         assert res.status_code == status.HTTP_200_OK
         data = res.data
-        assert len(data) == 2
-        program_ids = [data[0]['id'], data[1]['id'], ]
+        assert len(data) == 3
+        program_ids = [data[0]['id'], data[1]['id'], data[2]['id'], ]
         assert self.program_1.pk in program_ids
         assert self.program_3.pk in program_ids
-        assert self.program_2.pk not in program_ids
+        assert self.program_2.pk in program_ids
         assert self.program_no_live.pk not in program_ids
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1193

#### What's this PR do?
Removes the filter on program enrollments. The dashboard API will again show programs the user is not currently enrolled in.
