### PR TITLE
set default currency in UI

### DIFF
--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -30,7 +30,10 @@ import {
   setDocumentSentDate,
   updateDocumentSentDate,
 } from '../actions/documents';
-import { startCalculatorEdit } from '../actions/financial_aid';
+import {
+  startCalculatorEdit,
+  updateCalculatorEdit,
+} from '../actions/financial_aid';
 import type { UIState } from '../reducers/ui';
 import type {
   DocumentsState,
@@ -39,6 +42,7 @@ import type { CoursePricesState, DashboardState } from '../flow/dashboardTypes';
 import type { ProgramEnrollment } from '../flow/enrollmentTypes';
 import type { ProfileGetResult } from '../flow/profileTypes';
 import { skipFinancialAid } from '../actions/financial_aid';
+import { currencyForCountry } from '../util/currency';
 
 class DashboardPage extends React.Component {
   static contextTypes = {
@@ -118,9 +122,17 @@ class DashboardPage extends React.Component {
   };
 
   openFinancialAidCalculator = () => {
-    const { dispatch, currentProgramEnrollment } = this.props;
-    dispatch(setCalculatorDialogVisibility(true));
+    const {
+      dispatch,
+      currentProgramEnrollment,
+      profile: { profile: { country } }
+    } = this.props;
     dispatch(startCalculatorEdit(currentProgramEnrollment.id));
+    if ( country ) {
+      let currencyPrediction = currencyForCountry(country);
+      dispatch(updateCalculatorEdit({ currency: currencyPrediction }));
+    }
+    dispatch(setCalculatorDialogVisibility(true));
   };
 
   setDocumentSentDate = (newDate: string): void => {

--- a/static/js/util/currency.js
+++ b/static/js/util/currency.js
@@ -1,6 +1,27 @@
 // @flow
 import cc from 'currency-codes';
 import R from 'ramda';
+import iso3166 from 'iso-3166-2';
+
+export const excludedCurrencyCodes = [
+  'BOV',
+  'CHE',
+  'CHW',
+  'COU',
+  'MXV',
+  'SSP',
+  'USN',
+  'USS',
+  'UYI',
+  'XBA',
+  'XBB',
+  'XBC',
+  'XBD',
+  'XBT',
+  'XFU',
+  'XTS',
+  'XXX'
+];
 
 const codeToOption = code => (
   { value: code, label: cc.code(code).currency }
@@ -8,10 +29,22 @@ const codeToOption = code => (
 
 const labelSort = R.sortBy(R.compose(R.toLower, R.prop('label')));
 
-const excludeUnusedCodes = R.reject(R.flip(R.contains)(['USS', 'USN']));
+const invalidCurrency = R.flip(R.contains)(excludedCurrencyCodes);
 
 const codesToOptions = R.compose(
-  labelSort, R.map(codeToOption), excludeUnusedCodes
+  labelSort, R.map(codeToOption), R.reject(invalidCurrency)
 );
 
 export const currencyOptions = codesToOptions(cc.codes());
+
+const codeToCountryName = code => iso3166.country(code).name || '';
+
+const currencyToCode = currency => (
+  currency.length === 0 ? '' : currency[0].code
+);
+
+const excludeSingleCode = code => invalidCurrency(code) ? '' : code;
+
+export const currencyForCountry = R.compose(
+  excludeSingleCode, currencyToCode, cc.country, R.toLower, codeToCountryName
+);

--- a/static/js/util/currency_test.js
+++ b/static/js/util/currency_test.js
@@ -1,0 +1,50 @@
+import { assert } from 'chai';
+
+import {
+  currencyForCountry,
+  excludedCurrencyCodes,
+  currencyOptions,
+} from './currency';
+
+describe('currency', () => {
+  describe('currencyOptions', () => {
+    it('shouldnt include any options in the excluded list', () => {
+      excludedCurrencyCodes.forEach(code => {
+        assert.isUndefined(currencyOptions.find(option => option.value === code));
+      });
+    });
+  });
+
+  describe('currencyForCountry', () => {
+    it('should return a valid currency code for a country', () => {
+      [
+        ['US', 'USD'],
+        ['AF', 'AFN'],
+        ['JP', 'JPY'],
+        ['FR', 'EUR'],
+        ['GB', 'GBP'],
+        ['IN', 'INR'],
+      ].forEach(([country, currency]) => {
+        assert.equal(currencyForCountry(country), currency);
+      });
+    });
+
+    it('should return an empty string if you give it nonsense', () => {
+      assert.equal('', currencyForCountry('asdfasdf'));
+    });
+
+    it('should return an empty string if a country does not have a currency listing', () => {
+      assert.equal('', currencyForCountry('PS'));
+    });
+
+    it('should return an empty string if a countrys currency is in the excluded list', () => {
+      [
+        'UY',
+        'CH',
+        'SS',
+      ].forEach(country => {
+        assert.equal('', currencyForCountry(country));
+      });
+    });
+  });
+});


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1048 

#### What's this PR do?

This guesses what a user's currency should be when they start the financial aid calculator process, based on the `country` value in their profile.

#### Where should the reviewer start?

read over the code!

#### How should this be manually tested?

1. Delete any financial aid objects on your user
2. go to `/dashboard`
3. open the financial aid calculator

when you do the appropriate currency for the country on your profile should already be selected.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
