### PR TITLE
Implemented passed course display

### DIFF
--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -104,7 +104,9 @@ export default class CourseAction extends React.Component {
 
     switch (firstRun.status) {
     case STATUS_PASSED:
-      action = <i className="material-icons">done</i>;
+      action = <div className="passed" key="1">
+        Passed
+      </div>;
       break;
     case STATUS_CAN_UPGRADE: {
       let formattedUpgradeDate = moment(firstRun.course_upgrade_deadline).format(DASHBOARD_FORMAT);

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -69,13 +69,13 @@ describe('CourseAction', () => {
     assert.deepEqual(checkoutStub.args[0], [courseId]);
   };
 
-  it('shows a check mark for a passed course', () => {
+  it('shows passed for a passed course', () => {
     let course = findCourse(course => (
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_PASSED
     ));
     const wrapper = shallow(<CourseAction course={course} {...defaultParamsNow} />);
-    assert.equal(wrapper.find(".material-icons").text(), 'done');
+    assert.equal(wrapper.find(".passed").text(), 'Passed');
   });
 
   it('shows nothing for a failed course', () => {

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -269,6 +269,11 @@ c.validation-wrapper {
           background-color: $lightgrey;
           color: #ffffff;
         }
+
+        .passed {
+          background-color: #e0f5e6;
+          padding: 5px 10px;
+        }
       }
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1101

#### What's this PR do?
Shows 'passed' for passed courses similar to the mockup

#### How should this be manually tested?
Set a course to have status passed (or mock api.js accordingly), then look at the dashboard for that course

#### Screenshots (if appropriate)
![screenshot from 2016-10-06 13-54-27](https://cloud.githubusercontent.com/assets/863262/19164048/6a604884-8bcc-11e6-93d8-63910a93f216.png)
