### PR TITLE
financial aid skip API code

### DIFF
--- a/static/js/actions/financial_aid.js
+++ b/static/js/actions/financial_aid.js
@@ -4,6 +4,10 @@ import { createAction } from 'redux-actions';
 
 import type { Dispatcher } from '../flow/reduxTypes';
 import * as api from '../util/api';
+import {
+  fetchCoursePrices,
+  fetchDashboard,
+} from '.';
 
 export const START_CALCULATOR_EDIT = 'START_CALCULATOR_EDIT';
 export const startCalculatorEdit = createAction(START_CALCULATOR_EDIT);
@@ -37,6 +41,31 @@ export const addFinancialAid = (income: number, currency: string, programId: num
       () => {
         dispatch(receiveAddFinancialAidFailure());
         return Promise.reject();
+      });
+  };
+};
+
+export const REQUEST_SKIP_FINANCIAL_AID = 'REQUEST_SKIP_FINANCIAL_AID';
+export const requestSkipFinancialAid = createAction(REQUEST_SKIP_FINANCIAL_AID);
+
+export const RECEIVE_SKIP_FINANCIAL_AID_SUCCESS = 'RECEIVE_SKIP_FINANCIAL_AID_SUCCESS';
+export const receiveSkipFinancialAidSuccess = createAction(RECEIVE_SKIP_FINANCIAL_AID_SUCCESS);
+
+export const RECEIVE_SKIP_FINANCIAL_AID_FAILURE = 'RECEIVE_SKIP_FINANCIAL_AID_FAILURE';
+export const receiveSkipFinancialAidFailure = createAction(RECEIVE_SKIP_FINANCIAL_AID_FAILURE);
+
+export const skipFinancialAid = (programId: number): Dispatcher<*> => {
+  return (dispatch: Dispatch) => {
+    dispatch(requestSkipFinancialAid());
+    return api.skipFinancialAid(programId).then(
+      () => {
+        dispatch(receiveSkipFinancialAidSuccess());
+        dispatch(fetchCoursePrices());
+        dispatch(fetchDashboard());
+        return Promise.resolve();
+      },
+      () => {
+        dispatch(receiveSkipFinancialAidFailure());
       });
   };
 };

--- a/static/js/actions/financial_aid_test.js
+++ b/static/js/actions/financial_aid_test.js
@@ -14,6 +14,12 @@ import {
   receiveAddFinancialAidSuccess,
   RECEIVE_ADD_FINANCIAL_AID_FAILURE,
   receiveAddFinancialAidFailure,
+  REQUEST_SKIP_FINANCIAL_AID,
+  requestSkipFinancialAid,
+  RECEIVE_SKIP_FINANCIAL_AID_FAILURE,
+  receiveSkipFinancialAidFailure,
+  RECEIVE_SKIP_FINANCIAL_AID_SUCCESS,
+  receiveSkipFinancialAidSuccess,
 } from './financial_aid';
 import { assertCreatedActionHelper } from './util';
 
