### PR TITLE
Implemented enroll links

### DIFF
--- a/static/js/actions/enrollments.js
+++ b/static/js/actions/enrollments.js
@@ -78,3 +78,27 @@ export const clearEnrollments = createAction(CLEAR_ENROLLMENTS);
 
 export const SET_CURRENT_PROGRAM_ENROLLMENT = 'SET_CURRENT_PROGRAM_ENROLLMENT';
 export const setCurrentProgramEnrollment = createAction(SET_CURRENT_PROGRAM_ENROLLMENT);
+
+export const REQUEST_ADD_COURSE_ENROLLMENT = 'REQUEST_ADD_COURSE_ENROLLMENT';
+export const requestAddCourseEnrollment = createAction(REQUEST_ADD_COURSE_ENROLLMENT);
+
+export const RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS = 'RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS';
+export const receiveAddCourseEnrollmentSuccess = createAction(RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS);
+
+export const RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE = 'RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE';
+export const receiveAddCourseEnrollmentFailure = createAction(RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE);
+
+export const addCourseEnrollment = (courseId: string): Dispatcher<*> => {
+  return (dispatch: Dispatch) => {
+    dispatch(requestAddCourseEnrollment(courseId));
+    return api.addCourseEnrollment(courseId).
+      then(() => {
+        dispatch(receiveAddCourseEnrollmentSuccess());
+        dispatch(fetchDashboard());
+        dispatch(fetchCoursePrices());
+      }).
+      catch(() => {
+        dispatch(receiveAddCourseEnrollmentFailure());
+      });
+  };
+};

