### PR TITLE
Updated style: removed top pedding from searched page

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -168,7 +168,7 @@ export default class LearnerSearch extends SearchkitComponent {
               </Sticky>
             </Cell>
             <Cell col={9}>
-              <Card className="fullwidth" shadow={1}>
+              <Card className="fullwidth results-padding" shadow={1}>
                 <Grid className="search-header">
                   <Cell col={6} className="result-info">
                     <button

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -22,6 +22,10 @@
   .fullwidth {
     width: 100%;
     overflow: visible;
+
+    &.results-padding {
+      padding: 0 24px 30px;
+    }
   }
 
   // remove padding and margin from MDL layout components


### PR DESCRIPTION
#### What are the relevant tickets?
- fixes https://github.com/mitodl/micromasters/issues/1413

#### What's this PR do?
- removed empty space at the top of the learner search card.

#### How should this be manually tested?
- see /learners/ page

@pdpinch @roberthouse54 @aliceriot 
#### Screenshots (if appropriate)
<img width="1280" alt="screen shot 2016-10-24 at 3 39 24 pm" src="https://cloud.githubusercontent.com/assets/10431250/19642836/9c2547ba-9a00-11e6-8caf-f04df0f9d29b.png">
