### PR TITLE
Made small optimization to user serialization for search results

### DIFF
--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -13,7 +13,7 @@ from elasticsearch_dsl.connections import connections
 from profiles.models import Profile
 from profiles.serializers import ProfileSerializer
 from dashboard.models import ProgramEnrollment
-from dashboard.serializers import UserProgramSerializer
+from dashboard.serializers import UserProgramSearchSerializer
 from search.exceptions import ReindexException
 
 log = logging.getLogger(__name__)
@@ -134,7 +134,7 @@ def index_users(users, chunk_size=100):
     """
     Indexes a list of users via their ProgramEnrollments
     """
-    program_enrollments = ProgramEnrollment.objects.filter(user__in=users).select_related('user', 'program').all()
+    program_enrollments = ProgramEnrollment.prefetched_qset().filter(user__in=users)
     return index_program_enrolled_users(program_enrollments, chunk_size)
 
 
@@ -181,7 +181,7 @@ def serialize_program_enrolled_user(program_enrollment):
         # Just in case
         pass
 
-    serialized['program'] = UserProgramSerializer.serialize(program_enrollment)
+    serialized['program'] = UserProgramSearchSerializer.serialize(program_enrollment)
     return serialized
 
 

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -14,7 +14,7 @@ from dashboard.factories import (
     ProgramEnrollmentFactory
 )
 from dashboard.models import ProgramEnrollment
-from dashboard.serializers import UserProgramSerializer
+from dashboard.serializers import UserProgramSearchSerializer
 from courses.factories import (
     ProgramFactory,
     CourseFactory,
@@ -292,7 +292,7 @@ class SerializerTests(ESTestCase):
             'user_id': profile.user.id,
             'email': profile.user.email,
             'profile': ProfileSerializer(profile).data,
-            'program': UserProgramSerializer.serialize(program_enrollment)
+            'program': UserProgramSearchSerializer.serialize(program_enrollment)
         }
 
 

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -65,7 +65,7 @@
 
         .sk-item-list-option__text {
           margin-left: 10px;
-          color: m#666;
+          color: #666;
         }
 
         .sk-item-list-option__count {
@@ -75,14 +75,16 @@
     }
 
     .sk-hierarchical-menu-list {
+      width: 100%;
+
       .sk-hierarchical-menu-list__header {
-        margin: 15px 5px;
+        margin: 15px 5px 10px;
         font-size: 15px;
       }
 
       .sk-hierarchical-menu-list__root {
-        margin-left: 6px;
-        margin-right: 0;
+        margin-left: 10px;
+        margin-right: 10px;
 
         .sk-hierarchical-menu-option {
           >div {
@@ -91,6 +93,14 @@
 
           .sk-hierarchical-menu-option__text {
             margin-right: 15px;
+          }
+        }
+
+        .sk-hierarchical-menu-list__hierarchical-options > div {
+          align-items: stretch;
+
+          .sk-hierarchical-menu-option__count {
+            color: $font-gray;
           }
         }
       }


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #1600 

#### What's this PR do?

I initially thought we could optimize the queries to retrieve cached data for the User on a ProgramEnrollment in dashboard/serializers.py. It turns out that we pretty much optimal. I poked around this area of the code and found that (a) a User's Profile could be fetched in a single query using select_related, eliminating 1 query per user serialized, and (b) cached model serialization only needed the data property. Both of these changes can probably be extended to other areas of the code

#### How should this be manually tested?

Make sure you can still recreate the index and the dashboard API still works. You can also count the queries executed by search.indexing_api.index_users on master, then with the same users on this branch
