### PR TITLE
Replaced hard coded support email

### DIFF
--- a/static/js/components/ErrorMessage.js
+++ b/static/js/components/ErrorMessage.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import React from 'react';
 import Alert from 'react-bootstrap/lib/Alert';
 
@@ -39,6 +40,8 @@ export default class ErrorMessage extends React.Component {
       return '';
     };
 
+    let email = SETTINGS.support_email;
+
     return (
       <div className="alert-message">
         <Alert bsStyle="danger">
@@ -46,8 +49,8 @@ export default class ErrorMessage extends React.Component {
           process your request. Please reload the page.</p>
           <p>{ userMessageStr() }</p>
           <p>
-            If the error persists, please contact <a href="mailto:mitx-support@mit.edu">
-            mitx-support@mit.edu</a> specifying
+            If the error persists, please contact <a href={`mailto:${email}`}>
+            {email}</a> specifying
             this entire error message.
           </p>
         </Alert>

--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -37,7 +37,7 @@ describe("ErrorMessage", () => {
   errorString = errorString.replace(/\s\s+/g, ' ');
 
   let contactExpectation = `If the error persists, please contact
-      mitx-support@mit.edu specifying this entire error message.`;
+      ${SETTINGS.support_email} specifying this entire error message.`;
   contactExpectation = contactExpectation.replace(/\s\s+/g, ' ');
 
   describe('unit tests', () => {

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -4,7 +4,8 @@ const settings = {
   name: "full name",
   username: "jane",
   edx_base_url: "/edx/",
-  roles: []
+  roles: [],
+  support_email: "a_real_email@example.com"
 };
 global.SETTINGS = Object.assign({}, settings);
 

--- a/ui/templates/404.html
+++ b/ui/templates/404.html
@@ -15,6 +15,6 @@ PAGE NOT FOUND
 		<li><a href="/">Home page</a></li>
 	</ul>
 	<p>If you think there is a problem, please send an email to
-	<a href="mailto:mitx-support@mit.edu">mitx-support@mit.edu</a></p>
+	<a href="mailto:{{ support_email }}">{{ support_email }}</a></p>
 </div>
 {% endblock %}

--- a/ui/templates/500.html
+++ b/ui/templates/500.html
@@ -12,7 +12,7 @@ INTERNAL SERVER ERROR
 	<p>The page you requested has problems: an engineer will be blamed for this.</p>
 
 	<p>We get emails every time you see this page, keep refreshing if you're mad or just write to
-	<a href="mailto:mitx-support@mit.edu">mitx-support@mit.edu</a></p>
+	<a href="mailto:{{ support_email }}">{{ support_email }}</a></p>
 
 	<iframe width="630" height="473" src="https://www.youtube.com/embed/IAIPUGO1iko"
 		frameborder="0" allowfullscreen></iframe>

--- a/ui/views.py
+++ b/ui/views.py
@@ -75,6 +75,7 @@ class ReactView(View):  # pylint: disable=unused-argument
             "edx_base_url": settings.EDXORG_BASE_URL,
             "roles": roles,
             "search_url": reverse('search_api', kwargs={"elastic_url": ""}),
+            "support_email": settings.EMAIL_SUPPORT,
         }
 
         return render(
@@ -140,7 +141,8 @@ def standard_error_page(request, status_code, template_filename):
             "authenticated": authenticated,
             "name": name,
             "username": username,
-            "is_staff": has_role(request.user, [Staff.ROLE_ID, Instructor.ROLE_ID])
+            "is_staff": has_role(request.user, [Staff.ROLE_ID, Instructor.ROLE_ID]),
+            "support_email": settings.EMAIL_SUPPORT,
         }
     )
     response.status_code = status_code

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -5,6 +5,7 @@ import json
 
 from django.db.models.signals import post_save
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 from factory.django import mute_signals
 from factory.fuzzy import FuzzyText
 from mock import patch, Mock
@@ -170,11 +171,13 @@ class DashboardTests(ViewsTests):
         react_ga_debug = FuzzyText().fuzz()
         edx_base_url = FuzzyText().fuzz()
         host = FuzzyText().fuzz()
+        email_support = FuzzyText().fuzz()
         with self.settings(
             GA_TRACKING_ID=ga_tracking_id,
             REACT_GA_DEBUG=react_ga_debug,
             EDXORG_BASE_URL=edx_base_url,
             WEBPACK_DEV_SERVER_HOST=host,
+            EMAIL_SUPPORT=email_support,
         ):
             resp = self.client.get(DASHBOARD_URL)
             js_settings = json.loads(resp.context['js_settings_json'])
@@ -187,6 +190,7 @@ class DashboardTests(ViewsTests):
                 'edx_base_url': edx_base_url,
                 'roles': [],
                 'search_url': reverse('search_api', kwargs={"elastic_url": ""}),
+                'support_email': email_support,
             }
 
     def test_roles_setting(self):
@@ -243,17 +247,20 @@ class HandlerTests(ViewsTests):
             self.client.force_login(profile.user)
 
         # case with specific page
-        response = self.client.get('/404/')
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.context['authenticated'] is True
-        assert response.context['name'] == profile.preferred_name
-
-        # case with a fake page
-        with self.settings(DEBUG=False):
-            response = self.client.get('/gfh0o4n8741387jfmnub134fn348fr38f348f/')
+        with override_settings(EMAIL_SUPPORT='support'):
+            response = self.client.get('/404/')
             assert response.status_code == status.HTTP_404_NOT_FOUND
             assert response.context['authenticated'] is True
             assert response.context['name'] == profile.preferred_name
+            assert response.context['support_email'] == 'support'
+
+            # case with a fake page
+            with self.settings(DEBUG=False):
+                response = self.client.get('/gfh0o4n8741387jfmnub134fn348fr38f348f/')
+                assert response.status_code == status.HTTP_404_NOT_FOUND
+                assert response.context['authenticated'] is True
+                assert response.context['name'] == profile.preferred_name
+                assert response.context['support_email'] == 'support'
 
     def test_404_error_context_logged_out(self):
         """
@@ -280,10 +287,12 @@ class HandlerTests(ViewsTests):
             profile = self.create_and_login_user()
             self.client.force_login(profile.user)
 
-        response = self.client.get('/500/')
-        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-        assert response.context['authenticated'] is True
-        assert response.context['name'] == profile.preferred_name
+        with override_settings(EMAIL_SUPPORT='support'):
+            response = self.client.get('/500/')
+            assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+            assert response.context['authenticated'] is True
+            assert response.context['name'] == profile.preferred_name
+            assert response.context['support_email'] == 'support'
 
     def test_500_error_context_logged_out(self):
         """
@@ -398,11 +407,13 @@ class TestUsersPage(ViewsTests):
         react_ga_debug = FuzzyText().fuzz()
         edx_base_url = FuzzyText().fuzz()
         host = FuzzyText().fuzz()
+        email_support = FuzzyText().fuzz()
         with self.settings(
             GA_TRACKING_ID=ga_tracking_id,
             REACT_GA_DEBUG=react_ga_debug,
             EDXORG_BASE_URL=edx_base_url,
             WEBPACK_DEV_SERVER_HOST=host,
+            EMAIL_SUPPORT=email_support,
         ):
             # Mock has_permission so we don't worry about testing permissions here
             has_permission = Mock(return_value=True)
@@ -419,6 +430,7 @@ class TestUsersPage(ViewsTests):
                     'edx_base_url': edx_base_url,
                     'roles': [],
                     'search_url': reverse('search_api', kwargs={"elastic_url": ""}),
+                    'support_email': email_support,
                 }
                 assert has_permission.called
 
@@ -435,11 +447,13 @@ class TestUsersPage(ViewsTests):
         react_ga_debug = FuzzyText().fuzz()
         edx_base_url = FuzzyText().fuzz()
         host = FuzzyText().fuzz()
+        email_support = FuzzyText().fuzz()
         with self.settings(
             GA_TRACKING_ID=ga_tracking_id,
             REACT_GA_DEBUG=react_ga_debug,
             EDXORG_BASE_URL=edx_base_url,
             WEBPACK_DEV_SERVER_HOST=host,
+            EMAIL_SUPPORT=email_support,
         ):
             # Mock has_permission so we don't worry about testing permissions here
             has_permission = Mock(return_value=True)
@@ -455,7 +469,8 @@ class TestUsersPage(ViewsTests):
                     'host': host,
                     'edx_base_url': edx_base_url,
                     'roles': [],
-                    'search_url': reverse('search_api', kwargs={"elastic_url": ""})
+                    'search_url': reverse('search_api', kwargs={"elastic_url": ""}),
+                    'support_email': email_support,
                 }
                 assert has_permission.called
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1329

#### What's this PR do?
Uses `EMAIL_SUPPORT` in place of the hard coded support email

#### How should this be manually tested?
Go to `/404/` and `/500/` and verify that the email matches the environment variable or the default value set in `settings.py` for `EMAIL_SUPPORT`. Go to the dashboard, add a `raise Exception()` somewhere in `UserDashboard`, refresh, and verify that the error message contains the same email address.

