### PR TITLE
Fixed course run edx key save issue

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -183,6 +183,12 @@ class CourseRun(models.Model):
     def __str__(self):
         return self.title
 
+    def save(self, *args, **kwargs):
+        """Overridden save method"""
+        if not self.edx_course_key:
+            self.edx_course_key = None
+        super(CourseRun, self).save(*args, **kwargs)
+
     @property
     def is_current(self):
         """Checks if the course is running now"""

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -359,6 +359,23 @@ class CourseRunTests(CourseModelTests):
         course_run = self.create_run()
         assert "{}".format(course_run) == "Title Run"
 
+    def test_save(self):
+        """
+        Test that save method treats blank and null edx_course_key
+        values as null
+        """
+        test_run = CourseRun.objects.create(
+            course=self.course,
+            title='test_run'
+        )
+        test_run_blank_edx_key = CourseRun.objects.create(
+            course=self.course,
+            title='test_run_blank_edx_key',
+            edx_course_key=''
+        )
+        assert test_run.edx_course_key is None
+        assert test_run_blank_edx_key.edx_course_key is None
+
     def test_is_current_no_start(self):
         """Test for is_current property"""
         course_run = self.create_run()


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #1541 

#### What's this PR do?

Considers both blank ('') and null edx_course_key values as null for CourseRuns

#### How should this be manually tested?

Add multiple course runs with blank edx course keys Django admin

#### Any background context you want to provide?

Django admin tries to insert a blank string instead of `null` when adding a new course run

