### PR TITLE
Added management commands for fine-grained course state control

### DIFF
--- a/seed_data/lib.py
+++ b/seed_data/lib.py
@@ -1,0 +1,375 @@
+"""
+Library functions for interacting with test data
+"""
+import re
+from datetime import timedelta
+from functools import wraps
+from django.db import IntegrityError
+
+from django.contrib.auth.models import User
+from courses.models import Program, Course
+from dashboard.models import CachedCertificate, CachedEnrollment, CachedCurrentGrade
+from financialaid.factories import TierProgramFactory
+from financialaid.models import TierProgram
+from seed_data.management.commands import DEFAULT_GRADE, FAKE_PROGRAM_DESC_PREFIX
+from seed_data.utils import (
+    create_active_date_range,
+    create_future_date_range,
+    create_past_date_range,
+    future_date,
+    accepts_or_calculates_now
+)
+
+
+def fake_programs_query():
+    """Returns a queryset for programs that were added by the seed_db command"""
+    return Program.objects.filter(description__startswith=FAKE_PROGRAM_DESC_PREFIX)
+
+
+class ModelFinder(object):
+    """Finds a single model object that matches some given parameters or throws and error"""
+    model_cls = None
+    param_keys = {}
+
+    def result(self, objects, params):
+        """
+        Processes the results from a query; returns a single model object or throws a
+        relevant error if more or less than one record was found
+        """
+        if not params:
+            raise Exception('No parameters given for {} records. Accepted parameters: [{}]'.format(
+                self.model_cls.__name__,
+                self.param_keys
+            ))
+        elif len(objects) == 0:
+            raise Exception(
+                'No {} found with the given params ({})'.format(
+                    self.model_cls.__name__,
+                    params
+                )
+            )
+        elif len(objects) > 1:
+            raise Exception(
+                'Multiple {} records found with the given params ({}).\n{}'.format(
+                    self.model_cls.__name__,
+                    params,
+                    '\n'.join(str(obj) for obj in objects)
+                )
+            )
+        else:
+            return objects[0]
+
+    def calculate_params(self, **kwargs):
+        """Takes a set of keyword args and creates query parameters from them"""
+        raise NotImplementedError
+
+    def find(self, **kwargs):
+        """
+        Takes some keyword arguments that will be translated into query parameters, and
+        returns the result (or an error)
+        """
+        params = self.calculate_params(**kwargs)
+        users = self.model_cls.objects.filter(**params).all()
+        return self.result(users, params)
+
+
+class UserFinder(ModelFinder):
+    """Finds a single User"""
+    model_cls = User
+    param_keys = {'username', 'email'}
+
+    def calculate_params(self, **kwargs):
+        params = {}
+        if 'username' in kwargs:
+            params['username__contains'] = kwargs['username']
+        if 'email' in kwargs:
+            params['email__contains'] = kwargs['email']
+        return params
+
+
+class CourseFinder(ModelFinder):
+    """Finds a single Course"""
+    model_cls = Course
+    param_keys = {'program_title', 'course_level', 'course_title'}
+
+    def calculate_params(self, **kwargs):
+        params = {}
+        if 'program_title' in kwargs:
+            params['program__title__contains'] = kwargs['program_title']
+        if 'course_level' in kwargs:
+            params['title__endswith'] = kwargs['course_level']
+        if 'course_title' in kwargs:
+            params['title__contains'] = kwargs['course_title']
+        return params
+
+
+def course_state_editor(func):
+    """Decorator for any method that will be used to alter a Course's 'state'"""
+    @wraps(func)
+    def wrapper(*args, **kwargs):  # pylint: disable=missing-docstring
+        user = kwargs['user']
+        course_run = kwargs.get('course_run')
+        if not course_run:
+            course = kwargs['course']
+            clear_edx_data_for_course(user, course)
+            course_run = course.courserun_set.order_by('fuzzy_start_date', '-start_date').first()
+            kwargs['course_run'] = course_run
+            del kwargs['course']
+        ret_val = func(*args, **kwargs)
+        if is_fake_program_course_run(course_run) and course_run.start_date:
+            update_fake_course_run_edx_key(user, course_run)
+        return ret_val
+    return wrapper
+
+
+def cached_obj_editor(editing_func):
+    """Decorator for any method that changes information for a cached edX model object"""
+    @wraps(editing_func)
+    def wrapper(*args, **kwargs):  # pylint: disable=missing-docstring
+        obj = args[1]
+        if kwargs.get('blank', False):
+            obj.data = None
+            ret_val = None
+        else:
+            ret_val = editing_func(*args, **kwargs)
+        if kwargs.get('set_last_request', True):
+            obj.last_request = future_date()
+        if kwargs.get('save', True):
+            obj.save()
+        return ret_val
+    return wrapper
+
+
+class CachedHandler(object):
+    """Provides common functionality to retrieve/manipulate cached edX model objects"""
+    model_cls = None
+
+    def __init__(self, user):
+        self.user = user
+
+    def clear_all(self, course_run=None):
+        """Sets data to None for all cached edX objects associated with a User (and CourseRun, if provided)"""
+        params = {'user': self.user}
+        if course_run:
+            params['course_run'] = course_run
+        return self.model_cls.objects.filter(**params).update(data=None)
+
+    def refresh_all(self):
+        """Ensures that all of a User's cached edX objects are valid and will not trigger an edX API call"""
+        self.model_cls.objects.filter(user=self.user).update(last_request=future_date())
+
+    @classmethod
+    def set_edx_key(cls, obj, course_run):
+        """Sets the edX course id, wherever it exists in the cached object data property"""
+        raise NotImplementedError
+
+    def set_data(self, obj, course_run, **kwargs):
+        """Properly sets values on the cached edX object data property"""
+        raise NotImplementedError
+
+    def set_or_create(self, course_run, **kwargs):
+        """Ensures that a cached edX object exists, then properly sets values on the data property"""
+        obj = self.get_or_create(course_run)
+        obj.data = obj.data or {}
+        self.set_data(obj, course_run, **kwargs)
+        return obj
+
+    def get(self, course_run):
+        """Gets a cached edX object for a given User and CourseRun"""
+        return self.model_cls.objects.get(user=self.user, course_run=course_run)
+
+    def get_or_create(self, course_run):
+        """Gets or creates a cached edX object for a given User and CourseRun"""
+        try:
+            return self.model_cls.objects.get_or_create(user=self.user, course_run=course_run)[0]
+        except IntegrityError:
+            return self.model_cls.objects.create(user=self.user, course_run=course_run, last_request=future_date())
+
+
+class CachedEnrollmentHandler(CachedHandler):
+    """Provides functionality to CachedEnrollment objects"""
+    model_cls = CachedEnrollment
+
+    @classmethod
+    def set_edx_key(cls, obj, course_run):
+        obj.data['course_details']['course_id'] = course_run.edx_course_key
+
+    @cached_obj_editor
+    def set_data(self, obj, course_run, verified=True, **kwargs):
+        obj.data.update({
+            'user': self.user.username,
+            'mode': 'verified' if verified else 'not verified'
+        })
+        obj.data['course_details'] = obj.data.get('course_details', {})
+        obj.data['course_details'].update({
+            'course_id': course_run.edx_course_key,
+            'enrollment_start': course_run.enrollment_start.isoformat(),
+            'enrollment_end': course_run.enrollment_end.isoformat()
+        })
+
+
+class CachedCertificateHandler(CachedHandler):
+    """Provides functionality to CachedCertificate objects"""
+    model_cls = CachedCertificate
+
+    @classmethod
+    def set_edx_key(cls, obj, course_run):
+        obj.data['course_id'] = course_run.edx_course_key
+
+    @cached_obj_editor
+    def set_data(self, obj, course_run, grade=DEFAULT_GRADE, **kwargs):
+        obj.data.update({
+            'username': self.user.username,
+            'course_id': course_run.edx_course_key,
+            'certificate_type': 'verified',
+            'grade': str(grade)
+        })
+
+
+class CachedCurrentGradeHandler(CachedHandler):
+    """Provides functionality to CachedCurrentGrade objects"""
+    model_cls = CachedCurrentGrade
+
+    @classmethod
+    def set_edx_key(cls, obj, course_run):
+        obj.data['course_key'] = course_run.edx_course_key
+
+    @cached_obj_editor
+    def set_data(self, obj, course_run, grade=DEFAULT_GRADE, **kwargs):
+        obj.data.update({
+            'course_key': course_run.edx_course_key,
+            'username': self.user.username,
+            'percent': str(grade)
+        })
+
+
+CACHED_HANDLERS = {
+    CachedEnrollment: CachedEnrollmentHandler,
+    CachedCertificate: CachedCertificateHandler,
+    CachedCurrentGrade: CachedCurrentGradeHandler
+}
+
+
+def clear_edx_data_for_course_run(user, course_run, models=None):
+    """Clears all of a User's cached edX data for a CourseRun, or just the data for specific cached models"""
+    if models:
+        handlers = [CACHED_HANDLERS[model] for model in models]
+    else:
+        handlers = CACHED_HANDLERS.values()
+    for cached_model_handler in handlers:
+        cached_model_handler(user).clear_all(course_run=course_run)
+
+
+def clear_edx_data_for_course(user, course, models=None):
+    """Clears all of a User's cached edX data for a Course, or just the data for specific cached models"""
+    if models:
+        handlers = [CACHED_HANDLERS[model] for model in models]
+    else:
+        handlers = CACHED_HANDLERS.values()
+    for cached_model_handler in handlers:
+        for course_run in course.courserun_set.all():
+            cached_model_handler(user).clear_all(course_run=course_run)
+
+
+def refresh_all_cached_edx_data(user):
+    """Refreshes all cached edX data for a User"""
+    for cached_handler in CACHED_HANDLERS.values():
+        cached_handler(user).refresh_all()
+
+
+def update_cached_edx_data_for_run(user, course_run):
+    """Updates the course id in a User's cached edX objects based on a CourseRun.edx_course_key value"""
+    for cached_handler_cls in CACHED_HANDLERS.values():
+        cached_handler = cached_handler_cls(user)
+        cached_obj = cached_handler.get_or_create(course_run)
+        if cached_obj.data:
+            cached_handler.set_edx_key(cached_obj, course_run)
+            cached_obj.save()
+
+
+def set_course_run_past(course_run, save=True):
+    """Sets relevant CourseRun dates to the past relative to now"""
+    course_run.start_date, course_run.end_date = create_past_date_range(ended_days_ago=30, day_spread=30)
+    course_run.enrollment_start, course_run.enrollment_end = create_past_date_range(ended_days_ago=50, day_spread=10)
+    if save:
+        course_run.save()
+    return course_run
+
+
+@accepts_or_calculates_now
+def set_course_run_current(course_run, enrollable_now=True,  # pylint: disable=too-many-arguments
+                           enrollable_past=False, upgradeable=True, save=True, now=None):
+    """Sets relevant CourseRun dates to be current relative to now"""
+    course_run.end_date = None
+    if enrollable_now:
+        course_run.enrollment_start, course_run.enrollment_end = \
+            create_active_date_range(started_days_ago=10, days_until_end=5)
+    elif enrollable_past:
+        course_run.enrollment_start, course_run.enrollment_end = \
+            create_past_date_range(ended_days_ago=2, day_spread=10)
+    else:
+        course_run.enrollment_start, course_run.enrollment_end = create_future_date_range()
+    course_run.start_date = course_run.enrollment_start + timedelta(days=5)
+    if enrollable_now and not upgradeable:
+        course_run.upgrade_deadline = now - timedelta(days=1)
+    else:
+        course_run.upgrade_deadline = course_run.enrollment_end + timedelta(days=5)
+    if save:
+        course_run.save()
+    return course_run
+
+
+def set_course_run_future(course_run, enrollable_now=False, enrollable_past=False, save=True):
+    """Sets relevant CourseRun dates to the future relative to now"""
+    course_run.start_date, course_run.end_date = create_future_date_range(days_ahead=20, day_spread=30)
+    if enrollable_now:
+        course_run.enrollment_start, course_run.enrollment_end = create_active_date_range(day_spread=10)
+    elif enrollable_past:
+        course_run.enrollment_start, course_run.enrollment_end = create_past_date_range()
+    else:
+        course_run.enrollment_start, course_run.enrollment_end = create_future_date_range(days_ahead=15, day_spread=10)
+    course_run.upgrade_deadline = course_run.start_date + timedelta(days=5)
+    if save:
+        course_run.save()
+    return course_run
+
+
+def set_program_financial_aid(program, set_to=True):
+    """Changes a Program's financial aid availability"""
+    if set_to is True and TierProgram.objects.filter(program=program).count() == 0:
+        TierProgramFactory.create(program=program)
+    Program.objects.filter(id=program.id).update(financial_aid_availability=set_to)
+
+
+def needs_non_fa_program(func):
+    """Decorator that wraps any function that requires a non-financial-aid Program"""
+    @wraps(func)
+    def wrapper(*args, **kwargs):  # pylint: disable=missing-docstring
+        if kwargs['course_run'].course.program.financial_aid_availability:
+            raise Exception('Program needs to be non-FA to set course to passed')
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def update_fake_course_run_edx_key(user, course_run):
+    """
+    Convenience method to update a cached edX model based on the data from a CourseRun that was added
+    by the seed_db command
+    """
+    start_date = course_run.start_date
+    year = start_date.strftime('%Y')
+    month = start_date.strftime('%B')
+    short_month = month[:3]
+    course_run.edx_course_key = re.sub(r'\w{3}_\d{4}$', '{}_{}'.format(short_month, year), course_run.edx_course_key)
+    course_run.title = re.sub(r'\w+ \d{4}$', '{} {}'.format(month, year), course_run.title)
+    course_run.save()
+    update_cached_edx_data_for_run(user, course_run)
+    return course_run
+
+
+def is_fake_program_course_run(course_run):
+    """
+    Checks if a given CourseRun was added by the seed_db command
+    """
+    fake_program_titles = [program.title.replace(' ', '+') for program in fake_programs_query().all()]
+    return any([title in getattr(course_run, 'edx_course_key', '') for title in fake_program_titles])

