### PR TITLE
Refactored dashboard API

### DIFF
--- a/courses/views.py
+++ b/courses/views.py
@@ -10,7 +10,7 @@ from rest_framework.exceptions import (
     NotFound,
     ValidationError,
 )
-from rest_framework.generics import ListCreateAPIView
+from rest_framework.generics import CreateAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -38,7 +38,7 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ProgramSerializer
 
 
-class ProgramEnrollmentListView(ListCreateAPIView):
+class ProgramEnrollmentListView(CreateAPIView):
     """API for the User Program Enrollments"""
 
     serializer_class = ProgramSerializer
@@ -49,13 +49,6 @@ class ProgramEnrollmentListView(ListCreateAPIView):
     permission_classes = (
         IsAuthenticated,
     )
-
-    def get_queryset(self):
-        """
-        Filter programs by the user enrollment
-        """
-        queryset = Program.objects.filter(programenrollment__user=self.request.user, live=True)
-        return queryset.order_by('title')
 
     @transaction.atomic
     def create(self, request, *args, **kwargs):  # pylint: disable=unused-argument

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -33,8 +33,9 @@ class ProgramTests(ESTestCase):
         resp = self.client.get(reverse('program-list'))
 
         assert len(resp.json()) == 1
-        expected = ProgramSerializer(context={"request": Mock(user=self.user)}).to_representation(prog)
-        assert [expected] == resp.json()
+        context = {"request": Mock(user=self.user)}
+        data = ProgramSerializer(prog, context=context).data
+        assert [data] == resp.json()
 
     def test_doesnt_list_unlive_programs(self):
         """Not-live programs should NOT show up"""

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -1,11 +1,14 @@
 """Tests for the API"""
 # pylint: disable=no-self-use
 
+from mock import Mock
+
 from django.core.urlresolvers import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from courses.factories import ProgramFactory
+from courses.serializers import ProgramSerializer
 from dashboard.factories import ProgramEnrollmentFactory
 from dashboard.models import ProgramEnrollment
 from micromasters.factories import UserFactory
@@ -30,7 +33,8 @@ class ProgramTests(ESTestCase):
         resp = self.client.get(reverse('program-list'))
 
         assert len(resp.json()) == 1
-        assert prog.title == resp.json()[0]['title']
+        expected = ProgramSerializer(context={"request": Mock(user=self.user)}).to_representation(prog)
+        assert [expected] == resp.json()
 
     def test_doesnt_list_unlive_programs(self):
         """Not-live programs should NOT show up"""
@@ -81,7 +85,7 @@ class ProgramEnrollmentTests(ESTestCase, APITestCase):
     def test_anonymous(self):
         """Anonymous user cannot access the endpoint"""
         self.client.logout()
-        resp = self.client.get(self.url)
+        resp = self.client.post(self.url)
         assert resp.status_code == status.HTTP_403_FORBIDDEN
 
     def test_no_enrollments(self):
@@ -89,32 +93,12 @@ class ProgramEnrollmentTests(ESTestCase, APITestCase):
         self.client.logout()
         self.client.force_login(self.user2)
         resp = self.client.get(self.url)
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data == []
+        assert resp.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
-    def test_enrollments(self):
+    def test_no_get_for_enrollments(self):
         """Only the programs where the user is enrolled in are returned"""
         resp = self.client.get(self.url)
-        assert resp.status_code == status.HTTP_200_OK
-        assert len(resp.data) == 2
-        expected_enrollments_ids = [
-            program.pk for program in (self.program1, self.program2,)
-        ]
-        for enr in resp.data:
-            assert enr.get('id') in expected_enrollments_ids
-
-    def test_not_live_enrollments(self):
-        """Programs which are not live are hidden from the list"""
-        program = ProgramFactory.create(live=False)
-        ProgramEnrollment.objects.create(user=self.user1, program=program)
-        resp = self.client.get(self.url)
-        assert resp.status_code == status.HTTP_200_OK
-        assert len(resp.data) == 2
-        expected_enrollments_ids = [
-            program.pk for program in (self.program1, self.program2,)
-        ]
-        for enr in resp.data:
-            assert enr.get('id') in expected_enrollments_ids
+        assert resp.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
     def test_create_no_program_id(self):
         """Missing mandatory program_id parameter"""

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -97,7 +97,7 @@ class ProgramEnrollmentTests(ESTestCase, APITestCase):
         assert resp.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
     def test_no_get_for_enrollments(self):
