### PR TITLE
Handle invalid dates

### DIFF
--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -22,6 +22,7 @@ import {
   FA_STATUS_SKIPPED
 } from '../../constants';
 import { formatPrice } from '../../util/util';
+import { ifValidDate } from '../../util/date';
 
 export default class CourseAction extends React.Component {
   props: {
@@ -149,14 +150,15 @@ export default class CourseAction extends React.Component {
     }
     case STATUS_WILL_ATTEND: {
       let startDate = moment(run.course_start_date);
-      let daysUntilStart = startDate.diff(now, 'days');
-      description = this.renderBoxedDescription(`Course starts in ${daysUntilStart} days`);
+      let text = ifValidDate('', date => `Course starts in ${date.diff(now, 'days')} days`, startDate);
+      description = this.renderBoxedDescription(text);
       break;
     }
     case STATUS_CAN_UPGRADE: {
-      let formattedUpgradeDate = moment(run.course_upgrade_deadline).format(DASHBOARD_FORMAT);
+      let date = moment(run.course_upgrade_deadline);
       action = this.renderEnrollButton(run);
-      description = this.renderTextDescription(`Payment due: ${formattedUpgradeDate}`);
+      let text = ifValidDate('', date => `Payment due: ${date.format(DASHBOARD_FORMAT)}`, date); 
+      description = this.renderTextDescription(text);
       break;
     }
     case STATUS_OFFERED: {
@@ -165,12 +167,13 @@ export default class CourseAction extends React.Component {
         action = this.renderEnrollButton(run);
         description = this.renderPayLaterLink(run);
       } else {
+        let text;
         if (enrollmentStartDate) {
-          let formattedEnrollDate = enrollmentStartDate.format(DASHBOARD_FORMAT);
-          description = this.renderTextDescription(`Enrollment begins ${formattedEnrollDate}`);
+          text = ifValidDate('', date => `Enrollment begins ${date.format(DASHBOARD_FORMAT)}`, enrollmentStartDate);
         } else if (run.fuzzy_enrollment_start_date) {
-          description = this.renderTextDescription(`Enrollment begins ${run.fuzzy_enrollment_start_date}`);
+          text = `Enrollment begins ${run.fuzzy_enrollment_start_date}`;
         }
+        description = this.renderTextDescription(text);
       }
       break;
     }

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -22,7 +22,11 @@ import {
   FA_PENDING_STATUSES,
   FA_STATUS_SKIPPED
 } from '../../constants';
-import { findCourse, findAndCloneCourse } from '../../util/test_utils';
+import {
+  findCourse,
+  alterFirstRun,
+  findAndCloneCourse
+} from '../../util/test_utils';
 
 describe('CourseAction', () => {
   const now = moment();
@@ -62,10 +66,6 @@ describe('CourseAction', () => {
       descriptionText: descriptionText,
       linkText: linkText
     };
-  };
-
-  let alterFirstRun = (course, overrideObject) => {
-    course.runs[0] = Object.assign({}, course.runs[0], overrideObject);
   };
 
   let assertCheckoutButton = (button, courseId) => {
@@ -118,6 +118,17 @@ describe('CourseAction', () => {
     assertCheckoutButton(elements.button, firstRun.course_id);
   });
 
+  it('hides an invalid date with STATUS_OFFERED', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED
+    ));
+    alterFirstRun(course, {enrollment_start_date: '1999-13-92'});
+    const wrapper = shallow(<CourseAction course={course} {...defaultParamsNow} />);
+    let elements = getElements(wrapper);
+    assert.isUndefined(elements.descriptionText);
+  });
+
   it('shows an enroll button if user is not enrolled and enrollment starts today or earlier', () => {
     let course = findAndCloneCourse(course => (
       course.runs.length > 0 &&
@@ -154,6 +165,17 @@ describe('CourseAction', () => {
     assert.include(elements.buttonText, 'Pay Now');
     assert.equal(elements.descriptionText, `Payment due: ${formattedUpgradeDate}`);
     assertCheckoutButton(elements.button, firstRun.course_id);
+  });
+
+  it('hides an invalid date if user is enrolled but is not verified', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_CAN_UPGRADE
+    ));
+    alterFirstRun(course, { course_upgrade_deadline: '1999-13-92' });
+    const wrapper = shallow(<CourseAction course={course} {...defaultParamsNow} />);
+    let elements = getElements(wrapper);
+    assert.isUndefined(elements.descriptionText, 'Should not be any text');
   });
 
   it('shows a message if a user is not enrolled and the course has a future enrollment start date', () => {
@@ -211,6 +233,17 @@ describe('CourseAction', () => {
     assert.equal(wrapper.text(), "<Button />Processing...");
     assert.isTrue(wrapper.find("Button").props()['disabled']);
     assert.equal(wrapper.find("Spinner").length, 1);
+  });
+
+  it('hides an invalid date if the user is enrolled and the course has yet to start', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_WILL_ATTEND
+    ));
+    alterFirstRun(course, {course_start_date: "1999-13-92"});
+    const wrapper = shallow(<CourseAction course={course} {...defaultParamsNow} />);
+    let elements = getElements(wrapper);
+    assert.isUndefined(elements.descriptionText, 'Should not be any text');
   });
 
   describe('with financial aid', () => {

--- a/static/js/components/dashboard/CourseDescription.js
+++ b/static/js/components/dashboard/CourseDescription.js
@@ -15,6 +15,7 @@ import {
   STATUS_PENDING_ENROLLMENT,
   DASHBOARD_FORMAT,
 } from '../../constants';
+import { ifValidDate } from '../../util/date';
 
 const edxLinkBase = `${SETTINGS.edx_base_url}/courses/`;
 
@@ -29,8 +30,9 @@ export default class CourseDescription extends React.Component {
   }
 
   renderCourseDateMessage(label: string, dateString: string): React$Element<*> {
-    let formattedDate = moment(dateString).format(DASHBOARD_FORMAT);
-    return <span key='1'>{label}: {formattedDate}</span>;
+    let date = moment(dateString);
+    let text = ifValidDate('', date => `${label}: ${date.format(DASHBOARD_FORMAT)}`, date);
+    return <span key='1'>{text}</span>;
   }
 
   renderDetailContents(run: CourseRun) {

--- a/static/js/components/dashboard/CourseDescription_test.js
+++ b/static/js/components/dashboard/CourseDescription_test.js
@@ -6,7 +6,11 @@ import { assert } from 'chai';
 import _ from 'lodash';
 
 import CourseDescription from './CourseDescription';
-import { findCourse } from '../../util/test_utils';
+import {
+  findCourse,
+  findAndCloneCourse,
+  alterFirstRun,
+} from '../../util/test_utils';
 import {
   DASHBOARD_FORMAT,
   STATUS_PASSED,
@@ -72,6 +76,17 @@ describe('CourseDescription', () => {
     assert.include(elements.detailsText, `Ended: ${formattedDate}`);
   });
 
+  it('hides an invalid date with status passed', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_PASSED
+    ));
+    alterFirstRun(course, {course_end_date: '1999-13-92'});
+    const wrapper = shallow(<CourseDescription course={course} />);
+    let elements = getElements(wrapper);
+    assert.equal(elements.detailsText, '');
+  });
+
   it('does show date with status not-passed', () => {
     let course = findCourse(course => (
       course.runs.length > 0 &&
@@ -82,8 +97,18 @@ describe('CourseDescription', () => {
     let firstRun = course.runs[0];
     let courseEndDate = moment(firstRun.course_end_date);
     let formattedDate = courseEndDate.format(DASHBOARD_FORMAT);
-
     assert.equal(elements.detailsText, `Ended: ${formattedDate}`);
+  });
+
+  it('hides an invalid date with status not-passed', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_NOT_PASSED
+    ));
+    alterFirstRun(course, {course_end_date: '1999-13-92'});
+    const wrapper = shallow(<CourseDescription course={course} />);
+    let elements = getElements(wrapper);
+    assert.equal(elements.detailsText, '');
   });
 
   it('does not show anything when there are no runs for a course', () => {
@@ -108,6 +133,17 @@ describe('CourseDescription', () => {
     assert.equal(elements.detailsText, `Start date: ${formattedDate}`);
   });
 
+  it('hides an invalid date with status verified', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_CURRENTLY_ENROLLED
+    ));
+    alterFirstRun(course, { course_start_date: '1999-13-92' });
+    const wrapper = shallow(<CourseDescription course={course} />);
+    let elements = getElements(wrapper);
+    assert.equal(elements.detailsText, '');
+  });
+
   it('does show date with status enrolled', () => {
     let course = findCourse(course => (
       course.runs.length > 0 &&
@@ -122,6 +158,17 @@ describe('CourseDescription', () => {
     assert.include(elements.detailsText, `Start date: ${formattedDate}`);
   });
 
+  it('hides an invalid date with status enrolled', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_CAN_UPGRADE
+    ));
+    alterFirstRun(course, {course_start_date: '1999-13-92'});
+    const wrapper = shallow(<CourseDescription course={course} />);
+    let elements = getElements(wrapper);
+    assert.notInclude(elements.detailsText, 'Start date: ');
+  });
+
   it('does show date with status offered', () => {
     let course = findCourse(course => (
       course.runs.length > 0 &&
@@ -134,6 +181,17 @@ describe('CourseDescription', () => {
     let formattedDate = courseStartDate.format(DASHBOARD_FORMAT);
 
     assert.equal(elements.detailsText, `Start date: ${formattedDate}`);
+  });
+
+  it('hides an invalid date with status offered', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED
+    ));
+    alterFirstRun(course, {course_start_date: '1999-13-92'});
+    const wrapper = shallow(<CourseDescription course={course} />);
+    let elements = getElements(wrapper);
+    assert.equal(elements.detailsText, '');
   });
 
   it('shows a message when the user is auditing the course', () => {

--- a/static/js/util/date.js
+++ b/static/js/util/date.js
@@ -1,0 +1,6 @@
+// @flow
+import R from 'ramda';
+
+export const ifValidDate = R.curry((def, fn, date) => (
+  date.isValid() ? fn(date) : def
+));

--- a/static/js/util/date_test.js
+++ b/static/js/util/date_test.js
@@ -1,0 +1,20 @@
+// @flow
+import { assert } from 'chai';
+import moment from 'moment';
+
+import { ifValidDate } from './date';
+
+describe('ifValidDate', () => {
+  let formatFunc = date => date.format('YYYY-MM-DD');
+  let testFunc = ifValidDate('not valid', formatFunc);
+
+  it('should return the default value for an invalid date', () => {
+    let invalidDate = moment('1978-13-39');
+    assert.equal('not valid', testFunc(invalidDate));
+  });
+
+  it('should return fn(date) for a valid date', () => {
+    let validDate = moment('1949-06-02');
+    assert.equal('1949-06-02', testFunc(validDate));
+  });
+});

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -21,6 +21,10 @@ export function findCourse(courseSelector: (course: Course, program: Program) =>
   throw "Unable to find course";
 }
 
+export const alterFirstRun = (course: Course, overrideObject: Object): Course => {
+  course.runs[0] = Object.assign({}, course.runs[0], overrideObject);
+};
+
 export function findAndCloneCourse(courseSelector: (course: Course, program: Program) => boolean): Course {
   return _.cloneDeep(findCourse(courseSelector));
 }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1294 

#### What's this PR do?

This deals with invalid dates in the `CourseDescription` and `CourseAction` components, basically by testing to see if the date is valid before we try to format and display it.

#### How should this be manually tested?

What I did was alter the `getDashboard`, `getProgramEnrollments` and `getCoursePrices` functions in `api.js` to return their respective constants (from `constants.js`). Then you can alter relevant courseRuns in order to make invalid dates, to test that every case is covered. A good string to use is `'1999-13-92'`.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
