### PR TITLE
Fixed image size for faculty carousel

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -18,7 +18,7 @@ class FacultyImageSerializer(serializers.ModelSerializer):
     alt = serializers.CharField(source="default_alt_text")
     rendition = serializers.SerializerMethodField()
 
-    def get_rendition(self, image):
+    def get_rendition(self, image):  # pylint: disable=no-self-use
         """Serialize a rendition for the faculty image"""
         return RenditionSerializer().to_representation(image.get_rendition('fill-500x385'))
 

--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -13,32 +13,18 @@ class RenditionSerializer(serializers.ModelSerializer):
         fields = ("file", "width", "height")
 
 
-class ImageRenditionsField(serializers.RelatedField):
-    """
-    Field to output serialized versions of three sizes of an image:
-    small (100px), medium (500px), and large (1000px).
-    """
-    def to_representation(self, image):
-        serializer = RenditionSerializer()
-        small = image.get_rendition('fill-100x100')
-        medium = image.get_rendition('fill-500x500')
-        large = image.get_rendition('fill-1000x1000')
-        return {
-            "small": serializer.to_representation(small),
-            "medium": serializer.to_representation(medium),
-            "large": serializer.to_representation(large),
-        }
-
-
-class ImageSerializer(serializers.ModelSerializer):
-    """Serializer for Wagtail Image objects."""
+class FacultyImageSerializer(serializers.ModelSerializer):
+    """Serializer for faculty images."""
     alt = serializers.CharField(source="default_alt_text")
-    sizes = ImageRenditionsField(source='*', read_only=True)
+    rendition = serializers.SerializerMethodField()
+
+    def get_rendition(self, image):
+        """Serialize a rendition for the faculty image"""
+        return RenditionSerializer().to_representation(image.get_rendition('fill-500x385'))
 
     class Meta:  # pylint: disable=missing-docstring
         model = Image
-        fields = ("title", "alt", "file", "width", "height",
-                  "created_at", "file_size", "sizes")
+        fields = ('alt', 'rendition',)
 
 
 class ProgramSerializer(serializers.ModelSerializer):
@@ -50,7 +36,7 @@ class ProgramSerializer(serializers.ModelSerializer):
 
 class FacultySerializer(serializers.ModelSerializer):
     """Serializer for ProgramFaculty objects."""
-    image = ImageSerializer(read_only=True)
+    image = FacultyImageSerializer(read_only=True)
 
     class Meta:  # pylint: disable=missing-docstring
         model = ProgramFaculty

--- a/cms/serializers_test.py
+++ b/cms/serializers_test.py
@@ -1,24 +1,44 @@
 """
-Tests for serializers
+Tests for CMS serializers
 """
 from search.base import ESTestCase
-from cms.serializers import FacultySerializer
+from cms.serializers import (
+    FacultySerializer,
+    RenditionSerializer,
+)
 from cms.factories import FacultyFactory
 
 
+# pylint: disable=no-self-use
 class WagtailSerializerTests(ESTestCase):
     """
-    Tests for CourseRunSerializer
+    Tests for WagtailSerializer
     """
 
-    def test_faculty_serializer(self):  # pylint: disable=no-self-use
+    def test_faculty_serializer(self):
         """
-        Make sure program id appears correctly
+        Make sure faculty image information is serialized correctly
         """
         faculty = FacultyFactory.create()
         result = FacultySerializer().to_representation(faculty)
-        assert result['name'] == faculty.name
-        assert result['title'] == faculty.title
-        assert result['short_bio'] == faculty.short_bio
-        assert result['image']['title'] == faculty.image.title
-        assert result['image']['file'] == faculty.image.file.url
+        assert result == {
+            'name': faculty.name,
+            'title': faculty.title,
+            'short_bio': faculty.short_bio,
+            'image': {
+                'alt': faculty.image.default_alt_text,
+                'rendition': RenditionSerializer().to_representation(faculty.image.get_rendition('fill-500x385'))
+            }
+        }
+
+    def test_rendition_serializer(self):
+        """
+        Test rendition serializer
+        """
+        faculty = FacultyFactory.create()
+        rendition = faculty.image.get_rendition('fill-1x1')
+        assert RenditionSerializer().to_representation(rendition) == {
+            'file': rendition.url,
+            'width': rendition.width,
+            'height': rendition.height,
+        }

--- a/static/js/components/FacultyTile.js
+++ b/static/js/components/FacultyTile.js
@@ -10,23 +10,28 @@ export default class FacultyTile extends React.Component {
     image:     Object,
   }
   render() {
-    const { name, title, short_bio, image } = this.props;
-    const shortBio = short_bio;  // eslint-disable-line camelcase
-    let nameStr, imageTag;
+    const {
+      name,
+      title,
+      short_bio: shortBio,
+      image: {
+        alt,
+        rendition: {
+          width,
+          height,
+          file,
+        }
+      }
+    } = this.props;
+    let nameStr;
     if (title) {
       nameStr = `${name}, ${title}`;
     } else {
       nameStr = name;
     }
-    if ( image && image.file ) {
-      if (image.sizes && image.sizes.medium && image.sizes.medium.file) {
-        imageTag = <img src={image.sizes.medium.file} alt={image.alt} />;
-      } else {
-        imageTag = <img src={image.file} alt={image.alt} />;
-      }
-    } else {
-      imageTag = null;
-    }
+
+    let imageTag = <img src={file} alt={alt} width={width} height={height} />;
+
     return (
       <div className="faculty-tile">
         {imageTag}

--- a/static/js/components/FacultyTile.js
+++ b/static/js/components/FacultyTile.js
@@ -30,11 +30,9 @@ export default class FacultyTile extends React.Component {
       nameStr = name;
     }
 
-    let imageTag = <img src={file} alt={alt} width={width} height={height} />;
-
     return (
       <div className="faculty-tile">
-        {imageTag}
+        <img src={file} alt={alt} width={width} height={height} />
         <h4>{nameStr}</h4>
         <p>{shortBio}</p>
       </div>

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -304,6 +304,7 @@
     .slick-arrow {
       height: 40px;
       width: 40px;
+
       &:before {
         font-size: 40px;
       }

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -244,7 +244,6 @@
     }
 
     .faculty-tile {
-      height: 385px;
       padding: 250px 22px 20px 26px;
       margin: 0 auto;
       color: #ffffff;
@@ -274,7 +273,6 @@
       }
 
       img {
-        width: 100%;
         position: absolute;
         top: 0;
         left: 0;
@@ -292,19 +290,23 @@
     }
 
     .slick-prev {
-      left: -40px;
+      left: -50px;
     }
 
     .slick-next {
-      right: -30px;
+      right: -50px;
     }
 
     .slick-dots li button:before {
       font-size: 20px;
     }
 
-    .slick-arrow:before {
-      font-size: 40px;
+    .slick-arrow {
+      height: 40px;
+      width: 40px;
+      &:before {
+        font-size: 40px;
+      }
     }
 
     .slick-dots {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1292 

#### What's this PR do?
Updates the size to 500x385 to match the help text on the CMS, and also fixes some CSS to allow the user to click the buttons on the left and right sides

#### Screenshots (if appropriate)
![screenshot from 2016-10-07 15-56-49](https://cloud.githubusercontent.com/assets/863262/19203695/adc4f928-8ca6-11e6-8c26-32c9b69f7418.png)

