### PR TITLE
Limit HomePage to have only ProgramPage as a child page

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -33,6 +33,7 @@ class HomePage(Page):
     CMS page representing the homepage.
     """
     content_panels = []
+    subpage_types = ['ProgramPage']
 
     def get_context(self, request):
         programs = Program.objects.filter(live=True)


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #1279
#### What's this PR do?
Allow only ProgramPage type to be added as a child to HomePage in cms.

To test this try to add a child page to the homepage.
![screen shot 2016-10-12 at 4 23 27 pm](https://cloud.githubusercontent.com/assets/7574259/19326273/d3e101e8-9097-11e6-8359-46a95ea30de8.png)

