### PR TITLE
Modified mail.views responses to catch 401 status codes from mailgun …

### DIFF
--- a/financialaid/serializers.py
+++ b/financialaid/serializers.py
@@ -30,10 +30,8 @@ from financialaid.models import (
     FinancialAid,
     TierProgram
 )
-from mail.api import (
-    MailgunClient,
-    generate_financial_aid_email
-)
+from mail.api import MailgunClient
+from mail.utils import generate_financial_aid_email
 
 
 class FinancialAidRequestSerializer(serializers.Serializer):

--- a/financialaid/views_test.py
+++ b/financialaid/views_test.py
@@ -30,7 +30,7 @@ from financialaid.models import (
     FinancialAidAudit,
     CurrencyExchangeRate
 )
-from mail.api import generate_financial_aid_email
+from mail.utils import generate_financial_aid_email
 from mail.views_test import mocked_json
 
 

--- a/mail/api.py
+++ b/mail/api.py
@@ -6,19 +6,8 @@ import json
 import requests
 
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from rest_framework.status import HTTP_200_OK
 
-from dashboard.models import ProgramEnrollment
-from financialaid.api import get_formatted_course_price
-from financialaid.constants import (
-    FINANCIAL_AID_APPROVAL_SUBJECT,
-    FINANCIAL_AID_APPROVAL_MESSAGE,
-    FINANCIAL_AID_DOCUMENTS_RECEIVED_MESSAGE,
-    FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT,
-    FINANCIAL_AID_EMAIL_BODY
-)
-from financialaid.models import FinancialAidStatus
 from mail.models import FinancialAidEmailAudit
 
 
@@ -169,37 +158,3 @@ class MailgunClient:
                 email_body=body
             )
         return response
-
-
-def generate_financial_aid_email(financial_aid):
-    """
-    Generates the email subject and body for a FinancialAid status update. Accepted statuses are
-    FinancialAidStatus.APPROVED and FinancialAidStatus.PENDING_MANUAL_APPROVAL (documents have been received).
-    Args:
-        financial_aid (FinancialAid): The FinancialAid object in question
-    Returns:
-        dict: {"subject": (str), "body": (str)}
-    """
-    if financial_aid.status == FinancialAidStatus.APPROVED:
-        program_enrollment = ProgramEnrollment.objects.get(
-            user=financial_aid.user,
-            program=financial_aid.tier_program.program
-        )
-        message = FINANCIAL_AID_APPROVAL_MESSAGE.format(
-            program_name=financial_aid.tier_program.program.title,
-            price=get_formatted_course_price(program_enrollment)["price"]
-        )
-        subject = FINANCIAL_AID_APPROVAL_SUBJECT.format(program_name=financial_aid.tier_program.program.title)
-    elif financial_aid.status == FinancialAidStatus.PENDING_MANUAL_APPROVAL:
-        message = FINANCIAL_AID_DOCUMENTS_RECEIVED_MESSAGE
-        subject = FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT.format(
-            program_name=financial_aid.tier_program.program.title
-        )
-    else:
-        raise ValidationError("Invalid status on FinancialAid for generate_financial_aid_email()")
-    body = FINANCIAL_AID_EMAIL_BODY.format(
-        first_name=financial_aid.user.profile.first_name,
-        message=message,
-        program_name=financial_aid.tier_program.program.title
-    )
-    return {"subject": subject, "body": body}

--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -5,9 +5,7 @@ import json
 import string
 from unittest.mock import Mock, patch
 
-
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.db.models.signals import post_save
 from django.test import TestCase, override_settings
 from factory.django import mute_signals
@@ -16,17 +14,8 @@ from rest_framework.status import HTTP_200_OK
 
 from dashboard.models import ProgramEnrollment
 from ecommerce.factories import CoursePriceFactory
-from financialaid.api import get_formatted_course_price
-from financialaid.constants import (
-    FINANCIAL_AID_APPROVAL_MESSAGE,
-    FINANCIAL_AID_APPROVAL_SUBJECT,
-    FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT,
-    FINANCIAL_AID_DOCUMENTS_RECEIVED_MESSAGE,
-    FINANCIAL_AID_EMAIL_BODY
-)
 from financialaid.factories import FinancialAidFactory
-from financialaid.models import FinancialAidStatus
-from mail.api import MailgunClient, generate_financial_aid_email
+from mail.api import MailgunClient
 from mail.models import FinancialAidEmailAudit
 from mail.views_test import mocked_json
 from profiles.factories import ProfileFactory
