### PR TITLE
Add complete financial aid instructions

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -97,3 +97,6 @@ export const setProgram = createAction(SET_PROGRAM);
 
 export const SET_CONFIRM_SKIP_DIALOG_VISIBILITY = 'SET_CONFIRM_SKIP_DIALOG_VISIBILITY';
 export const setConfirmSkipDialogVisibility = createAction(SET_CONFIRM_SKIP_DIALOG_VISIBILITY);
+
+export const SET_DOCS_INSTRUCTIONS_VISIBILITY = 'SET_DOCS_INSTRUCTIONS_VISIBILITY';
+export const setDocsInstructionsVisibility = createAction(SET_DOCS_INSTRUCTIONS_VISIBILITY);

--- a/static/js/actions/ui_test.js
+++ b/static/js/actions/ui_test.js
@@ -24,6 +24,7 @@ import {
   SET_CALCULATOR_DIALOG_VISIBILITY,
   SET_PROGRAM,
   SET_CONFIRM_SKIP_DIALOG_VISIBILITY,
+  SET_DOCS_INSTRUCTIONS_VISIBILITY,
 
   clearUI,
   updateDialogText,
@@ -50,6 +51,7 @@ import {
   setCalculatorDialogVisibility,
   setProgram,
   setConfirmSkipDialogVisibility,
+  setDocsInstructionsVisibility,
 } from '../actions/ui';
 import { assertCreatedActionHelper } from './util';
 
@@ -81,6 +83,7 @@ describe('generated UI action helpers', () => {
       [setCalculatorDialogVisibility, SET_CALCULATOR_DIALOG_VISIBILITY],
       [setProgram, SET_PROGRAM],
       [setConfirmSkipDialogVisibility, SET_CONFIRM_SKIP_DIALOG_VISIBILITY],
+      [setDocsInstructionsVisibility, SET_DOCS_INSTRUCTIONS_VISIBILITY],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/components/DocsInstructionsDialog.js
+++ b/static/js/components/DocsInstructionsDialog.js
@@ -1,0 +1,85 @@
+// @flow
+import React from 'react';
+import Dialog from 'material-ui/Dialog';
+import Icon from 'react-mdl/lib/Icon';
+
+const dialogTitle = setDialogVisibility => (
+  <div className="docs-instructions-title">
+    <div className="text" key={1}>
+      Income Verification Instructions
+    </div>
+    <Icon name="close" onClick={() => setDialogVisibility(false)} key={2} />
+  </div>
+);
+
+type DocsInstructions = {
+  open:                 boolean,
+  setDialogVisibility:  (v: boolean) => void,
+};
+
+const DocsInstructionsDialog = ({ open, setDialogVisibility }: DocsInstructions) => (
+  <Dialog
+    open={open}
+    className="docs-instructions-dialog"
+    onRequestClose={() => setDialogVisibility(false)}
+    autoScrollBodyContent={true}
+    title={dialogTitle(setDialogVisibility)}
+  >
+    <div className="heading">
+      Whose income should I report?
+    </div>
+    <p>
+      Please report your own household income; that is, the combined income of all
+      people that are part of your household or place of residence. If you live
+      with, or are financially supported by your parent(s)/legal guardians, please
+      enter their combined income instead. For example, if you are a full-time
+      student with no income of your own, you should declare the combined income of
+      your parents or legal guardians instead.
+    </p>
+    <div className="heading">
+      What documents do you require to verify the income information I entered?
+    </div>
+    <p>
+      If we ask you for supporting documentation to verify the income you declared,
+      we require that you submit the a photocopy of the most recent tax return of all
+      income earners in your household as defined above.
+    </p>
+    <div className="heading">
+      What if I am unable to provide you with a tax return?
+    </div>
+    <p>
+      If you unable able to provide us with your tax return form, we will accept
+      notarized income statements. An income statement is a statement of annual
+      salary, printed on the official letterhead of the relevant employer (including
+      the employer’s address and contact information) and signed by the employer.
+      Notarization means that the income statement you submit to us has to signed
+      by an authorized notary and contain his or her official seal/stamp and
+      contact information. If your household income is based on more than one
+      earner, you have to submit notarized income statements for each of the people
+      whose income you used to calculate total household income.
+    </p>
+    <div className="heading">
+      What if I am unemployed, and not a student?
+    </div>
+    <p>
+      Please submit either one of the following: a tax return (filed for zero
+      income), a photocopy of an official receipt or check of unemployment benefits
+      received, or a notarized letter verifying your unemployment status.
+    </p>
+    <div className="heading">
+      What should I do if my financial documents are written in a language other than English?
+    </div>
+    <p>
+      Please submit notarized income statement(s) in English, if at all possible. If
+      the employer(s) in question are unable to provide you with income statement(s)
+      written in English, you have to provide a translation of the statement(s) and
+      submit this along with the original, notarized income statement when you mail
+      or fax your documents. If you are submitting a tax return in a language other
+      than English, you also have to provide a translation in addition to the tax
+      return. We do not require the translation to be certified – you can translate
+      the document yourself.
+    </p>
+  </Dialog>
+);
+
+export default DocsInstructionsDialog;

--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -41,6 +41,7 @@ export default class FinancialAidCard extends React.Component {
     setConfirmSkipDialogVisibility: (b: boolean) => void,
     ui:                             UIState,
     skipFinancialAid:               () => void,
+    setDocsInstructionsVisibility:  (b: boolean) => void,
   };
 
   submitDocuments = (): void => {
@@ -141,6 +142,7 @@ export default class FinancialAidCard extends React.Component {
       program,
       coursePrice,
       setConfirmSkipDialogVisibility,
+      setDocsInstructionsVisibility,
     } = this.props;
 
     switch (program.financial_aid_user_info.application_status) {
@@ -171,6 +173,11 @@ export default class FinancialAidCard extends React.Component {
           <Cell col={12}>
             Before you can pay, you need to verify your income. Please mail or fax an
             English-translated and notarized income tax or income statement document.
+          </Cell>
+          <Cell col={12}>
+            <a onClick={() => setDocsInstructionsVisibility(true)}>
+              Read Complete Instructions
+            </a>
           </Cell>
         </Grid>
 

--- a/static/js/components/dashboard/FinancialAidCard_test.js
+++ b/static/js/components/dashboard/FinancialAidCard_test.js
@@ -53,6 +53,7 @@ describe("FinancialAidCard", () => {
           ui={INITIAL_UI_STATE}
           setConfirmSkipDialogVisibility={setSkipDialogStub}
           skipFinancialAid={sandbox.stub()}
+          setDocsInstructionsVisibility={sandbox.stub()}
           {...props}
         />
       </MuiThemeProvider>

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -27,6 +27,7 @@ import { addCourseEnrollment } from '../actions/enrollments';
 import {
   setToastMessage,
   setConfirmSkipDialogVisibility,
+  setDocsInstructionsVisibility,
 } from '../actions/ui';
 import { createForm, findCourseRun } from '../util/util';
 import CourseListCard from '../components/dashboard/CourseListCard';
@@ -55,6 +56,7 @@ import type { ProfileGetResult } from '../flow/profileTypes';
 import type { Course, CourseRun } from '../flow/programTypes';
 import { skipFinancialAid } from '../actions/financial_aid';
 import { currencyForCountry } from '../util/currency';
+import DocsInstructionsDialog from '../components/DocsInstructionsDialog';
 
 class DashboardPage extends React.Component {
   static contextTypes = {
@@ -213,6 +215,11 @@ class DashboardPage extends React.Component {
     return dispatch(addCourseEnrollment(courseId));
   };
 
+  setDocsInstructionsVisibility = bool => {
+    const { dispatch } = this.props;
+    dispatch(setDocsInstructionsVisibility(bool));
+  };
+
   render() {
     const {
       dashboard,
@@ -249,12 +256,17 @@ class DashboardPage extends React.Component {
           skipFinancialAid={this.skipFinancialAid}
           updateDocumentSentDate={this.updateDocumentSentDate}
           setConfirmSkipDialogVisibility={this.setConfirmSkipDialogVisibility}
+          setDocsInstructionsVisibility={this.setDocsInstructionsVisibility}
           ui={ui}
         />;
       }
 
       dashboardContent = (
         <div className="double-column">
+          <DocsInstructionsDialog
+            open={ui.docsInstructionsVisibility}
+            setDialogVisibility={this.setDocsInstructionsVisibility}
+          />
           <div className="first-column">
             <DashboardUserCard profile={profile} program={program}/>
             {financialAidCard}

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -36,6 +36,7 @@ import {
   SET_PHOTO_DIALOG_VISIBILITY,
   SET_CALCULATOR_DIALOG_VISIBILITY,
   SET_CONFIRM_SKIP_DIALOG_VISIBILITY,
+  SET_DOCS_INSTRUCTIONS_VISIBILITY,
 } from '../actions/ui';
 import { PERSONAL_STEP } from '../constants';
 import type { ToastMessage } from '../flow/generalTypes';
@@ -76,6 +77,7 @@ export type UIState = {
   documentSentDate:             Object;
   selectedProgram:              Program;
   skipDialogVisibility:         boolean;
+  docsInstructionsVisibility:   boolean;
 };
 
 export const INITIAL_UI_STATE: UIState = {
@@ -106,6 +108,7 @@ export const INITIAL_UI_STATE: UIState = {
   documentSentDate: {},
   selectedProgram: null,
   skipDialogVisibility: false,
+  docsInstructionsVisibility: false,
 };
 
 export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
@@ -238,6 +241,8 @@ export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
     return { ...state, calculatorDialogVisibility: action.payload };
   case SET_CONFIRM_SKIP_DIALOG_VISIBILITY:
     return { ...state, skipDialogVisibility: action.payload };
+  case SET_DOCS_INSTRUCTIONS_VISIBILITY:
+    return { ...state, docsInstructionsVisibility: action.payload };
   default:
     return state;
   }

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -28,6 +28,7 @@ import {
   setPhotoDialogVisibility,
   setCalculatorDialogVisibility,
   setConfirmSkipDialogVisibility,
+  setDocsInstructionsVisibility,
 } from '../actions/ui';
 import { INITIAL_UI_STATE } from '../reducers/ui';
 import { PERSONAL_STEP } from '../constants';
@@ -184,6 +185,12 @@ describe('ui reducers', () => {
   describe('Skip dialog visibility', () => {
     it('should let you set skip dialog visibility', () => {
       assertReducerResultState(setConfirmSkipDialogVisibility, ui => ui.skipDialogVisibility, false);
+    });
+  });
+
+  describe('docs instructions visibility', () => {
+    it('should let you set the document instruction visibility', () => {
+      assertReducerResultState(setDocsInstructionsVisibility, ui => ui.docsInstructionsVisibility, false);
     });
   });
 });

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -132,10 +132,10 @@
   .price-explanation {
     display: flex;
     justify-content: space-between;
+  }
 
-    a {
-      cursor: pointer;
-    }
+  a {
+    cursor: pointer;
   }
 
   .document-row {

--- a/static/scss/docs-instructions.scss
+++ b/static/scss/docs-instructions.scss
@@ -1,0 +1,29 @@
+.docs-instructions-dialog {
+  .heading, p {
+    color: $font-black;
+  }
+
+  .heading {
+    margin: 15px 0;
+    font-weight: 500;
+  }
+
+  .heading:first-child {
+    margin-top: 0;
+  }
+
+  p {
+    text-align: justify;
+  }
+
+  .docs-instructions-title {
+    border-bottom: none !important;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+
+    i {
+      cursor: pointer;
+    }
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -26,6 +26,7 @@
 @import "profile-image";
 @import "profile-image-uploader";
 @import "calculator";
+@import "docs-instructions";
 
 .selected {
   font-weight: bold;


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #1358 

#### What's this PR do?

This adds a popup to the dashboard which contains all the info you could ever want about financial aid (specifically about income verification). There's a link in the `FinancialAidCard` which opens the dialog.

#### Where should the reviewer start?

#### How should this be manually tested?

Use the django shell or something to ensure your user has a financial aid object with `status = 'pending-docs'`. Then navigate to `/dashboard`, and you should see a link to 'Read Complete Instructions'. Clicking on that should open the pop-up.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

![readasdfasdf](https://cloud.githubusercontent.com/assets/6207644/19448536/42c2d24a-9470-11e6-9918-dbe44b366f87.png)

![insfasdf](https://cloud.githubusercontent.com/assets/6207644/19448543/46ec9bc6-9470-11e6-8a87-6ab6460dac84.png)


#### What GIF best describes this PR or how it makes you feel?
