### PR TITLE
Show only published children pages on the ProgramPage

### DIFF
--- a/cms/templates/cms/faqs_page.html
+++ b/cms/templates/cms/faqs_page.html
@@ -6,7 +6,7 @@
 
 {% block panel %}
   <div class="faqs">
-    {% for categorized in child_page.get_children.specific %}
+    {% for categorized in child_page.get_children.specific.live %}
       <h3 class="faq-category"> {{ categorized.title }}</h3>
       {% for faq in categorized.faqs.all %}
         <div class="faq accordion">

--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -58,7 +58,7 @@
            class="tab-link {% if active_tab == 'about' %}active-tab{% endif %}">
           About the Program
         </a>
-        {% for child in page.get_children %}
+        {% for child in page.get_children.live %}
           <a href="{{ child.url }}"
              class="tab-link {% if child.title == active_tab %}active-tab{% endif %}">
             {{ child.title }}


### PR DESCRIPTION
#### What are the relevant tickets?
Fix  #1543

On the program page show only published child pages.
To test this, unpublish an existing faqs page, and check if it has disappeared from the the program page.