--- a/seed_data/management/commands/__init__.py
+++ b/seed_data/management/commands/__init__.py
@@ -1,8 +1,13 @@
 """
 Globals for commands relating to seeding data into the database
 """
+from decimal import Decimal
 
 USER_DATA_PATH = 'seed_data/management/users.json'
 PROGRAM_DATA_PATH = 'seed_data/management/programs.json'
 FAKE_USER_USERNAME_PREFIX = 'fake.'
 FAKE_PROGRAM_DESC_PREFIX = '[FAKE] '
+
+DEFAULT_GRADE = Decimal('0.75')
+DEFAULT_FAILED_GRADE = Decimal('0.50')
+DEFAULT_COURSE_PRICE = Decimal('123.45')

--- a/seed_data/management/commands/alter_data.py
+++ b/seed_data/management/commands/alter_data.py
@@ -1,0 +1,344 @@
+"""
+Management commands that can be used to fine-tune course/program data
+(and associated enrollments/grades/etc) for a user.
+"""
+from decimal import Decimal
+import json
+from django.core.management import BaseCommand
+from django.db import transaction
+
+from courses.models import Program, CourseRun
+from seed_data.management.commands import DEFAULT_GRADE, DEFAULT_FAILED_GRADE
+from seed_data.utils import accepts_or_calculates_now, filter_dict_by_key_set, filter_dict_none_values
+from seed_data.lib import (
+    CACHED_HANDLERS,
+    CourseFinder,
+    UserFinder,
+    course_state_editor,
+    needs_non_fa_program,
+    CachedEnrollmentHandler,
+    CachedCertificateHandler,
+    CachedCurrentGradeHandler,
+    set_course_run_past,
+    set_course_run_current,
+    set_course_run_future,
+    set_program_financial_aid,
+)
+
+
+USAGE_DETAILS = (
+    """
+    Example commands:
+
+    # Turn financial aid off/on for a program with a title that contains 'Digital'
+    alter_data --action=turn_financial_aid_off --program-title="Digital"
+    alter_data --action=turn_financial_aid_on --program-title="Digital"
+
+    # For a user with a username 'staff', set the 'Digital Learning' 100-level course to enrolled
+    alter_data --action=set_course_to_enrolled --username=staff --program-title='Digital' --course-title='100'
+
+    # Set the 'Digital Learning' 200-level course to failed with a specific grade
+    alter_data --action=set_course_to_failed --username=staff --program-title='Digital' --course-title='200' --grade=45
+
+    # Set the 'Digital Learning' 300-level course to enrolled
+    alter_data --action=set_course_to_enrolled --username=staff --program-title='Digital' --course-title='300'
+
+    # Set the 'Digital Learning' 300-level course to enrolled, and set it to start in the future
+    """
+    "alter_data --action=set_course_to_enrolled --username=staff --program-title='Digital' --course-title='300' "
+    "--in-future"
+    """
+
+    # Set the 'Digital Learning' 300-level course to enrolled, but in need of upgrade (aka 'audit')
+    alter_data --action=set_course_to_needs_upgrade --username=staff --program-title='Digital' --course-title='300'
+
+    # (Another way to achieve the result of the above command...)
+    alter_data --action=set_course_to_enrolled --username=staff --program-title='Digital' --course-title='100' --audit
+
+    # Set the 'Digital Learning' 300-level course to enrolled and in need of upgrade, but past the deadline
+    """
+    "alter_data --action=set_course_to_needs_upgrade --username=staff --program-title='Digital' "
+    "--course-title='300' --missed-deadline"
+    """
+
+    # Set the 'Digital Learning' 100-level course to have an offered course run (and no enrollments)
+    alter_data --action=set_course_to_offered --username=staff --program-title='Digital' --course-title='100'
+
+    # Set the 'Digital Learning' 100-level course to have an offered course run with a fuzzy start date
+    alter_data --action=set_course_to_offered --username=staff --program-title='Digital' --course-title='100' --fuzzy
+
+    # Add a past failed course run with a specific grade
+    alter_data --action=add_past_failed_run --username=staff --program-title='Digital' --course-title='100' --grade=30
+
+    # Add a past failed course run, even if a previous failed run already exists
+    """
+    "alter_data --action=add_past_failed_run --username=staff --program-title='Digital' --course-title='100' "
+    "--add-if-exists"
+    """
+
+    # Add an enrollable future course run for a program called 'Test Program' and a course called 'Test Course'
+    alter_data --action=add_future_run --username=staff --program-title='Test Program' --course-title='Test Course'
+    """
+)
+
+NEW_COURSE_RUN_PREFIX = 'new-course-run'
+
+
+@course_state_editor
+@needs_non_fa_program
+def set_course_to_passed(user=None, course_run=None, grade=DEFAULT_GRADE):
+    """Sets a course to have a passed course run"""
+    set_course_run_past(course_run, save=True)
+    CachedEnrollmentHandler(user).set_or_create(course_run=course_run)
+    CachedCertificateHandler(user).set_or_create(course_run=course_run, grade=grade)
+    return course_run
+
+
+@course_state_editor
+@needs_non_fa_program
+def set_course_to_failed(user=None, course_run=None, grade=DEFAULT_FAILED_GRADE):
+    """Sets a course to have a failed course run"""
+    set_course_run_past(course_run, save=True)
+    CachedEnrollmentHandler(user).set_or_create(course_run=course_run)
+    CachedCurrentGradeHandler(user).set_or_create(course_run=course_run, grade=grade)
+    return course_run
+
+
+@course_state_editor
+@accepts_or_calculates_now
+def set_course_to_offered(user=None, course_run=None, now=None,  # pylint: disable=unused-argument
+                          in_future=False, fuzzy=False):
+    """Sets a course to have an offered course run that a given user is not enrolled in"""
+    if fuzzy:
+        course_run.fuzzy_start_date = 'Spring 2017'
+        course_run.fuzzy_enrollment_start_date = 'Spring 2017'
+        course_run.start_date = None
+        course_run.end_date = None
+        course_run.enrollment_end = None
+    elif in_future:
+        set_course_run_future(course_run)
+    else:
+        set_course_run_current(course_run)
+    course_run.save()
+    return course_run
+
+
+@course_state_editor
+def set_course_to_enrolled(user=None, course_run=None, in_future=False,  # pylint: disable=too-many-arguments
+                           grade=None, audit=False, missed_deadline=False):
+    """Sets a course to have a currently-enrolled course run"""
+    enrollable_setting = dict(enrollable_past=True) if missed_deadline else dict(enrollable_now=True)
+    if in_future:
+        set_course_run_future(course_run, save=True, **enrollable_setting)
+    else:
+        set_course_run_current(course_run, upgradeable=not missed_deadline, save=True, **enrollable_setting)
+    CachedEnrollmentHandler(user).set_or_create(course_run, verified=not audit)
+    if grade:
+        CachedCurrentGradeHandler(user).set_or_create(course_run, grade=grade)
+    return course_run
+
+
+@course_state_editor
+def set_course_to_needs_upgrade(**kwargs):
+    """Sets a course to have an enrolled course run that needs to be upgraded (aka 'audit')"""
+    kwargs.update(dict(audit=True, in_future=False))
+    return set_course_to_enrolled(**kwargs)
+
+
+@accepts_or_calculates_now
+def add_future_run(user=None, course=None, now=None):
+    """Adds a future enrollable course run for a course"""
+    base_edx_course_key = '{}-{}'.format(NEW_COURSE_RUN_PREFIX, now.strftime('%m-%d-%Y'))
+    default_title = base_edx_course_key
+    key_append = 0
+    new_course_run = None
+    created = False
+    with transaction.atomic():
+        while not new_course_run or not created:
+            new_course_run, created = CourseRun.objects.get_or_create(
+                course=course,
+                title=default_title,
+                edx_course_key='{}-{}'.format(base_edx_course_key, key_append),
+            )
+            key_append += 1
+    set_course_run_future(new_course_run, save=True)
+    CachedEnrollmentHandler(user).set_or_create(course_run=new_course_run, blank=True)
+    return new_course_run
+
+
+def clear_future_runs(user=None, course=None):  # pylint: disable=unused-argument
+    """Clears future enrollable course runs that were added by this script"""
+    return CourseRun.objects.filter(course=course, edx_course_key__startswith=NEW_COURSE_RUN_PREFIX).delete()
+
+
+@accepts_or_calculates_now
+def add_past_failed_run(user=None, course=None, now=None, grade=DEFAULT_FAILED_GRADE, add_if_exists=False):
+    """Adds a past failed course run for a given user and course"""
+    chosen_past_run = None
+    past_runs = CourseRun.objects.filter(
+        course=course,
+        end_date__lt=now,
+    ).exclude(end_date=None).order_by('-end_date').all()
+    # Loop through past course runs and find one without CachedCurrentGrade data
+    for past_run in past_runs:
+        if not CachedCurrentGradeHandler(user).get_or_create(past_run).data:
+            chosen_past_run = past_run
+            continue
+        elif not add_if_exists:
+            raise Exception("Past failed course run already exists (id: {}, title: {})".format(
+                past_run.id,
+                past_run.title
+            ))
+    if not chosen_past_run:
+        raise Exception("Can't find past run w/o CachedCurrentGrade")
+    # Add enrollment and failed grade for course run
+    CachedEnrollmentHandler(user).set_or_create(course_run=chosen_past_run)
+    CachedCurrentGradeHandler(user).set_or_create(course_run=chosen_past_run, grade=grade)
+    return chosen_past_run
+
+
+def course_info(user=None, course=None):
+    """Convenience method to show some consequential information for a course"""
+    results = {'course_title': course.title}
+    run_results = []
+    date_format = '%m/%d/%Y'
+    for run in course.courserun_set.order_by('-start_date').all():
+        run_result = {
+            'id': run.id,
+            'edx_course_key': run.edx_course_key,
+            'start_date': run.start_date.strftime(date_format) if run.start_date else None,
+            'end_date': run.end_date.strftime(date_format) if run.end_date else None
+        }
+        for date_key in ['enrollment_start', 'enrollment_end', 'upgrade_deadline']:
+            if getattr(run, date_key, None):
+                run_result[date_key] = getattr(run, date_key).strftime(date_format)
+        for model_cls in CACHED_HANDLERS.keys():
+            obj = model_cls.objects.filter(user=user, course_run=run).first()
+            if obj and obj.data:
+                run_result['edx_data'] = run_result.get('edx_data', {})
+                run_result['edx_data'][model_cls.__name__] = {
+                    'data': obj.data,
+                    'last_request': obj.last_request.strftime(date_format)
+                }
+        run_results.append(run_result)
+    results['course_runs'] = run_results
+    return results
+
+
+COURSE_COMMAND_FUNCTIONS = {
+    func.__name__: func for func in [
+        set_course_to_offered,
+        set_course_to_passed,
+        set_course_to_failed,
+        set_course_to_enrolled,
+        set_course_to_needs_upgrade,
+        add_future_run,
+        clear_future_runs,
+        add_past_failed_run,
+        course_info,
+    ]
+}
+
+ADDITIONAL_PARAMS = {
+    'grade': {
+        'type': int,
+        'help': "Course grade"
+    },
+    'in_future': {
+        'type': bool,
+        'help': "Include if you want the course run to be in the future"
+    },
+    'fuzzy': {
+        'type': bool,
+        'help': "Include if you want the course run to have a fuzzy start date"
+    },
+    'missed_deadline': {
+        'type': bool,
+        'help': "Include if you want the course run to have a missed upgrade deadline"
+    },
+    'audit': {
+        'type': bool,
+        'help': "Include if you want the course run to be an audit (ie: the user hasn't paid yet, needs to upgrade)"
+    },
+    'add_if_exists': {
+        'type': bool,
+        'help': "Include if you want to set a past run to failed even if there is an existing failed run"
+    },
+}
+
+
+class Command(BaseCommand):
+    """
+    Fine-tune course/program data (and associated enrollments/grades/etc) for a user.
+    """
+    help = "Fine-tune course/program data (and associated enrollments/grades/etc) for a user."
+
+    def add_arguments(self, parser):
+        # Add argument to show example commands
+        parser.add_argument(
+            '--usage',
+            action='store_true',
+            default=None,
+            help='Show usage details/example commands'
+        )
+        # Add arguments for allowed actions
+        allowed_action_names = list(COURSE_COMMAND_FUNCTIONS.keys())
+        allowed_action_names.extend(['turn_financial_aid_off', 'turn_financial_aid_on'])
+        parser.add_argument(
+            '--action',
+            choices=allowed_action_names,
+            help='Program-/Course-related action'
+        )
+        # Add arguments for parameters that will be used to find Courses/Users
+        for finder_cls in {CourseFinder, UserFinder}:
+            for param_key in finder_cls.param_keys:
+                parser.add_argument(
+                    '--{}'.format(param_key.replace('_', '-')),
+                    dest=param_key,
+                    action='store',
+                    help="Parameter to find a specific {}".format(finder_cls.model_cls.__name__)
+                )
+        # Add arguments for making more specific changes to course states
+        for arg_name, arg_props in ADDITIONAL_PARAMS.items():
+            parser.add_argument(
+                '--{}'.format(arg_name.replace('_', '-')),
+                dest=arg_name,
+                action='store_true' if arg_props['type'] == bool else 'store',
+                default=None,
+                help="{} (Only relevant to certain course actions)".format(arg_props['help'])
+            )
+
+    @staticmethod
+    def filter_options(options, desired_key_set):
+        """Filters the option dict by given keys and removes null values"""
+        return filter_dict_none_values(filter_dict_by_key_set(options, desired_key_set))
+
+    def handle(self, *args, **options):
+        if options['usage']:
+            self.stdout.write(USAGE_DETAILS)
+        elif 'turn_financial_aid_' in options['action']:
+            program = Program.objects.get(title__contains=options['program_title'])
+            set_to = options['action'].endswith('on')
+            set_program_financial_aid(program, set_to=set_to)
+        else:
+            action_func = COURSE_COMMAND_FUNCTIONS[options['action']]
+            user_finder_params = self.filter_options(options, UserFinder.param_keys)
+            user = UserFinder().find(**user_finder_params)
+            course_finder_params = self.filter_options(options, CourseFinder.param_keys)
+            course = CourseFinder().find(**course_finder_params)
+            additional_params = self.filter_options(options, ADDITIONAL_PARAMS.keys())
+            # Coerce 'grade' to decimal if it exists
+            if 'grade' in additional_params:
+                additional_params['grade'] = Decimal(int(additional_params['grade'])/100)
+            result = action_func(user=user, course=course, **additional_params)
+            if isinstance(result, CourseRun):
+                self.stdout.write("Course run changed: (id: {}, edx_course_key: {})\nUser: {}; Course: {}".format(
+                    result.id,
+                    result.edx_course_key,
+                    user.username,
+                    course.title
+                ))
+            elif isinstance(result, dict):
+                self.stdout.write(json.dumps(result, indent=2))
+            else:
+                self.stdout.write(result)

