### PR TITLE
Remove deprecated TEMPLATE_CONTEXT_PROCESSORS setting

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -201,17 +201,13 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'social.apps.django_app.context_processors.backends',
+                'social.apps.django_app.context_processors.login_redirect',
                 'ui.context_processors.google_analytics',
             ],
         },
     },
 ]
-
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'social.apps.django_app.context_processors.backends',
-    'social.apps.django_app.context_processors.login_redirect',
-    'django.core.context_processors.request'
-)
 
 WSGI_APPLICATION = 'micromasters.wsgi.application'
 


### PR DESCRIPTION
Previously, every time the micromasters application started up, it would display this warning in the terminal:

```
Performing system checks...

October 05, 2016 - 15:13:18
Django version 1.9.10, using settings 'micromasters.settings'
Starting development server at http://0.0.0.0:8079/
Quit the server with CONTROL-C.
System check identified some issues:

WARNINGS:
?: (1_8.W001) The standalone TEMPLATE_* settings were deprecated in
Django 1.8 and the TEMPLATES dictionary takes precedence. You must put
the values of the following settings into your default TEMPLATES dict:
TEMPLATE_CONTEXT_PROCESSORS.

System check identified 1 issue (0 silenced).
```

This pull request fixes this warning. It should have no effect on the functionality of the website.