### PR TITLE
Disallows deletion of financial aid objects in django admin

### DIFF
--- a/financialaid/admin.py
+++ b/financialaid/admin.py
@@ -16,6 +16,9 @@ class FinancialAidAdmin(admin.ModelAdmin):
     """Admin for FinancialAid"""
     model = FinancialAid
 
+    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
+        return False
+
     def save_model(self, request, obj, form, change):
         """
         Saves object and logs change to object


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #1323 

#### What's this PR do?

Updates the permissions on financial aid objects in the Django admin interface such that deleting a financial aid object is not allowed.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

