### PR TITLE
Added serialize_model, replaced to_dict

### DIFF
--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -196,6 +196,7 @@ class MMTrackTest(TestCase):
         fin_aid = FinancialAidFactory.create(
             user=self.user,
             tier_program=self.min_tier_program,
+            date_documents_sent=None,
         )
         mmtrack = MMTrack(
             user=self.user,

--- a/financialaid/factories.py
+++ b/financialaid/factories.py
@@ -8,6 +8,7 @@ from factory.django import DjangoModelFactory, mute_signals
 from factory.fuzzy import (
     FuzzyAttribute,
     FuzzyChoice,
+    FuzzyDate,
     FuzzyDateTime,
     FuzzyFloat,
     FuzzyInteger,
@@ -66,6 +67,7 @@ class FinancialAidFactory(DjangoModelFactory):
     original_currency = FuzzyText(length=3)
     country_of_income = FuzzyText(length=2)
     date_exchange_rate = FuzzyDateTime(datetime.datetime(2000, 1, 1, tzinfo=UTC))
+    date_documents_sent = FuzzyDate(datetime.date(2000, 1, 1))
 
     @classmethod
     def create(cls, **kwargs):

--- a/financialaid/models.py
+++ b/financialaid/models.py
@@ -13,7 +13,7 @@ from django.db import (
 
 from courses.models import Program
 from financialaid.constants import FinancialAidStatus
-from micromasters.utils import serialize_model
+from micromasters.utils import serialize_model_object
 
 
 class TimestampedModelQuerySet(models.query.QuerySet):
@@ -140,8 +140,8 @@ class FinancialAid(TimestampedModel):
         FinancialAidAudit.objects.create(
             acting_user=acting_user,
             financial_aid=self,
-            data_before=serialize_model(financialaid_before),
-            data_after=serialize_model(self),
+            data_before=serialize_model_object(financialaid_before),
+            data_after=serialize_model_object(self),
         )
 
 

--- a/financialaid/models.py
+++ b/financialaid/models.py
@@ -10,10 +10,10 @@ from django.db import (
     models,
     transaction,
 )
-from django.forms.models import model_to_dict
 
 from courses.models import Program
 from financialaid.constants import FinancialAidStatus
+from micromasters.utils import serialize_model
 
 
 class TimestampedModelQuerySet(models.query.QuerySet):
@@ -118,17 +118,6 @@ class FinancialAid(TimestampedModel):
     date_documents_sent = models.DateField(null=True, blank=True)
     justification = models.TextField(null=True)
 
-    def to_dict(self):
-        """
-        Get the model_to_dict of self
-        """
-        ret = model_to_dict(self)
-        if self.date_exchange_rate is not None:
-            ret["date_exchange_rate"] = ret["date_exchange_rate"].isoformat()
-        if self.date_documents_sent is not None:
-            ret["date_documents_sent"] = ret["date_documents_sent"].isoformat()
-        return ret
-
     def save(self, *args, **kwargs):
         """
         Override save to make sure only one FinancialAid object exists for a User and the associated Program
@@ -151,8 +140,8 @@ class FinancialAid(TimestampedModel):
         FinancialAidAudit.objects.create(
             acting_user=acting_user,
             financial_aid=self,
-            data_before=financialaid_before.to_dict(),
-            data_after=self.to_dict()
+            data_before=serialize_model(financialaid_before),
+            data_after=serialize_model(self),
         )
 
 

--- a/financialaid/models_test.py
+++ b/financialaid/models_test.py
@@ -14,7 +14,7 @@ from financialaid.models import (
     FinancialAidAudit,
     FinancialAidStatus
 )
-from micromasters.utils import serialize_model
+from micromasters.utils import serialize_model_object
 from profiles.factories import ProfileFactory
 from search.base import ESTestCase
 
@@ -62,7 +62,7 @@ class FinancialAidModelsTests(ESTestCase):
             profile = ProfileFactory.create()
         acting_user = profile.user
         financial_aid = FinancialAidFactory.create()
-        original_before_json = serialize_model(financial_aid)
+        original_before_json = serialize_model_object(financial_aid)
         # Make sure audit object is created
         assert FinancialAidAudit.objects.count() == 0
         financial_aid.status = FinancialAidStatus.AUTO_APPROVED
@@ -70,7 +70,7 @@ class FinancialAidModelsTests(ESTestCase):
         assert FinancialAidAudit.objects.count() == 1
         # Make sure the before and after data are correct
         financial_aid.refresh_from_db()
-        original_after_json = serialize_model(financial_aid)
+        original_after_json = serialize_model_object(financial_aid)
         financial_aid_audit = FinancialAidAudit.objects.first()
         before_json = financial_aid_audit.data_before
         after_json = financial_aid_audit.data_after

--- a/financialaid/models_test.py
+++ b/financialaid/models_test.py
@@ -1,7 +1,6 @@
 """
 Tests for financialaid models
 """
-import datetime
 from django.core.exceptions import ValidationError
 from django.db.models.signals import post_save
 from factory.django import mute_signals
@@ -15,6 +14,7 @@ from financialaid.models import (
     FinancialAidAudit,
     FinancialAidStatus
 )
+from micromasters.utils import serialize_model
 from profiles.factories import ProfileFactory
 from search.base import ESTestCase
 
@@ -62,7 +62,7 @@ class FinancialAidModelsTests(ESTestCase):
             profile = ProfileFactory.create()
         acting_user = profile.user
         financial_aid = FinancialAidFactory.create()
-        original_before_json = financial_aid.to_dict()
+        original_before_json = serialize_model(financial_aid)
         # Make sure audit object is created
         assert FinancialAidAudit.objects.count() == 0
         financial_aid.status = FinancialAidStatus.AUTO_APPROVED
@@ -70,7 +70,7 @@ class FinancialAidModelsTests(ESTestCase):
         assert FinancialAidAudit.objects.count() == 1
         # Make sure the before and after data are correct
         financial_aid.refresh_from_db()
-        original_after_json = financial_aid.to_dict()
+        original_after_json = serialize_model(financial_aid)
         financial_aid_audit = FinancialAidAudit.objects.first()
         before_json = financial_aid_audit.data_before
         after_json = financial_aid_audit.data_after
@@ -88,42 +88,3 @@ class FinancialAidModelsTests(ESTestCase):
                 self.assertAlmostEqual(value, original_after_json[field])
             else:
                 assert value == original_after_json[field]
-
-    def test_to_dict(self):
-        """
-        Tests the to_dict() function on FinancialAid
-        """
-        financial_aid = FinancialAidFactory.create(date_documents_sent=datetime.datetime.now())
-        financial_aid_dict = financial_aid.to_dict()
-        audit_key_list = [
-            "country_of_income",
-            "date_documents_sent",
-            "date_exchange_rate",
-            "id",
-            "income_usd",
-            "justification",
-            "original_currency",
-            "original_income",
-            "status",
-            "tier_program",
-            "user"
-        ]
-        assert set(financial_aid_dict.keys()) == set(audit_key_list)
-        assert financial_aid_dict["user"] == financial_aid.user.id
-        assert financial_aid_dict["tier_program"] == financial_aid.tier_program.id
-        assert financial_aid_dict["status"] == financial_aid.status
-        assert financial_aid_dict["original_currency"] == financial_aid.original_currency
-        assert financial_aid_dict["country_of_income"] == financial_aid.country_of_income
-        assert financial_aid_dict["date_exchange_rate"] == financial_aid.date_exchange_rate.isoformat()
-        assert financial_aid_dict["date_documents_sent"] == financial_aid.date_documents_sent.isoformat()
-        self.assertAlmostEqual(financial_aid_dict["income_usd"], financial_aid.income_usd)
-        self.assertAlmostEqual(financial_aid_dict["original_income"], financial_aid.original_income)
-
-    def test_to_dict_with_null_values(self):  # pylint: disable=no-self-use
-        """
-        Tests the to_dict() function on FinancialAid with none-values in date fields
-        """
-        financial_aid = FinancialAidFactory.create(date_exchange_rate=None, date_documents_sent=None)
-        financial_aid_dict = financial_aid.to_dict()
-        assert financial_aid_dict["date_exchange_rate"] is None
-        assert financial_aid_dict["date_documents_sent"] is None

--- a/micromasters/utils.py
+++ b/micromasters/utils.py
@@ -65,7 +65,7 @@ def custom_exception_handler(exc, context):
         )
 
 
-def serialize_model(obj):
+def serialize_model_object(obj):
     """
     Serialize model into a dict representable as JSON
 
@@ -77,6 +77,6 @@ def serialize_model(obj):
     """
     # serialize works on iterables so we need to wrap object in a list, then unwrap it
     data = json.loads(serialize('json', [obj]))[0]
-    fields = data['fields']
-    fields['id'] = data['pk']
-    return fields
+    serialized = data['fields']
+    serialized['id'] = data['pk']
+    return serialized

--- a/micromasters/utils.py
+++ b/micromasters/utils.py
@@ -5,6 +5,7 @@ import json
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.core.serializers import serialize
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
@@ -62,3 +63,20 @@ def custom_exception_handler(exc, context):
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             data=[formatted_exception_string]
         )
+
+
+def serialize_model(obj):
+    """
+    Serialize model into a dict representable as JSON
+
+    Args:
+        obj (django.db.models.Model): An instantiated Django model
+    Returns:
+        dict:
+            A representation of the model
+    """
+    # serialize works on iterables so we need to wrap object in a list, then unwrap it
+    data = json.loads(serialize('json', [obj]))[0]
+    fields = data['fields']
+    fields['id'] = data['pk']
+    return fields

--- a/micromasters/utils_test.py
+++ b/micromasters/utils_test.py
@@ -4,11 +4,25 @@ Tests for the utils module
 
 from django.core.exceptions import ImproperlyConfigured
 from django.template import RequestContext
-from django.test import RequestFactory, TestCase
+from django.test import (
+    override_settings,
+    RequestFactory,
+    TestCase,
+)
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
 
-from micromasters.utils import custom_exception_handler
+from ecommerce.factories import (
+    CoursePriceFactory,
+    ReceiptFactory,
+)
+from financialaid.factories import (
+    FinancialAidFactory,
+)
+from micromasters.utils import (
+    custom_exception_handler,
+    serialize_model,
+)
 
 
 class ExceptionHandlerTest(TestCase):
@@ -47,3 +61,66 @@ class ExceptionHandlerTest(TestCase):
         exp = IndexError('index error')
         resp = custom_exception_handler(exp, self.context)
         assert resp is None
+
+
+def format_as_iso8601(time):
+    """Helper function to format datetime with the Z at the end"""
+    # Can't use datetime.isoformat() because format is slightly different from this
+    iso_format = '%Y-%m-%dT%H:%M:%S.%f'
+    # chop off microseconds to make milliseconds
+    return time.strftime(iso_format)[:-3] + "Z"
+
+
+# pylint: disable=no-self-use
+class SerializerTests(TestCase):
+    """
+    Tests for serialize_model
+    """
+    def test_jsonfield(self):
+        """
+        Test a model with a JSONField is handled correctly
+        """
+        with override_settings(CYBERSOURCE_SECURITY_KEY='asdf'):
+            receipt = ReceiptFactory.create()
+            assert serialize_model(receipt) == {
+                'created_at': format_as_iso8601(receipt.created_at),
+                'data': receipt.data,
+                'id': receipt.id,
+                'modified_at': format_as_iso8601(receipt.modified_at),
+                'order': receipt.order.id,
+            }
+
+    def test_datetime(self):
+        """
+        Test that a model with a datetime and date field is handled correctly
+        """
+        financial_aid = FinancialAidFactory.create(justification=None)
+        assert serialize_model(financial_aid) == {
+            'country_of_income': financial_aid.country_of_income,
+            'created_on': format_as_iso8601(financial_aid.created_on),
+            'date_documents_sent': financial_aid.date_documents_sent.isoformat(),
+            'date_exchange_rate': format_as_iso8601(financial_aid.date_exchange_rate),
+            'id': financial_aid.id,
+            'income_usd': financial_aid.income_usd,
+            'justification': None,
+            'original_currency': financial_aid.original_currency,
+            'original_income': financial_aid.original_income,
+            'status': financial_aid.status,
+            'tier_program': financial_aid.tier_program.id,
+            'updated_on': format_as_iso8601(financial_aid.updated_on),
+            'user': financial_aid.user.id,
+        }
+
+    def test_decimal(self):
+        """
+        Test that a model with a decimal field is handled correctly
+        """
+        course_price = CoursePriceFactory.create()
+        assert serialize_model(course_price) == {
+            'course_run': course_price.course_run.id,
+            'created_at': format_as_iso8601(course_price.created_at),
+            'id': course_price.id,
+            'is_valid': course_price.is_valid,
+            'modified_at': format_as_iso8601(course_price.modified_at),
+            'price': str(course_price.price),
+        }

--- a/micromasters/utils_test.py
+++ b/micromasters/utils_test.py
@@ -21,7 +21,7 @@ from financialaid.factories import (
 )
 from micromasters.utils import (
     custom_exception_handler,
-    serialize_model,
+    serialize_model_object,
 )
 
 
@@ -82,7 +82,7 @@ class SerializerTests(TestCase):
         """
         with override_settings(CYBERSOURCE_SECURITY_KEY='asdf'):
             receipt = ReceiptFactory.create()
-            assert serialize_model(receipt) == {
+            assert serialize_model_object(receipt) == {
                 'created_at': format_as_iso8601(receipt.created_at),
                 'data': receipt.data,
                 'id': receipt.id,
@@ -95,7 +95,7 @@ class SerializerTests(TestCase):
         Test that a model with a datetime and date field is handled correctly
         """
         financial_aid = FinancialAidFactory.create(justification=None)
-        assert serialize_model(financial_aid) == {
+        assert serialize_model_object(financial_aid) == {
             'country_of_income': financial_aid.country_of_income,
             'created_on': format_as_iso8601(financial_aid.created_on),
             'date_documents_sent': financial_aid.date_documents_sent.isoformat(),
@@ -116,7 +116,7 @@ class SerializerTests(TestCase):
         Test that a model with a decimal field is handled correctly
         """
         course_price = CoursePriceFactory.create()
-        assert serialize_model(course_price) == {
+        assert serialize_model_object(course_price) == {
             'course_run': course_price.course_run.id,
             'created_at': format_as_iso8601(course_price.created_at),
             'id': course_price.id,


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1421 

#### What's this PR do?
Creates a general serializer method for models

#### How should this be manually tested?
Checkout master and make a financial aid request using the UI. Verify that `FinancialAidAudit` has information in `data_before` and `data_after` matching the most recent request. Then checkout this branch and in the UI skip financial aid. Verify that the information in `FinancialAidAudit` is substantially the same. `data_before` for the most recent entry and `data_after` for the second most recent entry should match up almost exactly. The formatted datetime output may differ slightly and there will be extra fields, but nothing else should change.
