### PR TITLE
Fixed course date issue in alter_data command

### DIFF
--- a/seed_data/utils.py
+++ b/seed_data/utils.py
@@ -4,6 +4,7 @@ General util functions for database seeding
 from datetime import datetime, timedelta
 from functools import wraps
 import math
+from pytz import timezone
 
 
 def accepts_or_calculates_now(func):
@@ -64,3 +65,11 @@ def create_past_date_range(ended_days_ago=5, day_spread=10, now=None):
 def future_date(now=None, days_in_future=30):
     """Creates a date in the future"""
     return now + timedelta(days=days_in_future)
+
+
+def localized_datetime(dt, tz='US/Eastern'):
+    """Ensures a localized datetime"""
+    if dt.tzinfo:
+        return dt.astimezone(timezone(tz))
+    else:
+        return timezone(tz).localize(dt)


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #1612 
Fixes #1613 

#### What's this PR do?

For the course_info convenience method, prints out a localized datetime (since that's what moment.js does)

#### How should this be manually tested?

Just run the `alter_data` command with the `course_info` action and some relevant parameters to find a program, course, and user, eg: `manage.py alter_data --action=course_info --username=staff --program-title='Digital' --course-title='100'`
