### PR TITLE
Use DRF API correctly

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -16,7 +16,7 @@ from wagtail.wagtailimages.models import Image
 
 from courses.models import Program
 from courses.serializers import CourseSerializer
-from micromasters.serializers import UserSerializer
+from micromasters.serializers import serialize_maybe_user
 from micromasters.utils import webpack_dev_server_host
 from profiles.api import get_social_username
 from roles.models import Instructor, Staff
@@ -26,12 +26,12 @@ from ui.views import get_bundle_url
 def faculty_for_carousel(faculty):
     """formats faculty info for the carousel"""
     from cms.serializers import FacultySerializer
-    return [FacultySerializer().to_representation(f) for f in faculty]
+    return FacultySerializer(faculty, many=True).data
 
 
 def courses_for_popover(courses):
     """formats course info for the popover"""
-    return [CourseSerializer().to_representation(c) for c in courses]
+    return CourseSerializer(courses, many=True).data
 
 
 class HomePage(Page):
@@ -216,7 +216,7 @@ def get_program_page_context(programpage, request):
         "environment": settings.ENVIRONMENT,
         "sentry_dsn": sentry.get_public_dsn(),
         "release_version": settings.VERSION,
-        "user": UserSerializer().to_representation(request.user),
+        "user": serialize_maybe_user(request.user),
     }
     username = get_social_username(request.user)
     context = super(ProgramPage, programpage).get_context(request)

--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -21,7 +21,8 @@ class FacultyImageSerializer(serializers.ModelSerializer):
 
     def get_rendition(self, image):  # pylint: disable=no-self-use
         """Serialize a rendition for the faculty image"""
-        return RenditionSerializer().to_representation(image.get_rendition('fill-500x385'))
+        rendition = image.get_rendition('fill-500x385')
+        return RenditionSerializer(rendition).data
 
     class Meta:  # pylint: disable=missing-docstring
         model = Image

--- a/cms/serializers_test.py
+++ b/cms/serializers_test.py
@@ -20,14 +20,16 @@ class WagtailSerializerTests(ESTestCase):
         Make sure faculty image information is serialized correctly
         """
         faculty = FacultyFactory.create()
-        result = FacultySerializer().to_representation(faculty)
-        assert result == {
+        rendition = faculty.image.get_rendition('fill-500x385')
+        rendition_data = RenditionSerializer(rendition).data
+        data = FacultySerializer(faculty).data
+        assert data == {
             'name': faculty.name,
             'title': faculty.title,
             'short_bio': faculty.short_bio,
             'image': {
                 'alt': faculty.image.default_alt_text,
-                'rendition': RenditionSerializer().to_representation(faculty.image.get_rendition('fill-500x385'))
+                'rendition': rendition_data,
             }
         }
 
@@ -37,7 +39,8 @@ class WagtailSerializerTests(ESTestCase):
         """
         faculty = FacultyFactory.create()
         rendition = faculty.image.get_rendition('fill-1x1')
