### PR TITLE
Logged exception being handled in custom_exception_handler

### DIFF
--- a/micromasters/utils.py
+++ b/micromasters/utils.py
@@ -2,6 +2,7 @@
 General micromasters utility functions
 """
 import json
+import logging
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -9,6 +10,9 @@ from django.core.serializers import serialize
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
+
+
+log = logging.getLogger(__name__)
 
 
 def webpack_dev_server_host(request):
@@ -50,6 +54,7 @@ def custom_exception_handler(exc, context):
     """
     # Call REST framework's default exception handler first,
     # to get the standard error response.
+    log.exception("An exception was intercepted by custom_exception_handler")
     response = exception_handler(exc, context)
 
     # if it is handled, just return the response


### PR DESCRIPTION
#### What are the relevant tickets?
None
#### What's this PR do?
Logs the `ImproperlyConfigured` exception which is raised sometimes

#### How should this be manually tested?
In `courses/serializers.py` add a field name to the `fields` list which obviously doesn't exist. Go to `/api/v0/programs/`. You should see the `ImproperlyConfigured` exception response. Look in your console output and you should see an exception about a field name along with an accurate stack trace.
