### PR TITLE
Fetch course prices and dashboard after every relevant change on the server

### DIFF
--- a/static/js/actions/documents.js
+++ b/static/js/actions/documents.js
@@ -2,6 +2,10 @@
 import { createAction } from 'redux-actions';
 import type { Dispatch } from 'redux';
 
+import {
+  fetchDashboard,
+  fetchCoursePrices,
+} from './';
 import * as api from '../util/api';
 import type { Dispatcher } from '../flow/reduxTypes';
 
@@ -23,6 +27,8 @@ export const updateDocumentSentDate = (financialAidId: number, dateSent: string)
     return api.updateDocumentSentDate(financialAidId, dateSent).then(
       () => {
         dispatch(receiveUpdateDocumentSentDateSuccess());
+        dispatch(fetchDashboard());
+        dispatch(fetchCoursePrices());
         return Promise.resolve();
       },
       () => {

--- a/static/js/actions/enrollments.js
+++ b/static/js/actions/enrollments.js
@@ -6,6 +6,10 @@ import {
   TOAST_SUCCESS,
   TOAST_FAILURE,
 } from '../constants';
+import {
+  fetchCoursePrices,
+  fetchDashboard,
+} from './';
 import { setToastMessage } from '../actions/ui';
 import type { Dispatcher } from '../flow/reduxTypes';
 import type {
@@ -55,6 +59,8 @@ export const addProgramEnrollment = (programId: number): Dispatcher<ProgramEnrol
           message: `You are now enrolled in the ${enrollment.title} MicroMasters`,
           icon: TOAST_SUCCESS
         }));
