### PR TITLE
Added past course run UI to dashboard

### DIFF
--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -73,7 +73,7 @@
               master’s degree program on campus, at MIT or other top universities.
 </p>
               <div class="sub-banner-logos">
-                <div class="sub-banner-logos-text">All MIT Micromasters courses are delivered on</div>
+                <div class="sub-banner-logos-text">All MIT MicroMasters courses are delivered on</div>
                 <img src="{% static 'images/edx_logo.png' %}" alt="edX">
               </div>
             </div>

--- a/courses/models.py
+++ b/courses/models.py
@@ -69,17 +69,27 @@ class Course(models.Model):
     class Meta:
         unique_together = ('program', 'position_in_program',)
 
-    def get_next_run(self):
+    def get_first_unexpired_run(self, course_run_to_exclude=None):
         """
-        Gets the next run associated with this course.
+        Gets the soonest unexpired run associated with this course.
         Note that it could be current as long as the enrollment window
         has not closed.
+
+        Args:
+            course_run_to_exclude (CourseRun): A CourseRun to exclude
+                from the query
+
+        Returns: CourseRun or None: An unexpired course run
+
         """
-        next_run_set = self.courserun_set.filter(CourseRun.get_active_enrollment_queryset())
-        if not next_run_set.count():
-            return
-        next_run_set = next_run_set.order_by('start_date')
-        return next_run_set[0]
+        future_run_queryset = (
+            self.courserun_set
+            .filter(CourseRun.unexpired_courserun_queryset())
+            .order_by('start_date')
+        )
+        if course_run_to_exclude:
+            future_run_queryset = future_run_queryset.exclude(pk=course_run_to_exclude.pk)
+        return future_run_queryset.first()
 
     def get_promised_run(self):
         """
@@ -95,7 +105,7 @@ class Course(models.Model):
         """
         Construct the course page url
         """
-        course_run = self.get_next_run()
+        course_run = self.get_first_unexpired_run()
         if not course_run:
             return ""
         if not course_run.edx_course_key:
@@ -111,8 +121,8 @@ class Course(models.Model):
         Return text that contains start and enrollment
         information about the course.
         """
-        course_run = self.get_next_run()
-        if not course_run:
+        course_run = self.get_first_unexpired_run()
+        if not course_run or not course_run.start_date:
             promised_run = self.get_promised_run()
             if promised_run:
                 return "Coming " + promised_run.fuzzy_start_date
@@ -210,7 +220,6 @@ class CourseRun(models.Model):
                     return self.enrollment_start <= now <= self.enrollment_end
                 else:
                     return self.enrollment_start <= now
-
         return False
 
     @property
@@ -223,18 +232,16 @@ class CourseRun(models.Model):
                 (self.upgrade_deadline > datetime.now(pytz.utc)))
 
     @staticmethod
-    def get_active_enrollment_queryset():
+    def unexpired_courserun_queryset():
         """
-        Returns a Q object that encapsulates the logic for filtering for CourseRun objects
-        that are active for enrollment.
+        Returns a Q object for CourseRuns that have not expired (ie: the enrollment
+        period has not passed, or the enrollment period is unspecified and the end
+        date occurs in the future)
         """
         now = datetime.now(pytz.utc)
         return (
-            # there is only the start date
-            (models.Q(enrollment_end=None) &
-             models.Q(end_date=None) & models.Q(start_date__lte=now)) |
-            # there is no enrollment date but the course has not ended yet
-            (models.Q(enrollment_end=None) & models.Q(end_date__gte=now)) |
-            # the enrollment end date is simply greater than now
+            (models.Q(enrollment_end=None) & (
+                models.Q(end_date__gte=now) | models.Q(end_date=None)
+            )) |
             models.Q(enrollment_end__gte=now)
         )

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -51,23 +51,17 @@ class CourseModelTests(ESTestCase):
         )
 
 
-class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
-    """Tests for Course model"""
+class GetFirstUnexpiredRunTests(CourseModelTests):  # pylint: disable=too-many-public-methods
+    """Tests for get_unexpired_run function"""
 
-    def test_to_string(self):
-        """Test for __str__ method"""
-        assert "{}".format(self.course) == "Title"
-
-    def test_get_next_run_no_run(self):
+    def test_no_run(self):
         """
-        Test for the get_next_run method
         No run available
         """
-        assert self.course.get_next_run() is None
+        assert self.course.get_first_unexpired_run() is None
 
-    def test_get_next_run_only_past(self):
+    def test_only_past(self):
         """
-        Test for the get_next_run method
         enrollment past and course past
         """
         self.create_run(
@@ -76,11 +70,10 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
             enr_start=self.now-timedelta(weeks=62),
             enr_end=self.now-timedelta(weeks=53),
         )
-        assert self.course.get_next_run() is None
+        assert self.course.get_first_unexpired_run() is None
 
-    def test_get_next_run_present_enroll_closed(self):
+    def test_present_enroll_closed(self):
         """
-        Test for the get_next_run method
         enrollment past, course present
         """
         self.create_run(
@@ -89,11 +82,10 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
             enr_start=self.now-timedelta(weeks=10),
             enr_end=self.now-timedelta(weeks=3),
         )
-        assert self.course.get_next_run() is None
+        assert self.course.get_first_unexpired_run() is None
 
-    def test_get_next_run_present_enroll_closed_course_future(self):
+    def test_present_enroll_closed_course_future(self):
         """
-        Test for the get_next_run method
         enrollment past, course future
         """
         self.create_run(
@@ -102,34 +94,31 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
             enr_start=self.now-timedelta(weeks=10),
             enr_end=self.now-timedelta(weeks=3),
         )
-        assert self.course.get_next_run() is None
+        assert self.course.get_first_unexpired_run() is None
 
-    def test_get_next_run_enroll_none_course_past(self):
+    def test_enroll_none_course_past(self):
         """
-        Test for the get_next_run method
         enrollment none, course past
         """
         self.create_run(
             start=self.now-timedelta(weeks=10),
             end=self.now-timedelta(weeks=3),
         )
-        assert self.course.get_next_run() is None
+        assert self.course.get_first_unexpired_run() is None
 
-    def test_get_next_run_only_present_forever(self):
+    def test_only_present_forever(self):
         """
-        Test for the get_next_run method
         enrollment none, course started in the past with no end
         """
         course_run = self.create_run(
             start=self.now-timedelta(weeks=52),
         )
-        next_run = self.course.get_next_run()
+        next_run = self.course.get_first_unexpired_run()
         assert isinstance(next_run, CourseRun)
         assert next_run.pk == course_run.pk
 
-    def test_get_next_run_enr_present_course_future(self):
+    def test_enr_present_course_future(self):
         """
-        Test for the get_next_run method
         enrollment present, course future
         """
         course_run = self.create_run(
@@ -138,13 +127,12 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
             enr_start=self.now-timedelta(weeks=10),
             enr_end=self.now+timedelta(weeks=1),
         )
-        next_run = self.course.get_next_run()
+        next_run = self.course.get_first_unexpired_run()
         assert isinstance(next_run, CourseRun)
         assert next_run.pk == course_run.pk
 
-    def test_get_next_run_present_enroll_open(self):
+    def test_present_enroll_open(self):
         """
-        Test for the get_next_run method
         enrollment present, course present
         """
         course_run = self.create_run(
@@ -153,13 +141,12 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
             enr_start=self.now-timedelta(weeks=10),
             enr_end=self.now+timedelta(weeks=1),
         )
-        next_run = self.course.get_next_run()
+        next_run = self.course.get_first_unexpired_run()
         assert isinstance(next_run, CourseRun)
         assert next_run.pk == course_run.pk
 
-    def test_get_next_run_present_enroll_open_null(self):
+    def test_present_enroll_open_null(self):
         """
-        Test for the get_next_run method
         enrollment past with no end, course present
         """
         course_run = self.create_run(
@@ -167,13 +154,12 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
             end=self.now+timedelta(weeks=2),
             enr_start=self.now-timedelta(weeks=10),
         )
-        next_run = self.course.get_next_run()
+        next_run = self.course.get_first_unexpired_run()
         assert isinstance(next_run, CourseRun)
         assert next_run.pk == course_run.pk
 
