### PR TITLE
Sorted programs in id order

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -36,7 +36,7 @@ class HomePage(Page):
     subpage_types = ['ProgramPage']
 
     def get_context(self, request):
-        programs = Program.objects.filter(live=True)
+        programs = Program.objects.filter(live=True).order_by("id")
         js_settings = {
             "gaTrackingID": settings.GA_TRACKING_ID,
             "host": webpack_dev_server_host(request),

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -155,6 +155,17 @@ class TestHomePage(ViewsTests):
             js_settings = json.loads(response.context['js_settings_json'])
             assert js_settings['gaTrackingID'] == ga_tracking_id
 
+    def test_program_order(self):
+        """
+        Assert that programs are output in id order
+        """
+        for i in range(10):
+            ProgramFactory.create(live=True, title="Program {}".format(i + 1))
+        response = self.client.get("/")
+        content = response.content.decode('utf-8')
+        indexes = [content.find("Program {}".format(i + 1)) for i in range(10)]
+        assert indexes == sorted(indexes)
+
 
 class DashboardTests(ViewsTests):
     """


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1290 

#### What's this PR do?
Sorts programs in id order

#### How should this be manually tested?
Create a couple live programs and view the thumbnails on the home page. They should be in the order they were created. Change the first program's id number to come after the second program, then refresh. The programs should swap in the home page.
