### PR TITLE
Speed up CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,22 @@
 # Set Ruby as the language so it doesn't download the pip things. Instead, let docker do that.
 language: ruby
-cache: bundler
-install:
-  - docker-compose -f travis-docker-compose.yml build
-  - docker-compose -f travis-docker-compose.yml run watch npm install --quiet
 
-script:
-  - docker-compose -f travis-docker-compose.yml run web tox
-  - docker-compose -f travis-docker-compose.yml run watch npm run-script coverage
-  - docker-compose -f travis-docker-compose.yml run watch npm run-script lint
-  - docker-compose -f travis-docker-compose.yml run watch npm run-script scss_lint
-  - docker-compose -f travis-docker-compose.yml run watch npm run-script flow
-  - docker-compose -f travis-docker-compose.yml run watch ./webpack_if_prod.sh
-services:
-  - docker
+matrix:
+  include:
+    - install: docker-compose -f travis-docker-compose.yml build
+      script: docker-compose -f travis-docker-compose.yml run web tox
+      services:
+        - docker
+      env:
+        name: Python
+    - install: docker build -t travis-watch -f ./travis/Dockerfile-travis-watch .
+      script: bash ./travis/js_tests.sh
+      services:
+        - docker
+      env:
+        name: JavaScript
+
+cache:
+  bundler: true
+  directories:
+    - $HOME/.npm

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -42,7 +42,7 @@ import { modifyTextField, activeDeleteDialog } from '../util/test_utils';
 import ValidationAlert from '../components/ValidationAlert';
 
 describe("UserPage", function() {
-  this.timeout(5000);
+  this.timeout(10000);
 
   let listenForActions, renderComponent, helper, patchUserProfileStub;
   let userActions = [RECEIVE_GET_USER_PROFILE_SUCCESS, REQUEST_GET_USER_PROFILE];

--- a/travis-docker-compose.yml
+++ b/travis-docker-compose.yml
@@ -2,8 +2,10 @@ db:
   image: postgres
   ports:
     - "5432"
+
 web:
   build: .
+  dockerfile: ./travis/Dockerfile-travis-web
   command: >
     /bin/bash -c '
     sleep 3 &&
@@ -23,19 +25,6 @@ web:
   links:
     - db
     - elastic
-
-watch:
-  build: .
-  dockerfile: Dockerfile-node
-  working_dir: /src
-  command: >
-    /bin/bash -c './webpack_if_prod.sh'
-  ports:
-    - "8078:8078"
-  volumes:
-    - .:/src
-  environment:
-    NODE_ENV: 'production'
 
 elastic:
   image: elasticsearch:2.4.1

--- a/travis/Dockerfile-travis-watch
+++ b/travis/Dockerfile-travis-watch
@@ -1,0 +1,21 @@
+FROM mitodl/mm_watch_travis
+
+WORKDIR /src
+
+COPY package.json /src
+
+COPY npm-shrinkwrap.json /src
+
+ADD ./webpack_if_prod.sh /src
+
+USER mitodl
+
+RUN npm install
+
+COPY . /src
+
+USER root
+
+RUN chown -R mitodl:mitodl /src
+
+USER mitodl

--- a/travis/Dockerfile-travis-watch-build
+++ b/travis/Dockerfile-travis-watch-build
@@ -1,0 +1,25 @@
+FROM node:6.2
+MAINTAINER ODL DevOps <mitx-devops@mit.edu>
+
+# this dockerfile builds the hub image for the watch container
+# we don't use this directly, instead we push to docker-hub, and
+# then Dockerfile-travis-watch uses that pushed image to bootstrap
+# itself
+
+RUN apt-get update && apt-get install libelf1
+
+RUN mkdir /src
+
+WORKDIR /src
+
+RUN adduser --disabled-password --gecos "" mitodl
+
+RUN chown -R mitodl:mitodl /src
+
+USER mitodl
+
+COPY package.json npm-shrinkwrap.json ./webpack_if_prod.sh /src/
+
+RUN npm install
+
+COPY . /src

--- a/travis/Dockerfile-travis-web
+++ b/travis/Dockerfile-travis-web
@@ -1,0 +1,11 @@
+FROM mitodl/mm_web_travis
+
+WORKDIR /tmp
+
+COPY requirements.txt /tmp/requirements.txt
+COPY test_requirements.txt /tmp/test_requirements.txt
+RUN pip install -r requirements.txt && pip install -r test_requirements.txt
+
+WORKDIR /src
+
+COPY . /src

--- a/travis/js_tests.sh
+++ b/travis/js_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+status=0
+
+function run_test {
+    "$@"
+    local test_status=$?
+    if [ $test_status -ne 0 ]; then
+        status=$test_status
+    fi
+    return $status
+}
+
+run_test docker run -t travis-watch npm run coverage
+run_test docker run -t travis-watch npm run lint
+run_test docker run -t travis-watch npm run scss_lint
+run_test docker run -t travis-watch npm run flow
+run_test docker run -e "NODE_ENV=production" -t travis-watch ./webpack_if_prod.sh
+
+exit $status


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1593 

#### What's this PR do?

A bunch of stuff! The goal is to reduce the CI build time. Before this PR our builds range between 13 and 20 minutes in length. A good chunk of that is taken up by building the docker containers and performing other setup steps, and all the tests are run sequentially.

This PR changes things around, without making any code changes, to get the build time down to about 5-6 minutes. I did that by:

- pushing pre-built containers to docker hub (https://hub.docker.com/r/mitodl/mm_watch_travis/ and https://hub.docker.com/r/mitodl/mm_web_travis/) which we pull on travis
- separating JS and Python tests into separate jobs (which run simultaneously)
- removing the `watch` container from `travis-docker-compose.yml`
- building the web, elastic, etc containers only for the python tests
- building the watch container only for the JS tests

That's about it! Hooray speed!

#### Where should the reviewer start?

Read over the changes and ensure they make sense!

#### How should this be manually tested?

Take a look at the builds to see the difference in build time. Make sure that using the development environment isn't different.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

![fast_build_yey](https://cloud.githubusercontent.com/assets/6207644/19862194/ba6ddfc4-9f65-11e6-835c-ae037c713cf0.png)

#### What GIF best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/p7QqHvffFcPYs/giphy.gif)