### PR TITLE
only photos allowed

### DIFF
--- a/static/js/actions/image_upload.js
+++ b/static/js/actions/image_upload.js
@@ -14,6 +14,9 @@ export const clearPhotoEdit = createAction(CLEAR_PHOTO_EDIT);
 export const UPDATE_PHOTO_EDIT = 'UPDATE_PHOTO_EDIT';
 export const updatePhotoEdit = createAction(UPDATE_PHOTO_EDIT);
 
+export const SET_PHOTO_ERROR = 'SET_PHOTO_ERROR';
+export const setPhotoError = createAction(SET_PHOTO_ERROR);
+
 export const REQUEST_PATCH_USER_PHOTO = 'REQUEST_PATCH_USER_PHOTO';
 export const requestPatchUserPhoto = createAction(REQUEST_PATCH_USER_PHOTO);
 

--- a/static/js/actions/image_upload_test.js
+++ b/static/js/actions/image_upload_test.js
@@ -9,6 +9,9 @@ import {
   updatePhotoEdit,
   UPDATE_PHOTO_EDIT,
 
+  setPhotoError,
+  SET_PHOTO_ERROR,
+
   requestPatchUserPhoto,
   REQUEST_PATCH_USER_PHOTO,
 
@@ -26,6 +29,7 @@ describe('generated image upload action helpers', () => {
       [startPhotoEdit, START_PHOTO_EDIT],
       [clearPhotoEdit, CLEAR_PHOTO_EDIT],
       [updatePhotoEdit, UPDATE_PHOTO_EDIT],
+      [setPhotoError, SET_PHOTO_ERROR],
       [requestPatchUserPhoto, REQUEST_PATCH_USER_PHOTO],
       [receivePatchUserPhotoFailure, RECEIVE_PATCH_USER_PHOTO_FAILURE],
       [receivePatchUserPhotoSuccess, RECEIVE_PATCH_USER_PHOTO_SUCCESS],

--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -10,17 +10,21 @@ import type { ImageUploadState } from '../reducers/image_upload';
 
 const onDrop = R.curry((startPhotoEdit, files) => startPhotoEdit(...files));
 
-const dropZone = onDrop => (
+const dropZone = (startPhotoEdit, setPhotoError) => (
   <Dropzone
-    onDrop={onDrop}
+    onDrop={onDrop(startPhotoEdit)}
     className="photo-active-item photo-dropzone"
     activeClassName="photo-active-item photo-dropzone active"
+    accept="image/*"
+    onDropRejected={() => setPhotoError('Please select a valid photo')}
   >
     <div>
       Drag a photo here or click to select a photo.
     </div>
   </Dropzone>
 );
+
+const imageError = err => <div className="img-error">{err}</div>;
 
 type ImageUploadProps = {
   photoDialogOpen:      boolean;
@@ -30,6 +34,7 @@ type ImageUploadProps = {
   imageUpload:          ImageUploadState;
   updateUserPhoto:      (i: string) => Promise<string>,
   updatePhotoEdit:      (b: Blob) => void;
+  setPhotoError:        (s: string) => void;
 };
 
 const ProfileImageUploader = ({
@@ -38,8 +43,9 @@ const ProfileImageUploader = ({
   startPhotoEdit,
   clearPhotoEdit,
   updatePhotoEdit,
-  imageUpload: { photo },
+  imageUpload: { photo, error },
   updateUserPhoto,
+  setPhotoError,
 }: ImageUploadProps) => (
   <Dialog
     open = {photoDialogOpen}
@@ -68,7 +74,8 @@ const ProfileImageUploader = ({
       </Button>
     ]}
   >
-    { photo ? <CropperWrapper {...{updatePhotoEdit, photo}} /> : dropZone(onDrop(startPhotoEdit)) }
+    { photo ? <CropperWrapper {...{updatePhotoEdit, photo}} /> : dropZone(startPhotoEdit, setPhotoError) }
+    { imageError(error) }
   </Dialog>
 );
 

--- a/static/js/containers/ProfileImage.js
+++ b/static/js/containers/ProfileImage.js
@@ -15,6 +15,7 @@ import {
   startPhotoEdit,
   clearPhotoEdit,
   updatePhotoEdit,
+  setPhotoError,
   updateUserPhoto,
 } from '../actions/image_upload';
 import { fetchUserProfile } from '../actions/profile';
@@ -34,6 +35,7 @@ class ProfileImage extends React.Component {
     updatePhotoEdit:      (b: Blob) => void,
     startPhotoEdit:       (p: File) => void,
     photoDialogOpen:      boolean,
+    setPhotoError:        (s: string) => void,
   };
 
   static defaultProps = {
@@ -102,6 +104,7 @@ const mapDispatchToProps = dispatch => ({
   startPhotoEdit: createActionHelper(dispatch, startPhotoEdit),
   clearPhotoEdit: createActionHelper(dispatch, clearPhotoEdit),
   updatePhotoEdit: createActionHelper(dispatch, updatePhotoEdit),
+  setPhotoError:  createActionHelper(dispatch, setPhotoError),
   dispatch: dispatch,
 });
 

--- a/static/js/reducers/image_upload.js
+++ b/static/js/reducers/image_upload.js
@@ -3,6 +3,7 @@ import {
   START_PHOTO_EDIT,
   CLEAR_PHOTO_EDIT,
   UPDATE_PHOTO_EDIT,
+  SET_PHOTO_ERROR,
   REQUEST_PATCH_USER_PHOTO,
   RECEIVE_PATCH_USER_PHOTO_FAILURE,
   RECEIVE_PATCH_USER_PHOTO_SUCCESS,
@@ -16,12 +17,14 @@ import type { Action } from '../flow/reduxTypes';
 
 export const INITIAL_IMAGE_UPLOAD_STATE = {
   edit: null,
+  error: null,
   photo: null,
   patchStatus: null,
 };
 
 export type ImageUploadState = {
   edit: ?Blob,
+  error: ?string,
   photo: ?File,
   patchStatus: ?string
 }
@@ -32,11 +35,14 @@ export const imageUpload = (state: ImageUploadState = INITIAL_IMAGE_UPLOAD_STATE
     return { ...state,
       photo: action.payload,
       edit: null,
+      error: null,
     };
   case CLEAR_PHOTO_EDIT:
     return INITIAL_IMAGE_UPLOAD_STATE;
   case UPDATE_PHOTO_EDIT:
     return { ...state, edit: action.payload };
+  case SET_PHOTO_ERROR:
+    return { ...state, error: action.payload };
   case REQUEST_PATCH_USER_PHOTO:
     return { ...state, patchStatus: FETCH_PROCESSING };
   case RECEIVE_PATCH_USER_PHOTO_SUCCESS:

--- a/static/js/reducers/image_upload_test.js
+++ b/static/js/reducers/image_upload_test.js
@@ -5,6 +5,8 @@ import {
   CLEAR_PHOTO_EDIT,
   updatePhotoEdit,
   UPDATE_PHOTO_EDIT,
+  setPhotoError,
+  SET_PHOTO_ERROR,
   requestPatchUserPhoto,
   REQUEST_PATCH_USER_PHOTO,
   RECEIVE_PATCH_USER_PHOTO_FAILURE,
@@ -46,10 +48,34 @@ describe('image upload reducer', () => {
     });
   });
 
+  it('should let you set an error', () => {
+    return dispatchThen(setPhotoError('an error'), [SET_PHOTO_ERROR]).then(state => {
+      assert.deepEqual(state, {
+        edit: null,
+        error: 'an error',
+        photo: null,
+        patchStatus: null
+      });
+    });
+  });
+
   it('should start editing a photo', () => {
     return dispatchThen(startPhotoEdit('a photo'), [START_PHOTO_EDIT]).then(state => {
       assert.deepEqual(state, {
         edit: null,
+        error: null,
+        photo: 'a photo',
+        patchStatus: null
+      });
+    });
+  });
+
+  it('should clear any errors when beginning to edit', () => {
+    store.dispatch(setPhotoError('an error'));
+    return dispatchThen(startPhotoEdit('a photo'), [START_PHOTO_EDIT]).then(state => {
+      assert.deepEqual(state, {
+        edit: null,
+        error: null,
         photo: 'a photo',
         patchStatus: null
       });
@@ -64,6 +90,7 @@ describe('image upload reducer', () => {
     return dispatchThen(updatePhotoEdit(second), [UPDATE_PHOTO_EDIT]).then(state => {
       assert.deepEqual(state, {
         edit: second,
+        error: null,
         photo: first,
         patchStatus: null
       });
@@ -75,6 +102,7 @@ describe('image upload reducer', () => {
     return dispatchThen(clearPhotoEdit(), [CLEAR_PHOTO_EDIT]).then(state => {
       assert.deepEqual(state, {
         edit: null,
+        error: null,
         photo: null,
         patchStatus: null
       });
@@ -94,6 +122,7 @@ describe('image upload reducer', () => {
       ]).then(state => {
         assert.deepEqual(state, {
           edit: null,
+          error: null,
           photo: null,
           patchStatus: FETCH_SUCCESS
         });
@@ -109,6 +138,7 @@ describe('image upload reducer', () => {
       ]).then(state => {
         assert.deepEqual(state, {
           edit: null,
+          error: null,
           photo: null,
           patchStatus: FETCH_FAILURE
         });
@@ -121,6 +151,7 @@ describe('image upload reducer', () => {
       return dispatchThen(requestPatchUserPhoto(), [REQUEST_PATCH_USER_PHOTO]).then(state => {
         assert.deepEqual(state, {
           edit: null,
+          error: null,
           photo: photo,
           patchStatus: FETCH_PROCESSING
         });

--- a/static/scss/profile-image-uploader.scss
+++ b/static/scss/profile-image-uploader.scss
@@ -3,6 +3,12 @@
     border-bottom: none !important;
   }
 
+  .img-error {
+    color: $validation-red;
+    font-size: 14px;
+    text-align: center;
+  }
+
   .photo-dropzone {
     background-color: $fg-grey;
     border-radius: 7px;


### PR DESCRIPTION
#### What are the relevant tickets?

part of #1273 ?

#### What's this PR do?

This restricts the drop area component to only accept image files, and if the user tries to upload a different MIME type it will show a little message letting them know what's up.

#### Where should the reviewer start?

read over the changes

#### How should this be manually tested?

Go to `/dashboard` and click on the little camera icon in the corner of your profile image. Select a different file, like a PDF or something. You should see a little red error message that says something like 'pick an image'. Then if you pick an image it should go away and let you crop it.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

![phototo](https://cloud.githubusercontent.com/assets/6207644/19284374/a5da18ae-8fc3-11e6-9a27-da088d0cac4f.png)


#### What GIF best describes this PR or how it makes you feel?

