### PR TITLE
Added REST API to enroll audit an user in a course run

### DIFF
--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -13,14 +13,16 @@ from requests.exceptions import HTTPError
 from rest_framework import status
 from rest_framework.test import APITestCase
 from edx_api.certificates.models import Certificates
-from edx_api.enrollments.models import Enrollments
+from edx_api.enrollments.models import Enrollments, Enrollment
 from edx_api.grades.models import CurrentGrades
 
 from backends.edxorg import EdxOrgOAuth2
-from courses.factories import ProgramFactory
-from dashboard.models import ProgramEnrollment
+from backends.utils import InvalidCredentialStored
+from courses.factories import ProgramFactory, CourseRunFactory
+from dashboard.models import ProgramEnrollment, CachedEnrollment
 from dashboard.utils import MMTrack
 from profiles.factories import UserFactory
+from search.base import ESTestCase
 
 
 class DashboardTest(APITestCase):
@@ -187,3 +189,102 @@ class DashboardTokensTest(APITestCase):
         res = self.get_with_mocked_enrollments()
         assert mock_refresh.called
         assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+
+class UserCourseEnrollmentTest(ESTestCase, APITestCase):
+    """
+    Tests for the UserCourseEnrollment REST API
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        # create an user
+        cls.user = UserFactory.create()
+        # create a social auth for the user
+        cls.user.social_auth.create(
+            provider=EdxOrgOAuth2.name,
+            uid="{}_edx".format(cls.user.username),
+            extra_data='{"access_token": "fooooootoken"}'
+        )
+
+        # create the course run
+        cls.course_id = "edx+fake+key"
+        cls.course_run = CourseRunFactory.create(edx_course_key=cls.course_id)
+
+        # url for the dashboard
+        cls.url = reverse('user_course_enrollments')
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_login(self.user)
+
+    def test_methods_not_allowed(self):
+        """
+        Test that only POST is allowed
+        """
+        for method in ['put', 'patch', 'get', 'delete']:
+            client = getattr(self.client, method)
+            resp = client(self.url)
+            assert resp.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    def test_login_required(self):
+        """
+        Only logged in users can make requests
+        """
+        self.client.logout()
+        resp = self.client.post(self.url, {}, format='json')
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_course_id_mandatory(self):
+        """
+        The request data must contain course_id
+        """
+        resp = self.client.post(self.url, {}, format='json')
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch('backends.utils.refresh_user_token', autospec=True)
+    def test_refresh_token_fails(self, mock_refresh):
+        """
+        Test for when the server is unable to refresh the OAUTH token
+        """
+        mock_refresh.side_effect = InvalidCredentialStored('foo', status.HTTP_417_EXPECTATION_FAILED)
+        resp = self.client.post(self.url, {'course_id': self.course_id}, format='json')
+        assert resp.status_code == status.HTTP_417_EXPECTATION_FAILED
+        assert mock_refresh.call_count == 1
+
+    @patch('edx_api.enrollments.CourseEnrollments.create_audit_student_enrollment', autospec=True)
+    @patch('backends.utils.refresh_user_token', autospec=True)
+    def test_enrollment_fails(self, mock_refresh, mock_edx_enr):  # pylint: disable=unused-argument
+        """
+        Test error when backend raises an exception
+        """
+        mock_edx_enr.side_effect = HTTPError()
+        resp = self.client.post(self.url, {'course_id': self.course_id}, format='json')
+        assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert mock_edx_enr.call_count == 1
+        # assert just the second argument, since the first is `self`
+        assert mock_edx_enr.call_args[0][1] == self.course_id
+
+    @patch('edx_api.enrollments.CourseEnrollments.create_audit_student_enrollment', autospec=True)
+    @patch('backends.utils.refresh_user_token', autospec=True)
+    def test_enrollment(self, mock_refresh, mock_edx_enr):  # pylint: disable=unused-argument
+        """
+        Test for happy path
+        """
+        cache_enr = CachedEnrollment.objects.filter(
+            user=self.user, course_run__edx_course_key=self.course_id).exclude(data=None).first()
+        assert cache_enr is None
+
+        enr_json = {'course_details': {'course_id': self.course_id}}
+        enrollment = Enrollment(enr_json)
+        mock_edx_enr.return_value = enrollment
+        resp = self.client.post(self.url, {'course_id': self.course_id}, format='json')
+        assert resp.status_code == status.HTTP_200_OK
+        assert mock_edx_enr.call_count == 1
+        assert mock_edx_enr.call_args[0][1] == self.course_id
+        assert resp.data == enr_json
+
+        cache_enr = CachedEnrollment.objects.filter(
+            user=self.user, course_run__edx_course_key=self.course_id).exclude(data=None).first()
+        assert cache_enr is not None

--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -13,7 +13,10 @@ from courses.views import (
     ProgramEnrollmentListView,
     ProgramViewSet,
 )
-from dashboard.views import UserDashboard
+from dashboard.views import (
+    UserCourseEnrollment,
+    UserDashboard,
+)
 from ecommerce.views import (
     CheckoutView,
     OrderFulfillmentView,
@@ -47,6 +50,7 @@ urlpatterns = [
     url(r'^api/v0/search/(?P<elastic_url>.*)', ElasticProxyView.as_view(), name='search_api'),
     url(r'^api/v0/checkout/$', CheckoutView.as_view(), name='checkout'),
     url(r'^api/v0/enrolledprograms/$', ProgramEnrollmentListView.as_view(), name='user_program_enrollments'),
+    url(r'^api/v0/course_enrollments/$', UserCourseEnrollment.as_view(), name='user_course_enrollments'),
     url(r'^api/v0/mail/$', SearchResultMailView.as_view(), name='search_result_mail_api'),
     url(r'^api/v0/financial_aid_mail/(?P<financial_aid_id>[\d]+)/$', FinancialAidMailView.as_view(),
         name='financial_aid_mail_api'),


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Introduces a REST API to enroll audit users in a course run

#### Where should the reviewer start?
`dashboard/views.py`