### PR TITLE
Prevented an enrollment failure from failing the order

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -290,7 +290,7 @@ def enroll_user_on_success(order):
         try:
             enrollments.append(enrollments_client.create_audit_student_enrollment(course_key))
         except Exception as ex:  # pylint: disable=broad-except
-            log.error(
+            log.exception(
                 "Error creating audit enrollment for course key %s for user %s",
                 course_key,
                 get_social_username(order.user),

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -233,7 +233,8 @@ class OrderFulfillmentViewTests(ESTestCase):
                 self.client.post(reverse('order-fulfillment'), data=data)
 
         assert Order.objects.count() == 1
-        assert Order.objects.first().status == Order.FAILED
+        # An enrollment failure should not prevent the order from being fulfilled
+        assert Order.objects.first().status == Order.FULFILLED
 
     def test_not_accept(self):
         """


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #1550 

#### What's this PR do?
If the enrollment failed, the order would fail. This is changed to not fail the order but to just log the enrollment failure instead.

#### How should this be manually tested?
Purchase a course without having a course key which exists on the edX instance. It should go through successfully
