### PR TITLE
Fix a bug in course enrollment text

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -129,12 +129,14 @@ class Course(models.Model):
             return "Ongoing - {end}".format(end=end_text)
         elif course_run.is_future:
             if course_run.is_future_enrollment_open:
-                end_text = 'Enrollment Open'
+                end_text = ' - Enrollment Open'
             elif course_run.enrollment_start:
-                end_text = 'Enrollment {:%m/%Y}'.format(
+                end_text = ' - Enrollment {:%m/%Y}'.format(
                     course_run.enrollment_start
                 )
-            return "Starts {start:%D} - {end}".format(
+            else:
+                end_text = ''
+            return "Starts {start:%D}{end}".format(
                 start=course_run.start_date,
                 end=end_text,
             )

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -281,6 +281,18 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
         )
         assert self.course.enrollment_text == text
 
+    def test_future_course_no_enr(self):
+        """Test course in the future, no enrollment dates"""
+        future_date = self.now + timedelta(weeks=1)
+        expected_text = 'Starts {:%D}'.format(future_date)
+        self.create_run(
+            start=future_date,
+            end=self.now + timedelta(weeks=10),
+            enr_start=None,
+            enr_end=None,
+        )
+        assert self.course.enrollment_text == expected_text
+
     def test_current_course(self):
         """Test current course, enrollment ends soon"""
         text = 'Ongoing - Enrollment Ends {:%D}'.format(


### PR DESCRIPTION
Fix for #1408. Restores the correct logic from the `get_course_enrollment_text()` function in 89d844044e578a179de3bce01067a927e618c872.