@@ -242,52 +231,3 @@ class FinancialAidMailAPITests(TestCase):
         assert audit.from_email == settings.MAILGUN_FROM_EMAIL
         assert audit.email_subject == ''
         assert audit.email_body == ''
-
-    def test_generate_financial_aid_email_approved(self, mock_post):  # pylint: disable=unused-argument
-        """
-        Tests generate_financial_aid_email() with status APPROVED
-        """
-        self.financial_aid.status = FinancialAidStatus.APPROVED
-        self.financial_aid.save()
-        email_dict = generate_financial_aid_email(self.financial_aid)
-        assert email_dict["subject"] == FINANCIAL_AID_APPROVAL_SUBJECT.format(
-            program_name=self.financial_aid.tier_program.program.title
-        )
-        assert email_dict["body"] == FINANCIAL_AID_EMAIL_BODY.format(
-            first_name=self.financial_aid.user.profile.first_name,
-            message=FINANCIAL_AID_APPROVAL_MESSAGE.format(
-                program_name=self.financial_aid.tier_program.program.title,
-                price=get_formatted_course_price(self.program_enrollment)["price"]
-            ),
-            program_name=self.financial_aid.tier_program.program.title
-        )
-
-    def test_generate_financial_aid_email_docs_sent(self, mock_post):  # pylint: disable=unused-argument
-        """
-        Tests generate_financial_aid_email() with status PENDING_MANUAL_APPROVAL
-        """
-        self.financial_aid.status = FinancialAidStatus.PENDING_MANUAL_APPROVAL
-        self.financial_aid.save()
-        email_dict = generate_financial_aid_email(self.financial_aid)
-        assert email_dict["subject"] == FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT.format(
-            program_name=self.financial_aid.tier_program.program.title
-        )
-        assert email_dict["body"] == FINANCIAL_AID_EMAIL_BODY.format(
-            first_name=self.financial_aid.user.profile.first_name,
-            message=FINANCIAL_AID_DOCUMENTS_RECEIVED_MESSAGE,
-            program_name=self.financial_aid.tier_program.program.title
-        )
-
-    def test_generate_financial_aid_email_invalid_statuses(self, mock_post):  # pylint: disable=unused-argument
-        """
-        Tests generate_financial_aid_email() with invalid statuses raises django ValidationError
-        """
-        invalid_statuses = [
-            FinancialAidStatus.AUTO_APPROVED,
-            FinancialAidStatus.CREATED,
-            FinancialAidStatus.PENDING_DOCS
-        ]
-        for status in invalid_statuses:
-            self.financial_aid.status = status
-            self.financial_aid.save()
-            self.assertRaises(ValidationError, generate_financial_aid_email, self.financial_aid)

--- a/mail/utils.py
+++ b/mail/utils.py
@@ -75,8 +75,15 @@ def generate_mailgun_response_json(response):
     Returns:
         dict
     """
-    if response.status_code == status.HTTP_401_UNAUTHORIZED:
-        message = "Mailgun API keys not properly configured."
-        log.error(message)
-        raise ImproperlyConfigured(message)
-    return response.json()
+    try:
+        response_json = response.json()
+    except ValueError:  # Includes JSONDecodeError since it inherits from ValueError
+        if response.status_code == status.HTTP_401_UNAUTHORIZED:
+            message = "Mailgun API keys not properly configured."
+            log.error(message)
+            raise ImproperlyConfigured(message)
+        else:
+            response_json = {
+                "message": response.reason
+            }
+    return response_json

--- a/mail/utils.py
+++ b/mail/utils.py
@@ -75,15 +75,14 @@ def generate_mailgun_response_json(response):
     Returns:
         dict
     """
+    if response.status_code == status.HTTP_401_UNAUTHORIZED:
+        message = "Mailgun API keys not properly configured."
+        log.error(message)
+        raise ImproperlyConfigured(message)
     try:
         response_json = response.json()
     except ValueError:  # Includes JSONDecodeError since it inherits from ValueError
-        if response.status_code == status.HTTP_401_UNAUTHORIZED:
-            message = "Mailgun API keys not properly configured."
-            log.error(message)
-            raise ImproperlyConfigured(message)
-        else:
-            response_json = {
-                "message": response.reason
-            }
+        response_json = {
+            "message": response.reason
+        }
     return response_json

