### PR TITLE
adds error handling for syncing exchange rates with API

### DIFF
--- a/financialaid/exceptions.py
+++ b/financialaid/exceptions.py
@@ -7,3 +7,15 @@ class NotSupportedException(Exception):
     """
     Not supported by current financial aid system.
     """
+
+
+class ExceededAPICallsException(Exception):
+    """
+    Exceeded maximum number of API calls per month to Open Exchange Rates (openexchangerates.org)
+    """
+
+
+class UnexpectedAPIErrorException(Exception):
+    """
+    Unexpected error in making an API call
+    """

--- a/financialaid/tasks.py
+++ b/financialaid/tasks.py
@@ -5,6 +5,7 @@ import requests
 
 from financialaid.api import update_currency_exchange_rate
 from financialaid.constants import CURRENCY_EXCHANGE_RATE_API_REQUEST_URL
+from financialaid.exceptions import ExceededAPICallsException, UnexpectedAPIErrorException
 from micromasters.celery import async
 
 
@@ -14,6 +15,12 @@ def sync_currency_exchange_rates():
     Updates all CurrencyExchangeRate objects to reflect latest exchange rates from
     Open Exchange Rates API (https://openexchangerates.org/).
     """
-    resp = requests.get(CURRENCY_EXCHANGE_RATE_API_REQUEST_URL).json()
-    latest_rates = resp["rates"]
+    resp = requests.get(CURRENCY_EXCHANGE_RATE_API_REQUEST_URL)
+    resp_json = resp.json()
+    # check specifically if maximum number of api calls per month has been exceeded
+    if resp.status_code == 429:
+        raise ExceededAPICallsException(resp_json["description"])
+    elif resp.status_code != 200:  # check for other API errors
+        raise UnexpectedAPIErrorException(resp_json["description"])
+    latest_rates = resp_json["rates"]
     update_currency_exchange_rate(latest_rates)


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #1267.

#### What's this PR do?

Adds error handling for API calls made to Open Exchange Rates (openexchangerates.org) for currency conversion; includes error handling for maximum monthly API calls exceeded.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

