### PR TITLE
Made detect_missing_migrations.sh use makemigrations --dry-run

### DIFF
--- a/detect_missing_migrations.sh
+++ b/detect_missing_migrations.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 TMPFILE=$(mktemp)
-./manage.py migrate --no-input >& "$TMPFILE"
-if cat "$TMPFILE" | grep "Your models have changes that are not yet reflected" > /dev/null
+./manage.py makemigrations --no-input --dry-run >& "$TMPFILE"
+if cat "$TMPFILE" | grep -v "No changes detected" > /dev/null
 then
     echo "Error: one or more migrations are missing:"
     echo

--- a/detect_missing_migrations.sh
+++ b/detect_missing_migrations.sh
@@ -10,14 +10,14 @@ fail() {
 }
 
 ./manage.py makemigrations --no-input --dry-run >& "$TMPFILE"
-if [[ $? ]]
+if [[ $? -ne 0 ]]
 then
     # makemigrations has returned a non-zero for some reason, possibly
     # because it needs input but --no-input is set
-    fail;
-elif cat "$TMPFILE" | grep -v "No changes detected" > /dev/null
+    fail
+elif [[ $(cat "$TMPFILE" | grep "No changes detected" | wc -l) -eq 0 ]]
 then
-    fail;
+    fail
 else
     rm "$TMPFILE"
 fi

--- a/detect_missing_migrations.sh
+++ b/detect_missing_migrations.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
 
 TMPFILE=$(mktemp)
-./manage.py makemigrations --no-input --dry-run >& "$TMPFILE"
-if cat "$TMPFILE" | grep -v "No changes detected" > /dev/null
-then
-    echo "Error: one or more migrations are missing:"
+fail() {
+    echo "Error: one or more migrations are missing"
     echo
     cat "$TMPFILE"
     rm "$TMPFILE"
     exit 1
+}
+
+./manage.py makemigrations --no-input --dry-run >& "$TMPFILE"
+if [[ $? ]]
+then
+    # makemigrations has returned a non-zero for some reason, possibly
+    # because it needs input but --no-input is set
+    fail;
+elif cat "$TMPFILE" | grep -v "No changes detected" > /dev/null
+then
+    fail;
 else
     rm "$TMPFILE"
 fi


### PR DESCRIPTION
#### What are the relevant tickets?
None
#### What's this PR do?
Switches to `./manage.py makemigrations --dry-run` so the detect script doesn't actually run migrations, which may be disruptive to dev environments.

#### How should this be manually tested?
Rename a field and run the script. It should error and show a migration which could be created. No migration should actually be generated.