--- a/static/js/actions/enrollments_test.js
+++ b/static/js/actions/enrollments_test.js
@@ -8,6 +8,9 @@ import {
   receiveAddProgramEnrollmentFailure,
   clearEnrollments,
   setCurrentProgramEnrollment,
+  requestAddCourseEnrollment,
+  receiveAddCourseEnrollmentSuccess,
+  receiveAddCourseEnrollmentFailure,
 
   REQUEST_GET_PROGRAM_ENROLLMENTS,
   RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
@@ -17,6 +20,9 @@ import {
   RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE,
   CLEAR_ENROLLMENTS,
   SET_CURRENT_PROGRAM_ENROLLMENT,
+  REQUEST_ADD_COURSE_ENROLLMENT,
+  RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
+  RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
 } from './enrollments';
 import { assertCreatedActionHelper } from './util';
 
@@ -31,6 +37,9 @@ describe('enrollment actions', () => {
       [receiveAddProgramEnrollmentFailure, RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE],
       [clearEnrollments, CLEAR_ENROLLMENTS],
       [setCurrentProgramEnrollment, SET_CURRENT_PROGRAM_ENROLLMENT],
+      [requestAddCourseEnrollment, REQUEST_ADD_COURSE_ENROLLMENT],
+      [receiveAddCourseEnrollmentSuccess, RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS],
+      [receiveAddCourseEnrollmentFailure, RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -31,6 +31,7 @@ export default class CourseAction extends React.Component {
     hasFinancialAid: boolean,
     openFinancialAidCalculator?: () => void,
     now: moment$Moment,
+    addCourseEnrollment: (courseId: string) => void
   };
 
   statusDescriptionClasses = {
@@ -112,11 +113,17 @@ export default class CourseAction extends React.Component {
 
   renderStatusDescription = this.renderDescription('boxed description');
 
-  renderPayLaterLink: Function = (): React$Element<*> => (
-    <div key="2">
-      <a href="#">Enroll and pay later</a>
-    </div>
-  );
+  handleAddCourseEnrollment = (event: Event, run: CourseRun): void => {
+    const { addCourseEnrollment } = this.props;
+    event.preventDefault();
+    addCourseEnrollment(run.course_id);
+  };
+
+  renderPayLaterLink(run: CourseRun): React$Element<*> {
+    return (
+      <a href="#" onClick={e => this.handleAddCourseEnrollment(e, run)}>Enroll and pay later</a>
+    );
+  }
 
   renderContents(run: CourseRun) {
     const { now } = this.props;
@@ -147,7 +154,7 @@ export default class CourseAction extends React.Component {
       let enrollmentStartDate = run.enrollment_start_date ? moment(run.enrollment_start_date) : null;
       if (this.isCurrentlyEnrollable(enrollmentStartDate)) {
         action = this.renderEnrollButton(run);
-        description = this.renderPayLaterLink();
+        description = this.renderPayLaterLink(run);
       } else {
         if (enrollmentStartDate) {
           let formattedEnrollDate = enrollmentStartDate.format(DASHBOARD_FORMAT);

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -16,6 +16,7 @@ export default class CourseListCard extends React.Component {
     coursePrice:                  CoursePrice,
     openFinancialAidCalculator?:  () => void,
     now?:                         Object,
+    addCourseEnrollment:          (courseId: string) => void,
   };
 
   render() {
@@ -25,6 +26,7 @@ export default class CourseListCard extends React.Component {
       now,
       checkout,
       openFinancialAidCalculator,
+      addCourseEnrollment,
     } = this.props;
     if (now === undefined) {
       now = moment();
@@ -41,6 +43,7 @@ export default class CourseListCard extends React.Component {
         checkout={checkout}
         openFinancialAidCalculator={openFinancialAidCalculator}
         now={now}
+        addCourseEnrollment={addCourseEnrollment}
       />
     );
 

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -17,6 +17,7 @@ export default class CourseRow extends React.Component {
     hasFinancialAid: boolean,
     openFinancialAidCalculator: () => void,
     now: moment$Moment,
+    addCourseEnrollment: (courseId: string) => void,
   };
 
   render() {
@@ -27,7 +28,8 @@ export default class CourseRow extends React.Component {
       hasFinancialAid,
       checkout,
       openFinancialAidCalculator,
-      now
+      now,
+      addCourseEnrollment,
     } = this.props;
 
     return <Grid className="course-row">
@@ -46,6 +48,7 @@ export default class CourseRow extends React.Component {
           checkout={checkout}
           openFinancialAidCalculator={openFinancialAidCalculator}
           now={now}
+          addCourseEnrollment={addCourseEnrollment}
         />
       </Cell>
     </Grid>;

--- a/static/js/components/dashboard/CourseRow_test.js
+++ b/static/js/components/dashboard/CourseRow_test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 import { assert } from 'chai';
+import sinon from 'sinon';
 
 import CourseRow from './CourseRow';
 import CourseAction from './CourseAction';
@@ -15,14 +16,24 @@ import {
 } from '../../constants';
 
 describe('CourseRow', () => {
+  let sandbox;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   it('forwards the appropriate props', () => {
     const course = DASHBOARD_RESPONSE[1].courses[0];
     const hasFinancialAid = true;
     const financialAid = FINANCIAL_AID_PARTIAL_RESPONSE;
     const coursePrice = COURSE_PRICES_RESPONSE[0];
-    const openFinancialAidCalculator = () => {};
+    const openFinancialAidCalculator = sinon.stub();
     const now = moment();
-    const checkout = () => null;
+    const checkout = sinon.stub();
+    const addCourseEnrollment = sinon.stub();
     const wrapper = shallow(
       <CourseRow
         course={course}
@@ -32,6 +43,7 @@ describe('CourseRow', () => {
         now={now}
         checkout={checkout}
         openFinancialAidCalculator={openFinancialAidCalculator}
+        addCourseEnrollment={addCourseEnrollment}
       />
     );
     assert.deepEqual(wrapper.find(CourseAction).props(), {
@@ -42,6 +54,7 @@ describe('CourseRow', () => {
       course,
       checkout,
       openFinancialAidCalculator,
+      addCourseEnrollment,
     });
     assert.deepEqual(wrapper.find(CourseDescription).props(), {
       course,

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -15,6 +15,7 @@ import {
   TOAST_SUCCESS,
   TOAST_FAILURE,
 } from '../constants';
+import { addCourseEnrollment } from '../actions/enrollments';
 import {
   setToastMessage,
   setConfirmSkipDialogVisibility,
@@ -157,6 +158,11 @@ class DashboardPage extends React.Component {
     return dispatch(updateDocumentSentDate(financialAidId, sentDate));
   };
 
+  addCourseEnrollment = (courseId: string): void => {
+    const { dispatch } = this.props;
+    return dispatch(addCourseEnrollment(courseId));
+  };
+
   render() {
     const {
       dashboard,
@@ -208,6 +214,7 @@ class DashboardPage extends React.Component {
               key={program.id}
               checkout={this.dispatchCheckout}
               openFinancialAidCalculator={this.openFinancialAidCalculator}
+              addCourseEnrollment={this.addCourseEnrollment}
             />
           </div>
           <div className="second-column">

--- a/static/js/flow/enrollmentTypes.js
+++ b/static/js/flow/enrollmentTypes.js
@@ -13,4 +13,5 @@ export type ProgramEnrollmentsState = {
   getStatus?: string,
   getErrorInfo?: APIErrorInfo,
   postStatus?: string,
+  coursePostStatus?: string,
 };

--- a/static/js/flow/enrollmentTypes.js
+++ b/static/js/flow/enrollmentTypes.js
@@ -13,5 +13,5 @@ export type ProgramEnrollmentsState = {
   getStatus?: string,
   getErrorInfo?: APIErrorInfo,
   postStatus?: string,
-  coursePostStatus?: string,
+  courseEnrollAddStatus?: string,
 };

--- a/static/js/reducers/enrollments.js
+++ b/static/js/reducers/enrollments.js
@@ -49,11 +49,11 @@ export const enrollments = (state: ProgramEnrollmentsState = INITIAL_ENROLLMENTS
   case CLEAR_ENROLLMENTS:
     return INITIAL_ENROLLMENTS_STATE;
   case REQUEST_ADD_COURSE_ENROLLMENT:
-    return { ...state, coursePostStatus: FETCH_PROCESSING };
+    return { ...state, courseEnrollAddStatus: FETCH_PROCESSING };
   case RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS:
-    return { ...state, coursePostStatus: FETCH_SUCCESS };
+    return { ...state, courseEnrollAddStatus: FETCH_SUCCESS };
   case RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE:
-    return { ...state, coursePostStatus: FETCH_FAILURE };
+    return { ...state, courseEnrollAddStatus: FETCH_FAILURE };
   default:
     return state;
   }

--- a/static/js/reducers/enrollments.js
+++ b/static/js/reducers/enrollments.js
@@ -10,6 +10,9 @@ import {
   RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE,
   CLEAR_ENROLLMENTS,
   SET_CURRENT_PROGRAM_ENROLLMENT,
+  REQUEST_ADD_COURSE_ENROLLMENT,
+  RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
+  RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
 } from '../actions/enrollments';
 import {
   FETCH_FAILURE,
@@ -45,6 +48,12 @@ export const enrollments = (state: ProgramEnrollmentsState = INITIAL_ENROLLMENTS
     return { ...state, postStatus: FETCH_FAILURE, postErrorInfo: action.payload };
   case CLEAR_ENROLLMENTS:
     return INITIAL_ENROLLMENTS_STATE;
+  case REQUEST_ADD_COURSE_ENROLLMENT:
+    return { ...state, coursePostStatus: FETCH_PROCESSING };
+  case RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS:
+    return { ...state, coursePostStatus: FETCH_SUCCESS };
+  case RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE:
+    return { ...state, coursePostStatus: FETCH_FAILURE };
   default:
     return state;
   }

--- a/static/js/reducers/enrollments_test.js
+++ b/static/js/reducers/enrollments_test.js
@@ -181,7 +181,7 @@ describe('enrollments', () => {
         assert.ok(addCourseEnrollmentStub.calledWith(courseKey));
         assert.ok(fetchCoursePricesStub.calledWith());
         assert.ok(fetchDashboardStub.calledWith());
-      })
+      });
     });
 
     it('should fail to add a course enrollment', () => {
@@ -196,7 +196,7 @@ describe('enrollments', () => {
         assert.ok(addCourseEnrollmentStub.calledWith(courseKey));
         assert.notOk(fetchCoursePricesStub.calledWith());
         assert.notOk(fetchDashboardStub.calledWith());
-      })
+      });
     });
   });
 

--- a/static/js/reducers/enrollments_test.js
+++ b/static/js/reducers/enrollments_test.js
@@ -20,6 +20,7 @@ import {
   receiveGetProgramEnrollmentsSuccess,
   clearEnrollments,
   setCurrentProgramEnrollment,
+  addCourseEnrollment,
 
   REQUEST_GET_PROGRAM_ENROLLMENTS,
   RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
@@ -29,19 +30,23 @@ import {
   RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE,
   CLEAR_ENROLLMENTS,
   SET_CURRENT_PROGRAM_ENROLLMENT,
+  REQUEST_ADD_COURSE_ENROLLMENT,
+  RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
+  RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
 } from '../actions/enrollments';
 import * as api from '../util/api';
 import * as actions from '../actions';
 import rootReducer from '../reducers';
 
 describe('enrollments', () => {
-  let sandbox, store, getProgramEnrollmentsStub, addProgramEnrollmentStub;
+  let sandbox, store, getProgramEnrollmentsStub, addProgramEnrollmentStub, addCourseEnrollmentStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     store = configureTestStore(rootReducer);
     getProgramEnrollmentsStub = sandbox.stub(api, 'getProgramEnrollments');
     addProgramEnrollmentStub = sandbox.stub(api, 'addProgramEnrollment');
+    addCourseEnrollmentStub = sandbox.stub(api, 'addCourseEnrollment');
   });
 
   afterEach(() => {
@@ -162,6 +167,36 @@ describe('enrollments', () => {
           programEnrollments: []
         });
       });
+    });
+
+    it('should add a course enrollment successfully', () => {
+      addCourseEnrollmentStub.returns(Promise.resolve());
+
+      let courseKey = 'course_key';
+      return dispatchThen(addCourseEnrollment(courseKey), [
+        REQUEST_ADD_COURSE_ENROLLMENT,
+        RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
+      ]).then(state => {
+        assert.equal(state.coursePostStatus, FETCH_SUCCESS);
+        assert.ok(addCourseEnrollmentStub.calledWith(courseKey));
+        assert.ok(fetchCoursePricesStub.calledWith());
+        assert.ok(fetchDashboardStub.calledWith());
+      })
+    });
+
+    it('should fail to add a course enrollment', () => {
+      addCourseEnrollmentStub.returns(Promise.reject());
+
+      let courseKey = 'course_key';
+      return dispatchThen(addCourseEnrollment(courseKey), [
+        REQUEST_ADD_COURSE_ENROLLMENT,
+        RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
+      ]).then(state => {
+        assert.equal(state.coursePostStatus, FETCH_FAILURE);
+        assert.ok(addCourseEnrollmentStub.calledWith(courseKey));
+        assert.notOk(fetchCoursePricesStub.calledWith());
+        assert.notOk(fetchDashboardStub.calledWith());
+      })
     });
   });
 

--- a/static/js/reducers/enrollments_test.js
+++ b/static/js/reducers/enrollments_test.js
@@ -177,7 +177,7 @@ describe('enrollments', () => {
         REQUEST_ADD_COURSE_ENROLLMENT,
         RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
       ]).then(state => {
-        assert.equal(state.coursePostStatus, FETCH_SUCCESS);
+        assert.equal(state.courseEnrollAddStatus, FETCH_SUCCESS);
         assert.isTrue(addCourseEnrollmentStub.calledWith(courseKey));
         assert.isTrue(fetchCoursePricesStub.calledWith());
         assert.isTrue(fetchDashboardStub.calledWith());
@@ -192,7 +192,7 @@ describe('enrollments', () => {
         REQUEST_ADD_COURSE_ENROLLMENT,
         RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
       ]).then(state => {
-        assert.equal(state.coursePostStatus, FETCH_FAILURE);
+        assert.equal(state.courseEnrollAddStatus, FETCH_FAILURE);
         assert.isTrue(addCourseEnrollmentStub.calledWith(courseKey));
         assert.isFalse(fetchCoursePricesStub.calledWith());
         assert.isFalse(fetchDashboardStub.calledWith());

--- a/static/js/reducers/enrollments_test.js
+++ b/static/js/reducers/enrollments_test.js
@@ -178,9 +178,9 @@ describe('enrollments', () => {
         RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
       ]).then(state => {
         assert.equal(state.coursePostStatus, FETCH_SUCCESS);
-        assert.ok(addCourseEnrollmentStub.calledWith(courseKey));
-        assert.ok(fetchCoursePricesStub.calledWith());
-        assert.ok(fetchDashboardStub.calledWith());
+        assert.isTrue(addCourseEnrollmentStub.calledWith(courseKey));
+        assert.isTrue(fetchCoursePricesStub.calledWith());
+        assert.isTrue(fetchDashboardStub.calledWith());
       });
     });
 
@@ -193,9 +193,9 @@ describe('enrollments', () => {
         RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
       ]).then(state => {
         assert.equal(state.coursePostStatus, FETCH_FAILURE);
-        assert.ok(addCourseEnrollmentStub.calledWith(courseKey));
-        assert.notOk(fetchCoursePricesStub.calledWith());
-        assert.notOk(fetchDashboardStub.calledWith());
+        assert.isTrue(addCourseEnrollmentStub.calledWith(courseKey));
+        assert.isFalse(fetchCoursePricesStub.calledWith());
+        assert.isFalse(fetchDashboardStub.calledWith());
       });
     });
   });

--- a/static/js/util/api.js
+++ b/static/js/util/api.js
@@ -224,3 +224,12 @@ export function updateDocumentSentDate(financialAidId: number, sentDate: string)
     })
   });
 }
+
+export function addCourseEnrollment(courseId: string) {
+  return mockableFetchJSONWithCSRF('/api/v0/course_enrollments/', {
+    method: 'POST',
+    body: JSON.stringify({
+      course_id: courseId,
+    })
+  });
+}

--- a/static/js/util/api_test.js
+++ b/static/js/util/api_test.js
@@ -19,6 +19,7 @@ import {
   addFinancialAid,
   skipFinancialAid,
   updateDocumentSentDate,
+  addCourseEnrollment,
 } from './api';
 import * as api from './api';
 import {
@@ -356,6 +357,34 @@ describe('api', function() {
             method: 'PATCH',
             body: JSON.stringify({
               date_documents_sent: sentDate
+            })
+          }));
+        });
+      });
+
+      it('adds a course enrollment', () => {
+        fetchJSONStub.returns(Promise.resolve());
+
+        let courseId = 'course_id';
+        return addCourseEnrollment(courseId).then(() => {
+          assert.ok(fetchJSONStub.calledWith('/api/v0/course_enrollments/', {
+            method: 'POST',
+            body: JSON.stringify({
+              course_id: courseId
+            })
+          }));
+        });
+      });
+
+      it('fails to add a course enrollment', () => {
+        fetchJSONStub.returns(Promise.reject());
+
+        let courseId = 'course_id';
+        return assert.isRejected(addCourseEnrollment(courseId)).then(() => {
+          assert.ok(fetchJSONStub.calledWith('/api/v0/course_enrollments/', {
+            method: 'POST',
+            body: JSON.stringify({
+              course_id: courseId
             })
           }));
         });


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1223

#### What's this PR do?
Implements the enroll link on the course row

#### How should this be manually tested?
Unenroll from a course on edX. Then click the enroll link for that same course on micromasters. Go back to edX and verify that the course is enrolled again.

#### Any background context you want to provide?
I noticed that we show the enroll link even if the user is currently enrolled when they need to upgrade, but I figured that's outside the scope of this PR