-    def test_get_next_run_present_enroll_open_with_future_present(self):
+    def test_present_enroll_open_with_future_present(self):
         """
-        Test for the get_next_run method
         one run with enrollment present and course present
         and one run with enrollment future and course future
         """
@@ -189,13 +175,12 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
             enr_start=self.now+timedelta(weeks=40),
             enr_end=self.now+timedelta(weeks=50),
         )
-        next_run = self.course.get_next_run()
+        next_run = self.course.get_first_unexpired_run()
         assert isinstance(next_run, CourseRun)
         assert next_run.pk == course_run.pk
 
-    def test_get_next_run_present_enroll_closed_with_future_present(self):
+    def test_present_enroll_closed_with_future_present(self):
         """
-        Test for the get_next_run method
         one run with enrollment past and course present
         and one run with enrollment future and course future
         """
@@ -211,13 +196,12 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
             enr_start=self.now+timedelta(weeks=40),
             enr_end=self.now+timedelta(weeks=50),
         )
-        next_run = self.course.get_next_run()
+        next_run = self.course.get_first_unexpired_run()
         assert isinstance(next_run, CourseRun)
         assert next_run.pk == course_run.pk
 
-    def test_get_next_run_future(self):
+    def test_future(self):
         """
-        Test for the get_next_run method
         enrollment in the future and course in the future
         """
         course_run = self.create_run(
@@ -226,22 +210,49 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
             enr_start=self.now+timedelta(weeks=40),
             enr_end=self.now+timedelta(weeks=50),
         )
-        next_run = self.course.get_next_run()
+        next_run = self.course.get_first_unexpired_run()
         assert isinstance(next_run, CourseRun)
         assert next_run.pk == course_run.pk
 
-    def test_get_next_run_enroll_none_course_future(self):
+    def test_enroll_none_course_future(self):
         """
-        Test for the get_next_run method
         enrollment none, course future
         """
         course_run = self.create_run(
             start=self.now+timedelta(weeks=1),
             end=self.now+timedelta(weeks=4),
         )
-        next_run = self.course.get_next_run()
+        next_run = self.course.get_first_unexpired_run()
         assert isinstance(next_run, CourseRun)
         assert next_run.pk == course_run.pk
+
+    def test_exclude_course_run(self):
+        """
+        Two runs, one of which will be excluded from the results.
+        """
+        course_run_earlier = self.create_run(
+            start=self.now-timedelta(days=2),
+            end=self.now+timedelta(days=10),
+            enr_start=self.now-timedelta(days=1),
+            enr_end=self.now+timedelta(days=4),
+        )
+        course_run_later = self.create_run(
+            start=self.now-timedelta(days=1),
+            end=self.now+timedelta(days=11),
+            enr_start=self.now,
+            enr_end=self.now+timedelta(days=5),
+        )
+        next_run = self.course.get_first_unexpired_run(course_run_to_exclude=course_run_earlier)
+        assert isinstance(next_run, CourseRun)
+        assert next_run.pk == course_run_later.pk
+
+
+class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
+    """Tests for Courses"""
+
+    def test_to_string(self):
+        """Test for __str__ method"""
+        assert "{}".format(self.course) == "Title"
 
     def test_future_course_enr_future(self):
         """Test Course that starts in the future, enrollment in future"""

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -7,12 +7,13 @@ import Spinner from 'react-mdl/lib/Spinner';
 import R from 'ramda';
 import _ from 'lodash';
 
