### PR TITLE
Handling n+1 queries in dashboard

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -209,17 +209,17 @@ def get_info_for_course(course, mmtrack):
     run_statuses.remove(run_status)
 
     if run_status.status == CourseRunStatus.NOT_ENROLLED:
-        next_run = course.get_first_unexpired_run()
+        next_run = CourseRun.get_first_unexpired_run(course)
         if next_run is not None:
             _add_run(next_run, mmtrack, CourseStatus.OFFERED)
     elif run_status.status == CourseRunStatus.NOT_PASSED:
         _add_run(run_status.course_run, mmtrack, CourseRunStatus.NOT_PASSED)
-        next_run = course.get_first_unexpired_run()
+        next_run = CourseRun.get_first_unexpired_run(course)
         if next_run is not None:
             _add_run(next_run, mmtrack, CourseStatus.OFFERED)
     elif run_status.status == CourseRunStatus.MISSED_DEADLINE:
-        _add_run(run_status.course_run, mmtrack, CourseRunStatus.MISSED_DEADLINE)
-        next_run = course.get_first_unexpired_run(course_run_to_exclude=run_status.course_run)
+        _add_run(run_status.course_run, mmtrack, CourseStatus.MISSED_DEADLINE)
+        next_run = CourseRun.get_first_unexpired_run(course)
         if next_run is not None:
             _add_run(next_run, mmtrack, CourseStatus.OFFERED)
     elif run_status.status == CourseRunStatus.CURRENTLY_ENROLLED:
@@ -229,7 +229,7 @@ def get_info_for_course(course, mmtrack):
         # if the user never passed the course she needs to enroll in the next one
         if not mmtrack.has_passed_course(run_status.course_run.edx_course_key):
             _add_run(run_status.course_run, mmtrack, CourseRunStatus.NOT_PASSED)
-            next_run = course.get_first_unexpired_run()
+            next_run = CourseRun.get_first_unexpired_run(course)
             if next_run is not None:
                 _add_run(next_run, mmtrack, CourseStatus.OFFERED)
         else:

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -503,7 +503,9 @@ class InfoCourseTest(CourseTests):
             autospec=True,
             side_effect=self.get_mock_run_status_func(
                 api.CourseRunStatus.CHECK_IF_PASSED, self.course_run, api.CourseRunStatus.CHECK_IF_PASSED),
-        ), patch('courses.models.Course.get_first_unexpired_run', autospec=True, return_value=None):
+        ), patch('courses.models.CourseRun.get_first_unexpired_run', new=MagicMock()) as mock_get_run:
+            # this is necessary because for some reason patching a classmethod by default gives a NonCallableMagicMock
+            mock_get_run.return_value = None
             self.assert_course_equal(
                 self.course,
                 api.get_info_for_course(self.course, self.mmtrack)

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -140,8 +140,12 @@ MIDDLEWARE_CLASSES = (
 
 # enable the nplusone profiler only in debug mode
 if DEBUG:
-    INSTALLED_APPS += ('nplusone.ext.django', )
-    MIDDLEWARE_CLASSES += ('nplusone.ext.django.NPlusOneMiddleware', )
+    INSTALLED_APPS += (
+        'nplusone.ext.django',
+    )
+    MIDDLEWARE_CLASSES += (
+        'nplusone.ext.django.NPlusOneMiddleware',
+    )
 
 AUTHENTICATION_BACKENDS = (
     'backends.edxorg.EdxOrgOAuth2',


### PR DESCRIPTION
#### What are the relevant tickets?

part of #1454
#### What's this PR do?

handles the N+1 queries in the dashboard
#### How should this be manually tested?

loading the dashboard api, you should not see the nplus1 messages anymore. everything else should be the same.
