### PR TITLE
Split enrollments reducer into programs and courseEnrollments

### DIFF
--- a/static/js/actions/course_enrollments.js
+++ b/static/js/actions/course_enrollments.js
@@ -1,0 +1,34 @@
+// @flow
+import type { Dispatch } from 'redux';
+import { createAction } from 'redux-actions';
+
+import {
+  fetchCoursePrices,
+  fetchDashboard,
+} from './';
+import type { Dispatcher } from '../flow/reduxTypes';
+import * as api from '../lib/api';
+
+export const REQUEST_ADD_COURSE_ENROLLMENT = 'REQUEST_ADD_COURSE_ENROLLMENT';
+export const requestAddCourseEnrollment = createAction(REQUEST_ADD_COURSE_ENROLLMENT);
+
+export const RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS = 'RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS';
+export const receiveAddCourseEnrollmentSuccess = createAction(RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS);
+
+export const RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE = 'RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE';
+export const receiveAddCourseEnrollmentFailure = createAction(RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE);
+
+export const addCourseEnrollment = (courseId: string): Dispatcher<*> => {
+  return (dispatch: Dispatch) => {
+    dispatch(requestAddCourseEnrollment(courseId));
+    return api.addCourseEnrollment(courseId).
+      then(() => {
+        dispatch(receiveAddCourseEnrollmentSuccess());
+        dispatch(fetchDashboard());
+        dispatch(fetchCoursePrices());
+      }).
+      catch(() => {
+        dispatch(receiveAddCourseEnrollmentFailure());
+      });
+  };
+};

--- a/static/js/actions/course_enrollments_test.js
+++ b/static/js/actions/course_enrollments_test.js
@@ -1,0 +1,21 @@
+// @flow
+import {
+  requestAddCourseEnrollment,
+  receiveAddCourseEnrollmentSuccess,
+  receiveAddCourseEnrollmentFailure,
+
+  REQUEST_ADD_COURSE_ENROLLMENT,
+  RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
+  RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
+} from './course_enrollments';
+import { assertCreatedActionHelper } from './util';
+
+describe('course enrollment actions', () => {
+  it('should create all action creators', () => {
+    [
+      [requestAddCourseEnrollment, REQUEST_ADD_COURSE_ENROLLMENT],
+      [receiveAddCourseEnrollmentSuccess, RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS],
+      [receiveAddCourseEnrollmentFailure, RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE],
+    ].forEach(assertCreatedActionHelper);
+  });
+});

--- a/static/js/actions/programs.js
+++ b/static/js/actions/programs.js
@@ -18,6 +18,8 @@ import type {
 } from '../flow/enrollmentTypes';
 import * as api from '../lib/api';
 
+export const SET_CURRENT_PROGRAM_ENROLLMENT = 'SET_CURRENT_PROGRAM_ENROLLMENT';
+export const setCurrentProgramEnrollment = createAction(SET_CURRENT_PROGRAM_ENROLLMENT);
 
 export const REQUEST_GET_PROGRAM_ENROLLMENTS = 'REQUEST_GET_PROGRAM_ENROLLMENTS';
 export const requestGetProgramEnrollments = createAction(REQUEST_GET_PROGRAM_ENROLLMENTS);
@@ -75,30 +77,3 @@ export const addProgramEnrollment = (programId: number): Dispatcher<ProgramEnrol
 
 export const CLEAR_ENROLLMENTS = 'CLEAR_ENROLLMENTS';
 export const clearEnrollments = createAction(CLEAR_ENROLLMENTS);
