### PR TITLE
pins elasticsearch in docker to 2.4.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ redis:
     - "6379"
 
 elastic:
-  image: elasticsearch
+  image: elasticsearch:2.4.1
   command: elasticsearch -Des.network.host=0.0.0.0 -Des.http.cors.enabled=true -Des.http.cors.allow-origin=*
   ports:
     - "9100:9200"

--- a/travis-docker-compose.yml
+++ b/travis-docker-compose.yml
@@ -38,7 +38,7 @@ watch:
     NODE_ENV: 'production'
 
 elastic:
-  image: elasticsearch
+  image: elasticsearch:2.4.1
   command: elasticsearch -Des.network.host=0.0.0.0
   ports:
     - "9200"


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #1579 

#### What's this PR do?

Pins elasticsearch (in docker) to version 2.4.1 instead of just pulling the latest version. This avoids a breaking change in the CLI of elasticsearch 5.0.

#### How should this be manually tested?

Try `docker-compose up` and `docker-compose up --build` on your existing docker build. Hopefully nothing changes. 

Try a clean build without this change, e.g. `docker-compose rm -f` and then `docker-compose up --build` It should fail with the elasticsearch error mentioned in the inssue. 

Try a clean build with this change. It should work. 

#### Any background context you want to provide?

This was a quick fix, and it seems like a good idea to pin the version. However, it may make more sense to figure out the new CLI in elasticsearch 5 and move forward. 
