### PR TITLE
Added persistent connection settings for DB

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: newrelic-admin run-program uwsgi uwsgi.ini
-worker: celery -A micromasters worker
+worker: celery -A micromasters worker -B
+extra_worker: celery -A micromasters worker

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -231,6 +231,7 @@ DEFAULT_DATABASE_CONFIG = dj_database_url.parse(
         'sqlite:///{0}'.format(os.path.join(BASE_DIR, 'db.sqlite3'))
     )
 )
+DEFAULT_DATABASE_CONFIG['CONN_MAX_AGE'] = int(get_var('MICROMASTERS_DB_CONN_MAX_AGE', 500))
 
 if get_var('MICROMASTERS_DB_DISABLE_SSL', False):
     DEFAULT_DATABASE_CONFIG['OPTIONS'] = {}


### PR DESCRIPTION
#### What are the relevant tickets?

#### What's this PR do?
Adds persistent DB connections by default and adds the beat scheduler to the Celery worker

#### Where should the reviewer start?

#### How should this be manually tested?
Using the locust load testing tool to validate performance improvements

#### Any background context you want to provide?
When this config is absent a new connection is made to the DB for every transaction which adds significant overhead. Adding this setting reduces latency and I/O for improved performance and capacity.

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

- Added var for setting DB persistent connections
- Added Celery beat and extra_worker to Procfile for task scheduling