### PR TITLE
Fixed celery scheduling for currency exhange rate updates

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -454,7 +454,7 @@ CELERYBEAT_SCHEDULE = {
         'schedule': crontab(minute=0, hour='*/6')
     },
     'update-currency-exchange-rates-every-24-hrs': {
-        'task': 'financialaid.tasks.update_currency_exchange_rates',
+        'task': 'financialaid.tasks.sync_currency_exchange_rates',
         'schedule': crontab(minute=0, hour='3')
     },
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1384 

#### What's this PR do?
There was a typo in the celery task configuration for syncing currency exchange rates.

#### Where should the reviewer start?

#### How should this be manually tested?
Not really sure if there's a better way than just merging this one line change and then checking to see if the `CurrencyExchangeRate` objects are updated daily.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

