### PR TITLE
Added enrolled field to ProgramSerializer

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -31,13 +31,10 @@ class ProgramSerializer(serializers.ModelSerializer):
 
     def get_enrolled(self, program):
         """
-        Returns true if the user
+        Returns true if the user is enrolled in the program
         """
-        if 'request' in self.context:
-            user = self.context['request'].user
-            return ProgramEnrollment.objects.filter(user=user, program=program).exists()
-        else:
-            return False
+        user = self.context['request'].user
+        return ProgramEnrollment.objects.filter(user=user, program=program).exists()
 
     class Meta:  # pylint: disable=missing-docstring
         model = Program

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -4,12 +4,14 @@ Serializers for courses
 from rest_framework import serializers
 
 from courses.models import Course, Program
+from dashboard.models import ProgramEnrollment
 
 
 # pylint: disable=no-self-use
 class ProgramSerializer(serializers.ModelSerializer):
     """Serializer for Program objects"""
     programpage_url = serializers.SerializerMethodField()
+    enrolled = serializers.SerializerMethodField()
 
     def get_programpage_url(self, program):
         """
@@ -27,12 +29,23 @@ class ProgramSerializer(serializers.ModelSerializer):
         except ProgramPage.DoesNotExist:
             return
 
+    def get_enrolled(self, program):
+        """
+        Returns true if the user
+        """
+        if 'request' in self.context:
+            user = self.context['request'].user
+            return ProgramEnrollment.objects.filter(user=user, program=program).exists()
+        else:
+            return False
+
     class Meta:  # pylint: disable=missing-docstring
         model = Program
         fields = (
             'id',
             'title',
             'programpage_url',
+            'enrolled',
         )
 
 

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -59,14 +59,24 @@ class ProgramSerializerTests(ESTestCase):
     Tests for ProgramSerializer
     """
 
+    @classmethod
+    def setUpTestData(cls):
+        """Create a program and user to test with"""
+        super().setUpTestData()
+
+        cls.program = ProgramFactory.create()
+        cls.user = UserFactory.create()
+        cls.context = {
+            "request": Mock(user=cls.user)
+        }
+
     def test_program_no_programpage(self):
         """
         Test ProgramSerializer without a program page
         """
-        program = ProgramFactory.create()
-        assert ProgramSerializer().to_representation(program) == {
-            'id': program.id,
-            'title': program.title,
+        assert ProgramSerializer(context=self.context).to_representation(self.program) == {
+            'id': self.program.id,
+            'title': self.program.title,
             'programpage_url': None,
             'enrolled': False,
         }
@@ -75,13 +85,12 @@ class ProgramSerializerTests(ESTestCase):
         """
         Test ProgramSerializer with a program page attached
         """
-        program = ProgramFactory.create()
-        programpage = ProgramPageFactory.build(program=program)
+        programpage = ProgramPageFactory.build(program=self.program)
         homepage = HomePage.objects.first()
         homepage.add_child(instance=programpage)
-        assert ProgramSerializer().to_representation(program) == {
-            'id': program.id,
-            'title': program.title,
+        assert ProgramSerializer(context=self.context).to_representation(self.program) == {
+            'id': self.program.id,
+            'title': self.program.title,
             'programpage_url': programpage.url,
             'enrolled': False,
         }
@@ -91,13 +100,10 @@ class ProgramSerializerTests(ESTestCase):
         """
         Test ProgramSerializer with an enrolled user
         """
-        program = ProgramFactory.create()
-        user = UserFactory.create()
-        ProgramEnrollment.objects.create(user=user, program=program)
-        request = Mock(user=user)
-        assert ProgramSerializer(context={"request": request}).to_representation(program) == {
-            'id': program.id,
-            'title': program.title,
+        ProgramEnrollment.objects.create(user=self.user, program=self.program)
+        assert ProgramSerializer(context=self.context).to_representation(self.program) == {
+            'id': self.program.id,
+            'title': self.program.title,
             'programpage_url': None,
             'enrolled': True,
         }

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -3,6 +3,7 @@ Tests for serializers
 """
 
 from django.test import override_settings
+from mock import Mock
 
 from cms.factories import ProgramPageFactory
 from cms.models import HomePage
@@ -15,6 +16,8 @@ from courses.serializers import (
     CourseSerializer,
     ProgramSerializer,
 )
+from dashboard.models import ProgramEnrollment
+from profiles.factories import UserFactory
 from search.base import ESTestCase
 
 
@@ -65,6 +68,7 @@ class ProgramSerializerTests(ESTestCase):
             'id': program.id,
             'title': program.title,
             'programpage_url': None,
+            'enrolled': False,
         }
 
     def test_program_with_programpage(self):
@@ -79,5 +83,21 @@ class ProgramSerializerTests(ESTestCase):
             'id': program.id,
             'title': program.title,
             'programpage_url': programpage.url,
+            'enrolled': False,
         }
         assert len(programpage.url) > 0
+
+    def test_program_enrolled(self):
+        """
+        Test ProgramSerializer with an enrolled user
+        """
+        program = ProgramFactory.create()
+        user = UserFactory.create()
+        ProgramEnrollment.objects.create(user=user, program=program)
+        request = Mock(user=user)
+        assert ProgramSerializer(context={"request": request}).to_representation(program) == {
+            'id': program.id,
+            'title': program.title,
+            'programpage_url': None,
+            'enrolled': True,
+        }

--- a/courses/views.py
+++ b/courses/views.py
@@ -80,5 +80,5 @@ class ProgramEnrollmentListView(ListCreateAPIView):
         status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
         return Response(
             status=status_code,
-            data=serializer(program).data
+            data=serializer(program, context={'request': request}).data
         )


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1195

#### What's this PR do?
Adds enrolled field to ProgramSerializer

#### How should this be manually tested?
Look at `/api/v0/programs/` and verify that the `enrolled` field matches the programs you are enrolled in
