### PR TITLE
Hide program drop down on `/profile` and `/settings`

### DIFF
--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -12,17 +12,20 @@ import type {
 import ProgramSelector from './ProgramSelector';
 import UserMenu from '../containers/UserMenu';
 
+const PROFILE_SETTINGS_REGEX = /^\/profile\/?|settings\/?|learner\/[a-z]?/;
+
 export default class Navbar extends React.Component {
   props: {
     addProgramEnrollment:        (programId: number) => void,
-    empty:                       boolean,
     children?:                   React$Element<*>[],
     currentProgramEnrollment:    ProgramEnrollment,
     dashboard:                   DashboardState,
-    enrollments:                 ProgramEnrollmentsState,
+    empty:                       boolean,
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
+    enrollments:                 ProgramEnrollmentsState,
+    pathname:                    string,
     setCurrentProgramEnrollment: (enrollment: ProgramEnrollment) => void,
     setEnrollDialogError:        (error: ?string) => void,
     setEnrollDialogVisibility:   (open: boolean) => void,
@@ -43,6 +46,7 @@ export default class Navbar extends React.Component {
       enrollDialogVisibility,
       enrollSelectedProgram,
       enrollments,
+      pathname,
       setCurrentProgramEnrollment,
       setEnrollDialogError,
       setEnrollDialogVisibility,
@@ -75,6 +79,7 @@ export default class Navbar extends React.Component {
                 enrollDialogVisibility={enrollDialogVisibility}
                 enrollSelectedProgram={enrollSelectedProgram}
                 enrollments={enrollments}
+                selectorVisibility={!PROFILE_SETTINGS_REGEX.test(pathname)}
                 setCurrentProgramEnrollment={setCurrentProgramEnrollment}
                 setEnrollDialogError={setEnrollDialogError}
                 setEnrollDialogVisibility={setEnrollDialogVisibility}

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -26,6 +26,7 @@ export default class ProgramSelector extends React.Component {
     setEnrollDialogError:        (error: ?string) => void,
     setEnrollDialogVisibility:   (open: boolean) => void,
     setEnrollSelectedProgram:    (programId: ?number) => void,
+    selectorVisibility:          boolean,
   };
 
   selectEnrollment = (option: Option): void => {
@@ -89,6 +90,7 @@ export default class ProgramSelector extends React.Component {
       setEnrollDialogError,
       setEnrollDialogVisibility,
       setEnrollSelectedProgram,
+      selectorVisibility,
     } = this.props;
     let currentId;
     if (!_.isNil(currentProgramEnrollment)) {
@@ -98,7 +100,7 @@ export default class ProgramSelector extends React.Component {
     let selected = programEnrollments.find(enrollment => enrollment.id === currentId);
     let options = this.makeOptions();
 
-    if (programEnrollments.length === 0) {
+    if (programEnrollments.length === 0 || selectorVisibility === false) {
       return <div className="program-selector" />;
     } else {
       return <div className="program-selector">

--- a/static/js/components/ProgramSelector_test.js
+++ b/static/js/components/ProgramSelector_test.js
@@ -49,6 +49,11 @@ describe('ProgramSelector', () => {
     assert.equal(wrapper.find("div").children().length, 0);
   });
 
+  it('renders an empty div if it is passed `selectorVisibility === false`', () => {
+    let wrapper = renderProgramSelector({ selectorVisibility: false });
+    assert.equal(wrapper.find("div").children().length, 0);
+  });
+
   it("renders the currently selected enrollment first, then all other enrollments", () => {
     let wrapper = renderProgramSelector();
     let selectProps = wrapper.find(Select).props();

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -35,7 +35,8 @@ describe('CourseAction', () => {
       checkout: checkoutStub,
       coursePrice: coursePrice,
       hasFinancialAid: false,
-      financialAid: {}
+      financialAid: {},
+      addCourseEnrollment: sandbox.stub(),
     };
     defaultParamsNow = Object.assign({}, defaultParams, { now: now });
   });

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -12,7 +12,8 @@ import { DASHBOARD_RESPONSE, COURSE_PRICES_RESPONSE } from '../../constants';
 describe('CourseListCard', () => {
   let defaultCardParams = {
     coursePrice: _.cloneDeep(COURSE_PRICES_RESPONSE[0]),
-    checkout: () => null
+    checkout: () => null,
+    addCourseEnrollment: () => undefined,
   };
 
   it('creates a CourseRow for each course', () => {

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -235,6 +235,7 @@ class App extends React.Component {
         enrollDialogVisibility={enrollDialogVisibility}
         enrollSelectedProgram={enrollSelectedProgram}
         enrollments={enrollments}
+        pathname={pathname}
         setCurrentProgramEnrollment={this.setCurrentProgramEnrollment}
         setEnrollDialogError={this.setEnrollDialogError}
         setEnrollDialogVisibility={this.setEnrollDialogVisibility}


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1298 

#### What's this PR do?

This makes it so that the program selector drop-down is hidden on urls matching `/profile` and `/settings`.

#### Where should the reviewer start?

#### How should this be manually tested?

Make sure that it doesn't show up on `/profile` and `/settings` and that it does show up on `/dashboard`, `/learners`, etc.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
