### PR TITLE
Added webpack_public_path

### DIFF
--- a/static/js/faculty_carousel.js
+++ b/static/js/faculty_carousel.js
@@ -1,5 +1,6 @@
 // @flow
-/* global SETTINGS:false */
+/* global SETTINGS: false */
+__webpack_public_path__ = `http://${SETTINGS.host}:8078/`;  // eslint-disable-line no-undef, camelcase
 import FacultyCarousel from './components/FacultyCarousel';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/static/js/sentry_client.js
+++ b/static/js/sentry_client.js
@@ -1,4 +1,5 @@
-/* global SETTINGS:false */
+/* global SETTINGS: false */
+__webpack_public_path__ = `http://${SETTINGS.host}:8078/`;  // eslint-disable-line no-undef, camelcase
 import Raven from 'raven-js';
 
 Raven.config(SETTINGS.sentry_dsn, {

--- a/static/js/signup_dialog.js
+++ b/static/js/signup_dialog.js
@@ -1,4 +1,5 @@
 /* global SETTINGS: false */
+__webpack_public_path__ = `http://${SETTINGS.host}:8078/`;  // eslint-disable-line no-undef, camelcase
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1398

#### What's this PR do?
Sets `__webpack_public_path__` on bundles where it is missing. This helps enable hot reloading, a dev feature

#### How should this be manually tested?
Change the color in some CSS and verify that there is not a full page refresh

