### PR TITLE
Fixed course description JS bug

### DIFF
--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -103,12 +103,12 @@ export default class CourseAction extends React.Component {
   }
 
   renderDescription = R.curry(
-    (className: string, runStatus: ?string, text: string): React$Element<*>|null => {
+    (className: string, runStatus: ?string, text: ?string): React$Element<*>|null => {
       let classDefinition = className;
       if (runStatus && this.statusDescriptionClasses[runStatus]) {
         classDefinition = `${classDefinition} ${this.statusDescriptionClasses[runStatus]}`;
       }
-      return text.length > 0 ? <div className={classDefinition} key="2">{text}</div> : null;
+      return text && text.length > 0 ? <div className={classDefinition} key="2">{text}</div> : null;
     }
   );
 
@@ -175,6 +175,8 @@ export default class CourseAction extends React.Component {
           text = ifValidDate('', date => `Enrollment begins ${date.format(DASHBOARD_FORMAT)}`, enrollmentStartDate);
         } else if (run.fuzzy_enrollment_start_date) {
           text = `Enrollment begins ${run.fuzzy_enrollment_start_date}`;
+        } else {
+          text = 'Enrollment information unavailable';
         }
         description = this.renderTextDescription(text);
       }

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -214,6 +214,22 @@ describe('CourseAction', () => {
     assert.equal(elements.descriptionText, 'Enrollment begins whenever');
   });
 
+  it('shows a message if a course run is offered with inadequate enrollment information', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_OFFERED
+    ));
+    let firstRun = alterFirstRun(course, {
+      fuzzy_enrollment_start_date: null,
+      enrollment_start_date: null
+    });
+    const wrapper = shallow(<CourseAction courseRun={firstRun} {...defaultParamsNow} />);
+    let elements = getElements(wrapper);
+
+    assert.equal(elements.button.length, 0);
+    assert.equal(elements.descriptionText, 'Enrollment information unavailable');
+  });
+
   it('shows a countdown message if the user is enrolled and the course starts in the future', () => {
     let course = findAndCloneCourse(course => (
       course.runs.length > 0 &&

--- a/static/js/util/date.js
+++ b/static/js/util/date.js
@@ -1,6 +1,6 @@
 // @flow
 import R from 'ramda';
 
-export const ifValidDate = R.curry((def, fn, date) => (
-  date.isValid() ? fn(date) : def
+export const ifValidDate = R.curry((defaultValue, fn, date) => (
+  date.isValid() ? fn(date) : defaultValue
 ));


### PR DESCRIPTION
#### What are the relevant tickets?

No associated issue

#### What's this PR do?

Fixes the CourseAction bug that was breaking the dashboard

#### How should this be manually tested?

Load the dashboard, preferably with a course that has course run with a `null` value for all date fields


