### PR TITLE
Refactor date validation

### DIFF
--- a/static/js/components/EducationDialog.js
+++ b/static/js/components/EducationDialog.js
@@ -105,7 +105,7 @@ export default class EducationDialog extends ProfileFormFields {
         {this.boundTextField(keySet('school_name'), 'School Name')}
       </Cell>
       <Cell col={5}>
-        {this.boundDateField(keySet('graduation_date'), 'Graduation Date', true)}
+        {this.boundDateField(keySet('graduation_date'), 'Graduation Date', true, true)}
       </Cell>
       <Cell col={4}>
         <CountrySelectField

--- a/static/js/components/inputs/DateField.js
+++ b/static/js/components/inputs/DateField.js
@@ -11,9 +11,10 @@ import { ISO_8601_FORMAT } from '../../constants';
 import { validationErrorSelector } from '../../util/util';
 import {
   validateMonth,
-  validateYear,
   validateDay,
-} from '../../util/validation';
+  validateYear,
+  validateNearFutureYear,
+} from '../../util/date_validation';
 
 export default class DateField extends React.Component {
   props: {
@@ -24,6 +25,7 @@ export default class DateField extends React.Component {
     keySet: Array<string>,
     label: string,
     omitDay: boolean,
+    allowFutureYear: boolean,
   };
 
   render() {
@@ -35,6 +37,7 @@ export default class DateField extends React.Component {
       keySet,
       label,
       omitDay,
+      allowFutureYear,
     } = this.props;
 
     // make a copy of keySet with a slightly different key for temporary storage of the textfields being edited
@@ -96,7 +99,13 @@ export default class DateField extends React.Component {
       let validatedMonth = validateMonth(newEdit.month);
       newEdit.month = mstr(validatedMonth);
 
-      let validatedYear = validateYear(newEdit.year);
+      let validatedYear;
+      if ( allowFutureYear ) {
+        validatedYear = validateNearFutureYear(newEdit.year);
+      } else {
+        validatedYear = validateYear(newEdit.year);
+      }
+
       newEdit.year = mstr(validatedYear);
 
       // keep text up to date

--- a/static/js/util/currency.js
+++ b/static/js/util/currency.js
@@ -29,7 +29,7 @@ const codeToOption = code => (
 
 const labelSort = R.sortBy(R.compose(R.toLower, R.prop('label')));
 
-const invalidCurrency = R.flip(R.contains)(excludedCurrencyCodes);
+const invalidCurrency = R.contains(R.__, excludedCurrencyCodes);
 
 const codesToOptions = R.compose(
   labelSort, R.map(codeToOption), R.reject(invalidCurrency)

--- a/static/js/util/date_validation.js
+++ b/static/js/util/date_validation.js
@@ -1,0 +1,70 @@
+// @flow
+import R from 'ramda';
+import moment from 'moment';
+
+import { S, ifNil } from './sanctuary';
+const { Maybe, Nothing } = S;
+import { filterPositiveInt } from './util';
+import { YEAR_VALIDATION_CUTOFF } from '../constants';
+
+/**
+ * Removes non-numeric characters and truncates output string
+ */
+const digits = R.replace(/[^\d]+/g, '');
+
+const trimLeadingZeros = (length, input) => (
+  input.length <= length ? input : R.replace(/^0+/, '', input)
+);
+
+export const sanitizeNumberString = R.curry((length, input) => (
+  R.slice(0, length, trimLeadingZeros(length, digits(String(input))))
+));
+
+/**
+  * validate a day input
+  */
+export const checkDayRange = ifNil(day => day > 31 ? Maybe.of(31) : Maybe.of(day));
+
+export const validateDay = R.compose(
+  checkDayRange, filterPositiveInt, sanitizeNumberString(2)
+);
+
+/**
+ * Validate a month input
+ */
+export const checkMonthRange = ifNil(month => month > 12 ? Maybe.of(12) : Maybe.of(month));
+
+export const validateMonth = R.compose(
+  checkMonthRange, filterPositiveInt, sanitizeNumberString(2)
+);
+
+/**
+  * Validate a year input
+  *
+  * checks to make sure a year n is in the range of
+  * x - YEAR_VALIDATION_CUTOFF <= n <= highCutoff,
+  * where x is moment().year()
+  */
+export const validYearInput = R.curry((highCutoff, year) => {
+  if ( year === undefined ) {
+    return Nothing();
+  } else {
+    return String(year).length < 4 ? Maybe.of(year) : checkYearRange(highCutoff, year);
+  }
+});
+
+export const checkYearRange = (highCutoff: number, year: number) => {
+  let now = moment().year();
+  return Maybe.of(R.max(now - YEAR_VALIDATION_CUTOFF, R.min(highCutoff, year)));
+};
+
+export const validateYear = ifNil(
+  R.compose(validYearInput(moment().year()), filterPositiveInt, sanitizeNumberString(4))
+);
+
+/**
+  * checks that year is valid, with years up to 10 years in the future being allowable
+  */
+export const validateNearFutureYear = ifNil(
+  R.compose(validYearInput(moment().add(10, 'years').year()), filterPositiveInt, sanitizeNumberString(4))
+);

--- a/static/js/util/date_validation_test.js
+++ b/static/js/util/date_validation_test.js
@@ -1,0 +1,245 @@
+// @flow
+import { assert } from 'chai';
+import moment from 'moment';
+import { S } from './sanctuary';
+const { Just } = S;
+
+import {
+  sanitizeNumberString,
+  checkYearRange,
+  checkMonthRange,
+  checkDayRange,
+  validateDay,
+  validateMonth,
+  validateYear,
+  validateNearFutureYear,
+} from './date_validation';
+import { YEAR_VALIDATION_CUTOFF } from '../constants';
+import { assertMaybeEquality, assertIsNothing } from './sanctuary_test';
+
+describe('Date validation', () => {
+  describe('helper functions', () => {
+    describe('sanitizeNumberString', () => {
+      describe('string input', () => {
+        it('should remove any non-numerical characters', () => {
+          [
+            ['-', 2, ''],
+            ['-32', 2, '32'],
+            ['asdf', 19, ''],
+            ['A(*@$%!@#$100', 2, '10'],
+            ['eggplant 1X00 hey', 10, '100']
+          ].forEach(([input, length, expectation]) => {
+            assert.deepEqual(sanitizeNumberString(length, input), expectation);
+          });
+        });
+
+        it('should trim the input down to the desired length', () => {
+          [
+            ['1999', 2, '19'],
+            ['1x9', 2, '19'],
+            ['1', 4, '1'],
+            ['', 18318, ''],
+            ['TESTS', 25, ''],
+            ['1991', 0, '']
+          ].forEach(([input, length, expectation]) => {
+            assert.deepEqual(sanitizeNumberString(length, input), expectation);
+          });
+        });
+
+        it('should leave leading zeros when under the length', () => {
+          assert.equal(sanitizeNumberString(2, '09'), '09');
+        });
+
+        it('should remove leading zeros when over the length', () => {
+          assert.equal(sanitizeNumberString(4, '01999'), '1999');
+        });
+      });
+
+      describe('numerical input', () => {
+        it('should return a string', () => {
+          assert.deepEqual(sanitizeNumberString(1, 3), '3');
+        });
+
+        it('should trim a number down to the correct number of places', () => {
+          [
+            [1999, 4, '1999'],
+            [1999, 2, '19'],
+            [112341234, 1, '1']
+          ].forEach(([input, length, expectation]) => {
+            assert.deepEqual(sanitizeNumberString(length, input), expectation);
+          });
+        });
+      });
+    });
+
+    describe('checkYearRange', () => {
+      const currentYear = moment().year();
+      const lowCutoff = currentYear - YEAR_VALIDATION_CUTOFF;
+
+      it('should return Just(low cutoff) if the year is too low', () => {
+        assertMaybeEquality(Just(lowCutoff), checkYearRange(currentYear, lowCutoff - 10));
+      });
+
+      it('should return the input if the year is between the cutoffs', () => {
+        assertMaybeEquality(Just(lowCutoff + 5), checkYearRange(currentYear, lowCutoff + 5));
+      });
+
+      it('should return the high cutoff if the year is too high', () => {
+        assertMaybeEquality(Just(currentYear), checkYearRange(currentYear, currentYear + 10));
+      });
+    });
+
+    describe('checkMonthRange', () => {
+      it('should return 12 at most', () => {
+        assertMaybeEquality(Just(12), checkMonthRange(25));
+      });
+
+      it('should return x when 1 <= x <= 12', () => {
+        for (let i = 1; i < 13; i++) {
+          assertMaybeEquality(Just(i), checkMonthRange(i));
+        }
+      });
+    });
+
+    describe('checkDayRange', () => {
+      it('should return 31 at most', () => {
+        assertMaybeEquality(Just(31), checkDayRange(35));
+      });
+
+      it('should return x when 1 <= x <= 31', () => {
+        for (let i = 1; i < 32; i++) {
+          assertMaybeEquality(Just(i), checkDayRange(i));
+        }
+      });
+    });
+  });
+
+  describe('validateMonth', () => {
+    it('handles months starting with 0 without treating as octal', () => {
+      assertMaybeEquality(Just(9), validateMonth("09"));
+    });
+
+    it('converts strings to numbers', () => {
+      for (let i = 1; i < 13; i++) {
+        assertMaybeEquality(Just(i), validateMonth(String(i)));
+      }
+    });
+
+    it('strips out any non-numerical characters', () => {
+      assertMaybeEquality(Just(12), validateMonth("1e2"));
+      assertMaybeEquality(Just(4), validateMonth("0-4"));
+      assertMaybeEquality(Just(3), validateMonth("-3"));
+    });
+
+    it('returns 12 for any number >= 12', () => {
+      assertMaybeEquality(Just(12), validateMonth("3.4"));
+      assertMaybeEquality(Just(12), validateMonth("13"));
+    });
+
+    it('will let a user input a leading zero', () => {
+      assertMaybeEquality(Just(0), validateMonth("0"));
+      assertMaybeEquality(Just(8), validateMonth("08"));
+    });
+
+    it('returns Nothing if the text is not an integer number', () => {
+      assertIsNothing(validateMonth(""));
+      assertIsNothing(validateMonth("two"));
+      assertIsNothing(validateMonth(null));
+      assertIsNothing(validateMonth({}));
+      assertIsNothing(validateMonth(undefined));
+    });
+  });
+
+  describe('year validation functions', () => {
+    [
+      [validateYear, 'validateYear'],
+      [validateNearFutureYear, 'validateNearFutureYear']
+    ].forEach(([func, name]) => {
+      describe(`basic validation for ${name}`, () => {
+        it('handles years starting with 0 without treating as octal', () => {
+          assertMaybeEquality(Just(1999), func("01999"));
+        });
+
+        it('converts strings to numbers', () => {
+          assertMaybeEquality(Just(1943), func("1943"));
+        });
+
+        it('strips non-numerical characters', () => {
+          assertMaybeEquality(Just(2004), func("2e004"));
+          assertMaybeEquality(Just(2014), func("201-4"));
+        });
+
+        it('returns values for years less than 1800 if they are less than 4 character', () => {
+          assertMaybeEquality(Just(3), func("3"));
+          assertMaybeEquality(Just(703), func("703"));
+          assertMaybeEquality(Just(0), func("0"));
+          assertMaybeEquality(Just(20), func("-20"));
+        });
+
+        it(`returns a minimum of ${YEAR_VALIDATION_CUTOFF} years ago`, () => {
+          let cutoff = moment().subtract(YEAR_VALIDATION_CUTOFF, 'years').year();
+          assertMaybeEquality(Just(cutoff), func(`${cutoff - 5}`));
+        });
+
+        it('returns an empty string if the text is not an integer number', () => {
+          assertIsNothing(func(""));
+          assertIsNothing(func("two"));
+          assertIsNothing(func(null));
+          assertIsNothing(func("@#"));
+          assertIsNothing(func({}));
+          assertIsNothing(func(undefined));
+        });
+      });
+    });
+
+    it('validateYear returns a maximum of the current year', () => {
+      let now = moment().year();
+      assertMaybeEquality(Just(now), validateYear(`${now + 3}`));
+    });
+
+    it('validateNearFutureYear returns a maximum of the current year + 10', () => {
+      let now = moment().year();
+      assertMaybeEquality(Just(now + 3), validateNearFutureYear(`${now + 3}`));
+      assertMaybeEquality(Just(now + 10), validateNearFutureYear(`${now + 45}`));
+    });
+  });
+
+  describe('validateDay', () => {
+    it('handles dates starting with 0 without treating as octal', () => {
+      assertMaybeEquality(Just(1), validateDay("01"));
+    });
+
+    it('converts strings to numbers', () => {
+      assertMaybeEquality(Just(3), validateDay("3"));
+    });
+
+    it("allows leading zeros", () => {
+      assertMaybeEquality(Just(0), validateDay("0"));
+      assertMaybeEquality(Just(1), validateDay("01"));
+    });
+
+    it('disallows non-numerical input', () => {
+      assertMaybeEquality(Just(3), validateDay("-3"));
+      assertMaybeEquality(Just(20), validateDay("2e0"));
+      assertMaybeEquality(Just(21), validateDay("2-1"));
+      assertMaybeEquality(Just(22), validateDay("2.2"));
+    });
+
+    it('returns 31 for dates greater than 31', () => {
+      assertMaybeEquality(Just(31), validateDay("32"));
+      assertMaybeEquality(Just(31), validateDay("71"));
+    });
+
+    it('truncates to the first 2 characters of input', () => {
+      assertMaybeEquality(Just(22), validateDay("220"));
+    });
+
+    it('returns an empty string if the text is not an integer number', () => {
+      assertIsNothing(validateDay(""));
+      assertIsNothing(validateDay("two"));
+      assertIsNothing(validateDay(null));
+      assertIsNothing(validateDay({}));
+      assertIsNothing(validateDay(undefined));
+    });
+  });
+});

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -129,7 +129,7 @@ export function boundTextField(keySet: string[], label: string): React$Element<*
  * to update date fields
  * pass in the name (used as placeholder), key for profile.
  */
-export function boundDateField(keySet: string[], label: string, omitDay: boolean): React$Element<*> {
+export function boundDateField(keySet: string[], label: string, omitDay: boolean, allowFutureYear: boolean = false): React$Element<*> { // eslint-disable-line max-len
   const {
     profile,
     errors,
@@ -145,6 +145,7 @@ export function boundDateField(keySet: string[], label: string, omitDay: boolean
     keySet={keySet}
     label={label}
     omitDay={omitDay}
+    allowFutureYear={allowFutureYear}
   />;
 }
 

--- a/static/js/util/profile_edit_test.js
+++ b/static/js/util/profile_edit_test.js
@@ -9,7 +9,7 @@ import {
   boundRadioGroupField,
   saveProfileStep,
 } from './profile_edit';
-import * as validation from '../util/validation';
+import * as dateValidation from '../util/date_validation';
 import { YEAR_VALIDATION_CUTOFF } from '../constants';
 
 describe('Profile Editing utility functions', () => {
@@ -132,9 +132,9 @@ describe('Profile Editing utility functions', () => {
     };
 
     beforeEach(() => {
-      validateYearSpy = sandbox.spy(validation, 'validateYear');
-      validateMonthSpy = sandbox.spy(validation, 'validateMonth');
-      validateDaySpy = sandbox.spy(validation, 'validateDay');
+      validateYearSpy = sandbox.spy(dateValidation, 'validateYear');
+      validateMonthSpy = sandbox.spy(dateValidation, 'validateMonth');
+      validateDaySpy = sandbox.spy(dateValidation, 'validateDay');
     });
 
     afterEach(() => {

--- a/static/js/util/sanctuary.js
+++ b/static/js/util/sanctuary.js
@@ -16,3 +16,10 @@ export const allJust = R.curry((items: S.Maybe[]) => (
  * converts a Maybe<String> to a string
  */
 export const mstr = S.maybe("", String);
+
+/*
+ * returns Nothing if the input is undefined|null,
+ * else passes the input through a provided function
+ * (the third argument to R.ifElse)
+ */
+export const ifNil = R.ifElse(R.isNil, () => S.Nothing());

--- a/static/js/util/sanctuary_test.js
+++ b/static/js/util/sanctuary_test.js
@@ -1,17 +1,16 @@
 // @flow
 import { assert } from 'chai';
 
-import { S, allJust, mstr } from './sanctuary';
+import { S, allJust, mstr, ifNil } from './sanctuary';
 const { Maybe, Just, Nothing } = S;
 
 export const assertMaybeEquality = (m1: Maybe, m2: Maybe) => {
-  assert(m1.equals(m2), "Maybe's should be equal");
+  assert(m1.equals(m2), `expected ${m1.value} to equal ${m2.value}`);
 };
 
 export const assertIsNothing = (m: Maybe) => assert(m.isNothing, "should be nothing");
 
 describe('sanctuary util functions', () => {
-
   describe('allJust', () => {
     let maybes = [
       Maybe.of(2),
@@ -37,6 +36,21 @@ describe('sanctuary util functions', () => {
     it('should print the value wrapped with Just', () => {
       assert.equal("4", mstr(Just(4)));
       assert.equal("some text", mstr(Just("some text")));
+    });
+  });
+
+  describe('ifNil', () => {
+    it('returns Nothing if the input is undefined', () => {
+      assertIsNothing(ifNil(x => x)(undefined));
+    });
+
+    it('returns Nothing if the input is null', () => {
+      assertIsNothing(ifNil(x => x)(null));
+    });
+
+    it('return func(input) if the input is not nil', () => {
+      let result = ifNil(x => x)('test input');
+      assert.equal('test input', result);
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1462 

#### What's this PR do?

This refactors our code for validating dates, to accomplish two goals:

1. Employment shouldn't allow an end date that is in the future
2. Education should allow an end date that is in the future

#### How should this be manually tested?

Well, run through the two things above and make sure they work!

Also make sure there are no regressions in date related code.