--- a/mail/utils.py
+++ b/mail/utils.py
@@ -1,0 +1,82 @@
+"""
+Utils for mail
+"""
+import logging
+
+from django.core.exceptions import (
+    ImproperlyConfigured,
+    ValidationError
+)
+from rest_framework import status
+
+from dashboard.models import ProgramEnrollment
+from financialaid.api import get_formatted_course_price
+from financialaid.constants import (
+    FINANCIAL_AID_APPROVAL_MESSAGE,
+    FINANCIAL_AID_APPROVAL_SUBJECT,
+    FINANCIAL_AID_DOCUMENTS_RECEIVED_MESSAGE,
+    FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT,
+    FINANCIAL_AID_EMAIL_BODY,
+    FinancialAidStatus
+)
+
+
+log = logging.getLogger(__name__)
+
+
+def generate_financial_aid_email(financial_aid):
+    """
+    Generates the email subject and body for a FinancialAid status update. Accepted statuses are
+    FinancialAidStatus.APPROVED and FinancialAidStatus.PENDING_MANUAL_APPROVAL (documents have been received).
+    Args:
+        financial_aid (FinancialAid): The FinancialAid object in question
+    Returns:
+        dict: {"subject": (str), "body": (str)}
+    """
+    if financial_aid.status == FinancialAidStatus.APPROVED:
+        program_enrollment = ProgramEnrollment.objects.get(
+            user=financial_aid.user,
+            program=financial_aid.tier_program.program
+        )
+        message = FINANCIAL_AID_APPROVAL_MESSAGE.format(
+            program_name=financial_aid.tier_program.program.title,
+            price=get_formatted_course_price(program_enrollment)["price"]
+        )
+        subject = FINANCIAL_AID_APPROVAL_SUBJECT.format(program_name=financial_aid.tier_program.program.title)
+    elif financial_aid.status == FinancialAidStatus.PENDING_MANUAL_APPROVAL:
+        message = FINANCIAL_AID_DOCUMENTS_RECEIVED_MESSAGE
+        subject = FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT.format(
+            program_name=financial_aid.tier_program.program.title
+        )
+    else:
+        # django.core.exceptions.ValidationError
+        raise ValidationError("Invalid status on FinancialAid for generate_financial_aid_email()")
+    body = FINANCIAL_AID_EMAIL_BODY.format(
+        first_name=financial_aid.user.profile.first_name,
+        message=message,
+        program_name=financial_aid.tier_program.program.title
+    )
+    return {"subject": subject, "body": body}
+
+
+def generate_mailgun_response_json(response):
+    """
+    Generates the json object for the mailgun response.
+
+    This is necessary because of inconsistent Response object formatting. Calling response.json() will return a valid
+    JSON-serializable dictionary object, except when the response returns 401 (and maybe others) from mailgun, in which
+    it will raise an exception because of improperly formatted content for the .json() call.
+
+    This function solves that problem by raising ImproperlyConfigured if the response returns 401, which will be caught
+    by a micromasters.utils.custom_exception_handler():
+
+    Args:
+        response (requests.Response): response object
+    Returns:
+        dict
+    """
+    if response.status_code == status.HTTP_401_UNAUTHORIZED:
+        message = "Mailgun API keys not properly configured."
+        log.error(message)
+        raise ImproperlyConfigured(message)
+    return response.json()

--- a/mail/utils_test.py
+++ b/mail/utils_test.py
@@ -113,14 +113,20 @@ class MailUtilsTests(TestCase):
         )
         with self.assertRaises(ImproperlyConfigured):
             generate_mailgun_response_json(response_401)
+
+    def test_generate_mailgun_response_json_with_failed_json_call(self):
+        """
+        Tests that generate_mailgun_response_json() returns without erroring if Response.json() call fails for
+        non 401 status code
+        """
         # Response.json() error