-
-export const SET_CURRENT_PROGRAM_ENROLLMENT = 'SET_CURRENT_PROGRAM_ENROLLMENT';
-export const setCurrentProgramEnrollment = createAction(SET_CURRENT_PROGRAM_ENROLLMENT);
-
-export const REQUEST_ADD_COURSE_ENROLLMENT = 'REQUEST_ADD_COURSE_ENROLLMENT';
-export const requestAddCourseEnrollment = createAction(REQUEST_ADD_COURSE_ENROLLMENT);
-
-export const RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS = 'RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS';
-export const receiveAddCourseEnrollmentSuccess = createAction(RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS);
-
-export const RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE = 'RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE';
-export const receiveAddCourseEnrollmentFailure = createAction(RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE);
-
-export const addCourseEnrollment = (courseId: string): Dispatcher<*> => {
-  return (dispatch: Dispatch) => {
-    dispatch(requestAddCourseEnrollment(courseId));
-    return api.addCourseEnrollment(courseId).
-      then(() => {
-        dispatch(receiveAddCourseEnrollmentSuccess());
-        dispatch(fetchDashboard());
-        dispatch(fetchCoursePrices());
-      }).
-      catch(() => {
-        dispatch(receiveAddCourseEnrollmentFailure());
-      });
-  };
-};

--- a/static/js/actions/programs_test.js
+++ b/static/js/actions/programs_test.js
@@ -20,7 +20,7 @@ import {
 } from './programs';
 import { assertCreatedActionHelper } from './util';
 