-import type { Course, CourseRun, FinancialAidUserInfo } from '../../flow/programTypes';
+import type { CourseRun, FinancialAidUserInfo } from '../../flow/programTypes';
 import type { CoursePrice } from '../../flow/dashboardTypes';
 import {
   STATUS_NOT_PASSED,
   STATUS_PASSED,
   STATUS_CAN_UPGRADE,
+  STATUS_MISSED_DEADLINE,
   STATUS_CURRENTLY_ENROLLED,
   STATUS_WILL_ATTEND,
   STATUS_OFFERED,
@@ -21,18 +22,19 @@ import {
   FA_PENDING_STATUSES,
   FA_STATUS_SKIPPED
 } from '../../constants';
+import { isCurrentlyEnrollable } from './util';
 import { formatPrice } from '../../util/util';
 import { ifValidDate } from '../../util/date';
 
 export default class CourseAction extends React.Component {
   props: {
     checkout: Function,
-    course: Course,
+    courseRun: CourseRun,
     coursePrice: CoursePrice,
+    now: moment$Moment,
     financialAid: FinancialAidUserInfo,
     hasFinancialAid: boolean,
     openFinancialAidCalculator?: () => void,
-    now: moment$Moment,
     addCourseEnrollment: (courseId: string) => void
   };
 
@@ -44,13 +46,6 @@ export default class CourseAction extends React.Component {
   getCoursePrice(): string {
     const { coursePrice } = this.props;
     return formatPrice(coursePrice.price);
-  }
-
-  isCurrentlyEnrollable(enrollmentStartDate: ?Object): boolean {
-    const { now } = this.props;
-    return enrollmentStartDate !== null &&
-      enrollmentStartDate !== undefined &&
-      enrollmentStartDate.isSameOrBefore(now, 'day');
   }
 
   needsPriceCalculation(): boolean {
@@ -144,6 +139,9 @@ export default class CourseAction extends React.Component {
     case STATUS_PASSED:
       description = this.renderStatusDescription(run.status, 'Passed');
       break;
+    case STATUS_NOT_PASSED:
+      description = this.renderStatusDescription(run.status, 'Failed');
+      break;
     case STATUS_CURRENTLY_ENROLLED: {
       description = this.renderBoxedDescription('In Progress');
       break;
@@ -163,7 +161,7 @@ export default class CourseAction extends React.Component {
     }
     case STATUS_OFFERED: {
       let enrollmentStartDate = run.enrollment_start_date ? moment(run.enrollment_start_date) : null;
-      if (this.isCurrentlyEnrollable(enrollmentStartDate)) {
+      if (isCurrentlyEnrollable(enrollmentStartDate, now)) {
         action = this.renderEnrollButton(run);
         description = this.renderPayLaterLink(run);
       } else {
@@ -177,8 +175,10 @@ export default class CourseAction extends React.Component {
       }
       break;
     }
-    case STATUS_NOT_PASSED:
-      // do nothing;
+    case STATUS_MISSED_DEADLINE:
+      description = this.renderTextDescription(
+        'You missed the payment deadline and will not receive MicroMasters credit for this course.'
+      );
       break;
     case STATUS_PENDING_ENROLLMENT:
       action = this.renderEnrollButton(run);
@@ -190,14 +190,10 @@ export default class CourseAction extends React.Component {
   }
 
   render() {
-    const { course } = this.props;
-    let firstRun: CourseRun = {};
-    if (course.runs.length > 0) {
-      firstRun = course.runs[0];
-    }
+    const { courseRun } = this.props;
 
     return <div className="course-action">
-      { this.renderContents(firstRun) }
+      { this.renderContents(courseRun) }
     </div>;
   }
 }

--- a/static/js/components/dashboard/CourseDescription.js
+++ b/static/js/components/dashboard/CourseDescription.js
@@ -4,11 +4,12 @@ import React from 'react';
 import _ from 'lodash';
 import moment from 'moment';
 
-import type { Course, CourseRun } from '../../flow/programTypes';
+import type { CourseRun } from '../../flow/programTypes';
 import {
   STATUS_PASSED,
   STATUS_NOT_PASSED,
   STATUS_CAN_UPGRADE,
+  STATUS_MISSED_DEADLINE,
   STATUS_CURRENTLY_ENROLLED,
   STATUS_OFFERED,
   STATUS_WILL_ATTEND,
@@ -21,18 +22,24 @@ const edxLinkBase = `${SETTINGS.edx_base_url}/courses/`;
 
 export default class CourseDescription extends React.Component {
   props: {
-    course: Course
+    courseRun: CourseRun,
+    courseTitle: ?string
   };
-
-  needsEdxLink(run: CourseRun): boolean {
-    // Any status besides 'offered' implies that the user has at some point enrolled 
-    return run.status && run.status !== STATUS_OFFERED;
-  }
 
   renderCourseDateMessage(label: string, dateString: string): React$Element<*> {
     let date = moment(dateString);
     let text = ifValidDate('', date => `${label}: ${date.format(DASHBOARD_FORMAT)}`, date);
     return <span key='1'>{text}</span>;
+  }
+
+  renderStartDateMessage(run: CourseRun, shouldStartInFuture: boolean): React$Element<*>|null {
+    if (run.course_start_date) {
+      return this.renderCourseDateMessage('Start date', run.course_start_date);
+    } else if (run.fuzzy_start_date && shouldStartInFuture) {
+      return <span key='1'>Coming {run.fuzzy_start_date}</span>;
+    } else {
+      return null;
+    }
   }
 
   renderDetailContents(run: CourseRun) {
@@ -44,48 +51,46 @@ export default class CourseDescription extends React.Component {
       dateMessage = this.renderCourseDateMessage('Ended', run.course_end_date);
       break;
     case STATUS_CAN_UPGRADE:
+    case STATUS_MISSED_DEADLINE:
     case STATUS_CURRENTLY_ENROLLED:
+      dateMessage = this.renderStartDateMessage(run, false);
+      break;
     case STATUS_WILL_ATTEND:
     case STATUS_OFFERED:
     case STATUS_PENDING_ENROLLMENT:
-      if (run.course_start_date) {
-        dateMessage = this.renderCourseDateMessage('Start date', run.course_start_date);
-      } else if (!_.isNil(run.fuzzy_start_date)) {
-        dateMessage = <span key='1'>Coming {run.fuzzy_start_date}</span>;
-      }
+      dateMessage = this.renderStartDateMessage(run, true);
       break;
     }
 
-    if (run.status === STATUS_CAN_UPGRADE) {
+    if (run.status === STATUS_CAN_UPGRADE || run.status === STATUS_MISSED_DEADLINE) {
       additionalDetail = <span key='2'>You are Auditing this Course.</span>;
     }
 
     return _.compact([dateMessage, additionalDetail]);
   }
 
-  renderViewCourseLink = (courseRun: CourseRun): React$Element<*>|void => (
-    <a href={`${edxLinkBase}${courseRun.course_id}`} target="_blank">
-      View on edX
-    </a>
+  renderViewCourseLink = (courseRun: CourseRun): React$Element<*>|null => (
+    (courseRun && courseRun.course_id) ?
+      <a href={`${edxLinkBase}${courseRun.course_id}`} target="_blank">
+        View on edX
+      </a> :
+      null
   );
 
   render() {
-    const { course } = this.props;
-    let firstRun: CourseRun = {};
+    const { courseRun, courseTitle } = this.props;
 
-    let detailContents;
-    if (course.runs.length > 0) {
-      firstRun = course.runs[0];
-      detailContents = this.renderDetailContents(firstRun);
+    let detailContents, title, edxLink;
+    if (courseRun && !_.isEmpty(courseRun)) {
+      detailContents = this.renderDetailContents(courseRun);
     } else {
       detailContents = <span className="no-runs">No future courses are currently scheduled.</span>;
     }
-
-    let title = course.title;
-    if(this.needsEdxLink(firstRun)) {
-      title = <span>{course.title} - {this.renderViewCourseLink(firstRun)}</span>;
+    edxLink = this.renderViewCourseLink(courseRun);
+    if(edxLink) {
+      title = <span>{courseTitle} - {edxLink}</span>;
     } else {
-      title = <span>{course.title}</span>;
+      title = <span>{courseTitle}</span>;
     }
 
     return <div className="course-description">

--- a/static/js/components/dashboard/CourseDescription_test.js
+++ b/static/js/components/dashboard/CourseDescription_test.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 import { assert } from 'chai';
-import _ from 'lodash';
 
 import CourseDescription from './CourseDescription';
 import {
@@ -16,6 +15,7 @@ import {
   STATUS_PASSED,
   STATUS_NOT_PASSED,
   STATUS_CAN_UPGRADE,
+  STATUS_MISSED_DEADLINE,
   STATUS_CURRENTLY_ENROLLED,
   STATUS_OFFERED,
   ALL_COURSE_STATUSES,
@@ -33,33 +33,34 @@ describe('CourseDescription', () => {
     };
   };
 
-  it('shows the course title', () => {
+  it('shows the course title and a link to view the course on edX', () => {
     for (let status of ALL_COURSE_STATUSES) {
       let course = findCourse(course => (
         course.runs.length > 0 &&
         course.runs[0].status === status
       ));
-      const wrapper = shallow(<CourseDescription course={course}/>);
+      let firstRun = course.runs[0];
+      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
       let elements = getElements(wrapper);
 
       assert.include(elements.titleText, course.title);
-    }
-  });
-
-  it('shows a link to view the course on edX if a user has ever enrolled', () => {
-    let edxLinkingStatuses = _.filter(ALL_COURSE_STATUSES, (s) => (s !== STATUS_OFFERED));
-    for (let status of edxLinkingStatuses) {
-      let course = findCourse(course => (
-        course.runs.length > 0 &&
-        course.runs[0].status === status
-      ));
-      const wrapper = shallow(<CourseDescription course={course}/>);
-      let elements = getElements(wrapper);
-
       assert.isAbove(elements.titleLink.length, 0);
       assert.equal(elements.titleLink.text(), 'View on edX');
       assert.isAbove(elements.titleLink.props().href.length, 0);
     }
+  });
+
+  it('does not show a link to view the course on edX if the course run lacks an id', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED
+    ));
+    let firstRun = course.runs[0];
+    firstRun.course_id = null;
+    const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+    let elements = getElements(wrapper);
+
+    assert.equal(elements.titleLink.length, 0);
   });
 
   it('does show date with status passed', () => {
@@ -67,9 +68,9 @@ describe('CourseDescription', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_PASSED
     ));
-    const wrapper = shallow(<CourseDescription course={course} />);
-    let elements = getElements(wrapper);
     let firstRun = course.runs[0];
+    const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+    let elements = getElements(wrapper);
     let courseEndDate = moment(firstRun.course_end_date);
     let formattedDate = courseEndDate.format(DASHBOARD_FORMAT);
 
@@ -81,8 +82,8 @@ describe('CourseDescription', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_PASSED
     ));
-    alterFirstRun(course, {course_end_date: '1999-13-92'});
-    const wrapper = shallow(<CourseDescription course={course} />);
+    let firstRun = alterFirstRun(course, {course_end_date: '1999-13-92'});
+    const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
     let elements = getElements(wrapper);
     assert.equal(elements.detailsText, '');
   });
@@ -92,9 +93,9 @@ describe('CourseDescription', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_NOT_PASSED
     ));
-    const wrapper = shallow(<CourseDescription course={course} />);
-    let elements = getElements(wrapper);
     let firstRun = course.runs[0];
+    const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+    let elements = getElements(wrapper);
     let courseEndDate = moment(firstRun.course_end_date);
     let formattedDate = courseEndDate.format(DASHBOARD_FORMAT);
     assert.equal(elements.detailsText, `Ended: ${formattedDate}`);
@@ -105,15 +106,14 @@ describe('CourseDescription', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_NOT_PASSED
     ));
-    alterFirstRun(course, {course_end_date: '1999-13-92'});
-    const wrapper = shallow(<CourseDescription course={course} />);
+    let firstRun = alterFirstRun(course, {course_end_date: '1999-13-92'});
+    const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
     let elements = getElements(wrapper);
     assert.equal(elements.detailsText, '');
   });
 
   it('does not show anything when there are no runs for a course', () => {
-    let course = findCourse(course => course.runs.length === 0);
-    const wrapper = shallow(<CourseDescription course={course} />);
+    const wrapper = shallow(<CourseDescription courseRun={{}} courseTitle={null} />);
     let elements = getElements(wrapper);
 
     assert.equal(elements.detailsText, 'No future courses are currently scheduled.');
@@ -124,9 +124,9 @@ describe('CourseDescription', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_CURRENTLY_ENROLLED
     ));
-    const wrapper = shallow(<CourseDescription course={course} />);
-    let elements = getElements(wrapper);
     let firstRun = course.runs[0];
+    const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+    let elements = getElements(wrapper);
     let courseStartDate = moment(firstRun.course_start_date);
     let formattedDate = courseStartDate.format(DASHBOARD_FORMAT);
 
@@ -138,8 +138,8 @@ describe('CourseDescription', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_CURRENTLY_ENROLLED
     ));
-    alterFirstRun(course, { course_start_date: '1999-13-92' });
-    const wrapper = shallow(<CourseDescription course={course} />);
+    let firstRun = alterFirstRun(course, { course_start_date: '1999-13-92' });
+    const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
     let elements = getElements(wrapper);
     assert.equal(elements.detailsText, '');
   });
@@ -149,9 +149,9 @@ describe('CourseDescription', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_CAN_UPGRADE
     ));
-    const wrapper = shallow(<CourseDescription course={course} />);
-    let elements = getElements(wrapper);
     let firstRun = course.runs[0];
+    const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+    let elements = getElements(wrapper);
     let courseStartDate = moment(firstRun.course_start_date);
     let formattedDate = courseStartDate.format(DASHBOARD_FORMAT);
 
@@ -163,8 +163,8 @@ describe('CourseDescription', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_CAN_UPGRADE
     ));
-    alterFirstRun(course, {course_start_date: '1999-13-92'});
-    const wrapper = shallow(<CourseDescription course={course} />);
+    let firstRun = alterFirstRun(course, {course_start_date: '1999-13-92'});
+    const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
     let elements = getElements(wrapper);
     assert.notInclude(elements.detailsText, 'Start date: ');
   });
@@ -174,13 +174,42 @@ describe('CourseDescription', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_OFFERED
     ));
-    const wrapper = shallow(<CourseDescription course={course} />);
-    let elements = getElements(wrapper);
     let firstRun = course.runs[0];
+    const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+    let elements = getElements(wrapper);
     let courseStartDate = moment(firstRun.course_start_date);
     let formattedDate = courseStartDate.format(DASHBOARD_FORMAT);
 
     assert.equal(elements.detailsText, `Start date: ${formattedDate}`);
+  });
+
+  it('shows fuzzy start date for a future offered course run that has no start date', () => {
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED
+    ));
+    let fuzzyStartDate = 'Spring 2016';
+    let firstRun = course.runs[0];
+    firstRun.fuzzy_start_date = fuzzyStartDate;
+    firstRun.course_start_date = null;
+    const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+    let elements = getElements(wrapper);
+
+    assert.equal(elements.detailsText, `Coming ${fuzzyStartDate}`);
+  });
+
+  it('shows nothing if a course run lacks a start date and fuzzy start date', () => {
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED
+    ));
+    let firstRun = course.runs[0];
+    firstRun.fuzzy_start_date = null;
+    firstRun.course_start_date = null;
+    const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+    let elements = getElements(wrapper);
+
+    assert.equal(elements.detailsText, '');
   });
 
   it('hides an invalid date with status offered', () => {
@@ -188,20 +217,23 @@ describe('CourseDescription', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_OFFERED
     ));
-    alterFirstRun(course, {course_start_date: '1999-13-92'});
-    const wrapper = shallow(<CourseDescription course={course} />);
+    let firstRun = alterFirstRun(course, {course_start_date: '1999-13-92'});
+    const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
     let elements = getElements(wrapper);
     assert.equal(elements.detailsText, '');
   });
 
   it('shows a message when the user is auditing the course', () => {
-    let course = findCourse(course => (
-      course.runs.length > 0 &&
-      course.runs[0].status === STATUS_CAN_UPGRADE
-    ));
-    const wrapper = shallow(<CourseDescription course={course} />);
-    let elements = getElements(wrapper);
+    [STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE].forEach(auditStatus => {
+      let course = findCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === auditStatus
+      ));
+      let firstRun = course.runs[0];
+      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+      let elements = getElements(wrapper);
 
-    assert.include(elements.detailsText, 'You are Auditing this Course');
+      assert.include(elements.detailsText, 'You are Auditing this Course');
+    });
   });
 });

