### PR TITLE
Make program selector use full dialog width

### DIFF
--- a/static/js/components/NewEnrollmentDialog.js
+++ b/static/js/components/NewEnrollmentDialog.js
@@ -94,6 +94,14 @@ export default class NewEnrollmentDialog extends React.Component {
         onChange={this.handleSelectedProgramChange}
         floatingLabelText="Select Program"
         errorText={enrollDialogError}
+        fullWidth={true}
+        style={{
+          width: "500px"
+        }}
+        menuStyle={{
+          width: "500px",
+          overflow: "hidden"
+        }}
       >
         {options}
       </SelectField>


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1281

#### What's this PR do?
Makes the select take up the full width of the dialog
#### Screenshots (if appropriate)
![screenshot from 2016-10-13 17-18-59](https://cloud.githubusercontent.com/assets/863262/19367432/303598f6-9169-11e6-9c17-ef71b86afa24.png)
