### PR TITLE
Staff users can see only students they are allowed to

### DIFF
--- a/roles/api.py
+++ b/roles/api.py
@@ -15,7 +15,7 @@ def get_advance_searchable_programs(user):
     Returns:
         list: list of courses.models.Program instances
     """
-    user_role_program = Role.objects.filter(user=user)
+    user_role_program = Role.objects.filter(user=user).select_related('program')
     programs = [
         role.program for role in user_role_program
         if has_object_permission('can_advance_search', user, role.program)

--- a/search/api.py
+++ b/search/api.py
@@ -48,9 +48,11 @@ def create_program_limit_query(user):
         should=[
             Q('term', **{'program.id': program.id}) for program in users_allowed_programs
         ],
+        # require that at least one program id matches the user's allowed programs
+        minimum_should_match=1,
         must=[
             Q('term', **{'program.is_learner': True})
-        ]
+        ],
     )
 
 
@@ -67,9 +69,10 @@ def create_search_obj(user, search_param_dict=None):
         Search: elasticsearch_dsl Search object
     """
     search_obj = Search(index=settings.ELASTICSEARCH_INDEX, doc_type=DOC_TYPES)
+    # the following filter should come first because the sequence matters in applying them
+    search_obj = search_obj.filter(create_program_limit_query(user))
     if search_param_dict is not None:
         search_obj.update_from_dict(search_param_dict)
-    search_obj = search_obj.query(create_program_limit_query(user))
     return search_obj
 
 

--- a/search/views.py
+++ b/search/views.py
@@ -28,12 +28,12 @@ class ElasticProxyView(APIView):
     )
     permission_classes = (IsAuthenticated, UserCanSearchPermission, )
 
-    def _execute_search_from_request(self, request):  # pylint: disable=no-self-use
+    def _execute_search_from_request(self, user, request_data):  # pylint: disable=no-self-use
         """
         Common function that will take care of handling requests coming from different methods.
         """
         try:
-            results = prepare_and_execute_search(request.user, search_param_dict=request.data)
+            results = prepare_and_execute_search(user, search_param_dict=request_data)
         except NoProgramAccessException:
             return Response(
                 status=status.HTTP_403_FORBIDDEN,
@@ -43,14 +43,8 @@ class ElasticProxyView(APIView):
             results.to_dict()
         )
 
-    def get(self, request, *args, **kwargs):
-        """
-        Handler for GET requests
-        """
-        return self._execute_search_from_request(request)
-
     def post(self, request, *args, **kwargs):
         """
         Handler for POST requests
         """
-        return self._execute_search_from_request(request)
+        return self._execute_search_from_request(request.user, request.data)

--- a/search/views_test.py
+++ b/search/views_test.py
@@ -62,15 +62,15 @@ class SearchTests(ESTestCase, APITestCase):
 
     def assert_status_code(self, status_code=status.HTTP_200_OK, json=None):
         """
-        Helper function to assert the status code for POST and GET
+        Helper function to assert the status code for POST
         """
         if json is None:
-            json = {}
-        resp_get = self.client.get(self.search_url)
-        assert resp_get.status_code == status_code
+            json = {'size': 1000}
+        else:
+            json.update({'size': 1000})
         resp_post = self.client.post(self.search_url, json, format='json')
         assert resp_post.status_code == status_code
-        return resp_get, resp_post
+        return resp_post
 
     def get_program_ids_in_hits(self, hits):  # pylint: disable=no-self-use
         """
@@ -96,31 +96,18 @@ class SearchTests(ESTestCase, APITestCase):
         """
         Test the proxy actually returns something
         """
-        resp, _ = self.assert_status_code()
+        resp = self.assert_status_code()
         assert 'hits' in resp.data
         assert 'hits' in resp.data['hits']
         assert len(resp.data['hits']['hits']) > 0
         assert isinstance(resp.data['hits']['hits'][0], dict)
-
-    def test_get_post_equivalent(self):
-        """
-        Get and post return the same result for the same query
-        """
-        resp_get, resp_post = self.assert_status_code()
-        assert len(resp_get.data['hits']['hits']) == len(resp_post.data['hits']['hits'])
-        hits_get = resp_get.data['hits']['hits']
-        hits_post = resp_post.data['hits']['hits']
-        hits_get.sort(key=lambda x: x['_id'])
-        hits_post.sort(key=lambda x: x['_id'])
-        for get_item, post_item in zip(hits_get, hits_post):
-            assert get_item == post_item
 
     def test_user_visibility(self):
         """
         Test that the user with the role can see only users belonging to the
         programs where she is power user
         """
-        resp, _ = self.assert_status_code()
+        resp = self.assert_status_code()
         hits = resp.data['hits']['hits']
         for hit in hits:
             assert '_source' in hit
@@ -141,15 +128,25 @@ class SearchTests(ESTestCase, APITestCase):
             role=Staff.ROLE_ID
         )
         # verify that by default the user sees all the users programs she has access to
-        resp, _ = self.assert_status_code()
+        resp = self.assert_status_code()
         program_ids_in_hits = self.get_program_ids_in_hits(resp.data['hits']['hits'])
         assert len(program_ids_in_hits) == 2
         assert self.program1.id in program_ids_in_hits
         assert self.program3.id in program_ids_in_hits
 
-        # request just users in one program
+        # request just users in one program with filters and query
         wanted_program_id = self.program3.id
-        filter_data = {
+
+        filter_params = {
+            "filter": {
+                "bool": {
+                    "should": [
+                        {"term": {"program.id": wanted_program_id}}
+                    ]
+                }
+            }
+        }
+        query_params = {
             "query": {
                 "bool": {
                     "should": [
@@ -158,8 +155,9 @@ class SearchTests(ESTestCase, APITestCase):
                 }
             }
         }
-        # verify that only the wanted program is in the hits
-        _, resp = self.assert_status_code(json=filter_data)
-        program_ids_in_hits = self.get_program_ids_in_hits(resp.data['hits']['hits'])
-        assert len(program_ids_in_hits) == 1
-        assert program_ids_in_hits[0] == wanted_program_id
+        for params in [filter_params, query_params]:
+            # verify that only the wanted program is in the hits
+            resp = self.assert_status_code(json=params)
+            program_ids_in_hits = self.get_program_ids_in_hits(resp.data['hits']['hits'])
+            assert len(program_ids_in_hits) == 1
+            assert program_ids_in_hits[0] == wanted_program_id


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #1588 

#### What's this PR do?
Fixes a bug that allowed staff users to see students of program where the staff user was not staff.

This PR also removes the GET request handling support from the ES proxy

#### Where should the reviewer start?
the bug has been fixed in
`search/api.py`

all the rest is work to fix the reason why this bug did not come out from the tests before.

#### How should this be manually tested?
Make sure the staff user can see only the students in the programs where she is staff