### PR TITLE
Updated process count and basicauth exemption

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -2,6 +2,7 @@
 http-socket = :$(PORT)
 master = true
 processes = 10
+cheaper = 2
 die-on-term = true
 wsgi-file = micromasters/wsgi.py
 memory-report = true
@@ -11,5 +12,6 @@ enable-threads = true
 single-interpreter = true
 if-env = HTTP_AUTH_CREDENTIALS
 plugins = python,router_basicauth
+route = ^/api/v\d+/order_fulfillment/? continue:
 route = ^/.* basicauth:MicroMasters,%(_)
 endif =


### PR DESCRIPTION
#### What are the relevant tickets?
#1393 
#### What's this PR do?
Removes basicauth from cybersource callback and decreases initial process count at startup
#### Where should the reviewer start?
Trying to go through checkout flow with HTTP_AUTH_CREDENTIALS env var set
#### How should this be manually tested?
Trying to go through checkout flow with HTTP_AUTH_CREDENTIALS env var set
#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

- Exempted CyberSource callback from basicauth
- Decreased initial count of processes using `cheaper` config