### PR TITLE
Set unique URL for tabs in program page

### DIFF
--- a/static/js/public.js
+++ b/static/js/public.js
@@ -121,3 +121,38 @@ jQuery(document).ready(function ($) {
     emailBody: description + CURRENT_PAGE_URL
   });
 });
+
+/**
+ * Set url hash if hash provided in the url,
+ * or set hash based on the active panel
+ */
+$(function(){
+  $('.mdl-tabs__tab').click(function(){
+    document.location.hash = $(this).attr('href');
+  });
+  if (document.location.hash){
+    setPanelActive(document.location.hash);
+  } else {
+    location.hash = $('.mdl-tabs__tab.is-active').attr('href');
+  }
+});
+
+$(window).on('hashchange', function () {
+  if (location.hash) {
+    setPanelActive(location.hash);
+  }
+});
+
+/**
+ *  Given a valid hash, set the corresponding panel active.
+ */
+function setPanelActive(hash){
+  var $panel = $(hash);
+  if ($panel.length > 0) {
+    $(".mdl-tabs__panel, .mdl-tabs__tab").removeClass('is-active');
+    $panel.addClass('is-active');
+    $(`a.mdl-tabs__tab[href="${hash}"]`).addClass('is-active');
+  } else {
+    location.hash = $('.mdl-tabs__tab.is-active').attr('href');
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Fix ##1191
#### What's this PR do?
Set a unique hash in the url for tabs in the Program page.

The user can directly go to desired tab having the correct hash in the url. If hash is invalid then the hash defaults to the panel that is active.

![screen shot 2016-10-03 at 3 35 39 pm](https://cloud.githubusercontent.com/assets/7574259/19050906/a91ec5fa-897e-11e6-9aba-fe1da76628cd.png)

