### PR TITLE
Make modals more consistent

### DIFF
--- a/static/js/components/ConfirmDeletion.js
+++ b/static/js/components/ConfirmDeletion.js
@@ -23,14 +23,14 @@ export default class ConfirmDeletion extends React.Component {
       <Button
         type='button'
         key='close'
-        className="cancel-button"
+        className="secondary-button cancel-button"
         onClick={close}>
         No
       </Button>,
       <Button
         key='delete'
         type='button'
-        className="delete-button"
+        className="primary-button delete-button"
         onClick={this.deleteAndClose}>
         Yes
       </Button>

--- a/static/js/components/ConfirmDeletion.js
+++ b/static/js/components/ConfirmDeletion.js
@@ -37,7 +37,9 @@ export default class ConfirmDeletion extends React.Component {
     ];
     return (
       <Dialog
-        className={"deletion-confirmation"}
+        title="Confirm Delete"
+        titleClassName="dialog-title"
+        contentClassName="dialog deletion-confirmation"
         open={open}
         onRequestClose={close}
         actions={actions}

--- a/static/js/components/ConfirmDeletion.js
+++ b/static/js/components/ConfirmDeletion.js
@@ -38,8 +38,9 @@ export default class ConfirmDeletion extends React.Component {
     return (
       <Dialog
         title="Confirm Delete"
+        className="deletion-confirmation-dialog-wrapper"
         titleClassName="dialog-title"
-        contentClassName="dialog deletion-confirmation"
+        contentClassName="dialog deletion-confirmation-dialog"
         open={open}
         onRequestClose={close}
         actions={actions}

--- a/static/js/components/ConfirmDeletion.js
+++ b/static/js/components/ConfirmDeletion.js
@@ -3,12 +3,14 @@ import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import Button from 'react-mdl/lib/Button';
 
+const dialogTitle = (item="entry") => (`Delete this ${item}?`);
+
 export default class ConfirmDeletion extends React.Component {
   props: {
     close:        () => void,
     deleteFunc:   () => void,
     open:         boolean,
-    confirmText:  string,
+    itemText:     string,
   };
 
   deleteAndClose: Function = (): void => {
@@ -18,26 +20,26 @@ export default class ConfirmDeletion extends React.Component {
   };
 
   render () {
-    const { close, open, confirmText } = this.props;
+    const { close, open, itemText } = this.props;
     let actions = [
       <Button
         type='button'
         key='close'
         className="secondary-button cancel-button"
         onClick={close}>
-        No
+        Cancel
       </Button>,
       <Button
         key='delete'
         type='button'
         className="primary-button delete-button"
         onClick={this.deleteAndClose}>
-        Yes
+        Delete
       </Button>
     ];
     return (
       <Dialog
-        title="Confirm Delete"
+        title={dialogTitle(itemText)}
         className="deletion-confirmation-dialog-wrapper"
         titleClassName="dialog-title"
         contentClassName="dialog deletion-confirmation-dialog"
@@ -46,7 +48,6 @@ export default class ConfirmDeletion extends React.Component {
         actions={actions}
         autoScrollBodyContent={true}
       >
-        { confirmText }
       </Dialog>
     );
   }

--- a/static/js/components/DocsInstructionsDialog.js
+++ b/static/js/components/DocsInstructionsDialog.js
@@ -22,6 +22,7 @@ const DocsInstructionsDialog = ({ open, setDialogVisibility }: DocsInstructions)
     title={dialogTitle(setDialogVisibility)}
     titleClassName="dialog-title"
     contentClassName="dialog docs-instructions-dialog"
+    className="docs-instructions-dialog-wrapper"
     open={open}
     onRequestClose={() => setDialogVisibility(false)}
     autoScrollBodyContent={true}

--- a/static/js/components/DocsInstructionsDialog.js
+++ b/static/js/components/DocsInstructionsDialog.js
@@ -19,11 +19,12 @@ type DocsInstructions = {
 
 const DocsInstructionsDialog = ({ open, setDialogVisibility }: DocsInstructions) => (
   <Dialog
+    title={dialogTitle(setDialogVisibility)}
+    titleClassName="dialog-title"
+    contentClassName="dialog docs-instructions-dialog"
     open={open}
-    className="docs-instructions-dialog"
     onRequestClose={() => setDialogVisibility(false)}
     autoScrollBodyContent={true}
-    title={dialogTitle(setDialogVisibility)}
   >
     <div className="heading">
       Whose income should I report?

--- a/static/js/components/EducationDialog.js
+++ b/static/js/components/EducationDialog.js
@@ -153,7 +153,6 @@ export default class EducationDialog extends ProfileFormFields {
         titleClassName="dialog-title"
         contentClassName="dialog education-dialog"
         open={educationDialogVisibility}
-        className="dashboard-dialog education-dashboard-dialog"
         onRequestClose={this.clearEducationEdit}
         actions={actions}
         autoScrollBodyContent={true}

--- a/static/js/components/EducationDialog.js
+++ b/static/js/components/EducationDialog.js
@@ -149,6 +149,9 @@ export default class EducationDialog extends ProfileFormFields {
 
     return (
       <Dialog
+        title="Education"
+        titleClassName="dialog-title"
+        contentClassName="dialog education-dialog"
         open={educationDialogVisibility}
         className="dashboard-dialog education-dashboard-dialog"
         onRequestClose={this.clearEducationEdit}

--- a/static/js/components/EducationDialog.js
+++ b/static/js/components/EducationDialog.js
@@ -135,13 +135,13 @@ export default class EducationDialog extends ProfileFormFields {
     let actions = <ValidationAlert {...this.props}>
       <Button
         type='button'
-        className="cancel-button"
+        className="secondary-button cancel-button"
         onClick={this.clearEducationEdit}>
         Cancel
       </Button>
       <Button
         type='button'
-        className="save-button"
+        className="primary-button save-button"
         onClick={this.saveEducationForm}>
         Save
       </Button>

--- a/static/js/components/EducationDialog.js
+++ b/static/js/components/EducationDialog.js
@@ -152,6 +152,7 @@ export default class EducationDialog extends ProfileFormFields {
         title="Education"
         titleClassName="dialog-title"
         contentClassName="dialog education-dialog"
+        className="education-dialog-wrapper"
         open={educationDialogVisibility}
         onRequestClose={this.clearEducationEdit}
         actions={actions}

--- a/static/js/components/EducationDisplay.js
+++ b/static/js/components/EducationDisplay.js
@@ -107,7 +107,7 @@ export default class EducationDisplay extends ProfileFormFields {
           deleteFunc={this.deleteEducationEntry}
           open={showEducationDeleteDialog}
           close={this.closeConfirmDeleteDialog}
-          confirmText="Delete this entry?"
+          itemText="degree"
         />
         <EducationDialog
           {...this.props}

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -208,7 +208,7 @@ class EducationForm extends ProfileFormFields {
           deleteFunc={this.deleteEducationEntry}
           open={showEducationDeleteDialog}
           close={this.closeConfirmDeleteDialog}
-          confirmText="Delete this entry?"
+          itemText="degree"
         />
         <EducationDialog {...this.props} showLevelForm={false} />
         {levelsGrid}

--- a/static/js/components/EmailCompositionDialog.js
+++ b/static/js/components/EmailCompositionDialog.js
@@ -60,11 +60,12 @@ const EmailCompositionDialog = (props: EmailDialogProps) => {
   } = props;
 
   return <Dialog
+    title="New Email"
+    titleClassName="dialog-title"
+    contentClassName="dialog email-composition-dialog"
     open={open}
-    className="email-composition-dialog"
     actions={createDialogActions(closeEmailDialog, sendEmail)}
     onRequestClose={closeEmailDialog}
-    title="New Email"
   >
     <div className="email-composition-contents">
       <span className="user-count">

--- a/static/js/components/EmailCompositionDialog.js
+++ b/static/js/components/EmailCompositionDialog.js
@@ -11,7 +11,7 @@ import type {
 const createDialogActions = (close, send) => ([
   <Button
     type="button"
-    className="dialog-button cancel-button"
+    className="secondary-button cancel-button"
     key="first"
     onClick={close}
   >
@@ -19,7 +19,7 @@ const createDialogActions = (close, send) => ([
   </Button>,
   <Button
     type="button"
-    className="dialog-button save-button"
+    className="primary-button save-button"
     key="second"
     onClick={send}
   >

--- a/static/js/components/EmailCompositionDialog.js
+++ b/static/js/components/EmailCompositionDialog.js
@@ -63,6 +63,7 @@ const EmailCompositionDialog = (props: EmailDialogProps) => {
     title="New Email"
     titleClassName="dialog-title"
     contentClassName="dialog email-composition-dialog"
+    className="email-composition-dialog-wrapper"
     open={open}
     actions={createDialogActions(closeEmailDialog, sendEmail)}
     onRequestClose={closeEmailDialog}

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -289,13 +289,13 @@ class EmploymentForm extends ProfileFormFields {
     const actions = <ValidationAlert {...this.props}>
       <Button
         type='button'
-        className="cancel-button"
+        className="secondary-button cancel-button"
         onClick={this.closeWorkDialog}>
         Cancel
       </Button>
       <Button
         type='button'
-        className="save-button"
+        className="primary-button save-button"
         onClick={this.saveWorkHistoryEntry}>
         Save
       </Button>

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -310,8 +310,10 @@ class EmploymentForm extends ProfileFormFields {
           confirmText="Delete this entry?"
         />
         <Dialog
+          title="Employment"
+          titleClassName="dialog-title"
+          contentClassName="dialog dashboard-dialog employment-dashboard-dialog"
           open={workDialogVisibility}
-          className="dashboard-dialog employment-dashboard-dialog"
           onRequestClose={this.closeWorkDialog}
           actions={actions}
           autoScrollBodyContent={true}

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -307,7 +307,7 @@ class EmploymentForm extends ProfileFormFields {
           deleteFunc={this.deleteWorkHistoryEntry}
           open={showWorkDeleteDialog}
           close={this.closeConfirmDeleteDialog}
-          confirmText="Delete this entry?"
+          itemText="position"
         />
         <Dialog
           title="Employment"

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -312,7 +312,7 @@ class EmploymentForm extends ProfileFormFields {
         <Dialog
           title="Employment"
           titleClassName="dialog-title"
-          contentClassName="dialog dashboard-dialog employment-dashboard-dialog"
+          contentClassName="dialog employment-dialog"
           open={workDialogVisibility}
           onRequestClose={this.closeWorkDialog}
           actions={actions}

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -313,6 +313,7 @@ class EmploymentForm extends ProfileFormFields {
           title="Employment"
           titleClassName="dialog-title"
           contentClassName="dialog employment-dialog"
+          className="employment-dialog-wrapper"
           open={workDialogVisibility}
           onRequestClose={this.closeWorkDialog}
           actions={actions}

--- a/static/js/components/NewEnrollmentDialog.js
+++ b/static/js/components/NewEnrollmentDialog.js
@@ -88,6 +88,7 @@ export default class NewEnrollmentDialog extends React.Component {
       title="Enroll in a new MicroMasters Program"
       titleClassName="dialog-title"
       contentClassName="dialog enroll-dialog"
+      className="enroll-dialog-wrapper"
       open={enrollDialogVisibility}
       actions={this.createDialogActions()}
     >

--- a/static/js/components/NewEnrollmentDialog.js
+++ b/static/js/components/NewEnrollmentDialog.js
@@ -85,8 +85,10 @@ export default class NewEnrollmentDialog extends React.Component {
     // onRequestClose is not used below because an extra click or touch event causes material-ui
     // to close the dialog right after opening it. See https://github.com/JedWatson/react-select/issues/532
     return <Dialog
-      open={enrollDialogVisibility}
       title="Enroll in a new MicroMasters Program"
+      titleClassName="dialog-title"
+      contentClassName="dialog enroll-dialog"
+      open={enrollDialogVisibility}
       actions={this.createDialogActions()}
     >
       <SelectField

--- a/static/js/components/NewEnrollmentDialog.js
+++ b/static/js/components/NewEnrollmentDialog.js
@@ -45,14 +45,14 @@ export default class NewEnrollmentDialog extends React.Component {
   createDialogActions = () => {
     return [
       <Button
-        className="cancel-button"
+        className="secondary-button cancel-button"
         key="cancel"
         onClick={this.closeDialog}
       >
         Cancel
       </Button>,
       <Button
-        className="enroll-button"
+        className="primary-button enroll-button"
         key="enroll"
         onClick={this.addEnrollment}
       >

--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -64,7 +64,7 @@ const ProfileImageUploader = ({
     actions = {[
       <Button
         type='button'
-        className='cancel-button'
+        className='secondary-button cancel-button'
         key="cancel"
         onClick={() => {
           setDialogVisibility(false);
@@ -74,7 +74,7 @@ const ProfileImageUploader = ({
       </Button>,
       <Button
         type='button'
-        className='save-button'
+        className='primary-button save-button'
         key="save"
         onClick={updateUserPhoto}>
         Save

--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -55,7 +55,8 @@ const ProfileImageUploader = ({
   <Dialog
     title="Upload a Profile Photo"
     titleClassName="dialog-title"
-    contentClassName="dialog dashboard-dialog photo-upload-dialog"
+    contentClassName="dialog photo-upload-dialog"
+    className="photo-upload-dialog-wrapper"
     onRequestClose={() => setDialogVisibility(false)}
     autoScrollBodyContent={true}
     contentStyle={{ maxWidth: '620px' }}

--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -53,12 +53,13 @@ const ProfileImageUploader = ({
   setPhotoError,
 }: ImageUploadProps) => (
   <Dialog
-    open = {photoDialogOpen}
-    className="dashboard-dialog photo-upload-dialog"
+    title="Upload a Profile Photo"
+    titleClassName="dialog-title"
+    contentClassName="dialog dashboard-dialog photo-upload-dialog"
     onRequestClose={() => setDialogVisibility(false)}
     autoScrollBodyContent={true}
-    title="Upload a Profile Photo"
     contentStyle={{ maxWidth: '620px' }}
+    open={photoDialogOpen}
     actions = {[
       <Button
         type='button'

--- a/static/js/components/SkipFinancialAidDialog.js
+++ b/static/js/components/SkipFinancialAidDialog.js
@@ -31,10 +31,9 @@ const SkipFinancialAidDialog = ({cancel, skip, open, fullPrice}: SkipProps) => (
   <Dialog
     title="Are you sure?"
     titleClassName="dialog-title"
-    contentClassName="dialog dialog-skip-financial-aid"
+    contentClassName="dialog skip-financial-aid-dialog"
+    className="skip-financial-aid-dialog-wrapper"
     open={open}
-    className="skip-aid-dialog-wrapper"
-    bodyClassName="skip-aid-dialog"
     onRequestClose={cancel}
     actions={skipActions(cancel, skip)}
   >

--- a/static/js/components/SkipFinancialAidDialog.js
+++ b/static/js/components/SkipFinancialAidDialog.js
@@ -7,13 +7,13 @@ const skipActions = (cancel, skip) => (
   <div className="actions">
     <Button
       type='button'
-      className="cancel-button"
+      className="secondary-button cancel-button"
       onClick={cancel}>
       Cancel
     </Button>
     <Button
       type='button'
-      className="save-button"
+      className="primary-button save-button"
       onClick={skip}>
       Pay Full Price
     </Button>

--- a/static/js/components/SkipFinancialAidDialog.js
+++ b/static/js/components/SkipFinancialAidDialog.js
@@ -29,12 +29,14 @@ type SkipProps = {
 
 const SkipFinancialAidDialog = ({cancel, skip, open, fullPrice}: SkipProps) => (
   <Dialog
+    title="Are you sure?"
+    titleClassName="dialog-title"
+    contentClassName="dialog dialog-skip-financial-aid"
     open={open}
     className="skip-aid-dialog-wrapper"
     bodyClassName="skip-aid-dialog"
     onRequestClose={cancel}
     actions={skipActions(cancel, skip)}
-    title="Are you sure?"
   >
     You may qualify for a reduced cost. Clicking "Pay Full Price"
     means that you are declining this option and you will pay the

--- a/static/js/components/UserPagePersonalDialog.js
+++ b/static/js/components/UserPagePersonalDialog.js
@@ -54,7 +54,9 @@ export default class UserPagePersonalDialog extends React.Component {
 
     return (
       <Dialog
-        className="dashboard-dialog personal-dialog"
+        title="Edit Personal Info"
+        titleClassName="dialog-title"
+        contentClassName="dialog dashboard-dialog personal-dialog"
         open={userPageDialogVisibility}
         onRequestClose={this.closePersonalDialog}
         actions={actions}

--- a/static/js/components/UserPagePersonalDialog.js
+++ b/static/js/components/UserPagePersonalDialog.js
@@ -40,13 +40,13 @@ export default class UserPagePersonalDialog extends React.Component {
     const actions = <ValidationAlert {...this.props}>
       <Button
         type='button'
-        className='cancel-button'
+        className='secondary-button cancel-button'
         onClick={this.closePersonalDialog}>
         Cancel
       </Button>
       <Button
         type='button'
-        className='save-button'
+        className='primary-button save-button'
         onClick={this.savePersonalInfo}>
         Save
       </Button>

--- a/static/js/components/UserPagePersonalDialog.js
+++ b/static/js/components/UserPagePersonalDialog.js
@@ -56,7 +56,8 @@ export default class UserPagePersonalDialog extends React.Component {
       <Dialog
         title="Edit Personal Info"
         titleClassName="dialog-title"
-        contentClassName="dialog dashboard-dialog personal-dialog"
+        contentClassName="dialog personal-dialog"
+        className="personal-dialog-wrapper"
         open={userPageDialogVisibility}
         onRequestClose={this.closePersonalDialog}
         actions={actions}

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -140,13 +140,14 @@ const FinancialAidCalculator = ({
     maxPossibleCost = formatPrice(program.financial_aid_user_info.max_possible_cost);
   }
   return <Dialog
+    title="Cost Calculator"
+    titleClassName="dialog-title"
+    contentClassName="dialog financial-aid-calculator"
     open={calculatorDialogVisibility}
-    contentClassName="financial-aid-calculator"
     bodyClassName="financial-aid-calculator-body"
     onRequestClose={closeDialogAndCancel}
     autoScrollBodyContent={true}
     actions={calculatorActions(openConfirmSkipDialog, closeDialogAndCancel, () => saveFinancialAid(financialAid))}
-    title="Cost Calculator"
   >
     <div className="copy">
       { `The cost of courses in the ${title} MicroMasters varies between ${minPossibleCost} and ${maxPossibleCost},

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -143,6 +143,7 @@ const FinancialAidCalculator = ({
     title="Cost Calculator"
     titleClassName="dialog-title"
     contentClassName="dialog financial-aid-calculator"
+    className="financial-aid-calculator-wrapper"
     open={calculatorDialogVisibility}
     bodyClassName="financial-aid-calculator-body"
     onRequestClose={closeDialogAndCancel}

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -83,9 +83,9 @@ describe('FinancialAidCalculator', () => {
       ], () => {
         wrapper.find('.pricing-actions').find('.dashboard-button').simulate('click');
         assert.equal(helper.store.getState().ui.calculatorDialogVisibility, true);
-        let calculator = document.querySelector('.financial-aid-calculator');
+        let calculator = document.querySelector('.financial-aid-calculator-wrapper');
         TestUtils.Simulate.click(calculator.querySelector('.full-price'));
-        let confirmDialog = document.querySelector('.skip-aid-dialog-wrapper');
+        let confirmDialog = document.querySelector('.skip-financial-aid-dialog-wrapper');
         TestUtils.Simulate.click(confirmDialog.querySelector('.save-button'));
       }).then(() => {
         assert(

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -87,20 +87,24 @@ describe("ProfilePage", function() {
         );
     });
 
-    let yesSwitchDialogTest = ([, div]) => {
-      let toggle = radioToggles(div, '.profile-radio-switch');
-      TestUtils.Simulate.change(toggle[0]);
-      activeDialog('dashboard-dialog');
-    };
-
     it('should launch a dialog to add an entry when an education switch is set to Yes', () => {
+      let dialogTest = ([, div]) => {
+        let toggle = radioToggles(div, '.profile-radio-switch');
+        TestUtils.Simulate.change(toggle[0]);
+        activeDialog('education-dialog-wrapper');
+      };
       setStep(EDUCATION_STEP);
-      return renderComponent('/profile').then(yesSwitchDialogTest);
+      return renderComponent('/profile').then(dialogTest);
     });
 
     it('should launch a dialog to add an entry when an employment switch is set to Yes', () => {
+      let dialogTest = ([, div]) => {
+        let toggle = radioToggles(div, '.profile-radio-switch');
+        TestUtils.Simulate.change(toggle[0]);
+        activeDialog('employment-dialog-wrapper');
+      };
       setStep(EMPLOYMENT_STEP);
-      return renderComponent('/profile').then(yesSwitchDialogTest);
+      return renderComponent('/profile').then(dialogTest);
     });
   });
 

--- a/static/js/containers/SignupDialog.js
+++ b/static/js/containers/SignupDialog.js
@@ -23,8 +23,10 @@ const SignupDialog = ({
   setDialogVisibility,
 }: signupProps) => {
   return <Dialog
-    open={open}
+    titleClassName="dialog-title"
+    contentClassName="dialog signup-dialog"
     className="signup-dialog-wrapper"
+    open={open}
     onRequestClose={() => setDialogVisibility(false)}
     contentStyle={dialogStyle}
     autoScrollBodyContent={true}

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -428,7 +428,7 @@ describe("UserPage", function() {
           return listenForActions(expectedActions, () => {
             TestUtils.Simulate.click(addButton);
 
-            let dialog = document.querySelector('.education-dashboard-dialog');
+            let dialog = document.querySelector('.education-dialog');
             let grid = dialog.getElementsByClassName('profile-tab-grid')[0];
             let inputs = grid.getElementsByTagName('input');
 
@@ -604,7 +604,7 @@ describe("UserPage", function() {
 
           return listenForActions(expectedActions, () => {
             TestUtils.Simulate.click(addButton);
-            let dialog = document.querySelector('.employment-dashboard-dialog');
+            let dialog = document.querySelector('.employment-dialog');
             let grid = dialog.querySelector('.profile-tab-grid');
             let inputs = grid.getElementsByTagName('input');
 

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -93,11 +93,11 @@ export const activeDialog = (dialogClassName: string): HTMLDivElement => {
 };
 
 export const activeDeleteDialog = () => (
-  activeDialog('deletion-confirmation')
+  activeDialog('deletion-confirmation-dialog-wrapper')
 );
 
 export const noActiveDeleteDialogs = () => (
-  noActiveDialogs('deletion-confirmation')
+  noActiveDialogs('deletion-confirmation-dialog-wrapper')
 );
 
 export const localStorageMock = (init: any = {}) => {

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -472,7 +472,7 @@
   }
 }
 
-.dashboard-dialog {
+.dashboard-page .dialog {
   width: 700px;
   padding: 30px;
 
@@ -490,22 +490,23 @@
   .cancel-button {
     background: none;
     color: #9a9a9a;
+
+    &:hover, &:active {
+      background: none;
+      color: #616161;
+    }
+
   }
 
   .save-button {
     color: #0c92e0;
     margin-right: 20px;
     background: none;
-  }
 
-  .save-button:hover {
-    background: none;
-    color: #0473b3;
-  }
-
-  .cancel-button:hover {
-    background: none;
-    color: #616161;
+    &:hover, &:active {
+      background: none;
+      color: #0473b3;
+    }
   }
 }
 

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -487,18 +487,7 @@
     padding: 0 2px;
   }
 
-  .cancel-button {
-    background: none;
-    color: #9a9a9a;
-
-    &:hover, &:active {
-      background: none;
-      color: #616161;
-    }
-
-  }
-
-  .save-button {
+  .primary-button {
     color: #0c92e0;
     margin-right: 20px;
     background: none;
@@ -507,6 +496,17 @@
       background: none;
       color: #0473b3;
     }
+  }
+
+  .secondary-button {
+    background: none;
+    color: #9a9a9a;
+
+    &:hover, &:active {
+      background: none;
+      color: #616161;
+    }
+
   }
 }
 

--- a/static/scss/responsive-styles.scss
+++ b/static/scss/responsive-styles.scss
@@ -82,7 +82,7 @@
 
   // Dialogs
 
-  .dashboard-dialog {
+  .dashboard-page .dialog {
     padding: 0;
   }
 

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -54,7 +54,7 @@
     <!-- End Smartlook tracking -->
   {% endif %}
   </head>
-  <body>
+  <body class="{% block bodyclass %}{% endblock %}">
     {% block content %}
     {% endblock %}
   </body>

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -2,6 +2,7 @@
 {% load i18n static %}
 
 {% block title %}{% trans "MITx MicroMasters" %}{% endblock %}
+{% block bodyclass %}dashboard-page{% endblock %}
 
 {% block content %}
 <div id="dashboard"></div>


### PR DESCRIPTION
Fixes #1452. This pull request does the following things to make the modals in our application more consistent:

* Applies a "dialog" class to every modal window
* Ensures that every modal has a title
* Applies a "dialog-title" class to every modal title
* Unified button styles for all buttons in dashboard modals

However, not all modals are created equally. The "Sign Up" modal on the landing page does _not_ have a title. This is intentional, and was specifically requested by @roberthouse54.

Note that the `className` property on the `<Dialog>` element applies the class name to the wrapper div around the modal window, which is used as an overlay for the entire page to catch people clicking outside of the modal to clear it. The `contentClassName` property applies the class name to the div containing the actual modal window itself, which is what we want to be able to style.