-        response_value_error = Mock(
+        response = Mock(
             spec=Response,
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             json=lambda: (_ for _ in []).throw(ValueError),  # To get .json() to throw ValueError
             reason="reason"
         )
         self.assertDictEqual(
-            generate_mailgun_response_json(response_value_error),
-            {"message": response_value_error.reason}
+            generate_mailgun_response_json(response),
+            {"message": response.reason}
         )

--- a/mail/utils_test.py
+++ b/mail/utils_test.py
@@ -1,0 +1,113 @@
+"""
+Tests for mail utils
+"""
+
+from django.core.exceptions import ValidationError, ImproperlyConfigured
+from django.test import TestCase
+from mock import Mock
+from requests import Response
+from rest_framework import status
+
+from dashboard.models import ProgramEnrollment
+from ecommerce.factories import CoursePriceFactory
+from financialaid.api import get_formatted_course_price
+from financialaid.constants import (
+    FINANCIAL_AID_APPROVAL_MESSAGE,
+    FINANCIAL_AID_APPROVAL_SUBJECT,
+    FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT,
+    FINANCIAL_AID_DOCUMENTS_RECEIVED_MESSAGE,
+    FINANCIAL_AID_EMAIL_BODY,
+    FinancialAidStatus
+)
+from financialaid.factories import FinancialAidFactory
+from mail.utils import generate_financial_aid_email, generate_mailgun_response_json
+from mail.views_test import mocked_json
+
+
+class MailUtilsTests(TestCase):
+    """
+    Tests for mail utils
+    """
+    @classmethod
+    def setUpTestData(cls):
+        cls.course_price = CoursePriceFactory.create(
+            is_valid=True
+        )
+        cls.financial_aid = FinancialAidFactory.create()
+        cls.tier_program = cls.financial_aid.tier_program
+        cls.tier_program.program = cls.course_price.course_run.course.program
+        cls.tier_program.save()
+        cls.program_enrollment = ProgramEnrollment.objects.create(
+            user=cls.financial_aid.user,
+            program=cls.tier_program.program
+        )
+
+    def setUp(self):
+        self.financial_aid.refresh_from_db()
+
+    def test_generate_financial_aid_email_approved(self):
+        """
+        Tests generate_financial_aid_email() with status APPROVED
+        """
+        self.financial_aid.status = FinancialAidStatus.APPROVED
+        self.financial_aid.save()
+        email_dict = generate_financial_aid_email(self.financial_aid)
+        assert email_dict["subject"] == FINANCIAL_AID_APPROVAL_SUBJECT.format(
+            program_name=self.financial_aid.tier_program.program.title
+        )
+        assert email_dict["body"] == FINANCIAL_AID_EMAIL_BODY.format(
+            first_name=self.financial_aid.user.profile.first_name,
+            message=FINANCIAL_AID_APPROVAL_MESSAGE.format(
+                program_name=self.financial_aid.tier_program.program.title,
+                price=get_formatted_course_price(self.program_enrollment)["price"]
+            ),
+            program_name=self.financial_aid.tier_program.program.title
+        )
+
+    def test_generate_financial_aid_email_docs_sent(self):
+        """
+        Tests generate_financial_aid_email() with status PENDING_MANUAL_APPROVAL
+        """
+        self.financial_aid.status = FinancialAidStatus.PENDING_MANUAL_APPROVAL
+        self.financial_aid.save()
+        email_dict = generate_financial_aid_email(self.financial_aid)
+        assert email_dict["subject"] == FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT.format(
+            program_name=self.financial_aid.tier_program.program.title
+        )
+        assert email_dict["body"] == FINANCIAL_AID_EMAIL_BODY.format(
+            first_name=self.financial_aid.user.profile.first_name,
+            message=FINANCIAL_AID_DOCUMENTS_RECEIVED_MESSAGE,
+            program_name=self.financial_aid.tier_program.program.title
+        )
+
+    def test_generate_financial_aid_email_invalid_statuses(self):
+        """
+        Tests generate_financial_aid_email() with invalid statuses raises django ValidationError
+        """
+        invalid_statuses = [
+            FinancialAidStatus.AUTO_APPROVED,
+            FinancialAidStatus.CREATED,
+            FinancialAidStatus.PENDING_DOCS
+        ]
+        for invalid_status in invalid_statuses:
+            self.financial_aid.status = invalid_status
+            self.financial_aid.save()
+            self.assertRaises(ValidationError, generate_financial_aid_email, self.financial_aid)
+
+    def test_generate_mailgun_response_json(self):
+        """
+        Tests that generate_mailgun_response_json() returns response.json() unless the status code is 401 in which
+        case it should raise ImproperlyConfigured
+        """
+        response = Mock(
+            spec=Response,
+            status_code=status.HTTP_200_OK,
+            json=mocked_json()
+        )
+        assert generate_mailgun_response_json(response) == response.json()
+        response_401 = Mock(
+            spec=Response,
+            status_code=status.HTTP_401_UNAUTHORIZED
+        )
+        with self.assertRaises(ImproperlyConfigured):
+            generate_mailgun_response_json(response_401)

--- a/mail/views.py
+++ b/mail/views.py
@@ -89,4 +89,7 @@ class FinancialAidMailView(GenericAPIView):
             subject=serializer.data['email_subject'],
             financial_aid=financial_aid
         )
