### PR TITLE
fixes FinancialAidAudit JSONfields

### DIFF
--- a/financialaid/models.py
+++ b/financialaid/models.py
@@ -4,13 +4,13 @@ Models for the Financial Aid App
 import datetime
 
 from django.contrib.auth.models import User
-from django.core import serializers
 from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import ValidationError
 from django.db import (
     models,
     transaction,
 )
+from django.forms.models import model_to_dict
 
 from courses.models import Program
 
@@ -149,6 +149,14 @@ class FinancialAid(TimestampedModel):
     date_exchange_rate = models.DateTimeField(null=True)
     date_documents_sent = models.DateField(null=True)
 
+    def to_dict(self):
+        """
+        Get the model_to_dict of self
+        """
+        ret = model_to_dict(self)
+        ret["date_exchange_rate"] = str(ret["date_exchange_rate"])
+        return ret
+
     def save(self, *args, **kwargs):
         """
         Override save to make sure only one FinancialAid object exists for a User and the associated Program
@@ -171,8 +179,8 @@ class FinancialAid(TimestampedModel):
         FinancialAidAudit.objects.create(
             acting_user=acting_user,
             financial_aid=self,
-            data_before=serializers.serialize("json", [financialaid_before, ]),
-            data_after=serializers.serialize("json", [self, ])
+            data_before=financialaid_before.to_dict(),
+            data_after=self.to_dict()
         )
 
 

--- a/financialaid/models.py
+++ b/financialaid/models.py
@@ -155,9 +155,9 @@ class FinancialAid(TimestampedModel):
         """
         ret = model_to_dict(self)
         if self.date_exchange_rate is not None:
-            ret["date_exchange_rate"] = str(ret["date_exchange_rate"])
+            ret["date_exchange_rate"] = ret["date_exchange_rate"].isoformat()
         if self.date_documents_sent is not None:
-            ret["date_documents_sent"] = str(ret["date_documents_sent"])
+            ret["date_documents_sent"] = ret["date_documents_sent"].isoformat()
         return ret
 
     def save(self, *args, **kwargs):

--- a/financialaid/models.py
+++ b/financialaid/models.py
@@ -154,7 +154,10 @@ class FinancialAid(TimestampedModel):
         Get the model_to_dict of self
         """
         ret = model_to_dict(self)
-        ret["date_exchange_rate"] = str(ret["date_exchange_rate"])
+        if self.date_exchange_rate is not None:
+            ret["date_exchange_rate"] = str(ret["date_exchange_rate"])
+        if self.date_documents_sent is not None:
+            ret["date_documents_sent"] = str(ret["date_documents_sent"])
         return ret
 
     def save(self, *args, **kwargs):

--- a/financialaid/models_test.py
+++ b/financialaid/models_test.py
@@ -96,24 +96,25 @@ class FinancialAidModelsTests(ESTestCase):
         financial_aid = FinancialAidFactory.create(date_documents_sent=datetime.datetime.now())
         financial_aid_dict = financial_aid.to_dict()
         audit_key_list = [
-            "user",
-            "tier_program",
-            "status",
-            "original_currency",
             "country_of_income",
-            "date_exchange_rate",
             "date_documents_sent",
+            "date_exchange_rate",
+            "id",
             "income_usd",
-            "original_income"
+            "original_currency",
+            "original_income",
+            "status",
+            "tier_program",
+            "user"
         ]
-        assert set(financial_aid_dict.keys()).issuperset(set(audit_key_list))
+        assert set(financial_aid_dict.keys()) == set(audit_key_list)
         assert financial_aid_dict["user"] == financial_aid.user.id
         assert financial_aid_dict["tier_program"] == financial_aid.tier_program.id
         assert financial_aid_dict["status"] == financial_aid.status
         assert financial_aid_dict["original_currency"] == financial_aid.original_currency
         assert financial_aid_dict["country_of_income"] == financial_aid.country_of_income
-        assert financial_aid_dict["date_exchange_rate"] == str(financial_aid.date_exchange_rate)
-        assert financial_aid_dict["date_documents_sent"] == str(financial_aid.date_documents_sent)
+        assert financial_aid_dict["date_exchange_rate"] == financial_aid.date_exchange_rate.isoformat()
+        assert financial_aid_dict["date_documents_sent"] == financial_aid.date_documents_sent.isoformat()
         self.assertAlmostEqual(financial_aid_dict["income_usd"], financial_aid.income_usd)
         self.assertAlmostEqual(financial_aid_dict["original_income"], financial_aid.original_income)
 
@@ -123,5 +124,5 @@ class FinancialAidModelsTests(ESTestCase):
         """
         financial_aid = FinancialAidFactory.create(date_exchange_rate=None, date_documents_sent=None)
         financial_aid_dict = financial_aid.to_dict()
-        assert financial_aid_dict["date_exchange_rate"] == financial_aid.date_exchange_rate
-        assert financial_aid_dict["date_documents_sent"] == financial_aid.date_documents_sent
+        assert financial_aid_dict["date_exchange_rate"] is None
+        assert financial_aid_dict["date_documents_sent"] is None


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #1229

#### What's this PR do?

Adds to_dict function to FinancialAid objects so that FinancialAidAudit objects are stored as searchable dicts. Note that this is a slight content change; here is the data now stored in FinancialAidAudit.data_before and .data_after:

{'country_of_income': 'USA',
 'date_exchange_rate': None,
 'id': 34,
 'income_usd': 39000,
 'original_currency': 'USD',
 'original_income': 39000,
 'status': 'created',
 'tier_program': 2,
 'user': 117}

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
