### PR TITLE
Enabled 'View on edX' link on dashboard

### DIFF
--- a/static/js/components/dashboard/CourseDescription.js
+++ b/static/js/components/dashboard/CourseDescription.js
@@ -1,3 +1,4 @@
+/* global SETTINGS: false */
 // @flow
 import React from 'react';
 import _ from 'lodash';
@@ -55,6 +56,30 @@ export default class CourseDescription extends React.Component {
     return '';
   };
 
+  renderViewCourseLink = (courseRun: CourseRun): React$Element<*>|void => {
+    let edxLink = `${SETTINGS.edx_base_url}/courses/${courseRun.course_id}`;
+
+    switch (courseRun.status) {
+    case STATUS_PASSED:
+    case STATUS_NOT_PASSED:
+    case STATUS_CAN_UPGRADE:
+    case STATUS_CURRENTLY_ENROLLED:
+      return (
+        <span>
+          <a href={edxLink} target="_blank" className="mm-minor-action link-view-on-edx">
+            - View on edX
+          </a>
+        </span>
+      );
+    }
+  }
+
+  renderCourseTitle = (title: string): React$Element<*> => (
+    <span className="course-description-title">
+      {title}
+    </span>
+  );
+
   render() {
     const { course } = this.props;
     let firstRun: CourseRun = {};
@@ -64,9 +89,8 @@ export default class CourseDescription extends React.Component {
     }
 
     return <div className="course-description">
-      <span className="course-description-title">
-        {course.title}
-      </span> <br />
+      {this.renderCourseTitle(course.title)} {this.renderViewCourseLink(firstRun)}
+      <br />
       <span className="course-description-result">
         {this.courseDateMessage(firstRun)}
       </span>

--- a/static/js/components/dashboard/CourseDescription_test.js
+++ b/static/js/components/dashboard/CourseDescription_test.js
@@ -30,6 +30,26 @@ describe('CourseDescription', () => {
     }
   });
 
+  for (let status of ALL_COURSE_STATUSES) {
+    it('shows the view on edX link if appropriate', () => {
+      let course = findCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
+      const wrapper = shallow(<CourseDescription course={course}/>);
+      switch (status) {
+      case STATUS_PASSED:
+      case STATUS_NOT_PASSED:
+      case STATUS_CAN_UPGRADE:
+      case STATUS_CURRENTLY_ENROLLED:
+        assert.equal(wrapper.find(".link-view-on-edx").text(), '- View on edX');
+        break;
+      default:
+        assert.equal(wrapper.find(".link-view-on-edx").length, 0);
+      }
+    });
+  }
+
   it(`does show date with status passed`, () => {
     let course = findCourse(course => (
       course.runs.length > 0 &&

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -31,10 +31,10 @@ export default class CourseRow extends React.Component {
     } = this.props;
 
     return <Grid className="course-row">
-      <Cell col={5}>
+      <Cell col={6}>
         <CourseDescription course={course} />
       </Cell>
-      <Cell col={3}>
+      <Cell col={2}>
         <CourseStatus course={course}/>
       </Cell>
       <Cell col={4}>

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -574,3 +574,7 @@ c.validation-wrapper {
 input::-ms-clear {
   display: none;
 }
+
+.link-view-on-edx {
+  font-size: 10pt !important;
+}


### PR DESCRIPTION
#### What are the relevant tickets?
- https://github.com/mitodl/micromasters/issues/1225

#### What's this PR do?
- Enabled 'View on edX' link on dashboard according to [mock](https://projects.invisionapp.com/share/NB7VM1GSG#/screens/185611170)
 
#### Where should the reviewer start?
- see components/dashboard/CourseDescription.js

#### How should this be manually tested?
- see ``/dashboard/``

cc @pdpinch @aliceriot @noisecapella 
#### Screenshots (if appropriate)
<img width="645" alt="screen shot 2016-10-06 at 3 23 20 pm" src="https://cloud.githubusercontent.com/assets/10431250/19148968/d7e6cdf4-8bd8-11e6-91fb-770d5014275f.png">