--- a/seed_data/management/commands/seed_db.py
+++ b/seed_data/management/commands/seed_db.py
@@ -20,24 +20,12 @@ from profiles.models import Employment, Education, Profile
 from roles.models import Role
 from roles.roles import Staff
 from search.indexing_api import recreate_index
+from seed_data.utils import first_matching_item, filter_dict_by_key_set
+from seed_data.lib import fake_programs_query
 from seed_data.management.commands import (  # pylint: disable=import-error
     USER_DATA_PATH, PROGRAM_DATA_PATH,
     FAKE_USER_USERNAME_PREFIX, FAKE_PROGRAM_DESC_PREFIX
 )
-
-
-# Util functions
-
-def first_matching_item(iterable, predicate):
-    """Returns the first item in an iterable that matches a given predicate"""
-    return next(x for x in iterable if predicate(x))
-
-
-def filter_dict_by_key_set(dict_to_filter, key_set):
-    """
-    Takes a dictionary and returns a copy without keys that don't exist in a given set
-    """
-    return {key: dict_to_filter[key] for key in dict_to_filter.keys() if key in key_set}
 
 
 def deserialize_model_data_on_object(model_obj, data, save=True):
@@ -290,9 +278,9 @@ class Command(BaseCommand):
         program_data_list = load_json_from_file(PROGRAM_DATA_PATH)
         user_data_list = load_json_from_file(USER_DATA_PATH)
         existing_fake_user_count = User.objects.filter(username__startswith=FAKE_USER_USERNAME_PREFIX).count()
