### PR TITLE
Added programpage_url to /api/v0/programs/

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -3,7 +3,8 @@ Serializers for Wagtail-related models
 """
 from rest_framework import serializers
 from wagtail.wagtailimages.models import Image, Rendition
-from cms.models import ProgramPage, ProgramFaculty
+
+from cms.models import ProgramFaculty
 
 
 class RenditionSerializer(serializers.ModelSerializer):
@@ -25,13 +26,6 @@ class FacultyImageSerializer(serializers.ModelSerializer):
     class Meta:  # pylint: disable=missing-docstring
         model = Image
         fields = ('alt', 'rendition',)
-
-
-class ProgramSerializer(serializers.ModelSerializer):
-    """Serializer for ProgramPage objects."""
-    class Meta:
-        model = ProgramPage
-        fields = ('description', 'faculty_description')
 
 
 class FacultySerializer(serializers.ModelSerializer):

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -6,15 +6,44 @@ from rest_framework import serializers
 from courses.models import Course, Program
 
 
+# pylint: disable=no-self-use
 class ProgramSerializer(serializers.ModelSerializer):
     """Serializer for Program objects"""
+    programpage_url = serializers.SerializerMethodField()
+
+    def get_programpage_url(self, program):
+        """
+        Returns the program page URL or None if no program page exists
+
+        Args:
+            program (courses.models.Program):
+                A program
+        Returns:
+            str: The programpage URL or None
+        """
+        from cms.models import ProgramPage
+        try:
+            return program.programpage.url
+        except ProgramPage.DoesNotExist:
+            return
+
     class Meta:  # pylint: disable=missing-docstring
         model = Program
-        fields = ('id', 'title',)
+        fields = (
+            'id',
+            'title',
+            'programpage_url',
+        )
 
 
 class CourseSerializer(serializers.ModelSerializer):
     """Serializer for Course objects"""
     class Meta:  # pylint: disable=missing-docstring
         model = Course
-        fields = ('id', 'title', 'description', 'url', 'enrollment_text')
+        fields = (
+            'id',
+            'title',
+            'description',
+            'url',
+            'enrollment_text',
+        )

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -3,17 +3,28 @@ Tests for serializers
 """
 
 from django.test import override_settings
-from courses.factories import CourseFactory, CourseRunFactory
-from courses.serializers import CourseSerializer
+
+from cms.factories import ProgramPageFactory
+from cms.models import HomePage
+from courses.factories import (
+    CourseFactory,
+    CourseRunFactory,
+    ProgramFactory,
+)
+from courses.serializers import (
+    CourseSerializer,
+    ProgramSerializer,
+)
 from search.base import ESTestCase
 
 
+# pylint: disable=no-self-use
 class CourseSerializerTests(ESTestCase):
     """
     Tests for CourseSerializer
     """
 
-    def test_course(self):  # pylint: disable=no-self-use
+    def test_course(self):
         """
         Make sure course serializes correctly
         """
@@ -29,7 +40,7 @@ class CourseSerializerTests(ESTestCase):
         assert result == expected
 
     @override_settings(EDXORG_BASE_URL="http://192.168.33.10:8000")
-    def test_course_with_run(self):  # pylint: disable=no-self-use
+    def test_course_with_run(self):
         """
         Make sure the course URL serializes properly
         """
@@ -38,3 +49,35 @@ class CourseSerializerTests(ESTestCase):
         result = CourseSerializer().to_representation(course)
         assert result['url'] == 'http://192.168.33.10:8000/courses/my-course-key/about'
         assert result['enrollment_text'] == course.enrollment_text
+
+
+class ProgramSerializerTests(ESTestCase):
+    """
+    Tests for ProgramSerializer
+    """
+
+    def test_program_no_programpage(self):
+        """
+        Test ProgramSerializer without a program page
+        """
+        program = ProgramFactory.create()
+        assert ProgramSerializer().to_representation(program) == {
+            'id': program.id,
+            'title': program.title,
+            'programpage_url': None,
+        }
+
+    def test_program_with_programpage(self):
+        """
+        Test ProgramSerializer with a program page attached
+        """
+        program = ProgramFactory.create()
+        programpage = ProgramPageFactory.build(program=program)
+        homepage = HomePage.objects.first()
+        homepage.add_child(instance=programpage)
+        assert ProgramSerializer().to_representation(program) == {
+            'id': program.id,
+            'title': program.title,
+            'programpage_url': programpage.url,
+        }
+        assert len(programpage.url) > 0


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1195

#### What's this PR do?
Adds `programpage_url` to `/api/v0/programs/`
#### How should this be manually tested?
Go to `/api/v0/programs/` and you should see the programpage urls for programs with CMS pages, or null if they don't have a connected page.
