### PR TITLE
Fixed error in year validation logic

### DIFF
--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -21,6 +21,8 @@ export const PERSONAL_STEP = 'personal';
 export const EMPLOYMENT_STEP = 'employment';
 export const EDUCATION_STEP = 'education';
 
+export const YEAR_VALIDATION_CUTOFF = 120;
+
 export const PROFILE_STEP_LABELS = new Map([
   [PERSONAL_STEP, "Personal"],
   [EDUCATION_STEP, "Education"],

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -8,3 +8,6 @@ declare var it: Function;
 declare var beforeEach: Function;
 declare var afterEach: Function;
 declare var describe: Function;
+
+// webpack
+declare var __webpack_public_path__: string; // eslint-disable-line camelcase

--- a/static/js/util/validation.js
+++ b/static/js/util/validation.js
@@ -20,6 +20,7 @@ import {
   EDUCATION_STEP,
   EMPLOYMENT_STEP,
 } from '../constants';
+import { YEAR_VALIDATION_CUTOFF } from '../constants';
 import { S } from './sanctuary';
 const { Maybe, Nothing } = S;
 
@@ -294,14 +295,16 @@ export function validateYear(input: string|number|null): Maybe<number> {
   if (year === undefined) {
     return Nothing();
   }
-  if ( year < 1800 ) {
+  let now = moment().year();
+  let cutoff = now - YEAR_VALIDATION_CUTOFF;
+  if ( year < cutoff ) {
     if ( String(year).length < 4 ) {
       return Maybe.of(year);
     }
-    return Maybe.of(1800);
+    return Maybe.of(cutoff);
   }
-  if ( year >= 2100) {
-    return Maybe.of(2100);
+  if ( year >= now ) {
+    return Maybe.of(now);
   }
   return Maybe.of(year);
 }

--- a/static/js/util/validation_test.js
+++ b/static/js/util/validation_test.js
@@ -26,6 +26,7 @@ import {
   EMPLOYMENT_STEP,
 } from '../constants';
 import { assertMaybeEquality, assertIsNothing } from './sanctuary_test';
+import { YEAR_VALIDATION_CUTOFF } from '../constants';
 
 describe('Profile validation functions', () => {
   let sandbox;
@@ -375,7 +376,7 @@ describe('Profile validation functions', () => {
 
     it('strips non-numerical characters', () => {
       assertMaybeEquality(Just(2004), validateYear("2e004"));
-      assertMaybeEquality(Just(2034), validateYear("203-4"));
+      assertMaybeEquality(Just(2014), validateYear("201-4"));
     });
 
     it('returns values for years less than 1800 if they are less than 4 character', () => {
@@ -385,15 +386,14 @@ describe('Profile validation functions', () => {
       assertMaybeEquality(Just(20), validateYear("-20"));
     });
 
-    it('returns 1800 for 4-character years less than 1800', () => {
-      assertMaybeEquality(Just(1800), validateYear("1799"));
-      assertMaybeEquality(Just(1800), validateYear("1099"));
+    it(`returns a minimum of ${YEAR_VALIDATION_CUTOFF} years ago`, () => {
+      let cutoff = moment().subtract(YEAR_VALIDATION_CUTOFF, 'years').year();
+      assertMaybeEquality(Just(cutoff), validateYear(`${cutoff - 5}`));
     });
 
-    it('returns 2100 for years >= 2100', () => {
-      assertMaybeEquality(Just(2100), validateYear("2100"));
-      assertMaybeEquality(Just(2100), validateYear("2300"));
-      assertMaybeEquality(Just(2100), validateYear("52300"));
+    it('returns a maximum of the current year', () => {
+      let now = moment().year();
+      assertMaybeEquality(Just(now), validateYear(`${now + 3}`));
     });
 
     it('returns an empty string if the text is not an integer number', () => {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1405 

#### What's this PR do?

this fixes the year validation for the profile. basically, the range of allowed years `n` now looks like `x - 120 <= n <= x` where `x` is the current year. when `x = 2016` the range is `1896 - 2016`.

#### Where should the reviewer start?

look over the logic and test changes.

#### How should this be manually tested?

go to `/learner` and open the basic info dialog. edit your birthday. you should only be able to enter years in the range above. years greater than or less than the bounds should be corrected to the closest bound (so that `1700 -> 1896`, and `2250 -> 2016`, for instance).

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