+        dispatch(fetchDashboard());
+        dispatch(fetchCoursePrices());
       }).
       catch(error => {
         dispatch(receiveAddProgramEnrollmentFailure(error));

--- a/static/js/actions/financial_aid.js
+++ b/static/js/actions/financial_aid.js
@@ -36,6 +36,8 @@ export const addFinancialAid = (income: number, currency: string, programId: num
     return api.addFinancialAid(income, currency, programId).then(
       () => {
         dispatch(receiveAddFinancialAidSuccess());
+        dispatch(fetchCoursePrices());
+        dispatch(fetchDashboard());
         return Promise.resolve();
       },
       () => {

--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -38,7 +38,6 @@ export default class FinancialAidCard extends React.Component {
     documents:                      DocumentsState,
     setDocumentSentDate:            (sentDate: string) => void,
     updateDocumentSentDate:         (financialAidId: number, sentDate: string) => Promise<*>,
-    fetchDashboard:                 () => void,
     setConfirmSkipDialogVisibility: (b: boolean) => void,
     ui:                             UIState,
     skipFinancialAid:               () => void,

--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -46,14 +46,13 @@ export default class FinancialAidCard extends React.Component {
 
   submitDocuments = (): void => {
     const {
-      fetchDashboard,
       program,
       documents,
       updateDocumentSentDate,
     } = this.props;
     const financialAidId = program.financial_aid_user_info.id;
 
-    updateDocumentSentDate(financialAidId, documents.documentSentDate).then(fetchDashboard);
+    updateDocumentSentDate(financialAidId, documents.documentSentDate);
   };
 
   renderDocumentStatus() {

--- a/static/js/components/dashboard/FinancialAidCard_test.js
+++ b/static/js/components/dashboard/FinancialAidCard_test.js
@@ -152,21 +152,15 @@ describe("FinancialAidCard", () => {
         assert.ok(setDocumentSentDate.calledWith("1999-01-01"));
       });
 
-      it('sends the document date', done => {
+      it('sends the document date', () => {
         let program = programWithStatus(FA_STATUS_PENDING_DOCS);
 
         let updateDocumentSentDate = sandbox.stub();
-        let fetchDashboard = () => {
-          // should be the last thing executed
-          done();
-        };
         updateDocumentSentDate.returns(Promise.resolve());
-        let wrapper = renderCard({ program, updateDocumentSentDate, fetchDashboard });
+        let wrapper = renderCard({ program, updateDocumentSentDate });
 
         wrapper.find(".dashboard-button").simulate('click');
         assert(updateDocumentSentDate.calledWith(123, '2011-11-11'));
-
-        // the test is also waiting for fetchDashboard to execute
       });
 
       for (let status of [FA_STATUS_DOCS_SENT, FA_STATUS_PENDING_MANUAL_APPROVAL]) {

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -25,7 +25,6 @@ import DashboardUserCard from '../components/dashboard/DashboardUserCard';
 import FinancialAidCard from '../components/dashboard/FinancialAidCard';
 import ErrorMessage from '../components/ErrorMessage';
 import ProgressWidget from '../components/ProgressWidget';
-import { fetchDashboard } from '../actions';
 import { setCalculatorDialogVisibility } from '../actions/ui';
 import {
   setDocumentSentDate,
@@ -141,11 +140,6 @@ class DashboardPage extends React.Component {
     dispatch(setConfirmSkipDialogVisibility(bool));
   };
 
-  fetchDashboard = (): void => {
-    const { dispatch } = this.props;
-    dispatch(fetchDashboard());
-  };
-
   updateDocumentSentDate = (financialAidId: number, sentDate: string): Promise<*> => {
     const { dispatch } = this.props;
     return dispatch(updateDocumentSentDate(financialAidId, sentDate));
@@ -186,7 +180,6 @@ class DashboardPage extends React.Component {
           setDocumentSentDate={this.setDocumentSentDate}
           skipFinancialAid={this.skipFinancialAid}
           updateDocumentSentDate={this.updateDocumentSentDate}
-          fetchDashboard={this.fetchDashboard}
           setConfirmSkipDialogVisibility={this.setConfirmSkipDialogVisibility}
           ui={ui}
         />;

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -17,10 +17,6 @@ import {
   setCalculatorDialogVisibility,
   setConfirmSkipDialogVisibility,
 } from '../actions/ui';
-import {
-  fetchCoursePrices,
-  fetchDashboard,
-} from '../actions';
 import { createSimpleActionHelpers } from '../util/redux';
 import SelectField from '../components/inputs/SelectField';
 import { currencyOptions } from '../util/currency';
@@ -189,10 +185,6 @@ const saveFinancialAid = R.curry((dispatch, current) => {
     dispatch(addFinancialAid(income, currency, programId)).then(() => {
       dispatch(clearCalculatorEdit());
       dispatch(setCalculatorDialogVisibility(false));
-
-      // refresh dashboard and prices to get the updated financial aid state
-      dispatch(fetchCoursePrices());
-      dispatch(fetchDashboard());
     });
   }
 });

--- a/static/js/reducers/documents_test.js
+++ b/static/js/reducers/documents_test.js
@@ -17,6 +17,7 @@ import {
   RECEIVE_UPDATE_DOCUMENT_SENT_DATE_FAILURE,
   updateDocumentSentDate,
 } from '../actions/documents';
+import * as actions from '../actions';
 import type { DocumentsState } from '../reducers/documents';
 import rootReducer from '../reducers';
 import * as api from '../util/api';
@@ -58,10 +59,14 @@ describe('documents reducers', () => {
   });
 
   describe('API functions', () => {
-    let updateDocumentSentDateStub;
+    let updateDocumentSentDateStub, fetchCoursePricesStub, fetchDashboardStub;
 
     beforeEach(() => {
       updateDocumentSentDateStub = sandbox.stub(api, 'updateDocumentSentDate');
+      fetchCoursePricesStub = sandbox.stub(actions, 'fetchCoursePrices');
+      fetchCoursePricesStub.returns({type: "fake"});
+      fetchDashboardStub = sandbox.stub(actions, 'fetchDashboard');
+      fetchDashboardStub.returns({type: "fake"});
     });
 
     it('should let you update the date documents were sent', () => {
@@ -74,6 +79,8 @@ describe('documents reducers', () => {
       ]).then(state => {
         assert.ok(updateDocumentSentDateStub.calledWith(programId, sentDate));
         assert.deepEqual(state.fetchStatus, FETCH_SUCCESS);
+        assert.ok(fetchCoursePricesStub.calledWith());
+        assert.ok(fetchDashboardStub.calledWith());
       });
     });
 
@@ -87,6 +94,8 @@ describe('documents reducers', () => {
       ]).then(state => {
         assert.ok(updateDocumentSentDateStub.calledWith(programId, sentDate));
         assert.deepEqual(state.fetchStatus, FETCH_FAILURE);
+        assert.notOk(fetchCoursePricesStub.calledWith());
+        assert.notOk(fetchDashboardStub.calledWith());
       });
     });
   });

--- a/static/js/reducers/enrollments_test.js
+++ b/static/js/reducers/enrollments_test.js
@@ -31,6 +31,7 @@ import {
   SET_CURRENT_PROGRAM_ENROLLMENT,
 } from '../actions/enrollments';
 import * as api from '../util/api';
+import * as actions from '../actions';
 import rootReducer from '../reducers';
 
 describe('enrollments', () => {
@@ -53,9 +54,14 @@ describe('enrollments', () => {
   };
 
   describe('enrollments reducer', () => {
-    let dispatchThen;
+    let dispatchThen, fetchCoursePricesStub, fetchDashboardStub;
     beforeEach(() => {
       dispatchThen = store.createDispatchThen(state => state.enrollments);
+
+      fetchCoursePricesStub = sandbox.stub(actions, 'fetchCoursePrices');
+      fetchCoursePricesStub.returns({type: "fake"});
+      fetchDashboardStub = sandbox.stub(actions, 'fetchDashboard');
+      fetchDashboardStub.returns({type: "fake"});
     });
 
     it('should have an empty default state', () => {
@@ -108,6 +114,8 @@ describe('enrollments', () => {
         assert.deepEqual(enrollmentsState.programEnrollments, PROGRAM_ENROLLMENTS.concat(newEnrollment));
         assert.equal(addProgramEnrollmentStub.callCount, 1);
         assert.deepEqual(addProgramEnrollmentStub.args[0], [newEnrollment.id]);
+        assert.ok(fetchCoursePricesStub.calledWith());
+        assert.ok(fetchDashboardStub.calledWith());
 
         assert.deepEqual(
           store.getState().ui.toastMessage,
@@ -133,13 +141,16 @@ describe('enrollments', () => {
         assert.deepEqual(enrollmentsState.programEnrollments, PROGRAM_ENROLLMENTS);
         assert.equal(addProgramEnrollmentStub.callCount, 1);
         assert.deepEqual(addProgramEnrollmentStub.args[0], [newEnrollment.id]);
+        assert.notOk(fetchCoursePricesStub.calledWith());
+        assert.notOk(fetchDashboardStub.calledWith());
 
         assert.deepEqual(
           store.getState().ui.toastMessage,
           {
             message: "There was an error during enrollment",
             icon: TOAST_FAILURE,
-          });
+          }
+        );
       });
     });
 

--- a/static/js/reducers/financial_aid_test.js
+++ b/static/js/reducers/financial_aid_test.js
@@ -28,6 +28,7 @@ import {
   FETCH_PROCESSING,
   FETCH_SUCCESS,
 } from '../actions';
+import * as actions from '../actions';
 import { setCurrentProgramEnrollment } from '../actions/enrollments';
 import {
   FINANCIAL_AID_EDIT,
@@ -39,6 +40,7 @@ import * as api from '../util/api';
 describe('financial aid reducers', () => {
   let sandbox, store, dispatchThen;
   let addFinancialAidStub, skipFinancialAidStub;
+  let fetchDashboardStub, fetchCoursePricesStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -47,6 +49,10 @@ describe('financial aid reducers', () => {
     store.dispatch(setCurrentProgramEnrollment(1));
     addFinancialAidStub = sandbox.stub(api, 'addFinancialAid');
     skipFinancialAidStub = sandbox.stub(api, 'skipFinancialAid');
+    fetchDashboardStub = sandbox.stub(actions, 'fetchDashboard');
+    fetchDashboardStub.returns({type: "fake"});
+    fetchCoursePricesStub = sandbox.stub(actions, 'fetchCoursePrices');
+    fetchCoursePricesStub.returns({type: "fake"});
   });
 
   afterEach(() => {
@@ -113,6 +119,8 @@ describe('financial aid reducers', () => {
         fetchStatus: FETCH_SUCCESS
       });
       assert.deepEqual(state, expectation);
+      assert.ok(fetchCoursePricesStub.calledWith());
+      assert.ok(fetchDashboardStub.calledWith());
     });
   });
 
@@ -132,6 +140,8 @@ describe('financial aid reducers', () => {
       });
       assert.deepEqual(state, expectation);
       assert.ok(addFinancialAidStub.calledWith(income, currency, programId));
+      assert.notOk(fetchCoursePricesStub.calledWith());
+      assert.notOk(fetchDashboardStub.calledWith());
     });
   });
 
@@ -145,6 +155,8 @@ describe('financial aid reducers', () => {
         fetchStatus: FETCH_SUCCESS
       });
       assert.ok(skipFinancialAidStub.calledWith(2));
+      assert.ok(fetchCoursePricesStub.calledWith());
+      assert.ok(fetchDashboardStub.calledWith());
     });
   });
 
@@ -158,6 +170,8 @@ describe('financial aid reducers', () => {
         fetchStatus: FETCH_FAILURE
       });
       assert.ok(skipFinancialAidStub.calledWith(2));
+      assert.notOk(fetchCoursePricesStub.calledWith());
+      assert.notOk(fetchDashboardStub.calledWith());
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1231 
Fixes #1238 

#### What's this PR do?
Calls `fetchDashboard` and `fetchCoursePrices` after each successful API call that modifies the server in a relevant way. This also moves some existing function calls into the reducer to make them easier to test.

#### How should this be manually tested?
Have at least one program enrollment which needs to be added. Add it in the program selector in the dashboard. The dashboard should refresh and you should see the new program.

Remove the program enrollment via Django shell and go to `/profile`. Select the program and continue through the signup flow. The dashboard should be refreshed with the course selected and you should see no error.

You should also test that these things still work:
 - adding a new financial aid request
 - submitting the document date for the financial aid request