### PR TITLE
Fixed detect_missing_migrations.sh

### DIFF
--- a/detect_missing_migrations.sh
+++ b/detect_missing_migrations.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
-set -e -o pipefail
 
-if ./manage.py migrate --fake --no-input | grep "Your models have changes that are not yet reflected" > /dev/null
+TMPFILE=$(mktemp)
+./manage.py migrate --no-input >& "$TMPFILE"
+if cat "$TMPFILE" | grep "Your models have changes that are not yet reflected" > /dev/null
 then
     echo "Error: one or more migrations are missing:"
     echo
-    ./manage.py migrate --fake --no-input
+    cat "$TMPFILE"
+    rm "$TMPFILE"
     exit 1
+else
+    rm "$TMPFILE"
 fi

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     -r{toxinidir}/test_requirements.txt
 commands =
     py.test {posargs}
+    ./detect_missing_migrations.sh
 
 passenv = *
 setenv =


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Adds back `detect_missing_migrations.sh` and fixes its behavior to run migrations without `--fake`

#### How should this be manually tested?
Tests should pass
