### PR TITLE
Profile: Load existing program enrollments for returning user

### DIFF
--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -24,7 +24,6 @@ import type { UIState } from '../reducers/ui';
 import type {
   AvailableProgram,
   AvailablePrograms,
-  AvailableProgramsState
 } from '../flow/enrollmentTypes';
 import type { Event } from '../flow/eventType';
 import {  validationErrorSelector } from '../util/util';
@@ -38,7 +37,7 @@ export default class PersonalTab extends React.Component {
     ui:             UIState,
     nextStep:       () => void,
     prevStep:       () => void,
-    programs:       AvailableProgramsState,
+    programs:       AvailablePrograms,
     setProgram:     Function,
     addProgramEnrollment: Function,
     currentProgramEnrollment: AvailableProgram,
@@ -55,10 +54,10 @@ export default class PersonalTab extends React.Component {
 
   setProgramHelper = (event: Event, key: string, value: string) => {
     const {
-      programs: { availablePrograms },
+      programs,
       setProgram,
     } = this.props;
-    let selected = availablePrograms.find(program => program.id === parseInt(value));
+    let selected = programs.find(program => program.id === parseInt(value));
     setProgram(selected);
   };
 
@@ -80,7 +79,7 @@ export default class PersonalTab extends React.Component {
 
   selectProgram = () => {
     const {
-      programs: { availablePrograms },
+      programs,
       errors
     } = this.props;
 
@@ -93,20 +92,20 @@ export default class PersonalTab extends React.Component {
         className={`program-selectfield ${validationErrorSelector(errors, ['program'])}`}
         errorText={_.get(errors, "program")}
       >
-        { this.programListing(availablePrograms) }
+        { this.programListing(programs) }
       </SelectField>
     );
   }
 
   componentWillMount() {
     const {
-      programs: { availablePrograms },
+      programs,
       currentProgramEnrollment,
       setProgram,
     } = this.props;
 
     if (currentProgramEnrollment) {
-      let selected = availablePrograms.find(program => program.id === currentProgramEnrollment.id);
+      let selected = programs.find(program => program.id === currentProgramEnrollment.id);
       setProgram(selected);
     }
   }

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -24,6 +24,7 @@ import type { UIState } from '../reducers/ui';
 import type { AvailablePrograms } from '../flow/enrollmentTypes';
 import type { Event } from '../flow/eventType';
 import {  validationErrorSelector } from '../util/util';
+import type { ProgramEnrollment } from '../flow/enrollmentTypes';
 
 export default class PersonalTab extends React.Component {
   props: {
@@ -37,6 +38,7 @@ export default class PersonalTab extends React.Component {
     programs:       AvailablePrograms,
     setProgram:     Function,
     addProgramEnrollment: Function,
+    currentProgramEnrollment: ProgramEnrollment,
   };
 
   programListing = (programs: AvailablePrograms) => {
@@ -53,9 +55,25 @@ export default class PersonalTab extends React.Component {
       programs,
       setProgram,
     } = this.props;
-    let selected = programs.find(program => program.id === value);
+    let selected = programs.find(program => program.id === parseInt(value));
     setProgram(selected);
   };
+
+  getSelectedProgramId = () : number|null => {
+    let programId = null;
+    const {
+      ui: { selectedProgram },
+      currentProgramEnrollment
+    } = this.props;
+
+    if (selectedProgram) {
+      programId = selectedProgram.id;
+    } else if(currentProgramEnrollment) {
+      programId = currentProgramEnrollment.id;
+    }
+
+    return programId;
+  }
 
   selectProgram = () => {
     const {
@@ -66,7 +84,7 @@ export default class PersonalTab extends React.Component {
 
     return (
       <SelectField
-        value={selectedProgram ? selectedProgram.id : null}
+        value={this.getSelectedProgramId()}
         style={{width: "65%"}}
         hintText="Select Program"
         onChange={this.setProgramHelper}

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -21,10 +21,13 @@ import type {
   UpdateProfileFunc,
 } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
-import type { AvailablePrograms } from '../flow/enrollmentTypes';
+import type {
+  AvailableProgram,
+  AvailablePrograms,
+  AvailableProgramsState
+} from '../flow/enrollmentTypes';
 import type { Event } from '../flow/eventType';
 import {  validationErrorSelector } from '../util/util';
-import type { ProgramEnrollment } from '../flow/enrollmentTypes';
 
 export default class PersonalTab extends React.Component {
   props: {
@@ -35,10 +38,10 @@ export default class PersonalTab extends React.Component {
     ui:             UIState,
     nextStep:       () => void,
     prevStep:       () => void,
-    programs:       AvailablePrograms,
+    programs:       AvailableProgramsState,
     setProgram:     Function,
     addProgramEnrollment: Function,
-    currentProgramEnrollment: ProgramEnrollment,
+    currentProgramEnrollment: AvailableProgram,
   };
 
   programListing = (programs: AvailablePrograms) => {
@@ -52,20 +55,20 @@ export default class PersonalTab extends React.Component {
 
   setProgramHelper = (event: Event, key: string, value: string) => {
     const {
-      programs,
+      programs: { availablePrograms },
       setProgram,
     } = this.props;
-    let selected = programs.find(program => program.id === parseInt(value));
+    let selected = availablePrograms.find(program => program.id === parseInt(value));
     setProgram(selected);
   };
 
   getSelectedProgramId = () : number|null => {
-    let programId = null;
     const {
       ui: { selectedProgram },
       currentProgramEnrollment
     } = this.props;
 
+    let programId = null;
     if (selectedProgram) {
       programId = selectedProgram.id;
     } else if(currentProgramEnrollment) {
@@ -77,8 +80,7 @@ export default class PersonalTab extends React.Component {
 
   selectProgram = () => {
     const {
-      programs,
-      ui: { selectedProgram },
+      programs: { availablePrograms },
       errors
     } = this.props;
 
@@ -91,9 +93,22 @@ export default class PersonalTab extends React.Component {
         className={`program-selectfield ${validationErrorSelector(errors, ['program'])}`}
         errorText={_.get(errors, "program")}
       >
-        { this.programListing(programs) }
+        { this.programListing(availablePrograms) }
       </SelectField>
     );
+  }
+
+  componentWillMount() {
+    const {
+      programs: { availablePrograms },
+      currentProgramEnrollment,
+      setProgram,
+    } = this.props;
+
+    if (currentProgramEnrollment) {
+      let selected = availablePrograms.find(program => program.id === currentProgramEnrollment.id);
+      setProgram(selected);
+    }
   }
 
   render() {

--- a/static/js/components/PersonalTab_test.js
+++ b/static/js/components/PersonalTab_test.js
@@ -10,7 +10,7 @@ describe("PersonalTab", () => {
 
   let renderPersonalTab = (selectedProgram = null, props = {}) => {
     return shallow(<PersonalTab
-      programs={PROGRAMS}
+      programs={{availablePrograms: PROGRAMS}}
       ui={{
         selectedProgram: selectedProgram,
       }}

--- a/static/js/components/PersonalTab_test.js
+++ b/static/js/components/PersonalTab_test.js
@@ -10,7 +10,7 @@ describe("PersonalTab", () => {
 
   let renderPersonalTab = (selectedProgram = null, props = {}) => {
     return shallow(<PersonalTab
-      programs={{availablePrograms: PROGRAMS}}
+      programs={PROGRAMS}
       ui={{
         selectedProgram: selectedProgram,
       }}

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -34,11 +34,13 @@ import type { ActionHelpers, AsyncActionHelpers } from '../lib/redux';
 import type { Validator, UIValidator } from '../lib/validation/profile';
 import type { Profile, Profiles, ProfileGetResult } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
-import type { AvailableProgramsState } from '../flow/enrollmentTypes';
+import type {
+  AvailableProgram,
+  AvailableProgramsState
+} from '../flow/enrollmentTypes';
 import type { Program } from '../flow/programTypes';
 import { addProgramEnrollment } from '../actions/programs';
 import { ALL_ERRORS_VISIBLE } from '../constants';
-import type { ProgramEnrollment } from '../flow/enrollmentTypes';
 
 type UpdateProfile = (isEdit: boolean, profile: Profile, validator: Validator|UIValidator) => void;
 
@@ -51,7 +53,7 @@ class ProfileFormContainer extends React.Component {
     ui:          UIState,
     params:      {[k: string]: string},
     programs:    AvailableProgramsState,
-    currentProgramEnrollment: ProgramEnrollment,
+    currentProgramEnrollment: AvailableProgram,
   };
 
   static contextTypes = {

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -38,6 +38,7 @@ import type { AvailableProgramsState } from '../flow/enrollmentTypes';
 import type { Program } from '../flow/programTypes';
 import { addProgramEnrollment } from '../actions/programs';
 import { ALL_ERRORS_VISIBLE } from '../constants';
+import type { ProgramEnrollment } from '../flow/enrollmentTypes';
 
 type UpdateProfile = (isEdit: boolean, profile: Profile, validator: Validator|UIValidator) => void;
 
@@ -49,7 +50,8 @@ class ProfileFormContainer extends React.Component {
     history:     Object,
     ui:          UIState,
     params:      {[k: string]: string},
-    programs:    AvailableProgramsState
+    programs:    AvailableProgramsState,
+    currentProgramEnrollment: ProgramEnrollment,
   };
 
   static contextTypes = {
@@ -61,6 +63,7 @@ class ProfileFormContainer extends React.Component {
       profiles: state.profiles,
       ui: state.ui,
       programs: state.programs,
+      currentProgramEnrollment: state.currentProgramEnrollment
     };
   };
 
@@ -176,6 +179,7 @@ class ProfileFormContainer extends React.Component {
       ui,
       programs,
       dispatch,
+      currentProgramEnrollment
     } = this.props;
     let errors, isEdit, profile;
 
@@ -203,6 +207,7 @@ class ProfileFormContainer extends React.Component {
       profile: profile,
       programs: programs.availablePrograms,
       saveProfile: this.saveProfile.bind(this, isEdit),
+      currentProgramEnrollment: currentProgramEnrollment,
       setProgram: this.setProgram,
       startProfileEdit: this.startProfileEdit,
       ui: ui,

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -38,12 +38,12 @@ import {
   SET_CONFIRM_SKIP_DIALOG_VISIBILITY,
   SET_DOCS_INSTRUCTIONS_VISIBILITY,
   SET_NAV_DRAWER_OPEN,
+  SET_PROGRAM,
 } from '../actions/ui';
 import { PERSONAL_STEP } from '../constants';
 import type { ToastMessage } from '../flow/generalTypes';
 import type { Action } from '../flow/reduxTypes';
-import { SET_PROGRAM } from '../actions/ui';
-import type { Program } from '../flow/programTypes';
+import type { AvailableProgram } from '../flow/enrollmentTypes';
 
 export type UIDialog = {
   title?: string;
@@ -77,7 +77,7 @@ export type UIState = {
   photoDialogVisibility:        boolean;
   calculatorDialogVisibility:   boolean;
   documentSentDate:             Object;
-  selectedProgram:              Program;
+  selectedProgram:              ?AvailableProgram;
   skipDialogVisibility:         boolean;
   docsInstructionsVisibility:   boolean;
   navDrawerOpen:                boolean;


### PR DESCRIPTION
#### What are the relevant tickets?
- fixes https://github.com/mitodl/micromasters/issues/1517
#### What's this PR do?
- Loads enrolled program for returning user on personal tab profile page.

@pdpinch @aliceriot @noisecapella 
##### previous state

<img width="921" alt="screen shot 2016-10-27 at 2 39 32 pm" src="https://cloud.githubusercontent.com/assets/10431250/19762399/373e66f6-9c53-11e6-8753-1c7fbd96bb68.png">
##### now state

<img width="1141" alt="screen shot 2016-10-27 at 2 38 11 pm" src="https://cloud.githubusercontent.com/assets/10431250/19762369/2643a082-9c53-11e6-9412-b31b77341d29.png">

**Note this PR is only for user who already filled his profile and returned back to profile page for next time**
