### PR TITLE
Removed course run view

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -3,7 +3,7 @@ Serializers for courses
 """
 from rest_framework import serializers
 
-from courses.models import Course, CourseRun, Program
+from courses.models import Course, Program
 
 
 class ProgramSerializer(serializers.ModelSerializer):
@@ -18,18 +18,3 @@ class CourseSerializer(serializers.ModelSerializer):
     class Meta:  # pylint: disable=missing-docstring
         model = Course
         fields = ('id', 'title', 'description', 'url', 'enrollment_text')
-
-
-class CourseRunSerializer(serializers.ModelSerializer):
-    """Serializer for CourseRun objects"""
-    program = serializers.SerializerMethodField()
-
-    class Meta:  # pylint: disable=missing-docstring
-        model = CourseRun
-        exclude = ('edx_course_key',)
-
-    def get_program(self, obj):  # pylint: disable=no-self-use
-        """
-        Get program id.
-        """
-        return obj.course.program.id

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -4,7 +4,7 @@ Tests for serializers
 
 from django.test import override_settings
 from courses.factories import CourseFactory, CourseRunFactory
-from courses.serializers import CourseSerializer, CourseRunSerializer
+from courses.serializers import CourseSerializer
 from search.base import ESTestCase
 
 
@@ -38,17 +38,3 @@ class CourseSerializerTests(ESTestCase):
         result = CourseSerializer().to_representation(course)
         assert result['url'] == 'http://192.168.33.10:8000/courses/my-course-key/about'
         assert result['enrollment_text'] == course.enrollment_text
-
-
-class CourseRunSerializerTests(ESTestCase):
-    """
-    Tests for CourseRunSerializer
-    """
-
-    def test_program(self):  # pylint: disable=no-self-use
-        """
-        Make sure program id appears correctly
-        """
-        course_run = CourseRunFactory.create()
-        result = CourseRunSerializer().to_representation(course_run)
-        assert result['program'] == course_run.course.program.id

--- a/courses/views.py
+++ b/courses/views.py
@@ -14,14 +14,8 @@ from rest_framework.generics import ListCreateAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from courses.models import (
-    CourseRun,
-    Program,
-)
-from courses.serializers import (
-    CourseRunSerializer,
-    ProgramSerializer,
-)
+from courses.models import Program
+from courses.serializers import ProgramSerializer
 from dashboard.models import ProgramEnrollment
 
 
@@ -42,19 +36,6 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
     )
     queryset = Program.objects.filter(live=True)
     serializer_class = ProgramSerializer
-
-
-class CourseRunViewSet(viewsets.ReadOnlyModelViewSet):
-    """API for the Program collection"""
-    authentication_classes = (
-        SessionAuthentication,
-        TokenAuthentication,
-    )
-    permission_classes = (
-        IsAuthenticated,
-    )
-    queryset = CourseRun.objects.filter(course__program__live=True)
-    serializer_class = CourseRunSerializer
 
 
 class ProgramEnrollmentListView(ListCreateAPIView):

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -41,39 +41,6 @@ class ProgramTests(ESTestCase):
         assert len(resp.json()) == 0
 
 
-class CourseTests(ESTestCase):
-    """Tests for the Course API"""
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-        cls.user = UserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-        self.client.force_login(self.user)
-
-    def test_list_course_if_program_live(self):
-        """
-        If the course belongs to a live program, show it.
-        """
-        course = CourseRunFactory.create(course__program__live=True)
-
-        resp = self.client.get(reverse('courserun-list'))
-
-        assert len(resp.json()) == 1
-        assert resp.json()[0]['id'] == course.id
-
-    def test_doesnt_list_courses_from_unlive_programs(self):
-        """
-        If the course belongs to a non-live program, hide it.
-        """
-        CourseRunFactory.create(course__program__live=False)
-
-        resp = self.client.get(reverse('courserun-list'))
-
-        assert len(resp.json()) == 0
-
-
 class ProgramEnrollmentTests(ESTestCase, APITestCase):
     """Tests for the ProgramEnrollment API"""
 

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -5,7 +5,7 @@ from django.core.urlresolvers import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from courses.factories import ProgramFactory, CourseRunFactory
+from courses.factories import ProgramFactory
 from dashboard.factories import ProgramEnrollmentFactory
 from dashboard.models import ProgramEnrollment
 from profiles.factories import UserFactory

--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -9,7 +9,6 @@ from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
 
 from courses.views import (
-    CourseRunViewSet,
     ProgramEnrollmentListView,
     ProgramViewSet,
 )
@@ -38,7 +37,6 @@ from mail.views import (
 
 router = routers.DefaultRouter()
 router.register(r'programs', ProgramViewSet)
-router.register(r'courses', CourseRunViewSet)
 router.register(r'profiles', ProfileViewSet)
 
 urlpatterns = [


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1195

#### What's this PR do?
Removes `/api/v0/courses/` and associated views

#### How should this be manually tested?
Nothing uses this API so there should be no change of behavior