-        assert RenditionSerializer().to_representation(rendition) == {
+        data = RenditionSerializer(rendition).data
+        assert data == {
             'file': rendition.url,
             'width': rendition.width,
             'height': rendition.height,

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -32,7 +32,7 @@ class CourseSerializerTests(ESTestCase):
         Make sure course serializes correctly
         """
         course = CourseFactory.create()
-        result = CourseSerializer().to_representation(course)
+        data = CourseSerializer(course).data
         expected = {
             "id": course.id,
             "title": course.title,
@@ -40,7 +40,7 @@ class CourseSerializerTests(ESTestCase):
             "url": "",
             "enrollment_text": "Not available",
         }
-        assert result == expected
+        assert data == expected
 
     @override_settings(EDXORG_BASE_URL="http://192.168.33.10:8000")
     def test_course_with_run(self):
@@ -49,9 +49,9 @@ class CourseSerializerTests(ESTestCase):
         """
         course_run = CourseRunFactory.create(edx_course_key='my-course-key')
         course = course_run.course
-        result = CourseSerializer().to_representation(course)
-        assert result['url'] == 'http://192.168.33.10:8000/courses/my-course-key/about'
-        assert result['enrollment_text'] == course.enrollment_text
+        data = CourseSerializer(course).data
+        assert data['url'] == 'http://192.168.33.10:8000/courses/my-course-key/about'
+        assert data['enrollment_text'] == course.enrollment_text
 
 
 class ProgramSerializerTests(ESTestCase):
@@ -74,7 +74,8 @@ class ProgramSerializerTests(ESTestCase):
         """
         Test ProgramSerializer without a program page
         """
-        assert ProgramSerializer(context=self.context).to_representation(self.program) == {
+        data = ProgramSerializer(self.program, context=self.context).data
+        assert data == {
             'id': self.program.id,
             'title': self.program.title,
             'programpage_url': None,
@@ -88,7 +89,8 @@ class ProgramSerializerTests(ESTestCase):
         programpage = ProgramPageFactory.build(program=self.program)
         homepage = HomePage.objects.first()
         homepage.add_child(instance=programpage)
-        assert ProgramSerializer(context=self.context).to_representation(self.program) == {
+        data = ProgramSerializer(self.program, context=self.context).data
+        assert data == {
             'id': self.program.id,
             'title': self.program.title,
             'programpage_url': programpage.url,
@@ -101,7 +103,8 @@ class ProgramSerializerTests(ESTestCase):
         Test ProgramSerializer with an enrolled user
         """
         ProgramEnrollment.objects.create(user=self.user, program=self.program)
-        assert ProgramSerializer(context=self.context).to_representation(self.program) == {
+        data = ProgramSerializer(self.program, context=self.context).data
+        assert data == {
             'id': self.program.id,
             'title': self.program.title,
             'programpage_url': None,

--- a/micromasters/serializers.py
+++ b/micromasters/serializers.py
@@ -11,7 +11,10 @@ log = logging.getLogger(__name__)
 
 
 class UserSerializer(serializers.ModelSerializer):
-    """Serializer for users."""
+    """
+    Serializer for User objects. Note that this will only work with
+    logged-in users, not anonymous users.
+    """
     username = serializers.SerializerMethodField()
     first_name = serializers.SerializerMethodField()
     last_name = serializers.SerializerMethodField()
@@ -59,10 +62,12 @@ class UserSerializer(serializers.ModelSerializer):
         except ObjectDoesNotExist:
             return None
 
-    def to_representation(self, obj):
-        """
-        Serialize anonymous users as None
-        """
-        if obj.is_anonymous():
-            return None
-        return super().to_representation(obj)
+
+def serialize_maybe_user(user):
+    """
+    Serialize a logged-in user to Python primitives, or an anonymous user
+    to `None`.
+    """
+    if user.is_anonymous():
+        return None
+    return UserSerializer(user).data

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -112,11 +112,10 @@ class ProfileGETTests(ProfileBaseTests):
         """
         with mute_signals(post_save):
             profile = ProfileFactory.create(user=self.user1)
+        profile_data = ProfileSerializer(profile).data
         self.client.force_login(self.user1)
         resp = self.client.get(self.url1)
-        assert resp.json() == format_image_expectation(
-            ProfileSerializer().to_representation(profile)
-        )
+        assert resp.json() == format_image_expectation(profile_data)
 
     def test_anonym_user_get_public_profile(self):
         """
@@ -124,9 +123,10 @@ class ProfileGETTests(ProfileBaseTests):
         """
         with mute_signals(post_save):
             profile = ProfileFactory.create(user=self.user2, account_privacy=Profile.PUBLIC)
+        profile_data = ProfileLimitedSerializer(profile).data
         self.client.logout()
         resp = self.client.get(self.url2)
-        assert resp.json() == ProfileLimitedSerializer().to_representation(profile)
+        assert resp.json() == profile_data
 
     def test_mm_user_get_public_profile(self):
         """
@@ -135,9 +135,10 @@ class ProfileGETTests(ProfileBaseTests):
         with mute_signals(post_save):
             profile = ProfileFactory.create(user=self.user2, account_privacy=Profile.PUBLIC)
             ProfileFactory.create(user=self.user1, verified_micromaster_user=False)
+        profile_data = ProfileLimitedSerializer(profile).data
         self.client.force_login(self.user1)
         resp = self.client.get(self.url2)
-        assert resp.json() == ProfileLimitedSerializer().to_representation(profile)
+        assert resp.json() == profile_data
 
     def test_vermm_user_get_public_profile(self):
         """
@@ -146,9 +147,10 @@ class ProfileGETTests(ProfileBaseTests):
         with mute_signals(post_save):
             profile = ProfileFactory.create(user=self.user2, account_privacy=Profile.PUBLIC)
             ProfileFactory.create(user=self.user1, verified_micromaster_user=True)
+        profile_data = ProfileLimitedSerializer(profile).data
         self.client.force_login(self.user1)
         resp = self.client.get(self.url2)
-        assert resp.json() == ProfileLimitedSerializer().to_representation(profile)
+        assert resp.json() == profile_data
 
     def test_anonym_user_get_public_to_mm_profile(self):
         """
@@ -178,9 +180,10 @@ class ProfileGETTests(ProfileBaseTests):
         with mute_signals(post_save):
             profile = ProfileFactory.create(user=self.user2, account_privacy=Profile.PUBLIC_TO_MM)
             ProfileFactory.create(user=self.user1, verified_micromaster_user=True)
+        profile_data = ProfileLimitedSerializer(profile).data
         self.client.force_login(self.user1)
         resp = self.client.get(self.url2)
-        assert resp.json() == ProfileLimitedSerializer().to_representation(profile)
+        assert resp.json() == profile_data
 
     def test_anonym_user_get_private_profile(self):
         """
@@ -245,10 +248,9 @@ class ProfileGETTests(ProfileBaseTests):
         )
 
         self.client.force_login(self.user1)
+        profile_data = ProfileSerializer(profile).data
         resp = self.client.get(self.url2)
-        assert resp.json() == format_image_expectation(
-            ProfileSerializer().to_representation(profile)
-        )
+        assert resp.json() == format_image_expectation(profile_data)
 
     def test_staff_sees_entire_profile(self):
         """
@@ -271,9 +273,8 @@ class ProfileGETTests(ProfileBaseTests):
 
         self.client.force_login(self.user1)
         resp = self.client.get(self.url2)
-        assert resp.json() == format_image_expectation(
-            ProfileSerializer().to_representation(profile)
-        )
+        profile_data = ProfileSerializer(profile).data
+        assert resp.json() == format_image_expectation(profile_data)
 
 
 class ProfilePATCHTests(ProfileBaseTests):
@@ -294,7 +295,7 @@ class ProfilePATCHTests(ProfileBaseTests):
             provider=EdxOrgOAuth2.name,
             uid="{}_edx".format(new_profile.user.username)
         )
-        patch_data = ProfileSerializer().to_representation(new_profile)
+        patch_data = ProfileSerializer(new_profile).data
         del patch_data['image']
 
         resp = self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
@@ -320,7 +321,7 @@ class ProfilePATCHTests(ProfileBaseTests):
             profile = ProfileFactory.create(user=self.user1, filled_out=False)
         self.client.force_login(self.user1)
 
-        patch_data = ProfileSerializer().to_representation(profile)
+        patch_data = ProfileSerializer(profile).data
         # PATCH may not succeed, we just care that the right serializer was used
         with patch(
             'profiles.views.ProfileFilledOutSerializer.__new__',
@@ -343,7 +344,7 @@ class ProfilePATCHTests(ProfileBaseTests):
             profile = ProfileFactory.create(user=self.user1, filled_out=True)
         self.client.force_login(self.user1)
 
-        patch_data = ProfileSerializer().to_representation(profile)
+        patch_data = ProfileSerializer(profile).data
         # PATCH may not succeed, we just care that the right serializer was used
         with patch(
             'profiles.views.ProfileFilledOutSerializer.__new__',

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -176,7 +176,7 @@ def serialize_program_enrolled_user(program_enrollment):
         'email': user.email
     }
     try:
-        serialized['profile'] = ProfileSerializer().to_representation(user.profile)
+        serialized['profile'] = ProfileSerializer(user.profile).data
     except Profile.DoesNotExist:
         # Just in case
         pass

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -291,7 +291,7 @@ class SerializerTests(ESTestCase):
             'id': program_enrollment.id,
             'user_id': profile.user.id,
             'email': profile.user.email,
-            'profile': ProfileSerializer().to_representation(profile),
+            'profile': ProfileSerializer(profile).data,
             'program': UserProgramSerializer.serialize(program_enrollment)
         }
 

--- a/ui/views.py
+++ b/ui/views.py
@@ -17,7 +17,7 @@ from rolepermissions.shortcuts import available_perm_status
 from rolepermissions.verifications import has_role
 
 from micromasters.utils import webpack_dev_server_host, webpack_dev_server_url
-from micromasters.serializers import UserSerializer
+from micromasters.serializers import serialize_maybe_user
 from profiles.api import get_social_username
 from profiles.permissions import CanSeeIfNotPrivate
 from roles.models import Instructor, Staff
@@ -72,7 +72,7 @@ class ReactView(View):  # pylint: disable=unused-argument
             "sentry_dsn": sentry.get_public_dsn(),
             "search_url": reverse('search_api', kwargs={"elastic_url": ""}),
             "support_email": settings.EMAIL_SUPPORT,
-            "user": UserSerializer().to_representation(request.user),
+            "user": serialize_maybe_user(request.user),
         }
 
         return render(
@@ -142,7 +142,7 @@ def standard_error_page(request, status_code, template_filename):
                 "release_version": settings.VERSION,
                 "environment": settings.ENVIRONMENT,
                 "sentry_dsn": sentry.get_public_dsn(),
-                "user": UserSerializer().to_representation(request.user),
+                "user": serialize_maybe_user(request.user),
             }),
             "authenticated": authenticated,
             "name": name,
@@ -171,7 +171,7 @@ def terms_of_service(request):
                 "release_version": settings.VERSION,
                 "environment": settings.ENVIRONMENT,
                 "sentry_dsn": sentry.get_public_dsn(),
-                "user": UserSerializer().to_representation(request.user),
+                "user": serialize_maybe_user(request.user),
             }),
             "signup_dialog_src": get_bundle_url(request, "signup_dialog.js"),
             "tracking_id": "",


### PR DESCRIPTION
The Serializer classes in Django REST Framework have `to_representation()` methods that are intended to be overridden by subclasses, but not called directly. This changes the codebase to use DRF's intended API for serializing instances to Python primitive datatypes.

According to [the official tutorial](http://www.django-rest-framework.org/tutorial/1-serialization/#working-with-serializers), Serializer classes work in the following two ways:
* To serialize a model instance to Python primitives, pass the instance to the Serializer constructor, and access the `.data` property of the Serializer object
* To deserialize Python primitives (data) into a model instance, pass the data to the Serializer constructor as a `data` keyword argument. Check if the data is valid by calling `.is_valid()` on the Serializer object (optional), and then create a model instance by calling `.save()` on the Serializer object. This will insert the data into the database, or update existing data in the database, and return a model instance.

This pull request should not result in any user-visible changes.