--- a/static/js/components/dashboard/CourseGrade.js
+++ b/static/js/components/dashboard/CourseGrade.js
@@ -2,31 +2,29 @@
 import React from 'react';
 import _ from 'lodash';
 
-import type { Course } from '../../flow/programTypes';
+import type { CourseRun } from '../../flow/programTypes';
+import { formatGrade } from './util';
 
 export default class CourseGrade extends React.Component {
   props: {
-    course: Course
+    courseRun: CourseRun
   };
 
   render() {
-    const { course } = this.props;
+    const { courseRun } = this.props;
 
-    let firstRun, grade, caption;
-    if (course.runs.length > 0) {
-      firstRun = course.runs[0];
-      if (!_.isNil(firstRun.final_grade)) {
-        grade = firstRun.final_grade;
-        caption = 'Final grade';
-      } else if (!_.isNil(firstRun.current_grade)) {
-        grade = firstRun.current_grade;
-        caption = 'Current grade';
-      }
+    let grade, caption;
+    if (!_.isNil(courseRun.final_grade)) {
+      grade = courseRun.final_grade;
+      caption = 'Final grade';
+    } else if (!_.isNil(courseRun.current_grade)) {
+      grade = courseRun.current_grade;
+      caption = 'Current grade';
     }
 
     if (grade && caption) {
       return <div className="course-grade">
-        <div className="number">{grade}%</div>
+        <div className="number">{formatGrade(grade)}</div>
         <div className="caption">{caption}</div>
       </div>;
     } else {

--- a/static/js/components/dashboard/CourseGrade_test.js
+++ b/static/js/components/dashboard/CourseGrade_test.js
@@ -2,25 +2,27 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { assert } from 'chai';
+import _ from 'lodash';
 
 import CourseGrade from './CourseGrade';
 
-import { findCourse, findAndCloneCourse } from '../../util/test_utils';
+import { findAndCloneCourse } from '../../util/test_utils';
 
 describe('CourseGrade', () => {
-  it("doesn't show anything if there are no runs", () => {
-    let course = findCourse(course => course.runs.length === 0);
-    const wrapper = shallow(<CourseGrade course={course}/>);
-    assert.equal(wrapper.text().trim(), "");
-  });
+  let gradeTypes = {
+    current_grade: "Current grade",
+    final_grade: "Final grade"
+  };
 
-  it("shows the percent grade for a currently-enrolled course", () => {
-    let course = findAndCloneCourse(course => course.runs.length > 0);
-    let grade = '50';
-    course.runs[0].current_grade = grade;
+  _.forEach(gradeTypes, function(expectedLabel: string, gradeKey: string) {
+    it(`shows the ${expectedLabel} for a course`, () => {
+      let course = findAndCloneCourse(course => course.runs.length > 0);
+      let grade = '50';
+      course.runs[0][gradeKey] = grade;
 
-    const wrapper = shallow(<CourseGrade course={course}/>);
-    assert.equal(wrapper.find(".course-grade .number").text(), `${grade}%`);
-    assert.equal(wrapper.find(".course-grade .caption").text(), 'Current grade');
+      const wrapper = shallow(<CourseGrade courseRun={course.runs[0]} />);
+      assert.equal(wrapper.find(".course-grade .number").text(), `${grade}%`);
+      assert.equal(wrapper.find(".course-grade .caption").text(), expectedLabel);
+    });
   });
 });

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -1,56 +1,156 @@
 // @flow
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
+import R from 'ramda';
 
 import CourseAction from './CourseAction';
 import CourseGrade from './CourseGrade';
 import CourseDescription from './CourseDescription';
-import type { Course, FinancialAidUserInfo } from '../../flow/programTypes';
+import CourseSubRow from './CourseSubRow';
+import type { Course, CourseRun, FinancialAidUserInfo } from '../../flow/programTypes';
 import type { CoursePrice } from '../../flow/dashboardTypes';
+import {
+  STATUS_MISSED_DEADLINE,
+  STATUS_NOT_PASSED,
+  STATUS_OFFERED,
+} from '../../constants';
 
 export default class CourseRow extends React.Component {
   props: {
-    checkout: Function,
     course: Course,
+    checkout: Function,
     coursePrice: CoursePrice,
+    now: moment$Moment,
     financialAid: FinancialAidUserInfo,
     hasFinancialAid: boolean,
     openFinancialAidCalculator: () => void,
-    now: moment$Moment,
     addCourseEnrollment: (courseId: string) => void,
   };
 
-  render() {
+  shouldDisplayGradeColumn = (run: CourseRun): boolean => (
+    run.status !== STATUS_MISSED_DEADLINE
+  );
+
+  needsToEnrollAgain = (run: CourseRun): boolean => (
+    run.status === STATUS_MISSED_DEADLINE || run.status === STATUS_NOT_PASSED
+  );
+
+  futureEnrollableRun = (course: Course): CourseRun|null => (
+    (course.runs.length > 1 && course.runs[1].status === STATUS_OFFERED) ? course.runs[1] : null
+  );
+
+  pastCourseRuns = (course: Course): Array<CourseRun> => (
+    (course.runs.length > 1) ?
+      R.drop(1, course.runs).filter(run => run.status !== STATUS_OFFERED) :
+      []
+  );
+
+  getFirstRun(): CourseRun {
+    const { course } = this.props;
+    let firstRun: CourseRun = {};
+    if (course.runs.length > 0) {
+      firstRun = course.runs[0];
+    }
+    return firstRun;
+  }
+
+  renderRowColumns(run: CourseRun): Array<React$Element<*>> {
     const {
       course,
       coursePrice,
+      checkout,
+      now,
       financialAid,
       hasFinancialAid,
-      checkout,
       openFinancialAidCalculator,
-      now,
       addCourseEnrollment,
     } = this.props;
 
-    return <Grid className="course-row">
-      <Cell col={6}>
-        <CourseDescription course={course} />
+    let lastColumnSize, lastColumnClass;
+    let columns = [
+      <Cell col={6} key="1">
+        <CourseDescription courseRun={run} courseTitle={course.title} />
       </Cell>
-      <Cell col={2}>
-        <CourseGrade course={course}/>
-      </Cell>
-      <Cell col={4}>
+    ];
+
+    if (this.shouldDisplayGradeColumn(run)) {
+      columns.push(
+        <Cell col={2} key="2">
+          <CourseGrade courseRun={run} />
+        </Cell>
+      );
+      lastColumnSize = 4;
+    } else {
+      lastColumnSize = 6;
+      lastColumnClass = 'long-description';
+    }
+
+    columns.push(
+      <Cell col={lastColumnSize} className={lastColumnClass} key="3">
         <CourseAction
-          course={course}
+          courseRun={run}
           coursePrice={coursePrice}
+          checkout={checkout}
+          now={now}
           hasFinancialAid={hasFinancialAid}
           financialAid={financialAid}
-          checkout={checkout}
           openFinancialAidCalculator={openFinancialAidCalculator}
-          now={now}
           addCourseEnrollment={addCourseEnrollment}
         />
       </Cell>
-    </Grid>;
+    );
+    return columns;
+  }
+
+  renderSubRows(): Array<React$Element<*>> {
+    const {
+      course,
+      coursePrice,
+      checkout,
+      now,
+      financialAid,
+      hasFinancialAid,
+      openFinancialAidCalculator,
+      addCourseEnrollment,
+    } = this.props;
+
+    let firstRun = this.getFirstRun();
+    let subRows = [];
+    let subRowRuns = [];
+
+    if (this.needsToEnrollAgain(firstRun)) {
+      subRowRuns.push(this.futureEnrollableRun(course));
+    }
+
+    subRowRuns = subRowRuns.concat(this.pastCourseRuns(course));
+
+    for (let [i, subRowRun] of Object.entries(subRowRuns)) {
+      subRows.push(
+        <CourseSubRow
+          courseRun={subRowRun}
+          coursePrice={coursePrice}
+          checkout={checkout}
+          now={now}
+          hasFinancialAid={hasFinancialAid}
+          financialAid={financialAid}
+          openFinancialAidCalculator={openFinancialAidCalculator}
+          addCourseEnrollment={addCourseEnrollment}
+          key={i}
+        />
+      );
+    }
+
+    return subRows;
+  }
+
+  render() {
+    let firstRun = this.getFirstRun();
+
+    return <div className="course-container">
+      <Grid className="course-row" key="0">
+        { this.renderRowColumns(firstRun) }
+      </Grid>
+      { this.renderSubRows() }
+    </div>;
   }
 }

--- a/static/js/components/dashboard/CourseRow_test.js
+++ b/static/js/components/dashboard/CourseRow_test.js
@@ -1,9 +1,10 @@
 // @flow
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import moment from 'moment';
 import { assert } from 'chai';
 import sinon from 'sinon';
+import _ from 'lodash';
 
 import CourseRow from './CourseRow';
 import CourseAction from './CourseAction';
@@ -12,13 +13,28 @@ import CourseGrade from './CourseGrade';
 import {
   DASHBOARD_RESPONSE,
   COURSE_PRICES_RESPONSE,
-  FINANCIAL_AID_PARTIAL_RESPONSE
+  FINANCIAL_AID_PARTIAL_RESPONSE,
+  STATUS_NOT_PASSED,
+  STATUS_OFFERED,
+  STATUS_MISSED_DEADLINE,
 } from '../../constants';
+import { generateCourseFromExisting } from '../../util/test_utils';
 
 describe('CourseRow', () => {
-  let sandbox;
+  let sandbox, defaultRowProps;
+
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
+    
+    defaultRowProps = {
+      hasFinancialAid: true,
+      financialAid: FINANCIAL_AID_PARTIAL_RESPONSE,
+      coursePrice: COURSE_PRICES_RESPONSE[0],
+      openFinancialAidCalculator: sinon.stub(),
+      now: moment(),
+      checkout: sinon.stub(),
+      addCourseEnrollment: sinon.stub()
+    };
   });
 
   afterEach(() => {
@@ -27,40 +43,94 @@ describe('CourseRow', () => {
 
   it('forwards the appropriate props', () => {
     const course = DASHBOARD_RESPONSE[1].courses[0];
-    const hasFinancialAid = true;
-    const financialAid = FINANCIAL_AID_PARTIAL_RESPONSE;
-    const coursePrice = COURSE_PRICES_RESPONSE[0];
-    const openFinancialAidCalculator = sinon.stub();
-    const now = moment();
-    const checkout = sinon.stub();
-    const addCourseEnrollment = sinon.stub();
+    const courseRun = course.runs[0];
+    const courseTitle = course.title;
+    
     const wrapper = shallow(
       <CourseRow
         course={course}
-        hasFinancialAid={hasFinancialAid}
-        financialAid={financialAid}
-        coursePrice={coursePrice}
-        now={now}
-        checkout={checkout}
-        openFinancialAidCalculator={openFinancialAidCalculator}
-        addCourseEnrollment={addCourseEnrollment}
+        {...defaultRowProps}
       />
     );
-    assert.deepEqual(wrapper.find(CourseAction).props(), {
-      now,
-      hasFinancialAid,
-      financialAid,
-      coursePrice,
-      course,
-      checkout,
-      openFinancialAidCalculator,
-      addCourseEnrollment,
-    });
+    assert.deepEqual(
+      wrapper.find(CourseAction).props(),
+      Object.assign({}, { courseRun }, defaultRowProps)
+    );
     assert.deepEqual(wrapper.find(CourseDescription).props(), {
-      course,
+      courseRun,
+      courseTitle,
     });
     assert.deepEqual(wrapper.find(CourseGrade).props(), {
-      course,
+      courseRun,
+    });
+  });
+
+  describe('with failed/missed-upgrade-deadline runs', () => {
+    let courseToClone = DASHBOARD_RESPONSE[1].courses[0];
+
+    it('shows two-column view when the upgrade deadline was missed', () => {
+      let pastCourseRunCount = 1;
+      let course = generateCourseFromExisting(courseToClone, pastCourseRunCount);
+      course.runs[0].status = STATUS_MISSED_DEADLINE;
+
+      const wrapper = shallow(
+        <CourseRow
+          course={course}
+          {...defaultRowProps}
+        />
+      );
+      assert.equal(wrapper.find('.course-container').children().length, 2);
+    });
+
+    it('shows subrows when a course has been taken multiple times', () => {
+      let courseRunCount = 3;
+      let course = generateCourseFromExisting(courseToClone, courseRunCount);
+      course.runs.forEach(run => {
+        run.status = STATUS_NOT_PASSED;
+      });
+
+      const wrapper = mount(
+        <CourseRow
+          course={course}
+          {...defaultRowProps}
+        />
+      );
+      assert.equal(
+        wrapper.find('.course-container .course-sub-row').length,
+        courseRunCount,
+        `Should have ${courseRunCount - 1} subrows for past runs & 1 subrow indicating future run status`
+      );
+    });
+
+    it('shows a subrow when a course was failed with no past runs and no available future runs', () => {
+      let pastCourseRunCount = 1;
+      let course = generateCourseFromExisting(courseToClone, pastCourseRunCount);
+      course.runs[0].status = STATUS_NOT_PASSED;
+
+      const wrapper = mount(
+        <CourseRow
+          course={course}
+          {...defaultRowProps}
+        />
+      );
+      assert.equal(wrapper.find('.course-container .course-sub-row').length, 1);
+    });
+
+    it('shows a subrow when a course was failed and a future run is available', () => {
+      let pastCourseRunCount = 1;
+      let course = generateCourseFromExisting(courseToClone, pastCourseRunCount);
+      let offeredCourseRun = _.cloneDeep(course.runs[0]);
+      course.runs[0].status = STATUS_NOT_PASSED;
+      offeredCourseRun.status = STATUS_OFFERED;
+      course.runs.push(offeredCourseRun);
+
+      const wrapper = mount(
+        <CourseRow
+          course={course}
+          {...defaultRowProps}
+        />
+      );
+      assert.equal(wrapper.find('.course-container .course-sub-row').length, 1);
     });
   });
 });

--- a/static/js/components/dashboard/CourseSubRow.js
+++ b/static/js/components/dashboard/CourseSubRow.js
@@ -1,0 +1,163 @@
+// @flow
+import React from 'react';
+import Grid, { Cell } from 'react-mdl/lib/Grid';
+import moment from 'moment';
+
+import CourseAction from './CourseAction';
+import type { CourseRun, FinancialAidUserInfo } from '../../flow/programTypes';
+import type { CoursePrice } from '../../flow/dashboardTypes';
+import { isCurrentlyEnrollable, formatGrade } from './util';
+import {
+  STATUS_OFFERED,
+  STATUS_NOT_PASSED,
+  DASHBOARD_FORMAT,
+  DASHBOARD_MONTH_FORMAT,
+} from '../../constants';
+
+export default class CourseSubRow extends React.Component {
+  props: {
+    courseRun: CourseRun,
+    checkout: Function,
+    coursePrice: CoursePrice,
+    now: moment$Moment,
+    financialAid: FinancialAidUserInfo,
+    hasFinancialAid: boolean,
+    openFinancialAidCalculator: () => void,
+    addCourseEnrollment: (courseId: string) => void,
+  };
+
+  getFormattedDateOrFuzzy(dateKey: string, fuzzyDateKey: string): string|null {
+    const { courseRun } = this.props;
+    if (courseRun[dateKey]) {
+      return moment(courseRun[dateKey]).format(DASHBOARD_FORMAT);
+    } else if (courseRun[fuzzyDateKey]) {
+      return courseRun[fuzzyDateKey];
+    }
+    return null;
+  }
+
+  getPastRunDateDisplay(): React$Element<*> {
+    const { courseRun } = this.props;
+
+    let dateText;
+    if (courseRun.course_end_date) {
+      let endDate = moment(courseRun.course_end_date).format(DASHBOARD_MONTH_FORMAT);
+      if (courseRun.course_start_date) {
+        let startDate = moment(courseRun.course_start_date).format(DASHBOARD_MONTH_FORMAT);
+        dateText = `${startDate} - ${endDate}`;
+      } else {
+        dateText = endDate;
+      }
+    } else if (courseRun.fuzzy_start_date) {
+      dateText = courseRun.fuzzy_start_date;
+    }
+    return <div className="detail" key="1">{ dateText }</div>;
+  }
+
+  renderOfferedDescription(): Array<React$Element<*>> {
+    const { courseRun, now } = this.props;
+
+    let rows = [
+      <div className="title" key="1">You can re-take this course!</div>
+    ];
+
+    let startDateText = this.getFormattedDateOrFuzzy('course_start_date', 'fuzzy_start_date');
+    if (startDateText) {
+      rows.push(
+        <div className="detail" key="2">Next course starts: { startDateText }</div>
+      );
+    }
+
+    let enrollStartDate = courseRun.enrollment_start_date ? moment(courseRun.enrollment_start_date) : null;
+    if (isCurrentlyEnrollable(enrollStartDate, now)) {
+      rows.push(
+        <div className="detail" key="3">Enrollment open</div>
+      );
+    } else {
+      let enrollStartDateText = this.getFormattedDateOrFuzzy('enrollment_start_date', 'fuzzy_enrollment_start_date');
+      if (enrollStartDateText) {
+        rows.push(
+          <div className="detail" key="3">Enrollment starts: { enrollStartDateText }</div>
+        );
+      }
+    }
+
+    return rows;
+  }
+
+  renderDescription(): React$Element<*> {
+    const { courseRun } = this.props;
+
+    let description = (courseRun.status === STATUS_OFFERED) ?
+      this.renderOfferedDescription() :
+      this.getPastRunDateDisplay();
+    return <div className="course-description">
+      { description }
+    </div>;
+  }
+
+  renderAction(): React$Element<any> {
+    const {
+      courseRun,
+      coursePrice,
+      checkout,
+      now,
+      financialAid,
+      hasFinancialAid,
+      openFinancialAidCalculator,
+      addCourseEnrollment
+    } = this.props;
+
+    if (courseRun.status === STATUS_OFFERED) {
+      let enrollStartDate = courseRun.enrollment_start_date ? moment(courseRun.enrollment_start_date) : null;
+      if (isCurrentlyEnrollable(enrollStartDate, now)) {
+        return <CourseAction
+          courseRun={courseRun}
+          coursePrice={coursePrice}
+          checkout={checkout}
+          now={now}
+          hasFinancialAid={hasFinancialAid}
+          financialAid={financialAid}
+          openFinancialAidCalculator={openFinancialAidCalculator}
+          addCourseEnrollment={addCourseEnrollment}
+        />;
+      }
+    }
+    return <div className="course-action">
+      { courseRun.status === STATUS_NOT_PASSED ? 'Failed' : '' }
+    </div>;
+  }
+
+  render() {
+    const { courseRun } = this.props;
+
+    let subRowClass = 'course-sub-row';
+    let contents;
+    if (!courseRun) {
+      contents = <Cell col={10}>
+        <div>No future courses are currently scheduled.</div>
+      </Cell>;
+    } else {
+      contents = [
+        <Cell col={6} key="1">
+          { this.renderDescription() }
+        </Cell>,
+        <Cell col={2} key="2">
+          <div className="course-grade">
+            { (courseRun.status === STATUS_NOT_PASSED) ? formatGrade(courseRun.final_grade) : '' }
+          </div>
+        </Cell>,
+        <Cell col={4} key="3">
+          { this.renderAction() }
+        </Cell>
+      ];
+      if (courseRun.status === STATUS_NOT_PASSED) {
+        subRowClass = `${subRowClass} course-not-passed`;
+      }
+    }
+
+    return <Grid className={subRowClass}>
+      { contents }
+    </Grid>;
+  }
+}

--- a/static/js/components/dashboard/CourseSubRow_test.js
+++ b/static/js/components/dashboard/CourseSubRow_test.js
@@ -1,0 +1,195 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import moment from 'moment';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import _ from 'lodash';
+
+import CourseSubRow from './CourseSubRow';
+import {
+  DASHBOARD_RESPONSE,
+  DASHBOARD_MONTH_FORMAT,
+  COURSE_PRICES_RESPONSE,
+  FINANCIAL_AID_PARTIAL_RESPONSE,
+  STATUS_NOT_PASSED,
+  STATUS_OFFERED,
+} from '../../constants';
+
+describe('CourseSubRow', () => {
+  let sandbox, defaultSubRowProps, courseRun, now;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    now = moment();
+    defaultSubRowProps = {
+      hasFinancialAid: true,
+      financialAid: FINANCIAL_AID_PARTIAL_RESPONSE,
+      coursePrice: COURSE_PRICES_RESPONSE[0],
+      openFinancialAidCalculator: sinon.stub(),
+      now: now,
+      checkout: sinon.stub(),
+      addCourseEnrollment: sinon.stub(),
+      key: '1'
+    };
+    courseRun = _.cloneDeep(DASHBOARD_RESPONSE[1].courses[0]);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('indicates that no future runs are available when a null course run was provided', () => {
+    const wrapper = shallow(
+      <CourseSubRow
+        courseRun={null}
+        {...defaultSubRowProps}
+      />
+    );
+    assert.include(wrapper.html(), 'No future courses are currently scheduled.');
+  });
+
+  it('shows information about a future course if the given course run has an "offered" status', () => {
+    courseRun.status = STATUS_OFFERED;
+    const wrapper = shallow(
+      <CourseSubRow
+        courseRun={courseRun}
+        {...defaultSubRowProps}
+      />
+    );
+    let subRowHTML = wrapper.html();
+    assert.include(subRowHTML, 'You can re-take this course!');
+  });
+
+  it('indicates open enrollment and presents an enrollment button if the course run is offered and current', () => {
+    courseRun = Object.assign(courseRun, {
+      status: STATUS_OFFERED,
+      enrollment_start_date: moment().add(-1, 'days'),
+      enrollment_end_date: moment().add(1, 'days')
+    });
+    const wrapper = mount(
+      <CourseSubRow
+        courseRun={courseRun}
+        {...defaultSubRowProps}
+      />
+    );
+    assert.include(wrapper.find(".course-description").html(), "Enrollment open");
+    assert.equal(wrapper.find(".course-grade").text().trim(), "");
+    let actionCell = wrapper.find(".course-action");
+    assert.equal(actionCell.find("button").text(), "Calculate Cost");
+    assert.equal(actionCell.find("a").text(), "Enroll and pay later");
+  });
+
+  it('indicates future enrollment and if a future course run is offered', () => {
+    courseRun = Object.assign(courseRun, {
+      status: STATUS_OFFERED,
+      enrollment_start_date: moment().add(1, 'days'),
+      enrollment_end_date: moment().add(3, 'days')
+    });
+    const wrapper = shallow(
+      <CourseSubRow
+        courseRun={courseRun}
+        {...defaultSubRowProps}
+      />
+    );
+    assert.include(wrapper.find(".course-description").html(), "Enrollment starts:");
+    assert.equal(wrapper.find(".course-action").text(), "");
+  });
+
+  it('shows fuzzy start date for offered course run if start date is missing', () => {
+    let fuzzyStartDate = 'Spring 2016';
+    courseRun = Object.assign(courseRun, {
+      status: STATUS_OFFERED,
+      course_start_date: null,
+      fuzzy_start_date: fuzzyStartDate
+    });
+    const wrapper = shallow(
+      <CourseSubRow
+        courseRun={courseRun}
+        {...defaultSubRowProps}
+      />
+    );
+    assert.equal(
+      wrapper.find(".course-description .detail").first().text(),
+      `Next course starts: ${fuzzyStartDate}`
+    );
+  });
+
+  it('omits course start date for offered course run if start date and fuzzy start date are missing', () => {
+    courseRun = Object.assign(courseRun, {
+      status: STATUS_OFFERED,
+      course_start_date: null,
+      fuzzy_start_date: null
+    });
+    const wrapper = mount(
+      <CourseSubRow
+        courseRun={courseRun}
+        {...defaultSubRowProps}
+      />
+    );
+    assert.notInclude(wrapper.find(".course-description").text(), "Next course starts:");
+  });
+
+  it('shows failed course information if the course run was failed', () => {
+    courseRun = Object.assign(courseRun, {
+      status: STATUS_NOT_PASSED,
+      final_grade: 50
+    });
+    const wrapper = shallow(
+      <CourseSubRow
+        courseRun={courseRun}
+        {...defaultSubRowProps}
+      />
+    );
+    assert.equal(wrapper.find(".course-grade").text(), "50%");
+    assert.equal(wrapper.find(".course-action").text(), "Failed");
+  });
+
+  it('shows a course date range for a failed course run', () => {
+    courseRun = Object.assign(courseRun, {
+      status: STATUS_NOT_PASSED,
+      course_start_date: moment().add(-3, 'months'),
+      course_end_date: moment().add(-1, 'months')
+    });
+    const wrapper = shallow(
+      <CourseSubRow
+        courseRun={courseRun}
+        {...defaultSubRowProps}
+      />
+    );
+    let formattedStart = courseRun.course_start_date.format(DASHBOARD_MONTH_FORMAT);
+    let formattedEnd = courseRun.course_end_date.format(DASHBOARD_MONTH_FORMAT);
+    assert.equal(wrapper.find(".course-description").text(), `${formattedStart} - ${formattedEnd}`);
+  });
+
+  it('shows a course end date for a failed course run', () => {
+    courseRun = Object.assign(courseRun, {
+      status: STATUS_NOT_PASSED,
+      course_start_date: null,
+      course_end_date: now
+    });
+    const wrapper = shallow(
+      <CourseSubRow
+        courseRun={courseRun}
+        {...defaultSubRowProps}
+      />
+    );
+    let formattedEnd = courseRun.course_end_date.format(DASHBOARD_MONTH_FORMAT);
+    assert.equal(wrapper.find(".course-description").text(), formattedEnd);
+  });
+
+  it('shows a fuzzy date for a failed course run', () => {
+    courseRun = Object.assign(courseRun, {
+      status: STATUS_NOT_PASSED,
+      course_start_date: null,
+      course_end_date: null,
+      fuzzy_start_date: 'Spring 2016'
+    });
+    const wrapper = shallow(
+      <CourseSubRow
+        courseRun={courseRun}
+        {...defaultSubRowProps}
+      />
+    );
+    assert.equal(wrapper.find(".course-description").text(), courseRun.fuzzy_start_date);
+  });
+});

--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -119,7 +119,7 @@ export default class FinancialAidCard extends React.Component {
         { courseListToolTip('filler-text', 'course-price') }
       </div>
       <div className="explanation">
-        The cost of courses in the {title} Micromasters varies
+        The cost of courses in the {title} MicroMasters varies
         between {price(minPossibleCost)} and {price(maxPossibleCost)},
         depending on your income and ability to pay.
       </div>

--- a/static/js/components/dashboard/util.js
+++ b/static/js/components/dashboard/util.js
@@ -2,6 +2,8 @@
 import ReactTooltip from 'react-tooltip';
 import IconButton from 'react-mdl/lib/IconButton';
 import React from 'react';
+import moment from 'moment';
+import _ from 'lodash';
 
 export const courseListToolTip = (text: string, id: string) => (
   <div>
@@ -16,3 +18,19 @@ export const courseListToolTip = (text: string, id: string) => (
     </ReactTooltip>
   </div>
 );
+
+export const isCurrentlyEnrollable = (enrollmentStartDate: ?moment$Moment, now: ?moment$Moment): boolean => (
+  enrollmentStartDate !== null &&
+    enrollmentStartDate !== undefined &&
+    enrollmentStartDate.isSameOrBefore(now || moment(), 'day')
+);
+
+export const formatGrade = (grade: number|string|null): string => {
+  if (_.isNil(grade) || grade === '') {
+    return '';
+  } else {
+    grade = Number(grade);
+    // isFinite will return true for numbers, false for strings and NaN
+    return _.isFinite(grade) ? `${_.round(grade)}%` : '';
+  }
+};

--- a/static/js/components/dashboard/util_test.js
+++ b/static/js/components/dashboard/util_test.js
@@ -1,0 +1,21 @@
+import { assert } from 'chai';
+import { formatGrade } from './util';
+
+describe('formatGrade', () => {
+  it('correctly formats a number-like grade', () => {
+    let expected = '80%';
+    assert.equal(formatGrade('80'), expected);
+    assert.equal(formatGrade('80.4'), expected);
+    assert.equal(formatGrade('79.6'), expected);
+    assert.equal(formatGrade(80), expected);
+    assert.equal(formatGrade(80.4), expected);
+    assert.equal(formatGrade(79.6), expected);
+  });
+
+  it('returns a blank string with null/blank/invalid input', () => {
+    let expected = '';
+    assert.equal(formatGrade(''), expected);
+    assert.equal(formatGrade(null), expected);
+    assert.equal(formatGrade('abc'), expected);
+  });
+});

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -7,6 +7,7 @@ export const DOCTORATE = 'p';
 
 export const ISO_8601_FORMAT = 'YYYY-MM-DD';
 export const DASHBOARD_FORMAT = 'M/D/Y';
+export const DASHBOARD_MONTH_FORMAT = 'M/Y';
 
 // NOTE: this is in order of attainment
 export const EDUCATION_LEVELS = [
@@ -38,6 +39,7 @@ export const STATUS_NOT_PASSED = 'not-passed';
 export const STATUS_CURRENTLY_ENROLLED = 'currently-enrolled';
 export const STATUS_WILL_ATTEND = 'will-attend';
 export const STATUS_CAN_UPGRADE = 'can-upgrade';
+export const STATUS_MISSED_DEADLINE = 'missed-deadline';
 export const STATUS_OFFERED = 'offered';
 
 // note: this status is not sent from the server
@@ -51,6 +53,7 @@ export const ALL_COURSE_STATUSES = [
   STATUS_CURRENTLY_ENROLLED,
   STATUS_WILL_ATTEND,
   STATUS_PENDING_ENROLLMENT,
+  STATUS_MISSED_DEADLINE,
 ];
 
 // financial aid statuses
@@ -536,17 +539,38 @@ export const DASHBOARD_RESPONSE = [
     "id": 4
   },
   {
+    "title": "Missed deadline program",
+    "description": "Missed deadline program",
+    "courses": [{
+      "id": 9,
+      "position_in_program": 0,
+      "title": "Course for the missed deadline program",
+      "description": "Course for the missed deadline program",
+      "prerequisites": "",
+      "runs": [{
+        "course_id": "course-v1:edX+missed+deadline",
+        "id": 6,
+        "status": STATUS_MISSED_DEADLINE,
+        "title": "Course run for the missed deadline program",
+        "position": 0,
+        "course_start_date": "2016-01-01",
+        "course_end_date": "2016-09-09T10:20:10Z",
+      }]
+    }],
+    "id": 5
+  },
+  {
     "title": "Last program",
     "description": "The last program",
     "courses": [
       {
-        "id": 9,
+        "id": 13,
         "position_in_program": 0,
         "title": "Course for last program in progress - no grade, action or description",
         "runs": [
           {
             "course_id": "course-v1:edX+DemoX+Demo_Course2",
-            "id": 6,
+            "id": 11,
             "status": STATUS_CURRENTLY_ENROLLED,
             "title": "Course run for last program",
             "position": 0,
@@ -560,7 +584,7 @@ export const DASHBOARD_RESPONSE = [
       },
     ],
     "financial_aid_availability": false,
-    "id": 5
+    "id": 6
   },
 ];
 

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -151,7 +151,7 @@ const FinancialAidCalculator = ({
     title="Cost Calculator"
   >
     <div className="copy">
-      { `The cost of courses in the ${title} Micromasters varies between ${minPossibleCost} and ${maxPossibleCost},
+      { `The cost of courses in the ${title} MicroMasters varies between ${minPossibleCost} and ${maxPossibleCost},
       depending on your income and ability to pay.`}
     </div>
     <div className="salary-input">

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -7,6 +7,7 @@ import { findCourseRun } from '../util/util';
 import { DASHBOARD_RESPONSE } from '../constants';
 import type {
   Course,
+  CourseRun,
   Program
 } from '../../flow/programTypes';
 
@@ -21,12 +22,45 @@ export function findCourse(courseSelector: (course: Course, program: Program) =>
   throw "Unable to find course";
 }
 
-export const alterFirstRun = (course: Course, overrideObject: Object): Course => {
+export const alterFirstRun = (course: Course, overrideObject: Object): CourseRun => {
   course.runs[0] = Object.assign({}, course.runs[0], overrideObject);
+  return course.runs[0];
 };
 
 export function findAndCloneCourse(courseSelector: (course: Course, program: Program) => boolean): Course {
   return _.cloneDeep(findCourse(courseSelector));
+}
+
+export function generateCourseFromExisting(courseToClone: Course, desiredRuns: number, runToCopy: ?CourseRun) {
+  let course = _.cloneDeep(courseToClone);
+  let currentRunCount = course.runs.length;
+  if (currentRunCount < desiredRuns) {
+    let courseRun = currentRunCount === 0 ? runToCopy : course.runs[0];
+    if (!courseRun) {
+      throw new Error('Need a course run to copy.');
+    }
+    let runsNeeded = desiredRuns - currentRunCount;
+    let idMax = _.max(_.map(course.runs, run => run.id)) || 0;
+    let positionMax = _.max(_.map(course.runs, run => run.position)) || 0;
+    for (let i = 0; i < runsNeeded; i++) {
+      let newCourseRun = _.cloneDeep(courseRun);
+      positionMax++;
+      idMax++;
+      Object.assign(newCourseRun, {
+        position: positionMax,
+        id: idMax,
+        course_id: `${newCourseRun.course_id}-new-${i}`
+      });
+      course.runs.push(newCourseRun);
+    }
+  } else if (currentRunCount > desiredRuns) {
+    course.runs = _.take(course.runs, desiredRuns);
+  }
+  Object.assign(course, {
+    id: 1,
+    position_in_program: 0
+  });
+  return course;
 }
 
 export const modifyTextField = (field, text) => {

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -206,13 +206,16 @@
       padding-left: 28px;
     }
 
+    .course-container {
+      border-bottom: 1px solid $lightgrey;
+    }
+
     .course-row {
       width: 100%;
       font-size: 11pt;
       min-height: 100px;
       align-items: center;
       padding: 0 20px;
-      border-bottom: 1px solid $lightgrey;
 
       &:last-child {
         border-bottom: none;
@@ -307,6 +310,48 @@
             border-color: #aaaaaa !important;
           }
         }
+      }
+
+      .long-description .course-action .description {
+        text-align: left;
+      }
+    }
+
+    .course-sub-row {
+      margin: 0px 15px 15px 15px;
+      font-size: 11pt;
+      min-height: 55px;
+      align-items: center;
+      padding: 5px 20px;
+      background-color: $fg-grey;
+      color: $darkgrey;
+
+      .course-description,
+      .course-grade,
+      .course-action  {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .course-action,
+      .course-grade {
+        align-items: center;
+        text-align: center;
+      }
+
+      .title {
+        font-weight: 500;
+        padding-bottom: 5px;
+        color: #000;
+      }
+
+      .detail {
+        font-weight: 400;
+        font-size: 10pt;
+      }
+
+      &.course-not-passed {
+        font-style: italic;
       }
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #939 
Fixes #1121 
Fixes #1122 

#### What's this PR do?

Handles courses with multiple runs per state. This is relevant in cases where the user has failed or missed an upgrade deadline for a course and we want to show them a future run, and also when the user has taken the course before multiple times.

#### Where should the reviewer start?

Probably CourseRow.js as well as dashboard/api.py where a few important changes were made

#### How should this be manually tested?

Here's a [gist](https://gist.github.com/gsidebo/478920b3ead11b4de742c076c2e8d64c) with some functions to help set up test data. Let me know if anything is confusing or doesn't work. Check #939 for the designs that these states should match

#### Screenshots (if appropriate)

![ss 2016-10-13 at 21 23 02](https://cloud.githubusercontent.com/assets/14932219/19372573/42b8a974-918b-11e6-9224-2b0e0eee57fd.png)


