### PR TITLE
Note Flow incompatibility within Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,5 +262,10 @@ Tests should be run in the Docker container, not the host machine. They can be r
     docker-compose run watch npm test /path/to/test.js
     # Run the JS linter
     docker-compose run watch npm run-script lint
+
+You can also run JS type-checking using [flow](https://flowtype.org), but this
+will *not* work if you run it in the Docker container (if you are not running
+Linux as your host operating system). Instead, run it on your host OS:
+
     # Run JS type-checking
-    docker-compose run watch npm run-script flow
+    npm run-script flow

--- a/README.md
+++ b/README.md
@@ -262,10 +262,12 @@ Tests should be run in the Docker container, not the host machine. They can be r
     docker-compose run watch npm test /path/to/test.js
     # Run the JS linter
     docker-compose run watch npm run-script lint
-
-You can also run JS type-checking using [flow](https://flowtype.org), but this
-will *not* work if you run it in the Docker container (if you are not running
-Linux as your host operating system). Instead, run it on your host OS:
-
     # Run JS type-checking
+    docker-compose run watch npm run-script flow
+
+Note that running [`flow`](https://flowtype.org) may not work properly if your
+host machine isn't running Linux. If you are using a Mac, you'll need to run
+`flow` on your host machine, like this:
+
+    npm install
     npm run-script flow


### PR DESCRIPTION
This pull request adds a note to the README, explaining that `flow` can't be run through Docker.

@aliceriot: I think this is why I was seeing an error when trying to run `flow`. For reference, here's the error I'm seeing:

```bash
$ docker-compose run watch npm run-script flow
npm info it worked if it ends with ok
npm info using npm@3.9.5
npm info using node@v6.2.2
npm info lifecycle micromasters@0.0.0~preflow: micromasters@0.0.0
npm info lifecycle micromasters@0.0.0~flow: micromasters@0.0.0

> micromasters@0.0.0 flow /src
> flow check

/src/node_modules/flow-bin/vendor/flow: 1: /src/node_modules/flow-bin/vendor/flow: Syntax error: word unexpected (expecting ")")

npm info lifecycle micromasters@0.0.0~flow: Failed to exec flow script
npm ERR! Linux 4.4.24-boot2docker
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run-script" "flow"
npm ERR! node v6.2.2
npm ERR! npm  v3.9.5
npm ERR! code ELIFECYCLE
npm ERR! micromasters@0.0.0 flow: `flow check`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the micromasters@0.0.0 flow script 'flow check'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the micromasters package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     flow check
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs micromasters
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls micromasters
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /src/npm-debug.log
```