### PR TITLE
Fixed header of search page

### DIFF
--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -155,26 +155,30 @@
     }
   }
 
-  .mm-filters:empty {
-    display: none !important;
+  .mm-filters {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin: 10px 0 15px 8px !important;
+
+    &:empty {
+      display: none !important;
+    }
   }
 
   .search-header {
     min-height: 100px;
-    padding-left: 5px;
-    padding-bottom: 0;
+    padding: 30px 0 0 5px;
     border-bottom: 1px solid $border-color;
     margin: 0;
 
     > * {
       display: flex;
       flex-direction: row;
-      align-items: center;
     }
 
     .pagination-sort {
       justify-content: flex-end;
-      align-items: center;
 
       .sk-pagination-navigation {
         display: flex;
@@ -257,6 +261,9 @@
       font-weight: 300;
       padding-left: 15px;
       color: $font-gray;
+      height: 36px;
+      align-items: center;
+      display: flex;
     }
 
     .learner-actions {

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -162,7 +162,7 @@
     margin: 10px 0 15px 8px !important;
 
     &:empty {
-      display: none !important;
+      display: none;
     }
   }
 


### PR DESCRIPTION
#### What are the relevant tickets?
- fixes https://github.com/mitodl/micromasters/issues/1538

#### What's this PR do?
- Fixes padding of search header when facets selected.

#### How should this be manually tested?
- see /learners page

@pdpinch @roberthouse54 @aliceriot 
#### Screenshots (if appropriate)
<img width="920" alt="screen shot 2016-11-02 at 6 14 43 pm" src="https://cloud.githubusercontent.com/assets/10431250/19930098/ad51df42-a128-11e6-8fb3-9042accc71fe.png">

<img width="917" alt="screen shot 2016-11-02 at 6 15 09 pm" src="https://cloud.githubusercontent.com/assets/10431250/19930099/ad550bae-a128-11e6-9d87-308e2a3ee570.png">
