### PR TITLE
makes fields read_only in django admin for financialaidaudit objects

### DIFF
--- a/financialaid/admin.py
+++ b/financialaid/admin.py
@@ -20,7 +20,9 @@ class FinancialAidAdmin(admin.ModelAdmin):
 class FinancialAidAuditAdmin(admin.ModelAdmin):
     """Admin for FinancialAidAudit"""
     model = FinancialAidAudit
-    readonly_fields = ["acting_user", "financial_aid", "data_before", "data_after"]
+    readonly_fields = [
+        f.name for f in FinancialAidAudit._meta.get_fields() if not f.auto_created  # pylint: disable=protected-access
+    ]
 
     def has_add_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
         return False

--- a/financialaid/admin.py
+++ b/financialaid/admin.py
@@ -20,6 +20,7 @@ class FinancialAidAdmin(admin.ModelAdmin):
 class FinancialAidAuditAdmin(admin.ModelAdmin):
     """Admin for FinancialAidAudit"""
     model = FinancialAidAudit
+    readonly_fields = ["acting_user", "financial_aid", "data_before", "data_after"]
 
     def has_add_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
         return False


### PR DESCRIPTION
#### What are the relevant tickets?

Addresses #1198.

#### What's this PR do?

Makes FinancialAidAudit objects not editable in the Django Admin interface. Note that there is not currently a way to disable editing on objects in the Django admin while still having them appear in the interface (https://code.djangoproject.com/ticket/8936). As a result we just set all of the fields to be read_only.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

