### PR TITLE
Line-height fix for Course list on program page

### DIFF
--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -143,6 +143,10 @@
       ol {
         list-style: none;
         padding: 0;
+
+        li {
+          margin: 0 0 22px 0;
+        }
       }
 
       .title, .title a {
@@ -151,6 +155,7 @@
         font-size: 16px;
         margin: 0 0 6px 0;
         cursor: pointer;
+        line-height: 1.4em;
 
         &:hover {
           text-decoration: underline;
@@ -160,6 +165,7 @@
       .description {
         color: $font-gray;
         font-size: 15px;
+        line-height: 1.4em;
       }
 
       .enrollment-dates {


### PR DESCRIPTION
#### What are the relevant tickets?

#1477 

#### What's this PR do?

This is a very quick fix to the line-height and spacing in the courses box on the Program page.

#### How should this be manually tested?

Look at the layout of the Courses text in the gray box on the program page. Make sure the text is long enough so it breaks to 2 lines.

#### Screenshot 

![image](https://cloud.githubusercontent.com/assets/20047260/19566158/436705ba-96b7-11e6-9ffa-ea188d1e9e16.png)
