### PR TITLE
Set background color of Zendesk button

### DIFF
--- a/static/js/entry/zendesk_widget.js
+++ b/static/js/entry/zendesk_widget.js
@@ -1,4 +1,4 @@
-/* global SETTINGS:false */
+/* global SETTINGS:false zE:false */
 __webpack_public_path__ = `http://${SETTINGS.host}:8078/`;  // eslint-disable-line no-undef, camelcase
 
 // Start of odl Zendesk Widget script
@@ -28,3 +28,71 @@ window.zEmbed || function (e, t) {
     o.close();
 }("https://assets.zendesk.com/embeddable_framework/main.js", "odl.zendesk.com");
  /*]]>*/
+
+
+// This will execute when Zendesk's Javascript is finished executing, and the
+// Web Widget API is available to be used. The HTML for the Zendesk widget
+// may *not* have been inserted into the DOM yet.
+zE(function() {
+  // trigger onZendeskIFrameExists at the appropriate time
+  let tries = 0;
+  let intervalID = setInterval(() => {
+    tries += 1;
+    let iframe = document.querySelector("iframe.zEWidget-launcher");
+    if (iframe) {
+      clearInterval(intervalID);
+      onZendeskIFrameExists();
+    } else if (tries > 100) { // max 100 tries (10 seconds)
+      console.error("couldn't find Zendesk iframe");  // eslint-disable-line no-console
+      clearInterval(intervalID);
+    }
+  }, 100); // check every 100 milliseconds
+});
+
+// This will execute when Zendesk's <iframe> element has been inserted into
+// the DOM. The <iframe> may *not* have finished loading its content yet.
+let onZendeskIFrameExists = () => {
+  // trigger onZendeskIFrameLoaded at the appropriate time
+  let tries = 0;
+  let intervalID = setInterval(() => {
+    tries += 1;
+    let iframe = document.querySelector("iframe.zEWidget-launcher");
+    let btn = iframe.contentDocument.querySelector(".Button--launcher");
+    if (btn) {
+      clearInterval(intervalID);
+      onZendeskIFrameLoaded();
+    } else if (tries > 100) { // max 100 tries (10 seconds)
+      console.error("couldn't load Zendesk iframe");  // eslint-disable-line no-console
+      clearInterval(intervalID);
+    }
+  }, 100); // check every 100 milliseconds
+};
+
+// This will execute when Zendesk's <iframe> element has finished loading
+// its content. It would be nice if we could just use iframe.onload,
+// but because the page is loaded from a different domain, the browser
+// won't allow us to detect that event.
+let onZendeskIFrameLoaded = () => {
+  let iframe = document.querySelector("iframe.zEWidget-launcher");
+  let btn = iframe.contentDocument.querySelector(".Button--launcher");
+
+  let regularBackgroundColor = "rgba(0, 0, 0, .14)";
+  let hoverBackgroundColor = window.getComputedStyle(btn).backgroundColor;
+  // We need to set a new background color, and unfortunately,
+  // the existing background color is set with "!important".
+  // As a result, the only way to overriding this existing color is to
+  // *also* use "!important".
+  let setHover = () => {
+    btn.style.setProperty(
+      "background-color", hoverBackgroundColor, "important"
+    );
+  };
+  let unsetHover = () => {
+    btn.style.setProperty(
+      "background-color", regularBackgroundColor, "important"
+    );
+  };
+  btn.onmouseenter = setHover;
+  btn.onmouseleave = unsetHover;
+  unsetHover();
+};

--- a/static/js/entry/zendesk_widget.js
+++ b/static/js/entry/zendesk_widget.js
@@ -36,9 +36,9 @@ window.zEmbed || function (e, t) {
 zE(function() {
   // trigger onZendeskIFrameExists at the appropriate time
   let tries = 0;
-  let intervalID = setInterval(() => {
+  const intervalID = setInterval(() => {
     tries += 1;
-    let iframe = document.querySelector("iframe.zEWidget-launcher");
+    const iframe = document.querySelector("iframe.zEWidget-launcher");
     if (iframe) {
       clearInterval(intervalID);
       onZendeskIFrameExists();
@@ -54,10 +54,10 @@ zE(function() {
 let onZendeskIFrameExists = () => {
   // trigger onZendeskIFrameLoaded at the appropriate time
   let tries = 0;
-  let intervalID = setInterval(() => {
+  const intervalID = setInterval(() => {
     tries += 1;
-    let iframe = document.querySelector("iframe.zEWidget-launcher");
-    let btn = iframe.contentDocument.querySelector(".Button--launcher");
+    const iframe = document.querySelector("iframe.zEWidget-launcher");
+    const btn = iframe.contentDocument.querySelector(".Button--launcher");
     if (btn) {
       clearInterval(intervalID);
       onZendeskIFrameLoaded();
@@ -73,21 +73,21 @@ let onZendeskIFrameExists = () => {
 // but because the page is loaded from a different domain, the browser
 // won't allow us to detect that event.
 let onZendeskIFrameLoaded = () => {
-  let iframe = document.querySelector("iframe.zEWidget-launcher");
-  let btn = iframe.contentDocument.querySelector(".Button--launcher");
+  const iframe = document.querySelector("iframe.zEWidget-launcher");
+  const btn = iframe.contentDocument.querySelector(".Button--launcher");
 
-  let regularBackgroundColor = "rgba(0, 0, 0, .14)";
-  let hoverBackgroundColor = window.getComputedStyle(btn).backgroundColor;
+  const regularBackgroundColor = "rgba(0, 0, 0, .14)";
+  const hoverBackgroundColor = window.getComputedStyle(btn).backgroundColor;
   // We need to set a new background color, and unfortunately,
   // the existing background color is set with "!important".
   // As a result, the only way to overriding this existing color is to
   // *also* use "!important".
-  let setHover = () => {
+  const setHover = () => {
     btn.style.setProperty(
       "background-color", hoverBackgroundColor, "important"
     );
   };
-  let unsetHover = () => {
+  const unsetHover = () => {
     btn.style.setProperty(
       "background-color", regularBackgroundColor, "important"
     );


### PR DESCRIPTION
Fixes #1487. This change hacks the Zendesk Web Widget API to detect when we can modify the DOM of Zendesk's modifications to the page, and then goes in and changes the background color of the button.

<img width="480" alt="zendesk button background changed" src="https://cloud.githubusercontent.com/assets/132355/19605713/b9f58138-978a-11e6-876f-110ef3b46464.png">