-        """Only the programs where the user is enrolled in are returned"""
+        """GET is not allowed for /api/v0/enrolledprograms/"""
         resp = self.client.get(self.url)
         assert resp.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -74,7 +74,7 @@ class UserDashboard(APIView):
         response_data = []
 
         all_programs = (
-            Program.objects.filter(live=True)
+            Program.objects.filter(live=True, programenrollment__user=request.user)
             .prefetch_related(
                 Prefetch('course_set__courserun_set', queryset=CourseRun.get_first_unexpired_run_qset())
             )

--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -45,11 +45,11 @@ class DashboardTest(APITestCase):
         # create the programs
         cls.program_1 = ProgramFactory.create(live=True)
         cls.program_2 = ProgramFactory.create(live=True)
-        cls.program_3 = ProgramFactory.create(live=True)
+        cls.program_not_enrolled = ProgramFactory.create(live=True)
         cls.program_no_live = ProgramFactory.create(live=False)
 
         # enroll the user in some courses
-        for program in [cls.program_1, cls.program_3, cls.program_no_live]:
+        for program in [cls.program_1, cls.program_2, cls.program_no_live]:
             ProgramEnrollment.objects.create(
                 user=cls.user,
                 program=program
@@ -95,13 +95,9 @@ class DashboardTest(APITestCase):
         res = self.get_with_mocked_refresh_backends()
 
         assert res.status_code == status.HTTP_200_OK
-        data = res.data
-        assert len(data) == 3
-        program_ids = [data[0]['id'], data[1]['id'], data[2]['id'], ]
-        assert self.program_1.pk in program_ids
-        assert self.program_3.pk in program_ids
-        assert self.program_2.pk in program_ids
-        assert self.program_no_live.pk not in program_ids
+        program_ids = [program['id'] for program in res.data]
+        # not live and not enrolled programs are missing
+        assert program_ids == [self.program_1.pk, self.program_2.pk]
 
 
 class DashboardTokensTest(APITestCase):

--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -19,6 +19,7 @@ from edx_api.grades.models import CurrentGrades
 from backends.edxorg import EdxOrgOAuth2
 from backends.utils import InvalidCredentialStored
 from courses.factories import ProgramFactory, CourseRunFactory
+from courses.models import Program
 from dashboard.models import ProgramEnrollment, CachedEnrollment
 from dashboard.utils import MMTrack
 from micromasters.factories import UserFactory
@@ -98,6 +99,7 @@ class DashboardTest(APITestCase):
         program_ids = [program['id'] for program in res.data]
         # not live and not enrolled programs are missing
         assert program_ids == [self.program_1.pk, self.program_2.pk]
+        assert Program.objects.count() == 4
 
 
 class DashboardTokensTest(APITestCase):

--- a/static/js/actions/programs.js
+++ b/static/js/actions/programs.js
@@ -13,8 +13,8 @@ import {
 import { setToastMessage } from '../actions/ui';
 import type { Dispatcher } from '../flow/reduxTypes';
 import type {
-  ProgramEnrollment,
-  ProgramEnrollments,
+  AvailableProgram,
+  AvailablePrograms,
 } from '../flow/enrollmentTypes';
 import * as api from '../lib/api';
 
@@ -30,10 +30,10 @@ export const receiveGetProgramEnrollmentsSuccess = createAction(RECEIVE_GET_PROG
 export const RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE = 'RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE';
 export const receiveGetProgramEnrollmentsFailure = createAction(RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE);
 
-export function fetchProgramEnrollments(): Dispatcher<ProgramEnrollments> {
+export function fetchProgramEnrollments(): Dispatcher<AvailablePrograms> {
   return (dispatch: Dispatch) => {
     dispatch(requestGetProgramEnrollments());
-    return api.getProgramEnrollments().
+    return api.getPrograms().
       then(enrollments => dispatch(receiveGetProgramEnrollmentsSuccess(enrollments))).
       catch(error => {
         dispatch(receiveGetProgramEnrollmentsFailure(error));
@@ -51,7 +51,7 @@ export const receiveAddProgramEnrollmentSuccess = createAction(RECEIVE_ADD_PROGR
 export const RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE = 'RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE';
 export const receiveAddProgramEnrollmentFailure = createAction(RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE);
 
-export const addProgramEnrollment = (programId: number): Dispatcher<ProgramEnrollment> => {
+export const addProgramEnrollment = (programId: number): Dispatcher<AvailableProgram> => {
   return (dispatch: Dispatch) => {
     dispatch(requestAddProgramEnrollment(programId));
     return api.addProgramEnrollment(programId).

--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -158,7 +158,7 @@ describe("ErrorMessage", () => {
       });
 
       it('shows an error if there is no matching current program enrollment', () => {
-        helper.enrollmentsGetStub.returns(Promise.resolve([]));
+        helper.programsGetStub.returns(Promise.resolve([]));
 
         return renderComponent("/dashboard").then(([wrapper]) => {
           let message = wrapper.find('.page-content').text();
@@ -249,7 +249,7 @@ describe("ErrorMessage", () => {
 
     describe('learners page', () => {
       it('shows an error if there is no matching current program enrollment', () => {
-        helper.enrollmentsGetStub.returns(Promise.resolve([]));
+        helper.programsGetStub.returns(Promise.resolve([]));
 
         return renderComponent("/learners").then(([wrapper]) => {
           let message = wrapper.find('.page-content').text();

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -30,7 +30,7 @@ import CustomNoHits from './search/CustomNoHits';
 import EmailCompositionDialog from './EmailCompositionDialog';
 import type { Option } from '../flow/generalTypes';
 import type { Email } from '../flow/emailTypes';
-import type { ProgramEnrollment } from '../flow/enrollmentTypes';
+import type { AvailableProgram } from '../flow/enrollmentTypes';
 
 let makeSearchkitTranslations: () => Object = () => {
   let translations = {};
@@ -90,7 +90,7 @@ export default class LearnerSearch extends SearchkitComponent {
     sendEmail:                () => void,
     email:                    Email,
     children:                 React$Element<*>[],
-    currentProgramEnrollment: ProgramEnrollment,
+    currentProgramEnrollment: AvailableProgram,
   };
 
   dropdownOptions: Option[] = [
@@ -130,12 +130,12 @@ export default class LearnerSearch extends SearchkitComponent {
     );
   }
 
-  renderFacets: Function = (currentProgramEnrollment: ProgramEnrollment): React$Element<*> => {
+  renderFacets: Function = (currentProgram: AvailableProgram): React$Element<*> => {
     if (_.isNull(this.getResults())) {
       return (
         <Card className="fullwidth" shadow={1}>
           <div className="no-hits left-nav">
-            {`There are no users in the ${currentProgramEnrollment.title} program.`}
+            {`There are no users in the ${currentProgram.title} program.`}
           </div>
         </Card>
       );

--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -10,7 +10,7 @@ import R from 'ramda';
 
 import type {
   ProgramEnrollment,
-  ProgramEnrollmentsState,
+  ProgramEnrollments,
 } from '../flow/enrollmentTypes';
 import ProgramSelector from './ProgramSelector';
 import UserMenu from '../containers/UserMenu';
@@ -30,7 +30,7 @@ export default class Navbar extends React.Component {
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
-    programs:                    ProgramEnrollmentsState,
+    programs:                    ProgramEnrollments,
     navDrawerOpen:               boolean,
     pathname:                    string,
     profile:                     Profile,

--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -8,7 +8,6 @@ import { ReactPageClick } from 'react-page-click';
 import Swipeable from 'react-swipeable';
 import R from 'ramda';
 
-import type { DashboardState } from '../flow/dashboardTypes';
 import type {
   ProgramEnrollment,
   ProgramEnrollmentsState,
@@ -27,7 +26,6 @@ export default class Navbar extends React.Component {
     addProgramEnrollment:        (programId: number) => void,
     children?:                   React$Element<*>[],
     currentProgramEnrollment:    ProgramEnrollment,
-    dashboard:                   DashboardState,
     empty:                       boolean,
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,

--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -9,8 +9,8 @@ import Swipeable from 'react-swipeable';
 import R from 'ramda';
 
 import type {
-  ProgramEnrollment,
-  ProgramEnrollments,
+  AvailableProgram,
+  AvailablePrograms,
 } from '../flow/enrollmentTypes';
 import ProgramSelector from './ProgramSelector';
 import UserMenu from '../containers/UserMenu';
@@ -25,16 +25,16 @@ export default class Navbar extends React.Component {
   props: {
     addProgramEnrollment:        (programId: number) => void,
     children?:                   React$Element<*>[],
-    currentProgramEnrollment:    ProgramEnrollment,
+    currentProgramEnrollment:    AvailableProgram,
     empty:                       boolean,
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
-    programs:                    ProgramEnrollments,
+    programs:                    AvailablePrograms,
     navDrawerOpen:               boolean,
     pathname:                    string,
     profile:                     Profile,
-    setCurrentProgramEnrollment: (enrollment: ProgramEnrollment) => void,
+    setCurrentProgramEnrollment: (program: AvailableProgram) => void,
     setEnrollDialogError:        (error: ?string) => void,
     setEnrollDialogVisibility:   (open: boolean) => void,
     setEnrollSelectedProgram:    (programId: ?number) => void,

--- a/static/js/components/Navbar_test.js
+++ b/static/js/components/Navbar_test.js
@@ -15,7 +15,7 @@ describe('Navbar', () => {
   const props = {
     profile: USER_PROFILE_RESPONSE,
     dashboard: { programs: DASHBOARD_RESPONSE },
-    programs: { programEnrollments: PROGRAM_ENROLLMENTS },
+    programs: PROGRAM_ENROLLMENTS,
   };
 
   let renderNavbar = () => shallow(<Navbar {...props} />);

--- a/static/js/components/Navbar_test.js
+++ b/static/js/components/Navbar_test.js
@@ -8,14 +8,14 @@ import Navbar from './Navbar';
 import {
   USER_PROFILE_RESPONSE,
   DASHBOARD_RESPONSE,
-  PROGRAM_ENROLLMENTS,
+  PROGRAMS,
 } from '../constants';
 
 describe('Navbar', () => {
   const props = {
     profile: USER_PROFILE_RESPONSE,
     dashboard: { programs: DASHBOARD_RESPONSE },
-    programs: PROGRAM_ENROLLMENTS,
+    programs: PROGRAMS,
   };
 
   let renderNavbar = () => shallow(<Navbar {...props} />);

--- a/static/js/components/NewEnrollmentDialog.js
+++ b/static/js/components/NewEnrollmentDialog.js
@@ -5,12 +5,12 @@ import _ from 'lodash';
 
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
-import type { ProgramEnrollmentsState } from '../flow/enrollmentTypes';
+import type { ProgramEnrollments } from '../flow/enrollmentTypes';
 
 export default class NewEnrollmentDialog extends React.Component {
   props: {
     addProgramEnrollment:        (programId: number) => void,
-    programs:                    ProgramEnrollmentsState,
+    programs:                    ProgramEnrollments,
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
@@ -69,10 +69,10 @@ export default class NewEnrollmentDialog extends React.Component {
       enrollDialogError,
       enrollDialogVisibility,
       enrollSelectedProgram,
-      programs: { programEnrollments },
+      programs,
     } = this.props;
 
-    let unenrolledPrograms = programEnrollments.filter(program => !program.enrolled);
+    let unenrolledPrograms = programs.filter(program => !program.enrolled);
     unenrolledPrograms = _.sortBy(unenrolledPrograms, 'title');
     let options = unenrolledPrograms.map(program =>
       <MenuItem value={program.id} primaryText={program.title} key={program.id} />

--- a/static/js/components/NewEnrollmentDialog.js
+++ b/static/js/components/NewEnrollmentDialog.js
@@ -72,8 +72,7 @@ export default class NewEnrollmentDialog extends React.Component {
       programs,
     } = this.props;
 
-    let unenrolledPrograms = programs.filter(program => !program.enrolled);
-    unenrolledPrograms = _.sortBy(unenrolledPrograms, 'title');
+    let unenrolledPrograms = _.sortBy(programs.filter(program => !program.enrolled), 'title');
     let options = unenrolledPrograms.map(program =>
       <MenuItem value={program.id} primaryText={program.title} key={program.id} />
     );

--- a/static/js/components/NewEnrollmentDialog.js
+++ b/static/js/components/NewEnrollmentDialog.js
@@ -5,12 +5,12 @@ import _ from 'lodash';
 
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
-import type { ProgramEnrollments } from '../flow/enrollmentTypes';
+import type { AvailablePrograms } from '../flow/enrollmentTypes';
 
 export default class NewEnrollmentDialog extends React.Component {
   props: {
     addProgramEnrollment:        (programId: number) => void,
-    programs:                    ProgramEnrollments,
+    programs:                    AvailablePrograms,
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,

--- a/static/js/components/NewEnrollmentDialog.js
+++ b/static/js/components/NewEnrollmentDialog.js
@@ -5,13 +5,11 @@ import _ from 'lodash';
 
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
-import type { DashboardState } from '../flow/dashboardTypes';
 import type { ProgramEnrollmentsState } from '../flow/enrollmentTypes';
 
 export default class NewEnrollmentDialog extends React.Component {
   props: {
     addProgramEnrollment:        (programId: number) => void,
-    dashboard:                   DashboardState,
     programs:                    ProgramEnrollmentsState,
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
@@ -68,15 +66,13 @@ export default class NewEnrollmentDialog extends React.Component {
 
   render() {
     const {
-      dashboard: { programs },
       enrollDialogError,
       enrollDialogVisibility,
       enrollSelectedProgram,
       programs: { programEnrollments },
     } = this.props;
 
-    let enrollmentLookup = new Map(programEnrollments.map(enrollment => [enrollment.id, null]));
-    let unenrolledPrograms = programs.filter(program => !enrollmentLookup.has(program.id));
+    let unenrolledPrograms = programEnrollments.filter(program => !program.enrolled);
     unenrolledPrograms = _.sortBy(unenrolledPrograms, 'title');
     let options = unenrolledPrograms.map(program =>
       <MenuItem value={program.id} primaryText={program.title} key={program.id} />

--- a/static/js/components/NewEnrollmentDialog_test.js
+++ b/static/js/components/NewEnrollmentDialog_test.js
@@ -12,7 +12,7 @@ import * as uiActions from '../actions/ui';
 
 import {
   DASHBOARD_RESPONSE,
-  PROGRAM_ENROLLMENTS,
+  PROGRAMS,
 } from '../constants';
 import NewEnrollmentDialog from './NewEnrollmentDialog';
 import IntegrationTestHelper from '../util/integration_test_helper';
@@ -30,7 +30,7 @@ describe("NewEnrollmentDialog", () => {
   const renderEnrollmentDialog = (props = {}) => {
     return shallow(
       <NewEnrollmentDialog
-        programs={PROGRAM_ENROLLMENTS}
+        programs={PROGRAMS}
         enrollDialogVisibility={true}
         {...props}
       />
@@ -42,7 +42,7 @@ describe("NewEnrollmentDialog", () => {
       let dialog = wrapper.find(NewEnrollmentDialog).at(0);
       let props = dialog.props();
 
-      assert.deepEqual(props.programs, PROGRAM_ENROLLMENTS);
+      assert.deepEqual(props.programs, PROGRAMS);
     });
   });
 
@@ -81,7 +81,7 @@ describe("NewEnrollmentDialog", () => {
   });
 
   it('can select the program enrollment via SelectField', () => {
-    let enrollment = PROGRAM_ENROLLMENTS[0];
+    let enrollment = PROGRAMS[0];
     let stub = helper.sandbox.stub();
     let wrapper = renderEnrollmentDialog({
       setEnrollSelectedProgram: stub
@@ -91,7 +91,7 @@ describe("NewEnrollmentDialog", () => {
   });
 
   it('can dispatch an addProgramEnrollment action for the currently selected enrollment', () => {
-    let selectedEnrollment = PROGRAM_ENROLLMENTS[0];
+    let selectedEnrollment = PROGRAMS[0];
     let visibilityStub = helper.sandbox.stub();
     let enrollStub = helper.sandbox.stub();
     let wrapper = renderEnrollmentDialog({
@@ -132,7 +132,7 @@ describe("NewEnrollmentDialog", () => {
   });
 
   it("only shows programs which the user is not already enrolled in", () => {
-    let enrollmentLookup = new Map(PROGRAM_ENROLLMENTS.map(enrollment => [enrollment.id, null]));
+    let enrollmentLookup = new Map(PROGRAMS.map(enrollment => [enrollment.id, null]));
     let unenrolledPrograms = DASHBOARD_RESPONSE.filter(program => !enrollmentLookup.has(program.id));
     unenrolledPrograms = _.sortBy(unenrolledPrograms, 'title');
     unenrolledPrograms = unenrolledPrograms.map(program => ({
@@ -140,7 +140,7 @@ describe("NewEnrollmentDialog", () => {
       id: program.id,
     }));
 
-    let selectedEnrollment = PROGRAM_ENROLLMENTS[0];
+    let selectedEnrollment = PROGRAMS[0];
 
     let wrapper = renderEnrollmentDialog({
       enrollDialogVisibility: false,
@@ -159,7 +159,7 @@ describe("NewEnrollmentDialog", () => {
   });
 
   it("shows the current enrollment in the SelectField", () => {
-    let selectedEnrollment = PROGRAM_ENROLLMENTS[0];
+    let selectedEnrollment = PROGRAMS[0];
 
     let wrapper = renderEnrollmentDialog({
       enrollSelectedProgram: selectedEnrollment,

--- a/static/js/components/NewEnrollmentDialog_test.js
+++ b/static/js/components/NewEnrollmentDialog_test.js
@@ -27,12 +27,22 @@ describe("NewEnrollmentDialog", () => {
     helper.cleanup();
   });
 
+  const renderEnrollmentDialog = (props = {}) => {
+    return shallow(
+      <NewEnrollmentDialog
+        programs={PROGRAM_ENROLLMENTS}
+        enrollDialogVisibility={true}
+        {...props}
+      />
+    )
+  };
+
   it('renders a dialog', () => {
     return helper.renderComponent("/dashboard").then(([wrapper]) => {
       let dialog = wrapper.find(NewEnrollmentDialog).at(0);
       let props = dialog.props();
 
-      assert.deepEqual(props.programs.programEnrollments, PROGRAM_ENROLLMENTS);
+      assert.deepEqual(props.programs, PROGRAM_ENROLLMENTS);
     });
   });
 
@@ -73,12 +83,9 @@ describe("NewEnrollmentDialog", () => {
   it('can select the program enrollment via SelectField', () => {
     let enrollment = PROGRAM_ENROLLMENTS[0];
     let stub = helper.sandbox.stub();
-    let wrapper = shallow(
-      <NewEnrollmentDialog
-        programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
-        enrollDialogVisibility={true}
-        setEnrollSelectedProgram={stub}
-      />);
+    let wrapper = renderEnrollmentDialog({
+      setEnrollSelectedProgram: stub
+    });
     wrapper.find(SelectField).props().onChange(null, null, enrollment);
     assert(stub.calledWith(enrollment));
   });
@@ -87,14 +94,11 @@ describe("NewEnrollmentDialog", () => {
     let selectedEnrollment = PROGRAM_ENROLLMENTS[0];
     let visibilityStub = helper.sandbox.stub();
     let enrollStub = helper.sandbox.stub();
-    let wrapper = shallow(
-      <NewEnrollmentDialog
-        programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
-        enrollDialogVisibility={true}
-        setEnrollDialogVisibility={visibilityStub}
-        addProgramEnrollment={enrollStub}
-        enrollSelectedProgram={selectedEnrollment}
-      />);
+    let wrapper = renderEnrollmentDialog({
+      setEnrollDialogVisibility: visibilityStub,
+      addProgramEnrollment: enrollStub,
+      enrollSelectedProgram: selectedEnrollment,
+    });
     let button = wrapper.find(Dialog).props().actions.find(
       button => button.props.className.includes("enroll")
     );
@@ -105,12 +109,9 @@ describe("NewEnrollmentDialog", () => {
 
   it("shows an error if the user didn't select any program when they click enroll", () => {
     let stub = helper.sandbox.stub();
-    let wrapper = shallow(
-      <NewEnrollmentDialog
-        programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
-        enrollDialogVisibility={true}
-        setEnrollDialogError={stub}
-      />);
+    let wrapper = renderEnrollmentDialog({
+      setEnrollDialogError: stub
+    });
     let button = wrapper.find(Dialog).props().actions.find(
       button => button.props.className.includes("enroll")
     );
@@ -120,12 +121,9 @@ describe("NewEnrollmentDialog", () => {
 
   it("clears the dialog when the user clicks cancel", () => {
     let stub = helper.sandbox.stub();
-    let wrapper = shallow(
-      <NewEnrollmentDialog
-        programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
-        enrollDialogVisibility={true}
-        setEnrollDialogVisibility={stub}
-      />);
+    let wrapper = renderEnrollmentDialog({
+      setEnrollDialogVisibility: stub
+    });
     let button = wrapper.find(Dialog).props().actions.find(
       button => button.props.className.includes("cancel")
     );
@@ -144,12 +142,10 @@ describe("NewEnrollmentDialog", () => {
 
     let selectedEnrollment = PROGRAM_ENROLLMENTS[0];
 
-    let wrapper = shallow(
-      <NewEnrollmentDialog
-        programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
-        enrollDialogVisibility={false}
-        enrollSelectedProgram={selectedEnrollment}
-      />);
+    let wrapper = renderEnrollmentDialog({
+      enrollDialogVisibility: false,
+      enrollSelectedProgram: selectedEnrollment
+    });
 
     let list = wrapper.find(MenuItem).map(menuItem => {
       let props = menuItem.props();
@@ -165,12 +161,10 @@ describe("NewEnrollmentDialog", () => {
   it("shows the current enrollment in the SelectField", () => {
     let selectedEnrollment = PROGRAM_ENROLLMENTS[0];
 
-    let wrapper = shallow(
-      <NewEnrollmentDialog
-        programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
-        enrollSelectedProgram={selectedEnrollment}
-        enrollDialogVisibility={false}
-      />);
+    let wrapper = renderEnrollmentDialog({
+      enrollSelectedProgram: selectedEnrollment,
+      enrollDialogVisibility: false
+    });
     let select = wrapper.find(SelectField);
     assert.equal(select.props().value, selectedEnrollment);
   });

--- a/static/js/components/NewEnrollmentDialog_test.js
+++ b/static/js/components/NewEnrollmentDialog_test.js
@@ -33,7 +33,6 @@ describe("NewEnrollmentDialog", () => {
       let props = dialog.props();
 
       assert.deepEqual(props.programs.programEnrollments, PROGRAM_ENROLLMENTS);
-      assert.deepEqual(props.dashboard.programs, DASHBOARD_RESPONSE);
     });
   });
 
@@ -76,7 +75,6 @@ describe("NewEnrollmentDialog", () => {
     let stub = helper.sandbox.stub();
     let wrapper = shallow(
       <NewEnrollmentDialog
-        dashboard={{programs: DASHBOARD_RESPONSE}}
         programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
         enrollDialogVisibility={true}
         setEnrollSelectedProgram={stub}
@@ -91,7 +89,6 @@ describe("NewEnrollmentDialog", () => {
     let enrollStub = helper.sandbox.stub();
     let wrapper = shallow(
       <NewEnrollmentDialog
-        dashboard={{programs: DASHBOARD_RESPONSE}}
         programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
         enrollDialogVisibility={true}
         setEnrollDialogVisibility={visibilityStub}
@@ -110,7 +107,6 @@ describe("NewEnrollmentDialog", () => {
     let stub = helper.sandbox.stub();
     let wrapper = shallow(
       <NewEnrollmentDialog
-        dashboard={{programs: DASHBOARD_RESPONSE}}
         programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
         enrollDialogVisibility={true}
         setEnrollDialogError={stub}
@@ -126,7 +122,6 @@ describe("NewEnrollmentDialog", () => {
     let stub = helper.sandbox.stub();
     let wrapper = shallow(
       <NewEnrollmentDialog
-        dashboard={{programs: DASHBOARD_RESPONSE}}
         programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
         enrollDialogVisibility={true}
         setEnrollDialogVisibility={stub}
@@ -151,7 +146,6 @@ describe("NewEnrollmentDialog", () => {
 
     let wrapper = shallow(
       <NewEnrollmentDialog
-        dashboard={{programs: DASHBOARD_RESPONSE}}
         programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
         enrollDialogVisibility={false}
         enrollSelectedProgram={selectedEnrollment}
@@ -173,7 +167,6 @@ describe("NewEnrollmentDialog", () => {
 
     let wrapper = shallow(
       <NewEnrollmentDialog
-        dashboard={{programs: DASHBOARD_RESPONSE}}
         programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
         enrollSelectedProgram={selectedEnrollment}
         enrollDialogVisibility={false}

--- a/static/js/components/NewEnrollmentDialog_test.js
+++ b/static/js/components/NewEnrollmentDialog_test.js
@@ -34,7 +34,7 @@ describe("NewEnrollmentDialog", () => {
         enrollDialogVisibility={true}
         {...props}
       />
-    )
+    );
   };
 
   it('renders a dialog', () => {

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -21,7 +21,7 @@ import type {
   UpdateProfileFunc,
 } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
-import type { ProgramEnrollmentsState, ProgramEnrollments } from '../flow/enrollmentTypes';
+import type { ProgramEnrollments } from '../flow/enrollmentTypes';
 import type { Event } from '../flow/eventType';
 import {  validationErrorSelector } from '../util/util';
 
@@ -34,7 +34,7 @@ export default class PersonalTab extends React.Component {
     ui:             UIState,
     nextStep:       () => void,
     prevStep:       () => void,
-    programs:       ProgramEnrollmentsState,
+    programs:       ProgramEnrollments,
     setProgram:     Function,
     addProgramEnrollment: Function,
   };

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -21,12 +21,11 @@ import type {
   UpdateProfileFunc,
 } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
-import type { DashboardState } from '../flow/dashboardTypes';
-import type { Program } from '../flow/programTypes';
+import type { ProgramEnrollmentsState, ProgramEnrollments } from '../flow/enrollmentTypes';
 import type { Event } from '../flow/eventType';
 import {  validationErrorSelector } from '../util/util';
 
-class PersonalTab extends React.Component {
+export default class PersonalTab extends React.Component {
   props: {
     profile:        Profile,
     errors:         ValidationErrors,
@@ -35,32 +34,32 @@ class PersonalTab extends React.Component {
     ui:             UIState,
     nextStep:       () => void,
     prevStep:       () => void,
-    dashboard:      DashboardState,
+    programs:       ProgramEnrollmentsState,
     setProgram:     Function,
     addProgramEnrollment: Function,
   };
 
-  programListing = (programs: Array<Program>) => {
+  programListing = (programs: ProgramEnrollments) => {
     const makeMenuItems = R.map(program => (
       <MenuItem value={program.id} key={program.id} primaryText={program.title} />
     ));
     const sortPrograms = R.sortBy(R.compose(R.toLower, R.prop('title')));
     const menuItems = R.compose(makeMenuItems, sortPrograms);
-    return menuItems(programs) ;
-  }
+    return menuItems(programs);
+  };
 
   setProgramHelper = (event: Event, key: string, value: string) => {
     const {
-      dashboard: { programs },
+      programs: { programEnrollments },
       setProgram,
     } = this.props;
-    let selected = programs.find(program => program.id === value);
+    let selected = programEnrollments.find(program => program.id === value);
     setProgram(selected);
-  }
+  };
 
   selectProgram = () => {
     const {
-      dashboard: { programs },
+      programs: { programEnrollments },
       ui: { selectedProgram },
       errors
     } = this.props;
@@ -71,10 +70,10 @@ class PersonalTab extends React.Component {
         style={{width: "65%"}}
         hintText="Select Program"
         onChange={this.setProgramHelper}
-        className={`program-select ${validationErrorSelector(errors, ['program'])}`}
+        className={`program-selectfield ${validationErrorSelector(errors, ['program'])}`}
         errorText={_.get(errors, "program")}
       >
-        { this.programListing(programs) }
+        { this.programListing(programEnrollments) }
       </SelectField>
     );
   }
@@ -108,5 +107,3 @@ class PersonalTab extends React.Component {
     );
   }
 }
-
-export default PersonalTab;

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -21,7 +21,7 @@ import type {
   UpdateProfileFunc,
 } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
-import type { ProgramEnrollments } from '../flow/enrollmentTypes';
+import type { AvailablePrograms } from '../flow/enrollmentTypes';
 import type { Event } from '../flow/eventType';
 import {  validationErrorSelector } from '../util/util';
 
@@ -34,12 +34,12 @@ export default class PersonalTab extends React.Component {
     ui:             UIState,
     nextStep:       () => void,
     prevStep:       () => void,
-    programs:       ProgramEnrollments,
+    programs:       AvailablePrograms,
     setProgram:     Function,
     addProgramEnrollment: Function,
   };
 
-  programListing = (programs: ProgramEnrollments) => {
+  programListing = (programs: AvailablePrograms) => {
     const makeMenuItems = R.map(program => (
       <MenuItem value={program.id} key={program.id} primaryText={program.title} />
     ));

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -50,16 +50,16 @@ export default class PersonalTab extends React.Component {
 
   setProgramHelper = (event: Event, key: string, value: string) => {
     const {
-      programs: { programEnrollments },
+      programs,
       setProgram,
     } = this.props;
-    let selected = programEnrollments.find(program => program.id === value);
+    let selected = programs.find(program => program.id === value);
     setProgram(selected);
   };
 
   selectProgram = () => {
     const {
-      programs: { programEnrollments },
+      programs,
       ui: { selectedProgram },
       errors
     } = this.props;
@@ -73,7 +73,7 @@ export default class PersonalTab extends React.Component {
         className={`program-selectfield ${validationErrorSelector(errors, ['program'])}`}
         errorText={_.get(errors, "program")}
       >
-        { this.programListing(programEnrollments) }
+        { this.programListing(programs) }
       </SelectField>
     );
   }

--- a/static/js/components/PersonalTab_test.js
+++ b/static/js/components/PersonalTab_test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { assert } from 'chai';
+import R from 'ramda';
+
+import PersonalTab from './PersonalTab';
+import { PROGRAM_ENROLLMENTS } from '../constants';
+
+describe("PersonalTab", () => {
+
+  let renderPersonalTab = (props = {}) => {
+    return shallow(<PersonalTab
+      programs={{
+        programEnrollments: PROGRAM_ENROLLMENTS
+      }}
+      ui={{
+        selectedProgram: null,
+      }}
+      {...props}
+    />);
+  };
+
+  it('should show a list of programs to enroll in for the learner page', () => {
+    let wrapper = renderPersonalTab();
+    let menuItems = wrapper.find("MenuItem");
+    assert.equal(menuItems.length, PROGRAM_ENROLLMENTS.length);
+    let sortedEnrollments = R.sortBy(R.compose(R.toLower, R.prop('title')))(PROGRAM_ENROLLMENTS);
+    menuItems.forEach((menuItem, i) => {
+      let program = sortedEnrollments[i];
+      assert.equal(program.title, menuItem.props()['primaryText']);
+      assert.equal(program.id, menuItem.props()['value']);
+    });
+  });
+
+  it('should have the current program enrollment selected', () => {
+    let selectedProgram = PROGRAM_ENROLLMENTS[0];
+
+    let wrapper = renderPersonalTab({
+      ui: {
+        selectedProgram
+      },
+    });
+    assert.equal(wrapper.find("SelectField").props()['value'], selectedProgram.id);
+  });
+});

--- a/static/js/components/PersonalTab_test.js
+++ b/static/js/components/PersonalTab_test.js
@@ -8,11 +8,11 @@ import { PROGRAMS } from '../constants';
 
 describe("PersonalTab", () => {
 
-  let renderPersonalTab = (props = {}) => {
+  let renderPersonalTab = (selectedProgram = null, props = {}) => {
     return shallow(<PersonalTab
       programs={PROGRAMS}
       ui={{
-        selectedProgram: null,
+        selectedProgram: selectedProgram,
       }}
       {...props}
     />);
@@ -33,11 +33,7 @@ describe("PersonalTab", () => {
   it('should have the current program enrollment selected', () => {
     let selectedProgram = PROGRAMS[0];
 
-    let wrapper = renderPersonalTab({
-      ui: {
-        selectedProgram
-      },
-    });
+    let wrapper = renderPersonalTab(selectedProgram);
     assert.equal(wrapper.find("SelectField").props()['value'], selectedProgram.id);
   });
 });

--- a/static/js/components/PersonalTab_test.js
+++ b/static/js/components/PersonalTab_test.js
@@ -4,13 +4,13 @@ import { assert } from 'chai';
 import R from 'ramda';
 
 import PersonalTab from './PersonalTab';
-import { PROGRAM_ENROLLMENTS } from '../constants';
+import { PROGRAMS } from '../constants';
 
 describe("PersonalTab", () => {
 
   let renderPersonalTab = (props = {}) => {
     return shallow(<PersonalTab
-      programs={PROGRAM_ENROLLMENTS}
+      programs={PROGRAMS}
       ui={{
         selectedProgram: null,
       }}
@@ -21,8 +21,8 @@ describe("PersonalTab", () => {
   it('should show a list of programs to enroll in for the learner page', () => {
     let wrapper = renderPersonalTab();
     let menuItems = wrapper.find("MenuItem");
-    assert.equal(menuItems.length, PROGRAM_ENROLLMENTS.length);
-    let sortedEnrollments = R.sortBy(R.compose(R.toLower, R.prop('title')))(PROGRAM_ENROLLMENTS);
+    assert.equal(menuItems.length, PROGRAMS.length);
+    let sortedEnrollments = R.sortBy(R.compose(R.toLower, R.prop('title')))(PROGRAMS);
     menuItems.forEach((menuItem, i) => {
       let program = sortedEnrollments[i];
       assert.equal(program.title, menuItem.props()['primaryText']);
@@ -31,7 +31,7 @@ describe("PersonalTab", () => {
   });
 
   it('should have the current program enrollment selected', () => {
-    let selectedProgram = PROGRAM_ENROLLMENTS[0];
+    let selectedProgram = PROGRAMS[0];
 
     let wrapper = renderPersonalTab({
       ui: {

--- a/static/js/components/PersonalTab_test.js
+++ b/static/js/components/PersonalTab_test.js
@@ -10,9 +10,7 @@ describe("PersonalTab", () => {
 
   let renderPersonalTab = (props = {}) => {
     return shallow(<PersonalTab
-      programs={{
-        programEnrollments: PROGRAM_ENROLLMENTS
-      }}
+      programs={PROGRAM_ENROLLMENTS}
       ui={{
         selectedProgram: null,
       }}

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -6,11 +6,11 @@ import {
 } from 'searchkit';
 import _ from 'lodash';
 
-import type { ProgramEnrollment } from '../flow/enrollmentTypes';
+import type { AvailableProgram } from '../flow/enrollmentTypes';
 
 export default class ProgramFilter extends SearchkitComponent {
   props: {
-    currentProgramEnrollment: ProgramEnrollment,
+    currentProgramEnrollment: AvailableProgram,
   };
 
   _accessor = new AnonymousAccessor(query => {

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -6,7 +6,7 @@ import Select from 'react-select';
 import NewEnrollmentDialog from './NewEnrollmentDialog';
 import type {
   ProgramEnrollment,
-  ProgramEnrollmentsState,
+  ProgramEnrollments,
 } from '../flow/enrollmentTypes';
 import type { Option } from '../flow/generalTypes';
 
@@ -16,7 +16,7 @@ export default class ProgramSelector extends React.Component {
   props: {
     addProgramEnrollment:        (programId: number) => void,
     currentProgramEnrollment:    ProgramEnrollment,
-    programs:                    ProgramEnrollmentsState,
+    programs:                    ProgramEnrollments,
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
@@ -29,7 +29,7 @@ export default class ProgramSelector extends React.Component {
 
   selectEnrollment = (option: Option): void => {
     const {
-      programs: { programEnrollments },
+      programs,
       setCurrentProgramEnrollment,
       setEnrollDialogError,
       setEnrollDialogVisibility,
@@ -40,7 +40,7 @@ export default class ProgramSelector extends React.Component {
       setEnrollSelectedProgram(null);
       setEnrollDialogError(null);
     } else {
-      let selected = programEnrollments.find(enrollment => enrollment.id === option.value);
+      let selected = programs.find(program => program.id === option.value);
       setCurrentProgramEnrollment(selected);
     }
   };
@@ -48,7 +48,7 @@ export default class ProgramSelector extends React.Component {
   makeOptions = (): Array<Option> => {
     const {
       currentProgramEnrollment,
-      programs: { programEnrollments },
+      programs,
     } = this.props;
 
     let currentId;
@@ -56,9 +56,9 @@ export default class ProgramSelector extends React.Component {
       currentId = currentProgramEnrollment.id;
     }
 
-    const sortedProgramEnrollments = _.sortBy(programEnrollments, 'title');
-    let enrolledPrograms = sortedProgramEnrollments.filter(program => program.enrolled);
-    let unenrolledPrograms = sortedProgramEnrollments.filter(program => !program.enrolled);
+    const sortedPrograms = _.sortBy(programs, 'title');
+    let enrolledPrograms = sortedPrograms.filter(program => program.enrolled);
+    let unenrolledPrograms = sortedPrograms.filter(program => !program.enrolled);
     let unselected = enrolledPrograms.filter(enrollment => enrollment.id !== currentId);
 
     let options = unselected.map(enrollment => ({
@@ -75,7 +75,6 @@ export default class ProgramSelector extends React.Component {
     let {
       addProgramEnrollment,
       programs,
-      programs: {programEnrollments},
       enrollDialogError,
       enrollDialogVisibility,
       enrollSelectedProgram,
@@ -90,10 +89,10 @@ export default class ProgramSelector extends React.Component {
       currentId = currentProgramEnrollment.id;
     }
 
-    let selected = programEnrollments.find(enrollment => enrollment.id === currentId);
+    let selected = programs.find(enrollment => enrollment.id === currentId);
     let options = this.makeOptions();
 
-    if (programEnrollments.length === 0 || selectorVisibility === false) {
+    if (programs.length === 0 || selectorVisibility === false) {
       return <div className="program-selector" />;
     } else {
       return <div className="program-selector">

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -5,8 +5,8 @@ import Select from 'react-select';
 
 import NewEnrollmentDialog from './NewEnrollmentDialog';
 import type {
-  ProgramEnrollment,
-  ProgramEnrollments,
+  AvailableProgram,
+  AvailablePrograms,
 } from '../flow/enrollmentTypes';
 import type { Option } from '../flow/generalTypes';
 
@@ -15,12 +15,12 @@ const ENROLL_SENTINEL = 'enroll';
 export default class ProgramSelector extends React.Component {
   props: {
     addProgramEnrollment:        (programId: number) => void,
-    currentProgramEnrollment:    ProgramEnrollment,
-    programs:                    ProgramEnrollments,
+    currentProgramEnrollment:    AvailableProgram,
+    programs:                    AvailablePrograms,
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
-    setCurrentProgramEnrollment: (enrollment: ProgramEnrollment) => void,
+    setCurrentProgramEnrollment: (enrollment: AvailableProgram) => void,
     setEnrollDialogError:        (error: ?string) => void,
     setEnrollDialogVisibility:   (open: boolean) => void,
     setEnrollSelectedProgram:    (programId: ?number) => void,

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import Select from 'react-select';
 
 import NewEnrollmentDialog from './NewEnrollmentDialog';
-import type { DashboardState } from '../flow/dashboardTypes';
 import type {
   ProgramEnrollment,
   ProgramEnrollmentsState,
@@ -21,7 +20,6 @@ export default class ProgramSelector extends React.Component {
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
-    dashboard:                   DashboardState,
     setCurrentProgramEnrollment: (enrollment: ProgramEnrollment) => void,
     setEnrollDialogError:        (error: ?string) => void,
     setEnrollDialogVisibility:   (open: boolean) => void,
@@ -51,7 +49,6 @@ export default class ProgramSelector extends React.Component {
     const {
       currentProgramEnrollment,
       programs: { programEnrollments },
-      dashboard: { programs },
     } = this.props;
 
     let currentId;
@@ -59,7 +56,9 @@ export default class ProgramSelector extends React.Component {
       currentId = currentProgramEnrollment.id;
     }
 
-    const sortedProgramEnrollments = _.sortBy(programEnrollments, 'title');
+    const sortedProgramEnrollments = _.sortBy(programEnrollments, 'title').filter(
+      enrollment => enrollment.enrolled
+    );
 
     let unselected = sortedProgramEnrollments.filter(enrollment => enrollment.id !== currentId);
     let options = unselected.map(enrollment => ({
@@ -67,8 +66,7 @@ export default class ProgramSelector extends React.Component {
       label: enrollment.title,
     }));
 
-    let enrollmentLookup = new Map(sortedProgramEnrollments.map(enrollment => [enrollment.id, null]));
-    let unenrolledPrograms = programs.filter(program => !enrollmentLookup.has(program.id));
+    let unenrolledPrograms = programEnrollments.filter(program => !program.enrolled);
     unenrolledPrograms = _.sortBy(unenrolledPrograms, 'title');
 
     if (unenrolledPrograms.length > 0) {
@@ -80,7 +78,6 @@ export default class ProgramSelector extends React.Component {
   render() {
     let {
       addProgramEnrollment,
-      dashboard,
       programs,
       programs: {programEnrollments},
       enrollDialogError,
@@ -114,7 +111,6 @@ export default class ProgramSelector extends React.Component {
         />
         <NewEnrollmentDialog
           addProgramEnrollment={addProgramEnrollment}
-          dashboard={dashboard}
           programs={programs}
           enrollDialogError={enrollDialogError}
           enrollDialogVisibility={enrollDialogVisibility}

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -56,19 +56,15 @@ export default class ProgramSelector extends React.Component {
       currentId = currentProgramEnrollment.id;
     }
 
-    const sortedProgramEnrollments = _.sortBy(programEnrollments, 'title').filter(
-      enrollment => enrollment.enrolled
-    );
+    const sortedProgramEnrollments = _.sortBy(programEnrollments, 'title');
+    let enrolledPrograms = sortedProgramEnrollments.filter(program => program.enrolled);
+    let unenrolledPrograms = sortedProgramEnrollments.filter(program => !program.enrolled);
+    let unselected = enrolledPrograms.filter(enrollment => enrollment.id !== currentId);
 
-    let unselected = sortedProgramEnrollments.filter(enrollment => enrollment.id !== currentId);
     let options = unselected.map(enrollment => ({
       value: enrollment.id,
       label: enrollment.title,
     }));
-
-    let unenrolledPrograms = programEnrollments.filter(program => !program.enrolled);
-    unenrolledPrograms = _.sortBy(unenrolledPrograms, 'title');
-
     if (unenrolledPrograms.length > 0) {
       options.push({label: "Enroll in a new program", value: ENROLL_SENTINEL});
     }

--- a/static/js/components/ProgramSelector_test.js
+++ b/static/js/components/ProgramSelector_test.js
@@ -13,11 +13,11 @@ import {
 describe('ProgramSelector', () => {
   let sandbox;
   // make a copy of enrollments
-  const enrollments = _.cloneDeep(PROGRAM_ENROLLMENTS);
+  const programs = _.cloneDeep(PROGRAM_ENROLLMENTS);
   // remove one enrollment so not all enrollments are enrolled
-  const unenrolled = enrollments[0];
+  const unenrolled = programs[0];
   unenrolled.enrolled = false;
-  const selectedEnrollment = enrollments[1];
+  const selectedEnrollment = programs[1];
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -30,7 +30,7 @@ describe('ProgramSelector', () => {
   let renderProgramSelector = (props) => {
     return shallow(
       <ProgramSelector
-        programs={{programEnrollments: enrollments}}
+        programs={programs}
         currentProgramEnrollment={selectedEnrollment}
         {...props}
       />
@@ -39,9 +39,7 @@ describe('ProgramSelector', () => {
 
   it('renders an empty div if there are no program enrollments', () => {
     let wrapper = renderProgramSelector({
-      programs: {
-        programEnrollments: []
-      },
+      programs: [],
     });
     assert.lengthOf(wrapper.find("div").children(), 0);
   });
@@ -55,17 +53,18 @@ describe('ProgramSelector', () => {
     let wrapper = renderProgramSelector();
     let selectProps = wrapper.find(Select).props();
 
-    let sortedEnrollments = _.sortBy(enrollments, 'title').filter(program => program.enrolled);
+    let enrollments = programs.filter(program => program.enrolled);
+    let sortedEnrollments = _.sortBy(enrollments, 'title');
     // make sure we are testing sorting meaningfully
     assert.notDeepEqual(sortedEnrollments, enrollments);
 
     let options = selectProps['options'];
     // include 'Enroll in a new program' which comes at the end if user can enroll in a new program
     let expectedEnrollments = sortedEnrollments.
-      filter(enrollment => enrollment.id !== selectedEnrollment.id).
-      map(enrollment => ({
-        label: enrollment.title,
-        value: enrollment.id,
+      filter(program => program.id !== selectedEnrollment.id).
+      map(program => ({
+        label: program.title,
+        value: program.id,
       })).
       concat({
         label: "Enroll in a new program",
@@ -75,26 +74,24 @@ describe('ProgramSelector', () => {
   });
 
   it("does not render the 'Enroll in a new program' option if there is not at least one available program", () => {
-    let allEnrollments = enrollments.map(program => Object.assign({}, program, {
+    let allEnrollments = programs.map(program => Object.assign({}, program, {
       enrolled: true
     }));
     let wrapper = renderProgramSelector({
-      programs: {
-        programEnrollments: allEnrollments
-      }
+      programs: allEnrollments
     });
     let selectProps = wrapper.find(Select).props();
     let sortedEnrollments = _.sortBy(allEnrollments, 'title');
     // make sure we are testing sorting meaningfully
-    assert.notDeepEqual(sortedEnrollments, enrollments);
+    assert.notDeepEqual(sortedEnrollments, allEnrollments);
 
     let options = selectProps['options'];
     // include 'Enroll in a new program' which comes at the end if user can enroll in a new program
     let expectedEnrollments = sortedEnrollments.
-      filter(enrollment => enrollment.id !== selectedEnrollment.id).
-      map(enrollment => ({
-        label: enrollment.title,
-        value: enrollment.id,
+      filter(program => program.id !== selectedEnrollment.id).
+      map(program => ({
+        label: program.title,
+        value: program.id,
       }));
     assert.deepEqual(options, expectedEnrollments);
   });
@@ -122,8 +119,7 @@ describe('ProgramSelector', () => {
       setCurrentProgramEnrollment,
     });
     let onChange = wrapper.find(Select).props()['onChange'];
-    let newSelectedEnrollment = enrollments[0];
-    onChange({value: newSelectedEnrollment.id});
-    assert(setCurrentProgramEnrollment.calledWith(newSelectedEnrollment));
+    onChange({value: unenrolled.id});
+    assert(setCurrentProgramEnrollment.calledWith(unenrolled));
   });
 });

--- a/static/js/components/ProgramSelector_test.js
+++ b/static/js/components/ProgramSelector_test.js
@@ -7,13 +7,13 @@ import sinon from 'sinon';
 
 import ProgramSelector from './ProgramSelector';
 import {
-  PROGRAM_ENROLLMENTS,
+  PROGRAMS,
 } from '../constants';
 
 describe('ProgramSelector', () => {
   let sandbox;
   // make a copy of enrollments
-  const programs = _.cloneDeep(PROGRAM_ENROLLMENTS);
+  const programs = _.cloneDeep(PROGRAMS);
   // remove one enrollment so not all enrollments are enrolled
   const unenrolled = programs[0];
   unenrolled.enrolled = false;

--- a/static/js/components/ProgramSelector_test.js
+++ b/static/js/components/ProgramSelector_test.js
@@ -7,18 +7,16 @@ import sinon from 'sinon';
 
 import ProgramSelector from './ProgramSelector';
 import {
-  DASHBOARD_RESPONSE,
+  PROGRAM_ENROLLMENTS,
 } from '../constants';
 
 describe('ProgramSelector', () => {
   let sandbox;
-  // define our own enrollments
-  const enrollments = DASHBOARD_RESPONSE.map(program => ({
-    id: program.id,
-    title: program.title,
-  }));
-  // remove one enrollment so that not all programs are enrolled
-  const unenrolled = enrollments.splice(0, 1)[0];
+  // make a copy of enrollments
+  const enrollments = _.cloneDeep(PROGRAM_ENROLLMENTS);
+  // remove one enrollment so not all enrollments are enrolled
+  const unenrolled = enrollments[0];
+  unenrolled.enrolled = false;
   const selectedEnrollment = enrollments[1];
 
   beforeEach(() => {
@@ -33,7 +31,6 @@ describe('ProgramSelector', () => {
     return shallow(
       <ProgramSelector
         programs={{programEnrollments: enrollments}}
-        dashboard={{programs: DASHBOARD_RESPONSE}}
         currentProgramEnrollment={selectedEnrollment}
         {...props}
       />
@@ -58,7 +55,7 @@ describe('ProgramSelector', () => {
     let wrapper = renderProgramSelector();
     let selectProps = wrapper.find(Select).props();
 
-    let sortedEnrollments = _.sortBy(enrollments, 'title');
+    let sortedEnrollments = _.sortBy(enrollments, 'title').filter(program => program.enrolled);
     // make sure we are testing sorting meaningfully
     assert.notDeepEqual(sortedEnrollments, enrollments);
 
@@ -78,7 +75,9 @@ describe('ProgramSelector', () => {
   });
 
   it("does not render the 'Enroll in a new program' option if there is not at least one available program", () => {
-    let allEnrollments = enrollments.concat(unenrolled);
+    let allEnrollments = enrollments.map(program => Object.assign({}, program, {
+      enrolled: true
+    }));
     let wrapper = renderProgramSelector({
       programs: {
         programEnrollments: allEnrollments

--- a/static/js/components/WelcomeBanner.js
+++ b/static/js/components/WelcomeBanner.js
@@ -9,7 +9,6 @@ import type { Profile } from '../flow/profileTypes';
 export default class WelcomeBanner extends React.Component {
   props: {
     profile:      Profile,
-    text:         string,
     children?:    React$Element<*>[],
   };
 

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -10,31 +10,37 @@ import CourseRow from './CourseRow';
 import { DASHBOARD_RESPONSE, COURSE_PRICES_RESPONSE } from '../../constants';
 
 describe('CourseListCard', () => {
-  let defaultCardParams = {
-    coursePrice: _.cloneDeep(COURSE_PRICES_RESPONSE[0]),
-    checkout: () => null,
-    addCourseEnrollment: () => undefined,
-  };
+  let program, defaultCardParams;
+  beforeEach(() => {
+    program = _.cloneDeep(DASHBOARD_RESPONSE[1]);
+    assert(program.courses.length > 0);
+    let coursePrice = COURSE_PRICES_RESPONSE.find(
+      coursePrice => coursePrice.program_id === program.id
+    );
+
+    defaultCardParams = {
+      coursePrice: coursePrice,
+      checkout: () => null,
+      addCourseEnrollment: () => undefined,
+    };
+  });
 
   it('creates a CourseRow for each course', () => {
-    const program = DASHBOARD_RESPONSE[1];
-    assert.isAbove(program.courses.length, 0);
     let now = moment();
     const wrapper = shallow(
       <CourseListCard program={program} now={now} {...defaultCardParams} />
     );
     assert.equal(wrapper.find(CourseRow).length, program.courses.length);
+    let courses = _.sortBy(program.courses, 'position_in_program');
     wrapper.find(CourseRow).forEach((courseRow, i) => {
       const props = courseRow.props();
       assert.equal(props.now, now);
-      assert.equal(props.course, program.courses[i]);
+      assert.deepEqual(props.course, courses[i]);
       assert.equal(props.checkout, defaultCardParams.checkout);
     });
   });
 
   it("fills in now if it's missing in the props", () => {
-    const program = DASHBOARD_RESPONSE[1];
-    assert.isAbove(program.courses.length, 0);
     const wrapper = shallow(
       <CourseListCard program={program} {...defaultCardParams} />
     );
@@ -47,7 +53,6 @@ describe('CourseListCard', () => {
   });
 
   it("doesn't show the personalized pricing box for programs without it", () => {
-    const program = _.cloneDeep(DASHBOARD_RESPONSE[1]);
     program.financial_aid_availability = false;
     const wrapper = shallow(
       <CourseListCard program={program} {...defaultCardParams} />

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -590,7 +590,7 @@ export const DASHBOARD_RESPONSE = [
   },
 ];
 
-export const PROGRAM_ENROLLMENTS = DASHBOARD_RESPONSE.map(program => ({
+export const PROGRAMS = DASHBOARD_RESPONSE.map(program => ({
   id: program.id,
   title: program.title,
   programpage_url: `/program${program.id}/`,

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -285,13 +285,6 @@ export const USER_PROGRAM_RESPONSE = {
 
 export const DASHBOARD_RESPONSE = [
   {
-    "title": "Empty program",
-    "description": "The empty program",
-    "courses": [
-    ],
-    "id": 2
-  },
-  {
     "description": "Not passed program",
     "title": "Not passed program",
     "courses": [
@@ -562,6 +555,13 @@ export const DASHBOARD_RESPONSE = [
     "id": 5
   },
   {
+    "title": "Empty program",
+    "description": "The empty program",
+    "courses": [
+    ],
+    "id": 2
+  },
+  {
     "title": "Last program",
     "description": "The last program",
     "courses": [
@@ -590,20 +590,12 @@ export const DASHBOARD_RESPONSE = [
   },
 ];
 
-export const PROGRAM_ENROLLMENTS = [
-  {
-    id: DASHBOARD_RESPONSE[1].id,
-    title: DASHBOARD_RESPONSE[1].title,
-    programpage_url: "/program/",
-    enrolled: true,
-  },
-  {
-    id: DASHBOARD_RESPONSE[2].id,
-    title: DASHBOARD_RESPONSE[2].title,
-    programpage_url: null,
-    enrolled: true,
-  },
-];
+export const PROGRAM_ENROLLMENTS = DASHBOARD_RESPONSE.map(program => ({
+  id: program.id,
+  title: program.title,
+  programpage_url: `/program${program.id}/`,
+  enrolled: true
+}));
 
 export const FINANCIAL_AID_PARTIAL_RESPONSE = {
   application_status: null,
@@ -612,17 +604,12 @@ export const FINANCIAL_AID_PARTIAL_RESPONSE = {
   min_possible_cost: 1000
 };
 
-export const COURSE_PRICES_RESPONSE = [{
-  program_id: DASHBOARD_RESPONSE[1].id,
-  price: 100.00,
+export const COURSE_PRICES_RESPONSE = DASHBOARD_RESPONSE.map(program => ({
+  program_id: program.id,
+  price: program.id * 100,
   financial_aid_availability: false,
   has_financial_aid_request: false
-}, {
-  program_id: DASHBOARD_RESPONSE[2].id,
-  price: 200.00,
-  financial_aid_availability: false,
-  has_financial_aid_request: false
-}];
+}));
 
 export const ERROR_RESPONSE = {
   "errorStatusCode": 500,

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -255,7 +255,7 @@ class App extends React.Component {
         enrollDialogVisibility={enrollDialogVisibility}
         enrollSelectedProgram={enrollSelectedProgram}
         pathname={pathname}
-        programs={programs.programEnrollments}
+        programs={programs.availablePrograms}
         setCurrentProgramEnrollment={this.setCurrentProgramEnrollment}
         setEnrollDialogError={this.setEnrollDialogError}
         setEnrollDialogVisibility={this.setEnrollDialogVisibility}

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -255,7 +255,7 @@ class App extends React.Component {
         enrollDialogVisibility={enrollDialogVisibility}
         enrollSelectedProgram={enrollSelectedProgram}
         pathname={pathname}
-        programs={programs}
+        programs={programs.programEnrollments}
         setCurrentProgramEnrollment={this.setCurrentProgramEnrollment}
         setEnrollDialogError={this.setEnrollDialogError}
         setEnrollDialogVisibility={this.setEnrollDialogVisibility}

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -45,8 +45,8 @@ import {
 import { validateProfileComplete } from '../lib/validation/profile';
 import type { DashboardState, CoursePricesState } from '../flow/dashboardTypes';
 import type {
-  ProgramEnrollment,
-  ProgramEnrollmentsState,
+  AvailableProgram,
+  AvailableProgramsState,
 } from '../flow/enrollmentTypes';
 import type { ProfileGetResult } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
@@ -58,11 +58,11 @@ class App extends React.Component {
     children:                 React$Element<*>[],
     userProfile:              ProfileGetResult,
     location:                 Object,
-    currentProgramEnrollment: ProgramEnrollment,
+    currentProgramEnrollment: AvailableProgram,
     dispatch:                 Dispatch,
     dashboard:                DashboardState,
     prices:                   CoursePricesState,
-    programs:                 ProgramEnrollmentsState,
+    programs:                 AvailableProgramsState,
     history:                  Object,
     ui:                       UIState,
     signupDialog:             Object,
@@ -187,7 +187,7 @@ class App extends React.Component {
     dispatch(setEnrollSelectedProgram(programId));
   };
 
-  setCurrentProgramEnrollment = (enrollment: ProgramEnrollment): void => {
+  setCurrentProgramEnrollment = (enrollment: AvailableProgram): void => {
     const { dispatch } = this.props;
     dispatch(setCurrentProgramEnrollment(enrollment));
   };

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -219,7 +219,6 @@ class App extends React.Component {
         navDrawerOpen,
       },
       location: { pathname },
-      dashboard,
       userProfile: { profile },
     } = this.props;
     let { children } = this.props;
@@ -251,7 +250,6 @@ class App extends React.Component {
       <Navbar
         addProgramEnrollment={this.addProgramEnrollment}
         currentProgramEnrollment={currentProgramEnrollment}
-        dashboard={dashboard}
         empty={empty}
         enrollDialogError={enrollDialogError}
         enrollDialogVisibility={enrollDialogVisibility}

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -121,7 +121,7 @@ describe('App', () => {
 
   describe('enrollments', () => {
     it('shows an error message if the enrollments GET fetch fails', () => {
-      helper.enrollmentsGetStub.returns(Promise.reject());
+      helper.programsGetStub.returns(Promise.reject());
       let types = [
         RECEIVE_DASHBOARD_SUCCESS,
         RECEIVE_COURSE_PRICES_SUCCESS,

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -51,7 +51,7 @@ import type {
   DocumentsState,
 } from '../reducers/documents';
 import type { CoursePricesState, DashboardState } from '../flow/dashboardTypes';
-import type { ProgramEnrollment } from '../flow/enrollmentTypes';
+import type { AvailableProgram } from '../flow/enrollmentTypes';
 import type { ProfileGetResult } from '../flow/profileTypes';
 import type { Course, CourseRun } from '../flow/programTypes';
 import { skipFinancialAid } from '../actions/financial_aid';
@@ -65,7 +65,7 @@ class DashboardPage extends React.Component {
 
   props: {
     profile:                  ProfileGetResult,
-    currentProgramEnrollment: ProgramEnrollment,
+    currentProgramEnrollment: AvailableProgram,
     dashboard:                DashboardState,
     prices:                   CoursePricesState,
     dispatch:                 Dispatch,

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -22,7 +22,7 @@ import SelectField from '../components/inputs/SelectField';
 import { currencyOptions } from '../lib/currency';
 import { validateFinancialAid } from '../lib/validation/profile';
 import { sanitizeNumberString } from '../lib/validation/date';
-import type { ProgramEnrollment } from '../flow/enrollmentTypes';
+import type { AvailableProgram } from '../flow/enrollmentTypes';
 import type {
   FinancialAidState,
   FinancialAidValidation,
@@ -117,7 +117,7 @@ type CalculatorProps = {
   validation:                 FinancialAidValidation,
   saveFinancialAid:           (f: FinancialAidState) => void,
   updateCalculatorEdit:       (f: FinancialAidState) => void,
-  currentProgramEnrollment:   ProgramEnrollment,
+  currentProgramEnrollment:   AvailableProgram,
   openConfirmSkipDialog:      () => void,
   programs:                   Array<Program>,
 };

--- a/static/js/containers/LearnerSearchPage.js
+++ b/static/js/containers/LearnerSearchPage.js
@@ -23,7 +23,7 @@ import {
 import { emailValidation } from '../lib/validation/profile';
 import type { UIState } from '../reducers/ui';
 import type { EmailState } from '../flow/emailTypes';
-import type { ProgramEnrollment } from '../flow/enrollmentTypes';
+import type { AvailableProgram } from '../flow/enrollmentTypes';
 import { getCookie } from '../lib/api';
 import { SEARCH_FILTER_DEFAULT_VISIBILITY } from '../constants';
 
@@ -35,7 +35,7 @@ const searchKit = new SearchkitManager(SETTINGS.search_url, {
 
 class LearnerSearchPage extends React.Component {
   props: {
-    currentProgramEnrollment: ProgramEnrollment,
+    currentProgramEnrollment: AvailableProgram,
     dispatch:                 Dispatch,
     email:                    EmailState,
     ui:                       UIState,

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 
 import IntegrationTestHelper from '../util/integration_test_helper';
 import {
-  PROGRAM_ENROLLMENTS,
+  PROGRAMS,
   ELASTICSEARCH_RESPONSE,
 } from '../constants';
 
@@ -38,12 +38,12 @@ describe('LearnerSearchPage', function () {
     return renderComponent('/learners').then(() => {
       let request = server.requests[server.requests.length - 1];
       let body = JSON.parse(request.requestBody);
-      assert.deepEqual(body.filter.bool.must[0].term['program.id'], PROGRAM_ENROLLMENTS[0].id);
+      assert.deepEqual(body.filter.bool.must[0].term['program.id'], PROGRAMS[0].id);
     });
   });
 
   it("doesn't filter by program id for current enrollment if it's not set to anything", () => {
-    helper.enrollmentsGetStub.returns(Promise.resolve([]));
+    helper.programsGetStub.returns(Promise.resolve([]));
 
     return renderComponent('/learners').then(() => {
       assert.lengthOf(server.requests, 0);

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -34,7 +34,7 @@ import type { ActionHelpers, AsyncActionHelpers } from '../lib/redux';
 import type { Validator, UIValidator } from '../lib/validation/profile';
 import type { Profile, Profiles, ProfileGetResult } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
-import type { DashboardState } from '../flow/dashboardTypes';
+import type { ProgramEnrollmentsState } from '../flow/enrollmentTypes';
 import type { Program } from '../flow/programTypes';
 import { addProgramEnrollment } from '../actions/programs';
 import { ALL_ERRORS_VISIBLE } from '../constants';
@@ -49,7 +49,7 @@ class ProfileFormContainer extends React.Component {
     history:     Object,
     ui:          UIState,
     params:      {[k: string]: string},
-    dashboard:   DashboardState
+    programs:    ProgramEnrollmentsState
   };
 
   static contextTypes = {
@@ -60,7 +60,7 @@ class ProfileFormContainer extends React.Component {
     return {
       profiles: state.profiles,
       ui: state.ui,
-      dashboard: state.dashboard,
+      programs: state.programs,
     };
   };
 
@@ -174,7 +174,7 @@ class ProfileFormContainer extends React.Component {
   profileProps: Function = (profileFromStore: ProfileGetResult) => {
     let {
       ui,
-      dashboard,
+      programs,
       dispatch,
     } = this.props;
     let errors, isEdit, profile;
@@ -197,11 +197,11 @@ class ProfileFormContainer extends React.Component {
 
     return {
       addProgramEnrollment: this.addProgramEnrollment,
-      dashboard: dashboard,
       dispatch: dispatch,
       errors: errors,
       fetchProfile: this.fetchProfile,
       profile: profile,
+      programs: programs,
       saveProfile: this.saveProfile.bind(this, isEdit),
       setProgram: this.setProgram,
       startProfileEdit: this.startProfileEdit,

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -34,7 +34,7 @@ import type { ActionHelpers, AsyncActionHelpers } from '../lib/redux';
 import type { Validator, UIValidator } from '../lib/validation/profile';
 import type { Profile, Profiles, ProfileGetResult } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
-import type { ProgramEnrollmentsState } from '../flow/enrollmentTypes';
+import type { AvailableProgramsState } from '../flow/enrollmentTypes';
 import type { Program } from '../flow/programTypes';
 import { addProgramEnrollment } from '../actions/programs';
 import { ALL_ERRORS_VISIBLE } from '../constants';
@@ -49,7 +49,7 @@ class ProfileFormContainer extends React.Component {
     history:     Object,
     ui:          UIState,
     params:      {[k: string]: string},
-    programs:    ProgramEnrollmentsState
+    programs:    AvailableProgramsState
   };
 
   static contextTypes = {

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -64,7 +64,7 @@ class ProfilePage extends ProfileFormContainer {
   render() {
     const { profiles } = this.props;
     const profileInfo = profiles[SETTINGS.user.username];
-    let props, text;
+    let props;
     let [prev, next] = this.stepTransitions();
     props = Object.assign({}, this.profileProps(profileInfo), {
       prevStep: prev,
@@ -79,7 +79,7 @@ class ProfilePage extends ProfileFormContainer {
         errorMessage = <ErrorMessage errorInfo={profileInfo.errorInfo} />;
       } else {
         content = <div>
-          <WelcomeBanner profile={profile} text={text} />
+          <WelcomeBanner profile={profile} />
           <div className="profile-pagination">
             {makeProfileProgressDisplay(this.currentStep())}
           </div>

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -173,19 +173,19 @@ describe("ProfilePage", function() {
     patchUserProfileStub.returns(Promise.resolve(USER_PROFILE_RESPONSE));
 
     helper.store.dispatch(setProgram(program));
-    return renderComponent(`/profile`).then(([wrapper]) => {
+    return renderComponent(`/profile`, [START_PROFILE_EDIT]).then(([wrapper]) => {
       assert.isFalse(addEnrollmentStub.called);
 
       return helper.listenForActions([
         REQUEST_PATCH_USER_PROFILE,
         RECEIVE_PATCH_USER_PROFILE_SUCCESS,
-        START_PROFILE_EDIT,
         CLEAR_PROFILE_EDIT,
         UPDATE_PROFILE_VALIDATION,
         REQUEST_ADD_PROGRAM_ENROLLMENT,
         RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS,
         SET_PROFILE_STEP,
         START_PROFILE_EDIT,
+        UPDATE_VALIDATION_VISIBILITY,
       ], () => {
         wrapper.find(".next").simulate("click");
       }).then(() => {

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -4,19 +4,29 @@ import { assert } from 'chai';
 import _ from 'lodash';
 
 import {
+  REQUEST_ADD_PROGRAM_ENROLLMENT,
+  RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS,
+} from '../actions/programs';
+import {
   REQUEST_GET_USER_PROFILE,
   REQUEST_PATCH_USER_PROFILE,
   RECEIVE_PATCH_USER_PROFILE_SUCCESS,
   START_PROFILE_EDIT,
   UPDATE_PROFILE_VALIDATION,
   UPDATE_VALIDATION_VISIBILITY,
+  CLEAR_PROFILE_EDIT,
 } from '../actions/profile';
-import { setProfileStep } from '../actions/ui';
+import {
+  setProfileStep,
+  setProgram,
+  SET_PROFILE_STEP,
+} from '../actions/ui';
 import {
   USER_PROFILE_RESPONSE,
   PERSONAL_STEP,
   EDUCATION_STEP,
   EMPLOYMENT_STEP,
+  PROGRAM_ENROLLMENTS,
 } from '../constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
 import * as api from '../lib/api';
@@ -155,9 +165,31 @@ describe("ProfilePage", function() {
     });
   });
 
-  it('select program display on personal tab', () => {
-    return renderComponent('/profile', [START_PROFILE_EDIT]).then(([, div]) => {
-      assert(div.querySelector(".program-select"), "Unable to find select program dropdown");
+  it('should enroll the user when they go to the next page', () => {
+    let addEnrollmentStub = helper.sandbox.stub(api, 'addProgramEnrollment');
+    let program = PROGRAM_ENROLLMENTS[0];
+    addEnrollmentStub.returns(Promise.resolve(program));
+
+    patchUserProfileStub.returns(Promise.resolve(USER_PROFILE_RESPONSE));
+
+    helper.store.dispatch(setProgram(program));
+    return renderComponent(`/profile`).then(([wrapper]) => {
+      assert.isFalse(addEnrollmentStub.called);
+
+      return helper.listenForActions([
+        REQUEST_PATCH_USER_PROFILE,
+        RECEIVE_PATCH_USER_PROFILE_SUCCESS,
+        START_PROFILE_EDIT,
+        CLEAR_PROFILE_EDIT,
+        UPDATE_PROFILE_VALIDATION,
+        REQUEST_ADD_PROGRAM_ENROLLMENT,
+        RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS,
+        SET_PROFILE_STEP,
+      ], () => {
+        wrapper.find(".next").simulate("click");
+      }).then(() => {
+        assert.isTrue(addEnrollmentStub.called);
+      });
     });
   });
 });

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -26,7 +26,7 @@ import {
   PERSONAL_STEP,
   EDUCATION_STEP,
   EMPLOYMENT_STEP,
-  PROGRAM_ENROLLMENTS,
+  PROGRAMS,
 } from '../constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
 import * as api from '../lib/api';
@@ -167,7 +167,7 @@ describe("ProfilePage", function() {
 
   it('should enroll the user when they go to the next page', () => {
     let addEnrollmentStub = helper.sandbox.stub(api, 'addProgramEnrollment');
-    let program = PROGRAM_ENROLLMENTS[0];
+    let program = PROGRAMS[0];
     addEnrollmentStub.returns(Promise.resolve(program));
 
     patchUserProfileStub.returns(Promise.resolve(USER_PROFILE_RESPONSE));

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -185,6 +185,7 @@ describe("ProfilePage", function() {
         REQUEST_ADD_PROGRAM_ENROLLMENT,
         RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS,
         SET_PROFILE_STEP,
+        START_PROFILE_EDIT,
       ], () => {
         wrapper.find(".next").simulate("click");
       }).then(() => {

--- a/static/js/flow/enrollmentTypes.js
+++ b/static/js/flow/enrollmentTypes.js
@@ -4,6 +4,8 @@ import type { APIErrorInfo } from './generalTypes';
 export type ProgramEnrollment = {
   id: number,
   title: string,
+  programpage_url: ?string,
+  enrolled: boolean,
 };
 
 export type ProgramEnrollments = Array<ProgramEnrollment>;

--- a/static/js/flow/enrollmentTypes.js
+++ b/static/js/flow/enrollmentTypes.js
@@ -1,17 +1,17 @@
 // @flow
 import type { APIErrorInfo } from './generalTypes';
 
-export type ProgramEnrollment = {
+export type AvailableProgram = {
   id: number,
   title: string,
   programpage_url: ?string,
   enrolled: boolean,
 };
 
-export type ProgramEnrollments = Array<ProgramEnrollment>;
+export type AvailablePrograms = Array<AvailableProgram>;
 
-export type ProgramEnrollmentsState = {
-  programEnrollments: ProgramEnrollments,
+export type AvailableProgramsState = {
+  programEnrollments: AvailablePrograms,
   getStatus?: string,
   getErrorInfo?: APIErrorInfo,
   postStatus?: string,

--- a/static/js/flow/enrollmentTypes.js
+++ b/static/js/flow/enrollmentTypes.js
@@ -11,10 +11,11 @@ export type AvailableProgram = {
 export type AvailablePrograms = Array<AvailableProgram>;
 
 export type AvailableProgramsState = {
-  programEnrollments: AvailablePrograms,
+  availablePrograms: AvailablePrograms,
   getStatus?: string,
   getErrorInfo?: APIErrorInfo,
   postStatus?: string,
+  postErrorInfo?: APIErrorInfo,
 };
 
 export type CourseEnrollmentsState = {

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -7,7 +7,7 @@ import R from 'ramda';
 import type { Profile, ProfileGetResult, ProfilePatchResult } from '../flow/profileTypes';
 import type { CheckoutResponse } from '../flow/checkoutTypes';
 import type { Dashboard } from '../flow/dashboardTypes';
-import type { ProgramEnrollment, ProgramEnrollments } from '../flow/enrollmentTypes';
+import type { AvailableProgram, AvailablePrograms } from '../flow/enrollmentTypes';
 import type { EmailSendResponse } from '../flow/emailTypes';
 
 export function getCookie(name: string): string|null {
@@ -171,11 +171,11 @@ export function sendSearchResultMail(subject: string, body: string, searchReques
   });
 }
 
-export function getProgramEnrollments(): Promise<ProgramEnrollments> {
+export function getPrograms(): Promise<AvailablePrograms> {
   return mockableFetchJSONWithCSRF('/api/v0/programs/', {}, true);
 }
 
-export function addProgramEnrollment(programId: number): Promise<ProgramEnrollment> {
+export function addProgramEnrollment(programId: number): Promise<AvailableProgram> {
   return mockableFetchJSONWithCSRF('/api/v0/enrolledprograms/', {
     method: 'POST',
     body: JSON.stringify({

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -172,7 +172,7 @@ export function sendSearchResultMail(subject: string, body: string, searchReques
 }
 
 export function getProgramEnrollments(): Promise<ProgramEnrollments> {
-  return mockableFetchJSONWithCSRF('/api/v0/enrolledprograms/', {}, true);
+  return mockableFetchJSONWithCSRF('/api/v0/programs/', {}, true);
 }
 
 export function addProgramEnrollment(programId: number): Promise<ProgramEnrollment> {

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -218,7 +218,7 @@ describe('api', function() {
       it('fetches program enrollments successfully', () => {
         fetchJSONStub.returns(Promise.resolve(PROGRAM_ENROLLMENTS));
         return getProgramEnrollments().then(enrollments => {
-          assert.ok(fetchJSONStub.calledWith('/api/v0/enrolledprograms/', {}, true));
+          assert.ok(fetchJSONStub.calledWith('/api/v0/programs/', {}, true));
           assert.deepEqual(enrollments, PROGRAM_ENROLLMENTS);
         });
       });
@@ -227,7 +227,7 @@ describe('api', function() {
         fetchJSONStub.returns(Promise.reject());
 
         return assert.isRejected(getProgramEnrollments()).then(() => {
-          assert.ok(fetchJSONStub.calledWith('/api/v0/enrolledprograms/', {}, true));
+          assert.ok(fetchJSONStub.calledWith('/api/v0/programs/', {}, true));
         });
       });
 

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -13,7 +13,7 @@ import {
   csrfSafeMethod,
   checkout,
   sendSearchResultMail,
-  getProgramEnrollments,
+  getPrograms,
   addProgramEnrollment,
   updateProfileImage,
   addFinancialAid,
@@ -27,7 +27,7 @@ import {
   DASHBOARD_RESPONSE,
   COURSE_PRICES_RESPONSE,
   USER_PROFILE_RESPONSE,
-  PROGRAM_ENROLLMENTS,
+  PROGRAMS,
 } from '../constants';
 
 describe('api', function() {
@@ -216,23 +216,23 @@ describe('api', function() {
 
     describe('for program enrollments', () => {
       it('fetches program enrollments successfully', () => {
-        fetchJSONStub.returns(Promise.resolve(PROGRAM_ENROLLMENTS));
-        return getProgramEnrollments().then(enrollments => {
+        fetchJSONStub.returns(Promise.resolve(PROGRAMS));
+        return getPrograms().then(enrollments => {
           assert.ok(fetchJSONStub.calledWith('/api/v0/programs/', {}, true));
-          assert.deepEqual(enrollments, PROGRAM_ENROLLMENTS);
+          assert.deepEqual(enrollments, PROGRAMS);
         });
       });
 
       it('fails to fetch program enrollments', () => {
         fetchJSONStub.returns(Promise.reject());
 
-        return assert.isRejected(getProgramEnrollments()).then(() => {
+        return assert.isRejected(getPrograms()).then(() => {
           assert.ok(fetchJSONStub.calledWith('/api/v0/programs/', {}, true));
         });
       });
 
       it('adds a program enrollment successfully', () => {
-        let enrollment = PROGRAM_ENROLLMENTS[0];
+        let enrollment = PROGRAMS[0];
         fetchJSONStub.returns(Promise.resolve(enrollment));
         fetchMock.mock('/api/v0/enrolledprograms/', (url, opts) => {
           assert.deepEqual(JSON.parse(opts.body), enrollment);
@@ -249,7 +249,7 @@ describe('api', function() {
 
       it('fails to add a program enrollment', () => {
         fetchJSONStub.returns(Promise.reject());
-        let enrollment = PROGRAM_ENROLLMENTS[0];
+        let enrollment = PROGRAMS[0];
 
         return assert.isRejected(addProgramEnrollment(enrollment.id)).then(() => {
           assert.ok(fetchJSONStub.calledWith('/api/v0/enrolledprograms/', {
@@ -262,7 +262,7 @@ describe('api', function() {
 
     describe('for adding financial aid', () => {
       it('add financial aid successfully', () => {
-        let programId = PROGRAM_ENROLLMENTS[0].id;
+        let programId = PROGRAMS[0].id;
         fetchJSONStub.returns(Promise.resolve());
 
         fetchMock.mock('/api/v0/financial_aid_request', () => {
@@ -284,7 +284,7 @@ describe('api', function() {
       it('fails to add financial aid', () => {
         fetchJSONStub.returns(Promise.reject());
 
-        let programId = PROGRAM_ENROLLMENTS[0].id;
+        let programId = PROGRAMS[0].id;
 
         return assert.isRejected(addFinancialAid(10000, 'USD', programId)).then(() => {
           assert.ok(fetchJSONStub.calledWith('/api/v0/financial_aid_request/', {

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -1,5 +1,8 @@
 /* global SETTINGS: false */
 import _ from 'lodash';
+import configureTestStore from 'redux-asserts';
+import { assert } from 'chai';
+import sinon from 'sinon';
 
 import {
   fetchUserProfile,
@@ -47,13 +50,9 @@ import {
   DASHBOARD_RESPONSE,
   USER_PROFILE_RESPONSE,
   CYBERSOURCE_CHECKOUT_RESPONSE,
-  STATUS_NOT_PASSED,
   ALL_ERRORS_VISIBLE,
 } from '../constants';
-import configureTestStore from 'redux-asserts';
 import rootReducer, { INITIAL_PROFILES_STATE } from '../reducers';
-import { assert } from 'chai';
-import sinon from 'sinon';
 
 describe('reducers', () => {
   let sandbox, store, dispatchThen;
@@ -307,7 +306,7 @@ describe('reducers', () => {
       let getRun = programs => programs[1].courses[0].runs[0];
 
       let run = getRun(DASHBOARD_RESPONSE);
-      assert.equal(run.status, STATUS_NOT_PASSED);
+      assert.notEqual(run.status, 'new_status');
       return dispatchThen(updateCourseStatus(run.course_id, 'new_status'), [UPDATE_COURSE_STATUS]).then(state => {
         assert.equal(getRun(state.programs).status, 'new_status');
       });

--- a/static/js/reducers/programs.js
+++ b/static/js/reducers/programs.js
@@ -39,7 +39,10 @@ export const programs = (state: ProgramEnrollmentsState = INITIAL_ENROLLMENTS_ST
     return {
       ...state,
       postStatus: FETCH_SUCCESS,
-      programEnrollments: state.programEnrollments.concat(action.payload)
+      programEnrollments: state.programEnrollments.filter(
+        // filter out old copy of program first
+        program => program.id !== action.payload.id
+      ).concat(action.payload)
     };
   case RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE:
     return { ...state, postStatus: FETCH_FAILURE, postErrorInfo: action.payload };
@@ -57,7 +60,9 @@ export const currentProgramEnrollment = (state: any = null, action: Action) => {
     return action.payload;
   case RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS:
     if (!_.isNil(state)) {
-      let enrollment = action.payload.find(enrollment => enrollment.id === state.id);
+      let enrollment = action.payload.find(enrollment => (
+        enrollment.id === state.id && enrollment.enrolled
+      ));
       if (enrollment === undefined) {
         // current enrollment not found in list
         state = null;

--- a/static/js/reducers/programs.js
+++ b/static/js/reducers/programs.js
@@ -21,16 +21,16 @@ import type {
   AvailableProgramsState,
 } from '../flow/enrollmentTypes';
 
-export const INITIAL_ENROLLMENTS_STATE: AvailableProgramsState = {
-  programEnrollments: []
+export const INITIAL_PROGRAMS_STATE: AvailableProgramsState = {
+  availablePrograms: []
 };
 
-export const programs = (state: AvailableProgramsState = INITIAL_ENROLLMENTS_STATE, action: Action) => {
+export const programs = (state: AvailableProgramsState = INITIAL_PROGRAMS_STATE, action: Action) => {
   switch (action.type) {
   case REQUEST_GET_PROGRAM_ENROLLMENTS:
     return { ...state, getStatus: FETCH_PROCESSING };
   case RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS:
-    return { ...state, getStatus: FETCH_SUCCESS, programEnrollments: action.payload };
+    return { ...state, getStatus: FETCH_SUCCESS, availablePrograms: action.payload };
   case RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE:
     return { ...state, getStatus: FETCH_FAILURE, getErrorInfo: action.payload };
   case REQUEST_ADD_PROGRAM_ENROLLMENT:
@@ -39,7 +39,7 @@ export const programs = (state: AvailableProgramsState = INITIAL_ENROLLMENTS_STA
     return {
       ...state,
       postStatus: FETCH_SUCCESS,
-      programEnrollments: state.programEnrollments.filter(
+      availablePrograms: state.availablePrograms.filter(
         // filter out old copy of program first
         program => program.id !== action.payload.id
       ).concat(action.payload)
@@ -47,7 +47,7 @@ export const programs = (state: AvailableProgramsState = INITIAL_ENROLLMENTS_STA
   case RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE:
     return { ...state, postStatus: FETCH_FAILURE, postErrorInfo: action.payload };
   case CLEAR_ENROLLMENTS:
-    return INITIAL_ENROLLMENTS_STATE;
+    return INITIAL_PROGRAMS_STATE;
   default:
     return state;
   }

--- a/static/js/reducers/programs.js
+++ b/static/js/reducers/programs.js
@@ -18,14 +18,14 @@ import {
 } from '../actions';
 import type { Action } from '../flow/reduxTypes';
 import type {
-  ProgramEnrollmentsState,
+  AvailableProgramsState,
 } from '../flow/enrollmentTypes';
 
-export const INITIAL_ENROLLMENTS_STATE: ProgramEnrollmentsState = {
+export const INITIAL_ENROLLMENTS_STATE: AvailableProgramsState = {
   programEnrollments: []
 };
 
-export const programs = (state: ProgramEnrollmentsState = INITIAL_ENROLLMENTS_STATE, action: Action) => {
+export const programs = (state: AvailableProgramsState = INITIAL_ENROLLMENTS_STATE, action: Action) => {
   switch (action.type) {
   case REQUEST_GET_PROGRAM_ENROLLMENTS:
     return { ...state, getStatus: FETCH_PROCESSING };

--- a/static/js/reducers/programs_test.js
+++ b/static/js/reducers/programs_test.js
@@ -67,7 +67,7 @@ describe('enrollments', () => {
     it('should have an empty default state', () => {
       return dispatchThen({type: 'unknown'}, ['unknown']).then(state => {
         assert.deepEqual(state, {
-          programEnrollments: []
+          availablePrograms: []
         });
       });
     });
@@ -80,7 +80,7 @@ describe('enrollments', () => {
         [REQUEST_GET_PROGRAM_ENROLLMENTS, RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS]
       ).then(enrollmentsState => {
         assert.equal(enrollmentsState.getStatus, FETCH_SUCCESS);
-        assert.deepEqual(enrollmentsState.programEnrollments, PROGRAMS);
+        assert.deepEqual(enrollmentsState.availablePrograms, PROGRAMS);
         assert.equal(getPrograms.callCount, 1);
         assert.deepEqual(getPrograms.args[0], []);
       });
@@ -95,7 +95,7 @@ describe('enrollments', () => {
       ).then(enrollmentsState => {
         assert.equal(enrollmentsState.getStatus, FETCH_FAILURE);
         assert.equal(enrollmentsState.getErrorInfo, "error");
-        assert.deepEqual(enrollmentsState.programEnrollments, []);
+        assert.deepEqual(enrollmentsState.availablePrograms, []);
         assert.equal(getPrograms.callCount, 1);
         assert.deepEqual(getPrograms.args[0], []);
       });
@@ -111,7 +111,7 @@ describe('enrollments', () => {
         SET_TOAST_MESSAGE,
       ]).then(enrollmentsState => {
         assert.equal(enrollmentsState.postStatus, FETCH_SUCCESS);
-        assert.deepEqual(enrollmentsState.programEnrollments, PROGRAMS.concat(newEnrollment));
+        assert.deepEqual(enrollmentsState.availablePrograms, PROGRAMS.concat(newEnrollment));
         assert.equal(addProgramEnrollmentStub.callCount, 1);
         assert.deepEqual(addProgramEnrollmentStub.args[0], [newEnrollment.id]);
         assert.ok(fetchCoursePricesStub.calledWith());
@@ -138,7 +138,7 @@ describe('enrollments', () => {
       ]).then(enrollmentsState => {
         assert.equal(enrollmentsState.postStatus, FETCH_FAILURE);
         assert.equal(enrollmentsState.postErrorInfo, "addError");
-        assert.deepEqual(enrollmentsState.programEnrollments, PROGRAMS);
+        assert.deepEqual(enrollmentsState.availablePrograms, PROGRAMS);
         assert.equal(addProgramEnrollmentStub.callCount, 1);
         assert.deepEqual(addProgramEnrollmentStub.args[0], [newEnrollment.id]);
         assert.notOk(fetchCoursePricesStub.calledWith());
@@ -159,7 +159,7 @@ describe('enrollments', () => {
 
       return dispatchThen(clearEnrollments(), [CLEAR_ENROLLMENTS]).then(enrollmentsState => {
         assert.deepEqual(enrollmentsState, {
-          programEnrollments: []
+          availablePrograms: []
         });
       });
     });

--- a/static/js/reducers/programs_test.js
+++ b/static/js/reducers/programs_test.js
@@ -10,7 +10,7 @@ import {
   SET_TOAST_MESSAGE,
 } from '../actions/ui';
 import {
-  PROGRAM_ENROLLMENTS,
+  PROGRAMS,
   TOAST_SUCCESS,
   TOAST_FAILURE,
 } from '../constants';
@@ -35,12 +35,12 @@ import * as actions from '../actions';
 import rootReducer from '../reducers';
 
 describe('enrollments', () => {
-  let sandbox, store, getProgramEnrollmentsStub, addProgramEnrollmentStub;
+  let sandbox, store, getPrograms, addProgramEnrollmentStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     store = configureTestStore(rootReducer);
-    getProgramEnrollmentsStub = sandbox.stub(api, 'getProgramEnrollments');
+    getPrograms = sandbox.stub(api, 'getPrograms');
     addProgramEnrollmentStub = sandbox.stub(api, 'addProgramEnrollment');
   });
 
@@ -73,21 +73,21 @@ describe('enrollments', () => {
     });
 
     it('should fetch program enrollments successfully', () => {
-      getProgramEnrollmentsStub.returns(Promise.resolve(PROGRAM_ENROLLMENTS));
+      getPrograms.returns(Promise.resolve(PROGRAMS));
 
       return dispatchThen(
         fetchProgramEnrollments(),
         [REQUEST_GET_PROGRAM_ENROLLMENTS, RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS]
       ).then(enrollmentsState => {
         assert.equal(enrollmentsState.getStatus, FETCH_SUCCESS);
-        assert.deepEqual(enrollmentsState.programEnrollments, PROGRAM_ENROLLMENTS);
-        assert.equal(getProgramEnrollmentsStub.callCount, 1);
-        assert.deepEqual(getProgramEnrollmentsStub.args[0], []);
+        assert.deepEqual(enrollmentsState.programEnrollments, PROGRAMS);
+        assert.equal(getPrograms.callCount, 1);
+        assert.deepEqual(getPrograms.args[0], []);
       });
     });
 
     it('should fail to fetch program enrollments', () => {
-      getProgramEnrollmentsStub.returns(Promise.reject("error"));
+      getPrograms.returns(Promise.reject("error"));
 
       return dispatchThen(
         fetchProgramEnrollments(),
@@ -96,14 +96,14 @@ describe('enrollments', () => {
         assert.equal(enrollmentsState.getStatus, FETCH_FAILURE);
         assert.equal(enrollmentsState.getErrorInfo, "error");
         assert.deepEqual(enrollmentsState.programEnrollments, []);
-        assert.equal(getProgramEnrollmentsStub.callCount, 1);
-        assert.deepEqual(getProgramEnrollmentsStub.args[0], []);
+        assert.equal(getPrograms.callCount, 1);
+        assert.deepEqual(getPrograms.args[0], []);
       });
     });
 
     it('should add a program enrollment successfully to the existing enrollments', () => {
       addProgramEnrollmentStub.returns(Promise.resolve(newEnrollment));
-      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
+      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAMS));
 
       return dispatchThen(addProgramEnrollment(newEnrollment.id), [
         REQUEST_ADD_PROGRAM_ENROLLMENT,
@@ -111,7 +111,7 @@ describe('enrollments', () => {
         SET_TOAST_MESSAGE,
       ]).then(enrollmentsState => {
         assert.equal(enrollmentsState.postStatus, FETCH_SUCCESS);
-        assert.deepEqual(enrollmentsState.programEnrollments, PROGRAM_ENROLLMENTS.concat(newEnrollment));
+        assert.deepEqual(enrollmentsState.programEnrollments, PROGRAMS.concat(newEnrollment));
         assert.equal(addProgramEnrollmentStub.callCount, 1);
         assert.deepEqual(addProgramEnrollmentStub.args[0], [newEnrollment.id]);
         assert.ok(fetchCoursePricesStub.calledWith());
@@ -129,7 +129,7 @@ describe('enrollments', () => {
 
     it('should fail to add a program enrollment and leave the existing state alone', () => {
       addProgramEnrollmentStub.returns(Promise.reject("addError"));
-      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
+      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAMS));
 
       return dispatchThen(addProgramEnrollment(newEnrollment.id), [
         REQUEST_ADD_PROGRAM_ENROLLMENT,
@@ -138,7 +138,7 @@ describe('enrollments', () => {
       ]).then(enrollmentsState => {
         assert.equal(enrollmentsState.postStatus, FETCH_FAILURE);
         assert.equal(enrollmentsState.postErrorInfo, "addError");
-        assert.deepEqual(enrollmentsState.programEnrollments, PROGRAM_ENROLLMENTS);
+        assert.deepEqual(enrollmentsState.programEnrollments, PROGRAMS);
         assert.equal(addProgramEnrollmentStub.callCount, 1);
         assert.deepEqual(addProgramEnrollmentStub.args[0], [newEnrollment.id]);
         assert.notOk(fetchCoursePricesStub.calledWith());
@@ -155,7 +155,7 @@ describe('enrollments', () => {
     });
 
     it('should clear the enrollments', () => {
-      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
+      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAMS));
 
       return dispatchThen(clearEnrollments(), [CLEAR_ENROLLMENTS]).then(enrollmentsState => {
         assert.deepEqual(enrollmentsState, {
@@ -176,22 +176,22 @@ describe('enrollments', () => {
     });
 
     it('should set the current enrollment', () => {
-      return dispatchThen(setCurrentProgramEnrollment(PROGRAM_ENROLLMENTS[1]), [SET_CURRENT_PROGRAM_ENROLLMENT]).
+      return dispatchThen(setCurrentProgramEnrollment(PROGRAMS[1]), [SET_CURRENT_PROGRAM_ENROLLMENT]).
         then(state => {
-          assert.deepEqual(state, PROGRAM_ENROLLMENTS[1]);
+          assert.deepEqual(state, PROGRAMS[1]);
         });
     });
 
     it("should pick the first enrollment if none is already set after receiving a list of enrollments", () => {
-      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
-      assert.deepEqual(store.getState().currentProgramEnrollment, PROGRAM_ENROLLMENTS[0]);
+      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAMS));
+      assert.deepEqual(store.getState().currentProgramEnrollment, PROGRAMS[0]);
     });
 
     it("should replace the current enrollment if it can't be found in the list of enrollments", () => {
       let enrollment = {"id": 999, "title": "not an enrollment anymore"};
       store.dispatch(setCurrentProgramEnrollment(enrollment));
-      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
-      assert.deepEqual(store.getState().currentProgramEnrollment, PROGRAM_ENROLLMENTS[0]);
+      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAMS));
+      assert.deepEqual(store.getState().currentProgramEnrollment, PROGRAMS[0]);
     });
 
     it("should clear the current enrollment if it can't be found in an empty list of enrollments", () => {
@@ -202,9 +202,9 @@ describe('enrollments', () => {
     });
 
     it("should not pick a current enrollment after receiving a list of enrollments if one is already picked", () => {
-      store.dispatch(setCurrentProgramEnrollment(PROGRAM_ENROLLMENTS[1]));
-      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAM_ENROLLMENTS));
-      assert.deepEqual(store.getState().currentProgramEnrollment, PROGRAM_ENROLLMENTS[1]);
+      store.dispatch(setCurrentProgramEnrollment(PROGRAMS[1]));
+      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAMS));
+      assert.deepEqual(store.getState().currentProgramEnrollment, PROGRAMS[1]);
     });
   });
 });

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -9,7 +9,7 @@ import * as api from '../lib/api';
 import {
   DASHBOARD_RESPONSE,
   COURSE_PRICES_RESPONSE,
-  PROGRAM_ENROLLMENTS,
+  PROGRAMS,
   USER_PROFILE_RESPONSE,
 } from '../constants';
 import {
@@ -55,8 +55,8 @@ class IntegrationTestHelper {
     this.coursePricesStub.returns(Promise.resolve(COURSE_PRICES_RESPONSE));
     this.profileGetStub = this.sandbox.stub(api, 'getUserProfile');
     this.profileGetStub.returns(Promise.resolve(USER_PROFILE_RESPONSE));
-    this.enrollmentsGetStub = this.sandbox.stub(api, 'getProgramEnrollments');
-    this.enrollmentsGetStub.returns(Promise.resolve(PROGRAM_ENROLLMENTS));
+    this.programsGetStub = this.sandbox.stub(api, 'getPrograms');
+    this.programsGetStub.returns(Promise.resolve(PROGRAMS));
     this.browserHistory = createMemoryHistory();
     this.currentLocation = null;
     this.browserHistory.listen(url => {

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -399,33 +399,71 @@ describe('utility functions', () => {
 
   describe('findCourseRun', () => {
     it('iterates and finds the course run, course, and program', () => {
-      let program = DASHBOARD_RESPONSE[1];
-      let course = program.courses[0];
-      let run = course.runs[0];
+      let run = {
+        id: 3,
+        course_id: "xyz"
+      };
+      let course = {
+        runs: [run],
+        id: 2
+      };
+      let program = {
+        courses: [course],
+        id: 1,
+      };
 
       assert.deepEqual(
-        findCourseRun(DASHBOARD_RESPONSE, _run => run.course_id === _run.course_id),
+        findCourseRun([program], _run => run.course_id === _run.course_id),
         [run, course, program],
       );
     });
 
-    it('finds courses with no course runs', () => {
-      let program = DASHBOARD_RESPONSE[1];
-      let course = program.courses[1];
-      assert.lengthOf(course.runs, 0);
+    it('skips runs when there is an exception', () => {
+      let run = {
+        id: 3,
+        course_id: "xyz"
+      };
+      let course = {
+        runs: [run],
+        id: 2
+      };
+      let program = {
+        courses: [course],
+        id: 1,
+      };
 
       assert.deepEqual(
-        findCourseRun(DASHBOARD_RESPONSE, (_run, _course) => _course.runs.length === 0),
+        findCourseRun([program], () => {
+          throw new Error();
+        }),
+        [null, null, null],
+      );
+    });
+
+    it('finds courses with no course runs', () => {
+      let course = {
+        runs: [],
+        id: 2
+      };
+      let program = {
+        courses: [course],
+        id: 1,
+      };
+
+      assert.deepEqual(
+        findCourseRun([program], (_run, _course) => _course.runs.length === 0),
         [null, course, program]
       );
     });
 
     it('finds a program with no courses', () => {
-      let program = DASHBOARD_RESPONSE[0];
-      assert.lengthOf(program.courses, 0);
+      let program = {
+        courses: [],
+        id: 1
+      };
 
       assert.deepEqual(
-        findCourseRun(DASHBOARD_RESPONSE, (_run, _course, _program) => _program.courses.length === 0),
+        findCourseRun([program], (_run, _course, _program) => _program.courses.length === 0),
         [null, null, program]
       );
     });

--- a/static/scss/signup-dialog.scss
+++ b/static/scss/signup-dialog.scss
@@ -32,12 +32,6 @@
     line-height: 1.4em;
   }
 
-  .program-select {
-    font-weight: 400;
-    font-size: 16px;
-    margin-bottom: 28px;
-  }
-
   .terms-of-service-text {
     font-size: 12px;
     max-width: 96%;


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #1195

#### What's this PR do?
- Makes `/api/v0/dashboard/` only show programs the user is enrolled in
- Adds programpage url to `/api/v0/programs/`
- Changes JS code to read `/api/v0/programs/` and to use those programs to list program enrollments

#### How should this be manually tested?
Everything should look the same on the front end. In particular check that you can enroll in the profile page and in the dashboard.
