### PR TITLE
Use bulk indexing for seed_db

### DIFF
--- a/seed_data/management/commands/seed_db.py
+++ b/seed_data/management/commands/seed_db.py
@@ -202,6 +202,7 @@ def deserialize_user_data_list(user_data_list, course_runs):
     for user_data in user_data_list:
         new_user = deserialize_user_data(user_data, course_runs)
         new_user_count += 1
+        # This function is run with mute_signals(post_save) so we need to create the profile explicitly.
         profile = Profile.objects.create(user=new_user)
         deserialize_model_data_on_object(profile, user_data)
         deserialize_profile_detail_data(profile, Employment, user_data['work_history'])
@@ -295,6 +296,8 @@ class Command(BaseCommand):
             self.stdout.write("Seed data appears to already exist.")
         else:
             recreate_index()
+            # Mute post_save to prevent updates to Elasticsearch on a per program or user basis.
+            # recreate_index() is run afterwards to do this indexing in bulk.
             with mute_signals(post_save):
                 fake_programs = deserialize_program_data_list(program_data_list)
                 fake_course_runs = CourseRun.objects.filter(

--- a/seed_data/management/commands/seed_db.py
+++ b/seed_data/management/commands/seed_db.py
@@ -4,6 +4,8 @@ Generates a set of realistic users/programs to help us test search functionality
 from datetime import datetime, timedelta
 from django.core.management import BaseCommand
 from django.contrib.auth.models import User
+from django.db.models.signals import post_save
+from factory.django import mute_signals
 
 from backends.edxorg import EdxOrgOAuth2
 from courses.models import Program, Course, CourseRun
@@ -14,7 +16,7 @@ from micromasters.utils import (
     load_json_from_file,
 )
 from profiles.api import get_social_username
-from profiles.models import Employment, Education
+from profiles.models import Employment, Education, Profile
 from roles.models import Role
 from roles.roles import Staff
 from search.indexing_api import recreate_index
@@ -200,6 +202,7 @@ def deserialize_user_data_list(user_data_list, course_runs):
     for user_data in user_data_list:
         new_user = deserialize_user_data(user_data, course_runs)
         new_user_count += 1
+        Profile.objects.create(user=new_user)
         deserialize_model_data_on_object(new_user.profile, user_data)
         deserialize_profile_detail_data(new_user.profile, Employment, user_data['work_history'])
         deserialize_profile_detail_data(new_user.profile, Education, user_data['education'])
@@ -292,11 +295,12 @@ class Command(BaseCommand):
             self.stdout.write("Seed data appears to already exist.")
         else:
             recreate_index()
-            fake_programs = deserialize_program_data_list(program_data_list)
-            fake_course_runs = CourseRun.objects.filter(
-                course__program__description__contains=FAKE_PROGRAM_DESC_PREFIX
-            ).all()
-            fake_user_count = deserialize_user_data_list(user_data_list, fake_course_runs)
+            with mute_signals(post_save):
+                fake_programs = deserialize_program_data_list(program_data_list)
+                fake_course_runs = CourseRun.objects.filter(
+                    course__program__description__contains=FAKE_PROGRAM_DESC_PREFIX
+                ).all()
+                fake_user_count = deserialize_user_data_list(user_data_list, fake_course_runs)
             recreate_index()
             program_msg = (
                 "Created {num} new programs from '{path}'."

--- a/seed_data/management/commands/seed_db.py
+++ b/seed_data/management/commands/seed_db.py
@@ -202,10 +202,10 @@ def deserialize_user_data_list(user_data_list, course_runs):
     for user_data in user_data_list:
         new_user = deserialize_user_data(user_data, course_runs)
         new_user_count += 1
-        Profile.objects.create(user=new_user)
-        deserialize_model_data_on_object(new_user.profile, user_data)
-        deserialize_profile_detail_data(new_user.profile, Employment, user_data['work_history'])
-        deserialize_profile_detail_data(new_user.profile, Education, user_data['education'])
+        profile = Profile.objects.create(user=new_user)
+        deserialize_model_data_on_object(profile, user_data)
+        deserialize_profile_detail_data(profile, Employment, user_data['work_history'])
+        deserialize_profile_detail_data(profile, Education, user_data['education'])
     return new_user_count
 
 

--- a/seed_data/management/commands/unseed_db.py
+++ b/seed_data/management/commands/unseed_db.py
@@ -5,8 +5,10 @@ from factory.django import mute_signals
 from django.core.management import BaseCommand
 from django.db.models.signals import post_delete
 from django.contrib.auth.models import User
+
 from courses.models import Program
 from dashboard.models import CachedEnrollment, CachedCertificate
+from search.indexing_api import recreate_index
 from seed_data.management.commands import (  # pylint: disable=import-error
     FAKE_USER_USERNAME_PREFIX, FAKE_PROGRAM_DESC_PREFIX,
 )
@@ -30,5 +32,6 @@ class Command(BaseCommand):
         with mute_signals(post_delete):
             for model_cls in [CachedEnrollment, CachedCertificate]:
                 model_cls.objects.filter(course_run__course__program__id__in=fake_program_ids).delete()
-        Program.objects.filter(id__in=fake_program_ids).delete()
-        User.objects.filter(username__startswith=FAKE_USER_USERNAME_PREFIX).delete()
+            Program.objects.filter(id__in=fake_program_ids).delete()
+            User.objects.filter(username__startswith=FAKE_USER_USERNAME_PREFIX).delete()
+        recreate_index()


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Mutes the signals which index the profiles as they are created. Instead they are bulk indexed via `recreate_index` after all profiles are created.

#### How should this be manually tested?
Run `./manage.py seed_db --staff-user staff` and verify that you can see the profiles which are created in the learner search at `/learners`.

#### Any background context you want to provide?
The `mute_signals` will also prevent profiles from being created automatically with the `User`, so there's a new `Profile.objects.create(...)` added to fix this.
