### PR TITLE
Changed logic to assign the student ID

### DIFF
--- a/profiles/factories.py
+++ b/profiles/factories.py
@@ -14,7 +14,6 @@ from factory.fuzzy import (
     FuzzyAttribute,
     FuzzyChoice,
     FuzzyDate,
-    FuzzyInteger,
     FuzzyDateTime,
     FuzzyText,
 )
@@ -77,7 +76,7 @@ class ProfileFactory(DjangoModelFactory):
     )
     edx_mailing_address = FuzzyText()
     date_joined_micromasters = FuzzyDateTime(datetime(1850, 1, 1, tzinfo=timezone.utc))
-    student_id = FuzzyInteger(1, 1000)
+    student_id = None
 
     image = ImageField()
 

--- a/profiles/models_test.py
+++ b/profiles/models_test.py
@@ -17,6 +17,7 @@ class ProfileTests(ESTestCase):
         with mute_signals(post_save):
             profile = ProfileFactory()
         assert profile.student_id is not None
+        assert profile.student_id == profile.id
 
     def test_student_id_increments(self):
         """test that a student id increments correctly"""


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #1399
#### What's this PR do?
Changes the code for assigning a student id to the user profile. Now the profile pk is used.