### PR TITLE
Fixed footer layout

### DIFF
--- a/static/scss/footer.scss
+++ b/static/scss/footer.scss
@@ -31,9 +31,8 @@ footer {
   .footer-cta {
     display: inline-block;
     vertical-align: middle;
-    width: 100%;
+    width: 50%;
     min-width: 150px;
-    padding: 0 0 60px 0;
 
     @include breakpoint(phone) {
       display: block;
@@ -42,8 +41,11 @@ footer {
     }
 
     &.non-marketing-pages {
-      min-width: 300px;
       margin-bottom: 60px;
+
+      @include breakpoint(desktop) {
+        min-width: 400px;
+      }
     }
 
     a {

--- a/ui/templates/footer.html
+++ b/ui/templates/footer.html
@@ -7,7 +7,7 @@
         <img src="{% static 'images/mit-logo-ltgray-white@72x38.svg' %}" alt="MIT" width="72" height="38">
         </a>
         {% if public_src %}
-          <div class="footer-button">
+          <div class="footer-cta">
             <a href="https://giving.mit.edu/explore/campus-student-life/digital-learning" target="_blank"
               class="mdl-button footer-button">Give to MIT
             </a>
@@ -28,7 +28,7 @@
         {% if public_src %}
           {% include "social_buttons.html" %}
         {% else %}
-          <div class="footer-button non-marketing-pages">
+          <div class="footer-cta non-marketing-pages">
             <a href="https://giving.mit.edu/explore/campus-student-life/digital-learning" target="_blank"
               class="btn btn-primary no-float">Give to MIT
             </a>


### PR DESCRIPTION
#### What's this PR do?
- Fixes footer layout issues on pages.
- Footer state on master (dashboard, learner, homepage, 404, 500)

<img width="1273" alt="screen shot 2016-10-26 at 6 07 31 pm" src="https://cloud.githubusercontent.com/assets/10431250/19727803/59ac9022-9baa-11e6-8b33-bf3532d78a42.png">

<img width="1277" alt="screen shot 2016-10-26 at 6 07 50 pm" src="https://cloud.githubusercontent.com/assets/10431250/19727805/59b3b7b2-9baa-11e6-869d-7101869f0dd9.png">

<img width="1280" alt="screen shot 2016-10-26 at 6 08 36 pm" src="https://cloud.githubusercontent.com/assets/10431250/19727804/59af542e-9baa-11e6-9cf5-455851242aeb.png">

#### How should this be manually tested?
- check footer on all MM pages

@pdpinch @roberthouse54 @aliceriot 
#### Screenshots (if appropriate)
##### Desktop layout:
- dashboard, 404, 500, learner
<img width="1278" alt="screen shot 2016-10-26 at 6 33 50 pm" src="https://cloud.githubusercontent.com/assets/10431250/19728061/6a1509a2-9bab-11e6-9285-a2abdba552f9.png">

- homepage, program
<img width="1278" alt="screen shot 2016-10-26 at 6 34 00 pm" src="https://cloud.githubusercontent.com/assets/10431250/19728063/6a19b038-9bab-11e6-9bbb-ae1859e70f9c.png">

##### Mobile layout:
<img width="339" alt="screen shot 2016-10-26 at 6 38 13 pm" src="https://cloud.githubusercontent.com/assets/10431250/19728064/6a369c02-9bab-11e6-8bb4-d4d3710c4d39.png">

<img width="342" alt="screen shot 2016-10-26 at 6 38 22 pm" src="https://cloud.githubusercontent.com/assets/10431250/19728062/6a1582e2-9bab-11e6-8cbb-d27ef16955fa.png">