-        existing_fake_program_count = Program.objects.filter(description__startswith=FAKE_PROGRAM_DESC_PREFIX).count()
+        existing_fake_program_count = fake_programs_query().count()
         if len(user_data_list) == existing_fake_user_count and len(program_data_list) == existing_fake_program_count:
-            fake_programs = Program.objects.filter(description__startswith=FAKE_PROGRAM_DESC_PREFIX).all()
+            fake_programs = fake_programs_query().all()
             self.stdout.write("Seed data appears to already exist.")
         else:
             recreate_index()

--- a/seed_data/utils.py
+++ b/seed_data/utils.py
@@ -1,0 +1,66 @@
+"""
+General util functions for database seeding
+"""
+from datetime import datetime, timedelta
+from functools import wraps
+import math
+
+
+def accepts_or_calculates_now(func):
+    """Decorator to wrap any function that should accept a 'now' date or calculate 'now' on its own"""
+    @wraps(func)
+    def wrapper(*args, **kwargs):  # pylint: disable=missing-docstring
+        if not kwargs.get('now'):
+            kwargs['now'] = datetime.now()
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def first_matching_item(iterable, predicate):
+    """Returns the first item in an iterable that matches a given predicate"""
+    return next(x for x in iterable if predicate(x))
+
+
+def filter_dict_by_key_set(dict_to_filter, key_set):
+    """Takes a dictionary and returns a copy without keys that don't exist in a given set"""
+    return {key: dict_to_filter[key] for key in dict_to_filter.keys() if key in key_set}
+
+
+def filter_dict_none_values(dict_to_filter):
+    """Takes a dictionary and returns a copy without keys that have a None value"""
+    return {key: value for key, value in dict_to_filter.items() if value is not None}
+
+
+@accepts_or_calculates_now
+def create_active_date_range(started_days_ago=None, days_until_end=None, day_spread=10, now=None):
+    """Returns a start/end datetime tuple that starts before now and ends after now"""
+    if started_days_ago and days_until_end:
+        start_datetime = now - timedelta(days=started_days_ago)
+        end_datetime = now + timedelta(days=days_until_end)
+    else:
+        day_incr = math.ceil(day_spread / 2)
+        start_datetime = now - timedelta(days=day_incr)
+        end_datetime = now + timedelta(days=day_incr)
+    return start_datetime, end_datetime
+
+
+@accepts_or_calculates_now
+def create_future_date_range(days_ahead=5, day_spread=10, now=None):
+    """Returns a start/end datetime tuple that starts and ends in the future"""
+    start_datetime = now + timedelta(days=days_ahead)
+    end_datetime = start_datetime + timedelta(days=day_spread)
+    return start_datetime, end_datetime
+
+
+@accepts_or_calculates_now
+def create_past_date_range(ended_days_ago=5, day_spread=10, now=None):
+    """Returns a start/end datetime tuple that starts and ends in the past"""
+    end_datetime = now - timedelta(days=ended_days_ago)
+    start_datetime = end_datetime - timedelta(days=day_spread)
+    return start_datetime, end_datetime
+
+
+@accepts_or_calculates_now
+def future_date(now=None, days_in_future=30):
+    """Creates a date in the future"""
+    return now + timedelta(days=days_in_future)


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #1497 

#### What's this PR do?

Adds a series of management commands that can fine-tune data so our various course states can be tested.

#### How should this be manually tested?

Seed the DB and make sure you have tiers created and some enrolled programs for your user. You can see some general option details by running `docker-compose run web ./manage.py alter_data --help`, and some example commands can be found by running `docker-compose run web ./manage.py alter_data --usage`. Try out some of those commands and check your dashboard to see the effects.

#### Any background context you want to provide?

1. **For now, these commands are only designed to work for non-FA programs**
1. There is some cleanup that can be done, but keep in mind that we're only going to be using these commands for testing. I'm not planning on adding unit tests for this reason.
