### PR TITLE
Added log.error for every ImproperlyConfigured exception raised

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -1,11 +1,15 @@
 """
 Models for course structure
 """
+import logging
 from datetime import datetime
 
 import pytz
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
+
+
+log = logging.getLogger(__name__)
 
 
 class Program(models.Model):
@@ -34,6 +38,7 @@ class Program(models.Model):
             course_run__course__program=self
         ).first()
         if course_price_object is None:
+            log.error('No course price available for program "%s"', self.title)
             # If no CoursePrice is valid for this program, can't meaningfully return any value
             raise ImproperlyConfigured('No course price available for program "{}".'.format(self.title))
         return course_price_object.price

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -96,6 +96,7 @@ class CourseFormatConditionalFields:
         Method to get from the ASSOCIATED_FIELDS dict
         """
         if course_status not in CourseStatus.all_statuses():
+            log.error('%s not defined in Courses.api.CourseStatus', course_status)
             raise ImproperlyConfigured(
                 '{} not defined in Courses.api.CourseStatus'.format(course_status))
         return cls.ASSOCIATED_FIELDS.get(course_status, [])

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -113,7 +113,7 @@ def create_unfulfilled_order(course_id, user):
     price_dict = get_formatted_course_price(enrollment)
     price = price_dict['price']
     if price <= 0:
-        log.warning(
+        log.error(
             "Price to be charged for course run %s for user %s is less than or equal to zero: %s",
             course_id,
             get_social_username(user),

--- a/financialaid/api.py
+++ b/financialaid/api.py
@@ -1,6 +1,8 @@
 """
 API helper functions for financialaid
 """
+import logging
+
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 from financialaid.constants import (
@@ -14,6 +16,9 @@ from financialaid.models import (
     FinancialAidStatus,
     TierProgram
 )
+
+
+log = logging.getLogger(__name__)
 
 
 def determine_tier_program(program, income):
@@ -78,7 +83,9 @@ def get_no_discount_tier_program(program_id):
     try:
         return TierProgram.objects.get(program_id=program_id, current=True, discount_amount=0)
     except TierProgram.DoesNotExist:
-        raise ImproperlyConfigured("No discount TierProgram has not yet been configured for this Program.")
+        log.error("No discount TierProgram has not yet been configured for Program with id %s.", program_id)
+        raise ImproperlyConfigured(
+            "No discount TierProgram has not yet been configured for Program with id {}.".format(program_id))
 
 
 def get_formatted_course_price(program_enrollment):


### PR DESCRIPTION
#### What are the relevant tickets?
N/A
#### What's this PR do?
Given that we have a custom exception handler that intercepts all the `ImproperlyConfigured` exceptions, we need a way to track when the error happens, so we should `log.error` before any `ImproperlyConfigured` is raised.