### PR TITLE
Protected detect_missing_migrations.sh against hanging for console input

### DIFF
--- a/detect_missing_migrations.sh
+++ b/detect_missing_migrations.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e -o pipefail
 
-if ./manage.py migrate --fake | grep "Your models have changes that are not yet reflected" > /dev/null
+if ./manage.py migrate --fake --no-input | grep "Your models have changes that are not yet reflected" > /dev/null
 then
     echo "Error: one or more migrations are missing:"
     echo
-    ./manage.py migrate --fake
+    ./manage.py migrate --fake --no-input
     exit 1
 fi


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Feeds `no` to `./manage.py migrate --fake` so that it won't hang on the content type question
