### PR TITLE
Updated my dashboard link

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -10,6 +10,7 @@ from wagtail.wagtailimages.models import Image
 from wagtail.wagtailcore.models import Page, Orderable
 from wagtail.wagtailcore.fields import RichTextField
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, InlinePanel, MultiFieldPanel
+from rolepermissions.verifications import has_role
 
 
 from courses.models import Program
@@ -17,6 +18,10 @@ from micromasters.utils import webpack_dev_server_host
 from profiles.api import get_social_username
 from ui.views import get_bundle_url
 from cms.api import get_course_enrollment_text, get_course_url
+from roles.models import (
+    Instructor,
+    Staff,
+)
 
 
 def faculty_for_carousel(faculty):
@@ -55,6 +60,7 @@ class HomePage(Page):
         context["style_public_src"] = get_bundle_url(request, "style_public.js")
         context["signup_dialog_src"] = get_bundle_url(request, "signup_dialog.js")
         context["authenticated"] = not request.user.is_anonymous()
+        context["is_staff"] = has_role(request.user, [Staff.ROLE_ID, Instructor.ROLE_ID])
         context["username"] = username
         context["js_settings_json"] = json.dumps(js_settings)
         context["title"] = self.title

--- a/ui/templates/base_error.html
+++ b/ui/templates/base_error.html
@@ -42,7 +42,11 @@
         {% if authenticated %}
         <ul class="nav navbar-toolbar navbar-left">
           <li class="active">
-            <a href="/dashboard">Dashboard</a>
+            {% if is_staff %}
+              <a href="/learners">Dashboard</a>
+            {% else %}
+              <a href="/dashboard">Dashboard</a>
+            {% endif %}
           </li>
         </ul>
         {% endif %}

--- a/ui/templates/header.html
+++ b/ui/templates/header.html
@@ -7,7 +7,11 @@
           </div>
         <div class="pull-right">
           {% if authenticated %}
-          <a class="header-dashboard-link" href="/dashboard">My Dashboard</a>
+            {% if is_staff %}
+              <a class="header-dashboard-link" href="/learners">My Dashboard</a>
+            {% else %}
+              <a class="header-dashboard-link" href="/dashboard">My Dashboard</a>
+            {% endif %}
           <a class="btn btn-login white-button upper-case" href="/logout">
             Sign Out
           </a>

--- a/ui/views.py
+++ b/ui/views.py
@@ -17,12 +17,17 @@ from django.shortcuts import (
 )
 from django.utils.decorators import method_decorator
 from rolepermissions.shortcuts import available_perm_status
+from rolepermissions.verifications import has_role
 
 from micromasters.utils import webpack_dev_server_host, webpack_dev_server_url
 from profiles.api import get_social_username
 from profiles.permissions import CanSeeIfNotPrivate
 from ui.decorators import (
     require_mandatory_urls,
+)
+from roles.models import (
+    Instructor,
+    Staff,
 )
 
 log = logging.getLogger(__name__)
@@ -132,7 +137,8 @@ def standard_error_page(request, status_code, template_filename):
             "js_settings_json": "{}",
             "authenticated": authenticated,
             "name": name,
-            "username": username
+            "username": username,
+            "is_staff": has_role(request.user, [Staff.ROLE_ID, Instructor.ROLE_ID])
         }
     )
     response.status_code = status_code


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes https://github.com/mitodl/micromasters/issues/1227

#### What's this PR do?
- Takes staff to learners page  on clicking 'My dashboard'.
- Take suer to dashboard page  on clicking 'My dashboard'.
- Same thing for 404 and 500 error pages

#### Where should the reviewer start?
- see cms/models.py
- see ui/templates/header.html
- see base erorr page

#### How should this be manually tested?
- open home page as staff and common user, click ``My dashboard`` link

@pdpinch @noisecapella 

<img width="660" alt="screen shot 2016-10-05 at 4 20 57 pm" src="https://cloud.githubusercontent.com/assets/10431250/19111217/cfc8b018-8b17-11e6-8ecd-531e6c229955.png">