-        return Response(data=generate_mailgun_response_json(mailgun_response), status=mailgun_response.status_code)
+        return Response(
+            status=mailgun_response.status_code,
+            data=generate_mailgun_response_json(mailgun_response)
+        )

--- a/mail/views.py
+++ b/mail/views.py
@@ -17,6 +17,7 @@ from financialaid.permissions import UserCanEditFinancialAid
 from mail.api import MailgunClient
 from mail.permissions import UserCanMessageLearnersPermission
 from mail.serializers import FinancialAidMailSerializer
+from mail.utils import generate_mailgun_response_json
 from search.api import (
     prepare_and_execute_search,
     get_all_query_matching_emails
@@ -55,7 +56,7 @@ class SearchResultMailView(APIView):
             data={
                 "batch_{}".format(batch_num): {
                     "status_code": resp.status_code,
-                    "data": resp.json()
+                    "data": generate_mailgun_response_json(resp)
                 } for batch_num, resp in enumerate(mailgun_responses)
             }
         )
@@ -88,4 +89,4 @@ class FinancialAidMailView(GenericAPIView):
             subject=serializer.data['email_subject'],
             financial_aid=financial_aid
         )
-        return Response(data=mailgun_response.json(), status=mailgun_response.status_code)
+        return Response(data=generate_mailgun_response_json(mailgun_response), status=mailgun_response.status_code)

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -3,6 +3,7 @@ Tests for HTTP email API views
 """
 from unittest.mock import Mock, patch
 
+from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.db.models.signals import post_save
 from rest_framework import status
@@ -92,6 +93,19 @@ class MailViewsTests(APITestCase):
             assert 'data' in resp_post.data[batch]
         assert resp_post.data['batch_0']['status_code'] == status.HTTP_200_OK
         assert resp_post.data['batch_1']['status_code'] == status.HTTP_400_BAD_REQUEST
+
+    def test_view_response_improperly_configured(self, mock_mailgun_client, mock_prepare_exec_search):
+        """
+        Test that the SearchResultMailView will raise ImproperlyConfigured if mailgun returns 401, which
+        results in returning 500 since micromasters.utils.custom_exception_hanlder catches ImproperlyConfigured
+        """
+        email_results = ['a@example.com', 'b@example.com']
+        mock_prepare_exec_search.return_value = email_results
+        mock_mailgun_client.send_batch.return_value = [
+            Mock(spec=Response, status_code=status.HTTP_401_UNAUTHORIZED),
+        ]
+        resp = self.client.post(self.search_result_mail_url, data=self.request_data, format='json')
+        assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
     def test_no_program_user_response(self, *args):  # pylint: disable=unused-argument
         """
@@ -203,3 +217,16 @@ class FinancialAidMailViewsTests(FinancialAidBaseTestCase, APITestCase):
         self.client.force_login(self.learner_user)
         resp = self.client.post(self.url, data=self.request_data, format='json')
         assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_send_financial_aid_view_improperly_configured(self, mock_mailgun_client):
+        """
+        Test that the FinancialAidMailView will raise ImproperlyConfigured if mailgun returns 401, which
+        results in returning 500 since micromasters.utils.custom_exception_hanlder catches ImproperlyConfigured
+        """
+        self.client.force_login(self.staff_user)
+        mock_mailgun_client.send_financial_aid_email.return_value = Mock(
+            spec=Response,
+            status_code=status.HTTP_401_UNAUTHORIZED
+        )
+        resp = self.client.post(self.url, data=self.request_data, format='json')
+        assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -3,7 +3,6 @@ Tests for HTTP email API views
 """
 from unittest.mock import Mock, patch
 
-from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.db.models.signals import post_save
 from rest_framework import status


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1368 

#### What's this PR do?
This PR modifies `mail.views` to raise `ImproperlyConfigured` if the response from mailgun returns 401. This fixes the bug where `response.json()` normally returns a dictionary, except for a mailgun 401 response which would raise an exception that the 401 response is not JSON-serializable.

3 tests were also added to cover this case.

#### Where should the reviewer start?
You can test this out in `/financial_aid/review/<program_id>` on your local machine _without_ a valid mailgun key.  Instead of returning a blob of html dump, it should return a 500 response from `micromasters.utils.custom_exception_handler` with the proper message.

#### How should this be manually tested?

#### Any background context you want to provide?
Since this adds an extra function, I created a new file `mail.utils` for the new function and also moved `mail.api.generate_financial_aid_email` over there.

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

…response to raise ImproperlyConfigured instead