### PR TITLE
add confirmation dialog for financial aid skipping

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -94,3 +94,6 @@ export const setCalculatorDialogVisibility = createAction(SET_CALCULATOR_DIALOG_
 
 export const SET_PROGRAM = 'SET_PROGRAM';
 export const setProgram = createAction(SET_PROGRAM);
+
+export const SET_CONFIRM_SKIP_DIALOG_VISIBILITY = 'SET_CONFIRM_SKIP_DIALOG_VISIBILITY';
+export const setConfirmSkipDialogVisibility = createAction(SET_CONFIRM_SKIP_DIALOG_VISIBILITY);

--- a/static/js/actions/ui_test.js
+++ b/static/js/actions/ui_test.js
@@ -23,6 +23,7 @@ import {
   SET_PHOTO_DIALOG_VISIBILITY,
   SET_CALCULATOR_DIALOG_VISIBILITY,
   SET_PROGRAM,
+  SET_CONFIRM_SKIP_DIALOG_VISIBILITY,
 
   clearUI,
   updateDialogText,
@@ -48,6 +49,7 @@ import {
   setPhotoDialogVisibility,
   setCalculatorDialogVisibility,
   setProgram,
+  setConfirmSkipDialogVisibility,
 } from '../actions/ui';
 import { assertCreatedActionHelper } from './util';
 
@@ -78,6 +80,7 @@ describe('generated UI action helpers', () => {
       [setPhotoDialogVisibility, SET_PHOTO_DIALOG_VISIBILITY],
       [setCalculatorDialogVisibility, SET_CALCULATOR_DIALOG_VISIBILITY],
       [setProgram, SET_PROGRAM],
+      [setConfirmSkipDialogVisibility, SET_CONFIRM_SKIP_DIALOG_VISIBILITY],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/components/SkipFinancialAidDialog.js
+++ b/static/js/components/SkipFinancialAidDialog.js
@@ -1,0 +1,46 @@
+// @flow
+import React from 'react';
+import Dialog from 'material-ui/Dialog';
+import Button from 'react-mdl/lib/Button';
+
+const skipActions = (cancel, skip) => (
+  <div className="actions">
+    <Button
+      type='button'
+      className="dialog-button cancel-button"
+      onClick={cancel}>
+      Cancel
+    </Button>
+    <Button
+      type='button'
+      className="dialog-button save-button"
+      onClick={skip}>
+      Pay Full Price
+    </Button>
+  </div>
+);
+
+type SkipProps = {
+  cancel:     () => void,
+  skip:       () => void,
+  open:       boolean,
+  fullPrice:  React$Element<*>,
+}
+
+const SkipFinancialAidDialog = ({cancel, skip, open, fullPrice}: SkipProps) => (
+  <Dialog
+    open={open}
+    bodyClassName="skip-aid-dialog"
+    onRequestClose={cancel}
+    actions={skipActions(cancel, skip)}
+    title="Are you sure?"
+  >
+    You may qualify for a reduced cost. Clicking "Pay Full Price"
+    means that you are declining this option and you will pay the
+    full price of
+    {" "}{fullPrice}{" "}
+    for each course in the program.
+  </Dialog>
+);
+
+export default SkipFinancialAidDialog;

--- a/static/js/components/dashboard/FinancialAidCard_test.js
+++ b/static/js/components/dashboard/FinancialAidCard_test.js
@@ -1,10 +1,12 @@
 // @flow
 import _ from 'lodash';
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { assert } from 'chai';
 import sinon from 'sinon';
 import moment from 'moment';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
 import FinancialAidCard from './FinancialAidCard';
 import {
@@ -20,27 +22,41 @@ import {
   FA_STATUS_REJECTED,
   FA_STATUS_SKIPPED,
 } from '../../constants';
+import { INITIAL_UI_STATE } from '../../reducers/ui';
 
 describe("FinancialAidCard", () => {
   let sandbox;
+  let openFinancialAidCalculatorStub, setSkipDialogStub;
+
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
+    openFinancialAidCalculatorStub = sandbox.stub();
+    setSkipDialogStub = sandbox.stub();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   let renderCard = (props = {}) => {
-    return shallow(
-      <FinancialAidCard
-        program={DASHBOARD_RESPONSE[1]}
-        coursePrice={COURSE_PRICES_RESPONSE[0]}
-        updateDocumentSentDate={sandbox.stub()}
-        documents={{
-          documentSentDate: '2011-11-11'
-        }}
-        fetchDashboard={sandbox.stub()}
-        openFinancialAidCalculator={sandbox.stub()}
-        setDocumentSentDate={sandbox.stub()}
-        {...props}
-      />
+    return mount(
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <FinancialAidCard
+          program={DASHBOARD_RESPONSE[1]}
+          coursePrice={COURSE_PRICES_RESPONSE[0]}
+          updateDocumentSentDate={sandbox.stub()}
+          documents={{
+            documentSentDate: '2011-11-11'
+          }}
+          fetchDashboard={sandbox.stub()}
+          openFinancialAidCalculator={openFinancialAidCalculatorStub}
+          setDocumentSentDate={sandbox.stub()}
+          ui={INITIAL_UI_STATE}
+          setConfirmSkipDialogVisibility={setSkipDialogStub}
+          skipFinancialAid={sandbox.stub()}
+          {...props}
+        />
+      </MuiThemeProvider>
     );
   };
 
@@ -71,14 +87,13 @@ describe("FinancialAidCard", () => {
     });
 
     it('calculates the cost when you click the button', () => {
-      let openFinancialAidCalculator = sandbox.stub();
       const program = programWithStatus();
       program.financial_aid_user_info.has_user_applied = false;
-      let wrapper = renderCard({ program, openFinancialAidCalculator });
+      let wrapper = renderCard({ program });
       let button = wrapper.find(".dashboard-button");
       assert.equal(button.text(), "Calculate your cost");
       button.simulate('click');
-      assert.ok(openFinancialAidCalculator.calledWith());
+      assert.ok(openFinancialAidCalculatorStub.calledWith());
     });
 
     it('shows the minimum and maximum price', () => {
@@ -89,6 +104,21 @@ describe("FinancialAidCard", () => {
       let min = program.financial_aid_user_info.min_possible_cost;
       let max = program.financial_aid_user_info.max_possible_cost;
       assert.deepEqual([`$${min}`, `$${max}`], wrapper.find(".price").map(node => node.text()));
+    });
+
+    it('shows a link to open the calculator', () => {
+      const program = programWithStatus();
+      program.financial_aid_user_info.has_user_applied = false;
+      let wrapper = renderCard({ program });
+      assert.equal(wrapper.find('.full-price').text(), 'Skip this and Pay Full Price');
+    });
+
+    it('opens the skip dialog when you click "Skip this..."', () => {
+      const program = programWithStatus();
+      program.financial_aid_user_info.has_user_applied = false;
+      let wrapper = renderCard({ program });
+      wrapper.find('.full-price').simulate('click');
+      assert.ok(setSkipDialogStub.calledWith(true), 'Dialog should get opened');
     });
   });
 
@@ -144,7 +174,7 @@ describe("FinancialAidCard", () => {
         it(`shows the document sent date for status ${status}`, () => {
           let program = programWithStatus(status);
           let wrapper = renderCard({ program });
-          assert(wrapper.html().includes('Documents mailed on 3/3/2003'));
+          assert(wrapper.text().includes('Documents mailed on 3/3/2003'));
         });
       }
     });

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -15,7 +15,10 @@ import {
   TOAST_SUCCESS,
   TOAST_FAILURE,
 } from '../constants';
-import { setToastMessage } from '../actions/ui';
+import {
+  setToastMessage,
+  setConfirmSkipDialogVisibility,
+} from '../actions/ui';
 import { createForm } from '../util/util';
 import CourseListCard from '../components/dashboard/CourseListCard';
 import DashboardUserCard from '../components/dashboard/DashboardUserCard';
@@ -128,8 +131,15 @@ class DashboardPage extends React.Component {
 
   skipFinancialAid = programId => {
     const { dispatch } = this.props;
-    dispatch(skipFinancialAid(programId));
-  }
+    dispatch(skipFinancialAid(programId)).then(() => {
+      this.setConfirmSkipDialogVisibility(false);
+    });
+  };
+
+  setConfirmSkipDialogVisibility = bool => {
+    const { dispatch } = this.props;
+    dispatch(setConfirmSkipDialogVisibility(bool));
+  };
 
   fetchDashboard = (): void => {
     const { dispatch } = this.props;
@@ -148,6 +158,7 @@ class DashboardPage extends React.Component {
       profile: { profile },
       documents,
       currentProgramEnrollment,
+      ui,
     } = this.props;
     const loaded = dashboard.fetchStatus !== FETCH_PROCESSING && prices.fetchStatus !== FETCH_PROCESSING;
     let errorMessage;
@@ -176,6 +187,8 @@ class DashboardPage extends React.Component {
           skipFinancialAid={this.skipFinancialAid}
           updateDocumentSentDate={this.updateDocumentSentDate}
           fetchDashboard={this.fetchDashboard}
+          setConfirmSkipDialogVisibility={this.setConfirmSkipDialogVisibility}
+          ui={ui}
         />;
       }
 

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -13,7 +13,10 @@ import {
   updateCalculatorValidation,
   skipFinancialAid,
 } from '../actions/financial_aid';
-import { setCalculatorDialogVisibility } from '../actions/ui';
+import {
+  setCalculatorDialogVisibility,
+  setConfirmSkipDialogVisibility,
+} from '../actions/ui';
 import {
   fetchCoursePrices,
   fetchDashboard,
@@ -86,14 +89,14 @@ const actionButtons = R.map(({ name, onClick, label}) => (
     { label }
   </Button>
 ));
-const calculatorActions = (skipFinancialAid, programId, cancel, save) => {
+const calculatorActions = (openSkipDialog, cancel, save) => {
   const buttonManifest = [
     { name: 'cancel', onClick: cancel, label: 'Cancel' },
     { name: 'main-action save', onClick: save, label: 'Calculate' },
   ];
 
   return <div className="actions">
-    <a className="full-price" onClick={skipFinancialAid(programId)}>
+    <a className="full-price" onClick={openSkipDialog}>
       Skip this and Pay Full Price
     </a>
     <div className="buttons">
@@ -119,7 +122,7 @@ type CalculatorProps = {
   saveFinancialAid:           (f: FinancialAidState) => void,
   updateCalculatorEdit:       (f: FinancialAidState) => void,
   currentProgramEnrollment:   ProgramEnrollment,
-  skipFinancialAid:           (p: number) => void,
+  openConfirmSkipDialog:      () => void,
 };
 
 const FinancialAidCalculator = ({
@@ -129,8 +132,8 @@ const FinancialAidCalculator = ({
   financialAid: { validation },
   saveFinancialAid,
   updateCalculatorEdit,
-  currentProgramEnrollment: { id, title },
-  skipFinancialAid,
+  currentProgramEnrollment: { title },
+  openConfirmSkipDialog,
 }: CalculatorProps) => (
   <Dialog
     open={calculatorDialogVisibility}
@@ -138,7 +141,7 @@ const FinancialAidCalculator = ({
     bodyClassName="financial-aid-calculator-body"
     onRequestClose={closeDialogAndCancel}
     autoScrollBodyContent={true}
-    actions={calculatorActions(skipFinancialAid, id, closeDialogAndCancel, () => saveFinancialAid(financialAid))}
+    actions={calculatorActions(openConfirmSkipDialog, closeDialogAndCancel, () => saveFinancialAid(financialAid))}
     title="Cost Calculator"
   >
     <div className="copy">
@@ -201,6 +204,11 @@ const skipFinancialAidHelper = R.curry((dispatch, programId) => () => {
   });
 });
 
+const openConfirmSkipDialogHelper = dispatch => () => {
+  closeDialogAndCancel(dispatch)();
+  dispatch(setConfirmSkipDialogVisibility(true));
+};
+
 const mapStateToProps = state => {
   const {
     ui: { calculatorDialogVisibility },
@@ -220,6 +228,7 @@ const mapDispatchToProps = dispatch => {
     closeDialogAndCancel: closeDialogAndCancel(dispatch),
     saveFinancialAid: saveFinancialAid(dispatch),
     skipFinancialAid: skipFinancialAidHelper(dispatch),
+    openConfirmSkipDialog: openConfirmSkipDialogHelper(dispatch),
     ...createSimpleActionHelpers(dispatch, [
       ['clearCalculatorEdit', clearCalculatorEdit],
       ['updateCalculatorEdit', updateCalculatorEdit],

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -35,6 +35,7 @@ import {
 
   SET_PHOTO_DIALOG_VISIBILITY,
   SET_CALCULATOR_DIALOG_VISIBILITY,
+  SET_CONFIRM_SKIP_DIALOG_VISIBILITY,
 } from '../actions/ui';
 import { PERSONAL_STEP } from '../constants';
 import type { ToastMessage } from '../flow/generalTypes';
@@ -74,6 +75,7 @@ export type UIState = {
   calculatorDialogVisibility:   boolean;
   documentSentDate:             Object;
   selectedProgram:              Program;
+  skipDialogVisibility:         boolean;
 };
 
 export const INITIAL_UI_STATE: UIState = {
@@ -103,6 +105,7 @@ export const INITIAL_UI_STATE: UIState = {
   calculatorDialogVisibility: false,
   documentSentDate: {},
   selectedProgram: null,
+  skipDialogVisibility: false,
 };
 
 export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
@@ -233,6 +236,8 @@ export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
     return { ...state, photoDialogVisibility: action.payload };
   case SET_CALCULATOR_DIALOG_VISIBILITY:
     return { ...state, calculatorDialogVisibility: action.payload };
+  case SET_CONFIRM_SKIP_DIALOG_VISIBILITY:
+    return { ...state, skipDialogVisibility: action.payload };
   default:
     return state;
   }

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -27,6 +27,7 @@ import {
   setEnrollSelectedProgram,
   setPhotoDialogVisibility,
   setCalculatorDialogVisibility,
+  setConfirmSkipDialogVisibility,
 } from '../actions/ui';
 import { INITIAL_UI_STATE } from '../reducers/ui';
 import type { UIState } from '../reducers/ui';
@@ -192,6 +193,12 @@ describe('ui reducers', () => {
   describe('Calculator visibility', () => {
     it('should let you set calculator visibility', () => {
       assertReducerResultState(setCalculatorDialogVisibility, ui => ui.calculatorDialogVisibility, false);
+    });
+  });
+
+  describe('Skip dialog visibility', () => {
+    it('should let you set skip dialog visibility', () => {
+      assertReducerResultState(setConfirmSkipDialogVisibility, ui => ui.skipDialogVisibility, false);
     });
   });
 });

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -70,7 +70,7 @@
 }
 
 .dialog-button {
-  width: 120px;
+  padding: 0 25px;
 
   &.cancel-button {
     color: white;

--- a/static/scss/calculator.scss
+++ b/static/scss/calculator.scss
@@ -64,5 +64,9 @@
     .buttons {
       display: flex;
     }
+
+    .full-price {
+      cursor: pointer;
+    }
   }
 }

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -182,6 +182,10 @@ c.validation-wrapper {
       display: flex;
       align-items: center;
       justify-content: space-between;
+
+      .full-price {
+        cursor: pointer;
+      }
     }
   }
 


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #1076 

#### What's this PR do?

This adds a little confirmation dialog when you're going to skip financial aid.

#### Where should the reviewer start?

Read over the code changes!

#### How should this be manually tested?

Go delete any financial aid objects on your user and then navigate to `/dashboard`. Then clicking `'Skip this and pay full price'` on either the main page or in the calculator dialog should open up the skip dialog. Clicking 'Cancel' should, well, cancel, and clicking on 'Pay full' should correctly mark you as wanting to pay in full. Your user should now have a financial aid object with `status === skipped` on it.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

![sure](https://cloud.githubusercontent.com/assets/6207644/19129546/b152475e-8b15-11e6-8b71-5902bff0867a.png)

#### What GIF best describes this PR or how it makes you feel?

