### PR TITLE
Fixed IE/Edge pop-up issues

### DIFF
--- a/static/js/signup_dialog.js
+++ b/static/js/signup_dialog.js
@@ -21,9 +21,11 @@ const dialogDiv = document.querySelector('#signup-dialog');
 const openDialog = () => store.dispatch(setDialogVisibility(true));
 
 // find the DOM element and attach openDialog to onClick
-for (let signUpButton of document.querySelectorAll('.open-signup-dialog')) {
+let nodes = [...document.querySelectorAll('.open-signup-dialog')];
+
+nodes.forEach(signUpButton => {
   signUpButton.onclick = openDialog;
-}
+});
 
 ReactDOM.render(
   <MuiThemeProvider muiTheme={getMuiTheme()}>

--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -8,10 +8,10 @@ let babelQuerySettings = {
 module.exports = {
   entry: {
     'dashboard': ['babel-polyfill', './static/js/dashboard'],
-    'signup_dialog': './static/js/signup_dialog',
+    'signup_dialog': ['babel-polyfill', './static/js/signup_dialog'],
     'faculty_carousel': './static/js/faculty_carousel',
     'financial_aid': './static/js/financial_aid/functions',
-    'public': ['babel-polyfill', './static/js/public'],
+    'public': './static/js/public',
     'style': './static/js/style',
     'style_public': './static/js/style_public',
     'sentry_client': './static/js/sentry_client.js',


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1353 
closes #1343 

#### What's this PR do?

This fixes the code for adding the `onclick` handler to the 'Log In' and 'Sign Up' buttons, and makes sure that `babel-polyfill` is always on the page.

#### Where should the reviewer start?

#### How should this be manually tested?

Well, get ahold of a windows machine and look at the PR build in Edge and IE11. Make sure you can open the signup dialog on all relevant pages, and that there are no regressions.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

