### PR TITLE
Exposed the financial aid obj ID in dashboard API

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -137,6 +137,7 @@ def get_info_for_program(mmtrack):
     }
     if mmtrack.financial_aid_available:
         data["financial_aid_user_info"] = {
+            "id": mmtrack.financial_aid_id,
             "has_user_applied": mmtrack.financial_aid_applied,
             "application_status": mmtrack.financial_aid_status,
             "min_possible_cost": mmtrack.financial_aid_min_price,

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -779,6 +779,7 @@ class InfoProgramTest(ESTestCase):
     def test_program_financial_aid(self, mock_info_course):
         """Test happy path"""
         kwargs = {
+            'financial_aid_id': 1122334455,
             'program': self.program,
             'financial_aid_available': True,
             'financial_aid_applied': True,
@@ -799,6 +800,7 @@ class InfoProgramTest(ESTestCase):
             "courses": [{'position_in_program': 1}, {'position_in_program': 1}],
             "financial_aid_availability": kwargs['financial_aid_available'],
             "financial_aid_user_info": {
+                "id": kwargs['financial_aid_id'],
                 "has_user_applied": kwargs['financial_aid_applied'],
                 "application_status": kwargs['financial_aid_status'],
                 "min_possible_cost": kwargs['financial_aid_min_price'],

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -29,7 +29,7 @@ class MMTrack:
     financial_aid_available = None
     financial_aid_applied = None
     financial_aid_status = None
-    financial_aid = None
+    financial_aid_id = None
     financial_aid_min_price = None
     financial_aid_max_price = None
     financial_aid_date_documents_sent = None
@@ -64,10 +64,12 @@ class MMTrack:
                     Q(user=user) & Q(tier_program__program=program))
                 self.financial_aid_applied = financial_aid_qset.exists()
                 if self.financial_aid_applied:
-                    self.financial_aid = financial_aid_qset.first()
-                    self.financial_aid_status = self.financial_aid.status
+                    financial_aid = financial_aid_qset.first()
+                    self.financial_aid_status = financial_aid.status
                     # set the sent document date
-                    self.financial_aid_date_documents_sent = self.financial_aid.date_documents_sent
+                    self.financial_aid_date_documents_sent = financial_aid.date_documents_sent
+                    # and the financial aid ID
+                    self.financial_aid_id = financial_aid.id
 
                 # set the price range for the program
                 self.financial_aid_min_price, self.financial_aid_max_price = self._get_program_fa_prices()

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -127,9 +127,10 @@ class MMTrackTest(TestCase):
         assert mmtrack.paid_course_ids == []
         assert mmtrack.financial_aid_applied is None
         assert mmtrack.financial_aid_status is None
-        assert mmtrack.financial_aid is None
+        assert mmtrack.financial_aid_id is None
         assert mmtrack.financial_aid_min_price is None
         assert mmtrack.financial_aid_max_price is None
+        assert mmtrack.financial_aid_date_documents_sent is None
 
     def test_init_financial_aid_track(self):
         """
@@ -153,9 +154,10 @@ class MMTrackTest(TestCase):
         assert mmtrack.paid_course_ids == []
         assert mmtrack.financial_aid_applied is False
         assert mmtrack.financial_aid_status is None
-        assert mmtrack.financial_aid is None
+        assert mmtrack.financial_aid_id is None
         assert mmtrack.financial_aid_min_price == 250
         assert mmtrack.financial_aid_max_price == 1000
+        assert mmtrack.financial_aid_date_documents_sent is None
 
     def test_init_financial_aid_with_application(self):
         """
@@ -176,9 +178,36 @@ class MMTrackTest(TestCase):
 
         assert mmtrack.financial_aid_applied is True
         assert mmtrack.financial_aid_status == fin_aid.status
-        assert mmtrack.financial_aid == fin_aid
+        assert mmtrack.financial_aid_id == fin_aid.id
         assert mmtrack.financial_aid_min_price == 250
         assert mmtrack.financial_aid_max_price == 1000
+        assert mmtrack.financial_aid_date_documents_sent is None
+
+    def test_init_financial_aid_with_documents_sent(self):
+        """
+        Sub case of test_init_financial_aid_with_application
+        where the user set a date for the financial aid documents sent
+        """
+        # create a financial aid application
+        fin_aid = FinancialAidFactory.create(
+            user=self.user,
+            tier_program=self.min_tier_program,
+            date_documents_sent=self.now,
+        )
+        mmtrack = MMTrack(
+            user=self.user,
+            program=self.program_financial_aid,
+            enrollments=self.enrollments,
+            current_grades=self.current_grades,
+            certificates=self.certificates
+        )
+
+        assert mmtrack.financial_aid_applied is True
+        assert mmtrack.financial_aid_status == fin_aid.status
+        assert mmtrack.financial_aid_id == fin_aid.id
+        assert mmtrack.financial_aid_min_price == 250
+        assert mmtrack.financial_aid_max_price == 1000
+        assert mmtrack.financial_aid_date_documents_sent == self.now.date()
 
     def test_course_price_mandatory(self):
         """


### PR DESCRIPTION
#### What's this PR do?
Exposes the financial aid object ID in the Dashboard REST API

It also adds one missing test for the financial aid documents sent date