-describe('enrollment actions', () => {
+describe('program enrollment actions', () => {
   it('should create all action creators', () => {
     [
       [requestGetProgramEnrollments, REQUEST_GET_PROGRAM_ENROLLMENTS],

--- a/static/js/actions/programs_test.js
+++ b/static/js/actions/programs_test.js
@@ -8,9 +8,6 @@ import {
   receiveAddProgramEnrollmentFailure,
   clearEnrollments,
   setCurrentProgramEnrollment,
-  requestAddCourseEnrollment,
-  receiveAddCourseEnrollmentSuccess,
-  receiveAddCourseEnrollmentFailure,
 
   REQUEST_GET_PROGRAM_ENROLLMENTS,
   RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
@@ -20,10 +17,7 @@ import {
   RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE,
   CLEAR_ENROLLMENTS,
   SET_CURRENT_PROGRAM_ENROLLMENT,
-  REQUEST_ADD_COURSE_ENROLLMENT,
-  RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
-  RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
-} from './enrollments';
+} from './programs';
 import { assertCreatedActionHelper } from './util';
 
 describe('enrollment actions', () => {
@@ -37,9 +31,6 @@ describe('enrollment actions', () => {
       [receiveAddProgramEnrollmentFailure, RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE],
       [clearEnrollments, CLEAR_ENROLLMENTS],
       [setCurrentProgramEnrollment, SET_CURRENT_PROGRAM_ENROLLMENT],
-      [requestAddCourseEnrollment, REQUEST_ADD_COURSE_ENROLLMENT],
-      [receiveAddCourseEnrollmentSuccess, RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS],
-      [receiveAddCourseEnrollmentFailure, RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -20,7 +20,7 @@ import {
   RECEIVE_PATCH_USER_PROFILE_FAILURE,
   CLEAR_PROFILE_EDIT,
 } from '../actions/profile';
-import { RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS } from '../actions/enrollments';
+import { RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS } from '../actions/programs';
 import {
   DASHBOARD_RESPONSE,
   ERROR_RESPONSE,

--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -32,7 +32,7 @@ export default class Navbar extends React.Component {
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
-    enrollments:                 ProgramEnrollmentsState,
+    programs:                    ProgramEnrollmentsState,
     navDrawerOpen:               boolean,
     pathname:                    string,
     profile:                     Profile,

--- a/static/js/components/Navbar_test.js
+++ b/static/js/components/Navbar_test.js
@@ -15,7 +15,7 @@ describe('Navbar', () => {
   const props = {
     profile: USER_PROFILE_RESPONSE,
     dashboard: { programs: DASHBOARD_RESPONSE },
-    enrollments: { programEnrollments: PROGRAM_ENROLLMENTS },
+    programs: { programEnrollments: PROGRAM_ENROLLMENTS },
   };
 
   let renderNavbar = () => shallow(<Navbar {...props} />);

--- a/static/js/components/NewEnrollmentDialog.js
+++ b/static/js/components/NewEnrollmentDialog.js
@@ -12,7 +12,7 @@ export default class NewEnrollmentDialog extends React.Component {
   props: {
     addProgramEnrollment:        (programId: number) => void,
     dashboard:                   DashboardState,
-    enrollments:                 ProgramEnrollmentsState,
+    programs:                    ProgramEnrollmentsState,
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
@@ -72,7 +72,7 @@ export default class NewEnrollmentDialog extends React.Component {
       enrollDialogError,
       enrollDialogVisibility,
       enrollSelectedProgram,
-      enrollments: { programEnrollments },
+      programs: { programEnrollments },
     } = this.props;
 
     let enrollmentLookup = new Map(programEnrollments.map(enrollment => [enrollment.id, null]));

--- a/static/js/components/NewEnrollmentDialog_test.js
+++ b/static/js/components/NewEnrollmentDialog_test.js
@@ -7,9 +7,7 @@ import { shallow } from 'enzyme';
 import Dialog from 'material-ui/Dialog';
 import SelectField from 'material-ui/SelectField';
 
-import {
-} from '../actions/enrollments';
-import * as enrollmentActions from '../actions/enrollments';
+import * as enrollmentActions from '../actions/programs';
 import * as uiActions from '../actions/ui';
 
 import {
@@ -34,7 +32,7 @@ describe("NewEnrollmentDialog", () => {
       let dialog = wrapper.find(NewEnrollmentDialog).at(0);
       let props = dialog.props();
 
-      assert.deepEqual(props.enrollments.programEnrollments, PROGRAM_ENROLLMENTS);
+      assert.deepEqual(props.programs.programEnrollments, PROGRAM_ENROLLMENTS);
       assert.deepEqual(props.dashboard.programs, DASHBOARD_RESPONSE);
     });
   });
@@ -79,7 +77,7 @@ describe("NewEnrollmentDialog", () => {
     let wrapper = shallow(
       <NewEnrollmentDialog
         dashboard={{programs: DASHBOARD_RESPONSE}}
-        enrollments={{programEnrollments: PROGRAM_ENROLLMENTS}}
+        programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
         enrollDialogVisibility={true}
         setEnrollSelectedProgram={stub}
       />);
@@ -94,7 +92,7 @@ describe("NewEnrollmentDialog", () => {
     let wrapper = shallow(
       <NewEnrollmentDialog
         dashboard={{programs: DASHBOARD_RESPONSE}}
-        enrollments={{programEnrollments: PROGRAM_ENROLLMENTS}}
+        programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
         enrollDialogVisibility={true}
         setEnrollDialogVisibility={visibilityStub}
         addProgramEnrollment={enrollStub}
@@ -113,7 +111,7 @@ describe("NewEnrollmentDialog", () => {
     let wrapper = shallow(
       <NewEnrollmentDialog
         dashboard={{programs: DASHBOARD_RESPONSE}}
-        enrollments={{programEnrollments: PROGRAM_ENROLLMENTS}}
+        programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
         enrollDialogVisibility={true}
         setEnrollDialogError={stub}
       />);
@@ -129,7 +127,7 @@ describe("NewEnrollmentDialog", () => {
     let wrapper = shallow(
       <NewEnrollmentDialog
         dashboard={{programs: DASHBOARD_RESPONSE}}
-        enrollments={{programEnrollments: PROGRAM_ENROLLMENTS}}
+        programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
         enrollDialogVisibility={true}
         setEnrollDialogVisibility={stub}
       />);
@@ -154,7 +152,7 @@ describe("NewEnrollmentDialog", () => {
     let wrapper = shallow(
       <NewEnrollmentDialog
         dashboard={{programs: DASHBOARD_RESPONSE}}
-        enrollments={{programEnrollments: PROGRAM_ENROLLMENTS}}
+        programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
         enrollDialogVisibility={false}
         enrollSelectedProgram={selectedEnrollment}
       />);
@@ -176,7 +174,7 @@ describe("NewEnrollmentDialog", () => {
     let wrapper = shallow(
       <NewEnrollmentDialog
         dashboard={{programs: DASHBOARD_RESPONSE}}
-        enrollments={{programEnrollments: PROGRAM_ENROLLMENTS}}
+        programs={{programEnrollments: PROGRAM_ENROLLMENTS}}
         enrollSelectedProgram={selectedEnrollment}
         enrollDialogVisibility={false}
       />);

--- a/static/js/components/ProgramSelector.js
+++ b/static/js/components/ProgramSelector.js
@@ -17,7 +17,7 @@ export default class ProgramSelector extends React.Component {
   props: {
     addProgramEnrollment:        (programId: number) => void,
     currentProgramEnrollment:    ProgramEnrollment,
-    enrollments:                 ProgramEnrollmentsState,
+    programs:                    ProgramEnrollmentsState,
     enrollDialogError:           ?string,
     enrollDialogVisibility:      boolean,
     enrollSelectedProgram:       ?number,
@@ -31,7 +31,7 @@ export default class ProgramSelector extends React.Component {
 
   selectEnrollment = (option: Option): void => {
     const {
-      enrollments: { programEnrollments },
+      programs: { programEnrollments },
       setCurrentProgramEnrollment,
       setEnrollDialogError,
       setEnrollDialogVisibility,
@@ -50,7 +50,7 @@ export default class ProgramSelector extends React.Component {
   makeOptions = (): Array<Option> => {
     const {
       currentProgramEnrollment,
-      enrollments: { programEnrollments },
+      programs: { programEnrollments },
       dashboard: { programs },
     } = this.props;
 
@@ -81,8 +81,8 @@ export default class ProgramSelector extends React.Component {
     let {
       addProgramEnrollment,
       dashboard,
-      enrollments,
-      enrollments: {programEnrollments},
+      programs,
+      programs: {programEnrollments},
       enrollDialogError,
       enrollDialogVisibility,
       enrollSelectedProgram,
@@ -115,7 +115,7 @@ export default class ProgramSelector extends React.Component {
         <NewEnrollmentDialog
           addProgramEnrollment={addProgramEnrollment}
           dashboard={dashboard}
-          enrollments={enrollments}
+          programs={programs}
           enrollDialogError={enrollDialogError}
           enrollDialogVisibility={enrollDialogVisibility}
           enrollSelectedProgram={enrollSelectedProgram}

--- a/static/js/components/ProgramSelector_test.js
+++ b/static/js/components/ProgramSelector_test.js
@@ -32,7 +32,7 @@ describe('ProgramSelector', () => {
   let renderProgramSelector = (props) => {
     return shallow(
       <ProgramSelector
-        enrollments={{programEnrollments: enrollments}}
+        programs={{programEnrollments: enrollments}}
         dashboard={{programs: DASHBOARD_RESPONSE}}
         currentProgramEnrollment={selectedEnrollment}
         {...props}
@@ -42,7 +42,7 @@ describe('ProgramSelector', () => {
 
   it('renders an empty div if there are no program enrollments', () => {
     let wrapper = renderProgramSelector({
-      enrollments: {
+      programs: {
         programEnrollments: []
       },
     });
@@ -80,7 +80,7 @@ describe('ProgramSelector', () => {
   it("does not render the 'Enroll in a new program' option if there is not at least one available program", () => {
     let allEnrollments = enrollments.concat(unenrolled);
     let wrapper = renderProgramSelector({
-      enrollments: {
+      programs: {
         programEnrollments: allEnrollments
       }
     });

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -591,11 +591,15 @@ export const DASHBOARD_RESPONSE = [
 export const PROGRAM_ENROLLMENTS = [
   {
     id: DASHBOARD_RESPONSE[1].id,
-    title: DASHBOARD_RESPONSE[1].title
+    title: DASHBOARD_RESPONSE[1].title,
+    programpage_url: "/program/",
+    enrolled: true,
   },
   {
     id: DASHBOARD_RESPONSE[2].id,
-    title: DASHBOARD_RESPONSE[2].title
+    title: DASHBOARD_RESPONSE[2].title,
+    programpage_url: null,
+    enrolled: true,
   },
 ];
 

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -31,7 +31,7 @@ import {
   clearEnrollments,
   fetchProgramEnrollments,
   setCurrentProgramEnrollment,
-} from '../actions/enrollments';
+} from '../actions/programs';
 import {
   setEnrollDialogError,
   setEnrollDialogVisibility,
@@ -62,7 +62,7 @@ class App extends React.Component {
     dispatch:                 Dispatch,
     dashboard:                DashboardState,
     prices:                   CoursePricesState,
-    enrollments:              ProgramEnrollmentsState,
+    programs:                 ProgramEnrollmentsState,
     history:                  Object,
     ui:                       UIState,
     signupDialog:             Object,
@@ -120,8 +120,8 @@ class App extends React.Component {
   }
 
   fetchEnrollments() {
-    const { enrollments, dispatch } = this.props;
-    if (enrollments.getStatus === undefined) {
+    const { programs, dispatch } = this.props;
+    if (programs.getStatus === undefined) {
       dispatch(fetchProgramEnrollments());
     }
   }
@@ -202,7 +202,7 @@ class App extends React.Component {
   render() {
     const {
       currentProgramEnrollment,
-      enrollments,
+      programs,
       ui: {
         enrollDialogError,
         enrollDialogVisibility,
@@ -220,8 +220,8 @@ class App extends React.Component {
       empty = true;
     }
 
-    if (enrollments.getStatus === FETCH_FAILURE) {
-      children = <ErrorMessage errorInfo={enrollments.getErrorInfo} />;
+    if (programs.getStatus === FETCH_FAILURE) {
+      children = <ErrorMessage errorInfo={programs.getErrorInfo} />;
       empty = true;
     }
 
@@ -248,8 +248,8 @@ class App extends React.Component {
         enrollDialogError={enrollDialogError}
         enrollDialogVisibility={enrollDialogVisibility}
         enrollSelectedProgram={enrollSelectedProgram}
-        enrollments={enrollments}
         pathname={pathname}
+        programs={programs}
         setCurrentProgramEnrollment={this.setCurrentProgramEnrollment}
         setEnrollDialogError={this.setEnrollDialogError}
         setEnrollDialogVisibility={this.setEnrollDialogVisibility}
@@ -286,7 +286,8 @@ const mapStateToProps = (state) => {
     prices:                   state.prices,
     ui:                       state.ui,
     currentProgramEnrollment: state.currentProgramEnrollment,
-    enrollments:              state.enrollments,
+    programs:                 state.programs,
+    courseEnrollments:        state.courseEnrollments,
     signupDialog:             state.signupDialog,
   };
 };

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -21,8 +21,8 @@ import {
 import {
   CLEAR_ENROLLMENTS,
   RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE,
-} from '../actions/enrollments';
-import * as enrollmentActions from '../actions/enrollments';
+} from '../actions/programs';
+import * as enrollmentActions from '../actions/programs';
 import {
   CLEAR_UI,
   SET_PROFILE_STEP,

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -23,7 +23,7 @@ import {
   STATUS_PASSED,
   STATUS_CURRENTLY_ENROLLED,
 } from '../constants';
-import { addCourseEnrollment } from '../actions/enrollments';
+import { addCourseEnrollment } from '../actions/course_enrollments';
 import {
   setToastMessage,
   setConfirmSkipDialogVisibility,

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -34,7 +34,7 @@ import type { Profile, Profiles, ProfileGetResult } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 import type { DashboardState } from '../flow/dashboardTypes';
 import type { Program } from '../flow/programTypes';
-import { addProgramEnrollment } from '../actions/enrollments';
+import { addProgramEnrollment } from '../actions/programs';
 
 type UpdateProfile = (isEdit: boolean, profile: Profile, validator: Validator|UIValidator) => void;
 

--- a/static/js/flow/enrollmentTypes.js
+++ b/static/js/flow/enrollmentTypes.js
@@ -13,5 +13,8 @@ export type ProgramEnrollmentsState = {
   getStatus?: string,
   getErrorInfo?: APIErrorInfo,
   postStatus?: string,
+};
+
+export type CourseEnrollmentsState = {
   courseEnrollAddStatus?: string,
 };

--- a/static/js/reducers/course_enrollments.js
+++ b/static/js/reducers/course_enrollments.js
@@ -1,0 +1,30 @@
+// @flow
+import {
+  REQUEST_ADD_COURSE_ENROLLMENT,
+  RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
+  RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
+} from '../actions/course_enrollments';
+import {
+  FETCH_FAILURE,
+  FETCH_SUCCESS,
+  FETCH_PROCESSING
+} from '../actions';
+import type { Action } from '../flow/reduxTypes';
+import type {
+  CourseEnrollmentsState,
+} from '../flow/enrollmentTypes';
+
+export const INITIAL_ENROLLMENTS_STATE: CourseEnrollmentsState = {};
+
+export const courseEnrollments = (state: CourseEnrollmentsState = INITIAL_ENROLLMENTS_STATE, action: Action) => {
+  switch (action.type) {
+  case REQUEST_ADD_COURSE_ENROLLMENT:
+    return { ...state, courseEnrollAddStatus: FETCH_PROCESSING };
+  case RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS:
+    return { ...state, courseEnrollAddStatus: FETCH_SUCCESS };
+  case RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE:
+    return { ...state, courseEnrollAddStatus: FETCH_FAILURE };
+  default:
+    return state;
+  }
+};

--- a/static/js/reducers/course_enrollments_test.js
+++ b/static/js/reducers/course_enrollments_test.js
@@ -1,0 +1,80 @@
+import configureTestStore from 'redux-asserts';
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+import {
+  FETCH_SUCCESS,
+  FETCH_FAILURE,
+} from '../actions';
+import {
+  addCourseEnrollment,
+
+  REQUEST_ADD_COURSE_ENROLLMENT,
+  RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
+  RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
+} from '../actions/course_enrollments';
+import * as api from '../lib/api';
+import * as actions from '../actions';
+import rootReducer from '../reducers';
+
+describe('enrollments', () => {
+  let sandbox, store, addCourseEnrollmentStub;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    store = configureTestStore(rootReducer);
+    addCourseEnrollmentStub = sandbox.stub(api, 'addCourseEnrollment');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('enrollments reducer', () => {
+    let dispatchThen, fetchCoursePricesStub, fetchDashboardStub;
+    beforeEach(() => {
+      dispatchThen = store.createDispatchThen(state => state.courseEnrollments);
+
+      fetchCoursePricesStub = sandbox.stub(actions, 'fetchCoursePrices');
+      fetchCoursePricesStub.returns({type: "fake"});
+      fetchDashboardStub = sandbox.stub(actions, 'fetchDashboard');
+      fetchDashboardStub.returns({type: "fake"});
+    });
+
+    it('should have an empty default state', () => {
+      return dispatchThen({type: 'unknown'}, ['unknown']).then(state => {
+        assert.deepEqual(state, {});
+      });
+    });
+
+    it('should add a course enrollment successfully', () => {
+      addCourseEnrollmentStub.returns(Promise.resolve());
+
+      let courseKey = 'course_key';
+      return dispatchThen(addCourseEnrollment(courseKey), [
+        REQUEST_ADD_COURSE_ENROLLMENT,
+        RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
+      ]).then(state => {
+        assert.equal(state.courseEnrollAddStatus, FETCH_SUCCESS);
+        assert.isTrue(addCourseEnrollmentStub.calledWith(courseKey));
+        assert.isTrue(fetchCoursePricesStub.calledWith());
+        assert.isTrue(fetchDashboardStub.calledWith());
+      });
+    });
+
+    it('should fail to add a course enrollment', () => {
+      addCourseEnrollmentStub.returns(Promise.reject());
+
+      let courseKey = 'course_key';
+      return dispatchThen(addCourseEnrollment(courseKey), [
+        REQUEST_ADD_COURSE_ENROLLMENT,
+        RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
+      ]).then(state => {
+        assert.equal(state.courseEnrollAddStatus, FETCH_FAILURE);
+        assert.isTrue(addCourseEnrollmentStub.calledWith(courseKey));
+        assert.isFalse(fetchCoursePricesStub.calledWith());
+        assert.isFalse(fetchDashboardStub.calledWith());
+      });
+    });
+  });
+});

--- a/static/js/reducers/financial_aid_test.js
+++ b/static/js/reducers/financial_aid_test.js
@@ -29,7 +29,7 @@ import {
   FETCH_SUCCESS,
 } from '../actions';
 import * as actions from '../actions';
-import { setCurrentProgramEnrollment } from '../actions/enrollments';
+import { setCurrentProgramEnrollment } from '../actions/programs';
 import { FINANCIAL_AID_EDIT } from './financial_aid';
 import rootReducer from '../reducers';
 import * as api from '../lib/api';

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -40,8 +40,9 @@ import { ui } from './ui';
 import { email } from './email';
 import {
   currentProgramEnrollment,
-  enrollments,
-} from './enrollments';
+  programs,
+} from './programs';
+import { courseEnrollments } from './course_enrollments';
 import type { DashboardState, CoursePricesState } from '../flow/dashboardTypes';
 import type { Action } from '../flow/reduxTypes';
 import type {
@@ -253,7 +254,8 @@ export default combineReducers({
   email,
   checkout,
   prices,
-  enrollments,
+  programs,
+  courseEnrollments,
   currentProgramEnrollment,
   signupDialog,
   imageUpload,

--- a/static/js/reducers/programs.js
+++ b/static/js/reducers/programs.js
@@ -10,10 +10,7 @@ import {
   RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE,
   CLEAR_ENROLLMENTS,
   SET_CURRENT_PROGRAM_ENROLLMENT,
-  REQUEST_ADD_COURSE_ENROLLMENT,
-  RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
-  RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
-} from '../actions/enrollments';
+} from '../actions/programs';
 import {
   FETCH_FAILURE,
   FETCH_SUCCESS,
@@ -28,7 +25,7 @@ export const INITIAL_ENROLLMENTS_STATE: ProgramEnrollmentsState = {
   programEnrollments: []
 };
 
-export const enrollments = (state: ProgramEnrollmentsState = INITIAL_ENROLLMENTS_STATE, action: Action) => {
+export const programs = (state: ProgramEnrollmentsState = INITIAL_ENROLLMENTS_STATE, action: Action) => {
   switch (action.type) {
   case REQUEST_GET_PROGRAM_ENROLLMENTS:
     return { ...state, getStatus: FETCH_PROCESSING };
@@ -48,12 +45,6 @@ export const enrollments = (state: ProgramEnrollmentsState = INITIAL_ENROLLMENTS
     return { ...state, postStatus: FETCH_FAILURE, postErrorInfo: action.payload };
   case CLEAR_ENROLLMENTS:
     return INITIAL_ENROLLMENTS_STATE;
-  case REQUEST_ADD_COURSE_ENROLLMENT:
-    return { ...state, courseEnrollAddStatus: FETCH_PROCESSING };
-  case RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS:
-    return { ...state, courseEnrollAddStatus: FETCH_SUCCESS };
-  case RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE:
-    return { ...state, courseEnrollAddStatus: FETCH_FAILURE };
   default:
     return state;
   }

--- a/static/js/reducers/programs_test.js
+++ b/static/js/reducers/programs_test.js
@@ -20,7 +20,6 @@ import {
   receiveGetProgramEnrollmentsSuccess,
   clearEnrollments,
   setCurrentProgramEnrollment,
-  addCourseEnrollment,
 
   REQUEST_GET_PROGRAM_ENROLLMENTS,
   RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
@@ -30,23 +29,19 @@ import {
   RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE,
   CLEAR_ENROLLMENTS,
   SET_CURRENT_PROGRAM_ENROLLMENT,
-  REQUEST_ADD_COURSE_ENROLLMENT,
-  RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
-  RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
-} from '../actions/enrollments';
+} from '../actions/programs';
 import * as api from '../lib/api';
 import * as actions from '../actions';
 import rootReducer from '../reducers';
 
 describe('enrollments', () => {
-  let sandbox, store, getProgramEnrollmentsStub, addProgramEnrollmentStub, addCourseEnrollmentStub;
+  let sandbox, store, getProgramEnrollmentsStub, addProgramEnrollmentStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     store = configureTestStore(rootReducer);
     getProgramEnrollmentsStub = sandbox.stub(api, 'getProgramEnrollments');
     addProgramEnrollmentStub = sandbox.stub(api, 'addProgramEnrollment');
-    addCourseEnrollmentStub = sandbox.stub(api, 'addCourseEnrollment');
   });
 
   afterEach(() => {
@@ -61,7 +56,7 @@ describe('enrollments', () => {
   describe('enrollments reducer', () => {
     let dispatchThen, fetchCoursePricesStub, fetchDashboardStub;
     beforeEach(() => {
-      dispatchThen = store.createDispatchThen(state => state.enrollments);
+      dispatchThen = store.createDispatchThen(state => state.programs);
 
       fetchCoursePricesStub = sandbox.stub(actions, 'fetchCoursePrices');
       fetchCoursePricesStub.returns({type: "fake"});
@@ -166,36 +161,6 @@ describe('enrollments', () => {
         assert.deepEqual(enrollmentsState, {
           programEnrollments: []
         });
-      });
-    });
-
-    it('should add a course enrollment successfully', () => {
-      addCourseEnrollmentStub.returns(Promise.resolve());
-
-      let courseKey = 'course_key';
-      return dispatchThen(addCourseEnrollment(courseKey), [
-        REQUEST_ADD_COURSE_ENROLLMENT,
-        RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
-      ]).then(state => {
-        assert.equal(state.courseEnrollAddStatus, FETCH_SUCCESS);
-        assert.isTrue(addCourseEnrollmentStub.calledWith(courseKey));
-        assert.isTrue(fetchCoursePricesStub.calledWith());
-        assert.isTrue(fetchDashboardStub.calledWith());
-      });
-    });
-
-    it('should fail to add a course enrollment', () => {
-      addCourseEnrollmentStub.returns(Promise.reject());
-
-      let courseKey = 'course_key';
-      return dispatchThen(addCourseEnrollment(courseKey), [
-        REQUEST_ADD_COURSE_ENROLLMENT,
-        RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
-      ]).then(state => {
-        assert.equal(state.courseEnrollAddStatus, FETCH_FAILURE);
-        assert.isTrue(addCourseEnrollmentStub.calledWith(courseKey));
-        assert.isFalse(fetchCoursePricesStub.calledWith());
-        assert.isFalse(fetchDashboardStub.calledWith());
       });
     });
   });

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -25,7 +25,7 @@ import {
 import {
   REQUEST_GET_PROGRAM_ENROLLMENTS,
   RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
-} from '../actions/enrollments';
+} from '../actions/programs';
 import rootReducer from '../reducers';
 import { makeDashboardRoutes } from '../dashboard_routes';
 import { localStorageMock } from '../util/test_utils';


### PR DESCRIPTION
#### What are the relevant tickets?

Part of #1195
#### What's this PR do?

Splits `enrollments` reducer into `courseEnrollments` and `programs`. There should be no change in functionality.
#### How should this be manually tested?

Make sure that if you click the 'Enroll' link, it makes a POST to the course enrollment API. Also make sure that the programs list is fetched correctly (you should see your enrolled programs in the selector) and that you can still enroll in a new program.
