### PR TITLE
Protected audit tables

### DIFF
--- a/ecommerce/migrations/0008_protect_audit.py
+++ b/ecommerce/migrations/0008_protect_audit.py
@@ -9,11 +9,11 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            "CREATE RULE delete_protect AS ON DELETE TO ecommerce_orderaudit DO INSTEAD NOTHING",
-            "DROP RULE delete_protect ON ecommerce_orderaudit",
+            sql="CREATE RULE delete_protect AS ON DELETE TO ecommerce_orderaudit DO INSTEAD NOTHING",
+            reverse_sql="DROP RULE delete_protect ON ecommerce_orderaudit",
         ),
         migrations.RunSQL(
-            "CREATE RULE update_protect AS ON UPDATE TO ecommerce_orderaudit DO INSTEAD NOTHING",
-            "DROP RULE update_protect ON ecommerce_orderaudit",
+            sql="CREATE RULE update_protect AS ON UPDATE TO ecommerce_orderaudit DO INSTEAD NOTHING",
+            reverse_sql="DROP RULE update_protect ON ecommerce_orderaudit",
         ),
     ]

--- a/ecommerce/migrations/0008_protect_audit.py
+++ b/ecommerce/migrations/0008_protect_audit.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ecommerce', '0007_orderaudit'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "CREATE RULE delete_protect AS ON DELETE TO ecommerce_orderaudit DO INSTEAD NOTHING",
+            "DROP RULE delete_protect ON ecommerce_orderaudit",
+        ),
+        migrations.RunSQL(
+            "CREATE RULE update_protect AS ON UPDATE TO ecommerce_orderaudit DO INSTEAD NOTHING",
+            "DROP RULE update_protect ON ecommerce_orderaudit",
+        ),
+    ]

--- a/ecommerce/migrations/0009_protect_audit.py
+++ b/ecommerce/migrations/0009_protect_audit.py
@@ -4,7 +4,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('ecommerce', '0007_orderaudit'),
+        ('ecommerce', '0008_add_refunded_status'),
     ]
 
     operations = [

--- a/financialaid/migrations/0019_protect_audit.py
+++ b/financialaid/migrations/0019_protect_audit.py
@@ -9,11 +9,11 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            "CREATE RULE delete_protect AS ON DELETE TO financialaid_financialaidaudit DO INSTEAD NOTHING",
-            "DROP RULE delete_protect ON financialaid_financialaidaudit",
+            sql="CREATE RULE delete_protect AS ON DELETE TO financialaid_financialaidaudit DO INSTEAD NOTHING",
+            reverse_sql="DROP RULE delete_protect ON financialaid_financialaidaudit",
         ),
         migrations.RunSQL(
-            "CREATE RULE update_protect AS ON UPDATE TO financialaid_financialaidaudit DO INSTEAD NOTHING",
-            "DROP RULE update_protect ON financialaid_financialaidaudit",
+            sql="CREATE RULE update_protect AS ON UPDATE TO financialaid_financialaidaudit DO INSTEAD NOTHING",
+            reverse_sql="DROP RULE update_protect ON financialaid_financialaidaudit",
         ),
     ]

--- a/financialaid/migrations/0019_protect_audit.py
+++ b/financialaid/migrations/0019_protect_audit.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('financialaid', '0018_alter_audit_nullability'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "CREATE RULE delete_protect AS ON DELETE TO financialaid_financialaidaudit DO INSTEAD NOTHING",
+            "DROP RULE delete_protect ON financialaid_financialaidaudit",
+        ),
+        migrations.RunSQL(
+            "CREATE RULE update_protect AS ON UPDATE TO financialaid_financialaidaudit DO INSTEAD NOTHING",
+            "DROP RULE update_protect ON financialaid_financialaidaudit",
+        ),
+    ]

--- a/mail/migrations/0003_protect_audit.py
+++ b/mail/migrations/0003_protect_audit.py
@@ -9,11 +9,11 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            "CREATE RULE delete_protect AS ON DELETE TO mail_financialaidemailaudit DO INSTEAD NOTHING",
-            "DROP RULE delete_protect ON mail_financialaidemailaudit",
+            sql="CREATE RULE delete_protect AS ON DELETE TO mail_financialaidemailaudit DO INSTEAD NOTHING",
+            reverse_sql="DROP RULE delete_protect ON mail_financialaidemailaudit",
         ),
         migrations.RunSQL(
-            "CREATE RULE update_protect AS ON UPDATE TO mail_financialaidemailaudit DO INSTEAD NOTHING",
-            "DROP RULE update_protect ON mail_financialaidemailaudit",
+            sql="CREATE RULE update_protect AS ON UPDATE TO mail_financialaidemailaudit DO INSTEAD NOTHING",
+            reverse_sql="DROP RULE update_protect ON mail_financialaidemailaudit",
         ),
     ]

--- a/mail/migrations/0003_protect_audit.py
+++ b/mail/migrations/0003_protect_audit.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mail', '0002_update_audit'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "CREATE RULE delete_protect AS ON DELETE TO mail_financialaidemailaudit DO INSTEAD NOTHING",
+            "DROP RULE delete_protect ON mail_financialaidemailaudit",
+        ),
+        migrations.RunSQL(
+            "CREATE RULE update_protect AS ON UPDATE TO mail_financialaidemailaudit DO INSTEAD NOTHING",
+            "DROP RULE update_protect ON mail_financialaidemailaudit",
+        ),
+    ]


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1450 

#### What's this PR do?
Adds postgres rules for `OrderAudit`, `FinancialAidAudit`, and `FinancialAidEmailAudit` to prevent `UPDATE` or `DELETE` of the table.

#### How should this be manually tested?
You should be able to run the migrations and reverse the migrations successfully. Any attempt to edit and save an existing instance of one of the audit models will cause an exception. For example, try saving an `OrderAudit` instance in the Django Admin. If you reverse the migration, you should be able to save the `OrderAudit` instance again without error.