@@ -27,6 +33,9 @@ describe('financial aid actions', () => {
       [requestAddFinancialAid, REQUEST_ADD_FINANCIAL_AID],
       [receiveAddFinancialAidSuccess, RECEIVE_ADD_FINANCIAL_AID_SUCCESS],
       [receiveAddFinancialAidFailure, RECEIVE_ADD_FINANCIAL_AID_FAILURE],
+      [requestSkipFinancialAid, REQUEST_SKIP_FINANCIAL_AID],
+      [receiveSkipFinancialAidFailure, RECEIVE_SKIP_FINANCIAL_AID_FAILURE],
+      [receiveSkipFinancialAidSuccess, RECEIVE_SKIP_FINANCIAL_AID_SUCCESS],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -25,7 +25,7 @@ export default class CourseAction extends React.Component {
     coursePrice: CoursePrice,
     financialAid: FinancialAidUserInfo,
     hasFinancialAid: boolean,
-    openFinancialAidCalculator: () => void,
+    openFinancialAidCalculator?: () => void,
     now: moment$Moment,
   };
 

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -11,11 +11,11 @@ import FinancialAidCalculator from '../../containers/FinancialAidCalculator';
 
 export default class CourseListCard extends React.Component {
   props: {
-    checkout:                   Function,
-    program:                    Program,
-    coursePrice:                CoursePrice,
-    openFinancialAidCalculator: () => void,
-    now?:                       Object,
+    checkout:                     Function,
+    program:                      Program,
+    coursePrice:                  CoursePrice,
+    openFinancialAidCalculator?:  () => void,
+    now?:                         Object,
   };
 
   render() {

--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -29,6 +29,7 @@ export default class FinancialAidCard extends React.Component {
     openFinancialAidCalculator: () => void,
     documentSentDate: Object,
     setDocumentSentDate: Function,
+    skipFinancialAid: (p: number) => void,
   };
 
   renderDocumentStatus() {
@@ -82,6 +83,7 @@ export default class FinancialAidCard extends React.Component {
     const {
       program,
       openFinancialAidCalculator,
+      skipFinancialAid,
     } = this.props;
     const {
       min_possible_cost: minPossibleCost,
@@ -97,12 +99,17 @@ export default class FinancialAidCard extends React.Component {
         Courses cost varies between {price(minPossibleCost)} and {price(maxPossibleCost)} (full
         price), depending on your income and ability to pay.
       </div>
-      <button
-        className="mm-button dashboard-button"
-        onClick={openFinancialAidCalculator}
-      >
-        Calculate your cost
-      </button>
+      <div className="pricing-actions">
+        <button
+          className="mm-button dashboard-button"
+          onClick={openFinancialAidCalculator}
+        >
+          Calculate your cost
+        </button>
+        <a className="full-price" onClick={() => skipFinancialAid(program.id)}>
+          Skip this and Pay Full Price
+        </a>
+      </div>
     </div>;
   }
 

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -29,6 +29,7 @@ import type { UIState } from '../reducers/ui';
 import type { CoursePricesState, DashboardState } from '../flow/dashboardTypes';
 import type { ProgramEnrollment } from '../flow/enrollmentTypes';
 import type { ProfileGetResult } from '../flow/profileTypes';
+import { skipFinancialAid } from '../actions/financial_aid';
 
 class DashboardPage extends React.Component {
   static contextTypes = {
@@ -118,6 +119,11 @@ class DashboardPage extends React.Component {
     dispatch(setDocumentSentDate(newDate));
   };
 
+  skipFinancialAid = programId => {
+    const { dispatch } = this.props;
+    dispatch(skipFinancialAid(programId));
+  }
+
   render() {
     const {
       dashboard,
@@ -150,6 +156,7 @@ class DashboardPage extends React.Component {
           openFinancialAidCalculator={this.openFinancialAidCalculator}
           documentSentDate={documentSentDate}
           setDocumentSentDate={this.setDocumentSentDate}
+          skipFinancialAid={this.skipFinancialAid}
         />;
       }
 

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -11,6 +11,7 @@ import {
   clearCalculatorEdit,
   addFinancialAid,
   updateCalculatorValidation,
+  skipFinancialAid,
 } from '../actions/financial_aid';
 import { setCalculatorDialogVisibility } from '../actions/ui';
 import {
@@ -85,15 +86,14 @@ const actionButtons = R.map(({ name, onClick, label}) => (
     { label }
   </Button>
 ));
-
-const calculatorActions = (cancel, save) => {
+const calculatorActions = (skipFinancialAid, programId, cancel, save) => {
   const buttonManifest = [
     { name: 'cancel', onClick: cancel, label: 'Cancel' },
     { name: 'main-action save', onClick: save, label: 'Calculate' },
   ];
 
   return <div className="actions">
-    <a className="full-price">
+    <a className="full-price" onClick={skipFinancialAid(programId)}>
       Skip this and Pay Full Price
     </a>
     <div className="buttons">
@@ -119,6 +119,7 @@ type CalculatorProps = {
   saveFinancialAid:           (f: FinancialAidState) => void,
   updateCalculatorEdit:       (f: FinancialAidState) => void,
   currentProgramEnrollment:   ProgramEnrollment,
+  skipFinancialAid:           (p: number) => void,
 };
 
 const FinancialAidCalculator = ({
@@ -128,7 +129,8 @@ const FinancialAidCalculator = ({
   financialAid: { validation },
   saveFinancialAid,
   updateCalculatorEdit,
-  currentProgramEnrollment: { title },
+  currentProgramEnrollment: { id, title },
+  skipFinancialAid,
 }: CalculatorProps) => (
   <Dialog
     open={calculatorDialogVisibility}
@@ -136,7 +138,7 @@ const FinancialAidCalculator = ({
     bodyClassName="financial-aid-calculator-body"
     onRequestClose={closeDialogAndCancel}
     autoScrollBodyContent={true}
-    actions={calculatorActions(closeDialogAndCancel, () => saveFinancialAid(financialAid))}
+    actions={calculatorActions(skipFinancialAid, id, closeDialogAndCancel, () => saveFinancialAid(financialAid))}
     title="Cost Calculator"
   >
     <div className="copy">
@@ -192,6 +194,13 @@ const saveFinancialAid = R.curry((dispatch, current) => {
   }
 });
 
+const skipFinancialAidHelper = R.curry((dispatch, programId) => () => {
+  dispatch(skipFinancialAid(programId)).then(() => {
+    dispatch(clearCalculatorEdit());
+    dispatch(setCalculatorDialogVisibility(false));
+  });
+});
+
 const mapStateToProps = state => {
   const {
     ui: { calculatorDialogVisibility },
@@ -210,6 +219,7 @@ const mapDispatchToProps = dispatch => {
   return {
     closeDialogAndCancel: closeDialogAndCancel(dispatch),
     saveFinancialAid: saveFinancialAid(dispatch),
+    skipFinancialAid: skipFinancialAidHelper(dispatch),
     ...createSimpleActionHelpers(dispatch, [
       ['clearCalculatorEdit', clearCalculatorEdit],
       ['updateCalculatorEdit', updateCalculatorEdit],

--- a/static/js/reducers/financial_aid.js
+++ b/static/js/reducers/financial_aid.js
@@ -6,7 +6,10 @@ import {
   UPDATE_CALCULATOR_VALIDATION,
   REQUEST_ADD_FINANCIAL_AID,
   RECEIVE_ADD_FINANCIAL_AID_SUCCESS,
-  RECEIVE_ADD_FINANCIAL_AID_FAILURE
+  RECEIVE_ADD_FINANCIAL_AID_FAILURE,
+  REQUEST_SKIP_FINANCIAL_AID,
+  RECEIVE_SKIP_FINANCIAL_AID_FAILURE,
+  RECEIVE_SKIP_FINANCIAL_AID_SUCCESS,
 } from '../actions/financial_aid';
 import {
   FETCH_FAILURE,
@@ -56,6 +59,12 @@ export const financialAid = (state: FinancialAidState = INITIAL_FINANCIAL_AID_ST
   case RECEIVE_ADD_FINANCIAL_AID_SUCCESS:
     return { ...state, fetchStatus: FETCH_SUCCESS };
   case RECEIVE_ADD_FINANCIAL_AID_FAILURE:
+    return { ...state, fetchStatus: FETCH_FAILURE };
+  case REQUEST_SKIP_FINANCIAL_AID:
+    return { ...state, fetchStatus: FETCH_PROCESSING };
+  case RECEIVE_SKIP_FINANCIAL_AID_SUCCESS:
+    return { ...state, fetchStatus: FETCH_SUCCESS };
+  case RECEIVE_SKIP_FINANCIAL_AID_FAILURE:
     return { ...state, fetchStatus: FETCH_FAILURE };
   default:
     return state;

--- a/static/js/reducers/financial_aid_test.js
+++ b/static/js/reducers/financial_aid_test.js
@@ -18,6 +18,10 @@ import {
   RECEIVE_ADD_FINANCIAL_AID_SUCCESS,
   RECEIVE_ADD_FINANCIAL_AID_FAILURE,
   addFinancialAid,
+  REQUEST_SKIP_FINANCIAL_AID,
+  RECEIVE_SKIP_FINANCIAL_AID_FAILURE,
+  RECEIVE_SKIP_FINANCIAL_AID_SUCCESS,
+  skipFinancialAid,
 } from '../actions/financial_aid';
 import {
   FETCH_FAILURE,
@@ -34,7 +38,7 @@ import * as api from '../util/api';
 
 describe('financial aid reducers', () => {
   let sandbox, store, dispatchThen;
-  let addFinancialAidStub;
+  let addFinancialAidStub, skipFinancialAidStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -42,6 +46,7 @@ describe('financial aid reducers', () => {
     dispatchThen = store.createDispatchThen(state => state.financialAid);
     store.dispatch(setCurrentProgramEnrollment(1));
     addFinancialAidStub = sandbox.stub(api, 'addFinancialAid');
+    skipFinancialAidStub = sandbox.stub(api, 'skipFinancialAid');
   });
 
   afterEach(() => {
@@ -120,6 +125,32 @@ describe('financial aid reducers', () => {
         fetchStatus: FETCH_FAILURE
       });
       assert.deepEqual(state, expectation);
+    });
+  });
+
+  it('should let you skip financial aid', () => {
+    skipFinancialAidStub.returns(Promise.resolve());
+    return dispatchThen(skipFinancialAid(2), [
+      REQUEST_SKIP_FINANCIAL_AID,
+      RECEIVE_SKIP_FINANCIAL_AID_SUCCESS
+    ]).then(state => {
+      assert.deepEqual(state, {
+        fetchStatus: FETCH_SUCCESS
+      });
+      assert.ok(skipFinancialAidStub.calledWith(2));
+    });
+  });
+
+  it('should fail to skip financial aid', () => {
+    skipFinancialAidStub.returns(Promise.reject());
+    return dispatchThen(skipFinancialAid(2), [
+      REQUEST_SKIP_FINANCIAL_AID,
+      RECEIVE_SKIP_FINANCIAL_AID_FAILURE
+    ]).then(state => {
+      assert.deepEqual(state, {
+        fetchStatus: FETCH_FAILURE
+      });
+      assert.ok(skipFinancialAidStub.calledWith(2));
     });
   });
 });

--- a/static/js/util/api.js
+++ b/static/js/util/api.js
@@ -210,3 +210,9 @@ export function addFinancialAid(income: number, currency: string, programId: num
 export function getCoursePrices(): Promise<*> {
   return mockableFetchJSONWithCSRF('/api/v0/course_prices/', {});
 }
+
+export function skipFinancialAid(programId: number): Promise<*> {
+  return mockableFetchJSONWithCSRF(`/api/v0/financial_aid_skip/${programId}/`, {
+    method: 'PATCH',
+  });
+}

--- a/static/js/util/api_test.js
+++ b/static/js/util/api_test.js
@@ -17,6 +17,7 @@ import {
   addProgramEnrollment,
   updateProfileImage,
   addFinancialAid,
+  skipFinancialAid,
 } from './api';
 import * as api from './api';
 import {
@@ -291,6 +292,33 @@ describe('api', function() {
               original_currency: 'USD',
               program_id: 3
             })
+          }));
+        });
+      });
+    });
+
+    describe('for skipping financial aid', () => {
+      let programId = 2;
+      it('successfully skips financial aid', () => {
+        fetchJSONStub.returns(Promise.resolve());
+
+        fetchMock.mock('/api/v0/financial_aid_skip/2/', () => {
+          return { status: 200 };
+        });
+
+        return skipFinancialAid(programId).then(() => {
+          assert.ok(fetchJSONStub.calledWith('/api/v0/financial_aid_skip/2/', {
+            method: 'PATCH'
+          }));
+        });
+      });
+
+      it('fails to skip financial aid', () => {
+        fetchJSONStub.returns(Promise.reject());
+
+        return assert.isRejected(skipFinancialAid(programId)).then(() => {
+          assert.ok(fetchJSONStub.calledWith('/api/v0/financial_aid_skip/2/', {
+            method: 'PATCH'
           }));
         });
       });

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -180,6 +180,12 @@ c.validation-wrapper {
         font-weight: 600;
       }
     }
+
+    .pricing-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
   }
 
   .course-list {


### PR DESCRIPTION
#### What are the relevant tickets?

part of #1076 

#### What's this PR do?

This adds a 'skip' link which skips the financial aid system. We record this, so we know that the user has already opted-out of financial and and we can show different ui.

#### Where should the reviewer start?

read over the code!

#### How should this be manually tested?

delete the financial aid object on your user for a program which has financial aid enabled. Then visit the dashboard. clicking on the 'skip this and pay full price' link should cause the ui to update (now showing course prices) and should also create a financial ad object attached to your user.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

