### PR TITLE
Changed education and employment titles

### DIFF
--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -253,11 +253,13 @@ class EducationForm extends ProfileFormFields {
     const {
       ui: { educationDialogIndex },
       showSwitch,
-      profile: { education },
+      profile,
     } = this.props;
 
-    let educationDegreeLevel = _.get(education[educationDialogIndex], "degree_name") || BACHELORS;
-    let keySet = (key) => ['education', educationDialogIndex, key];
+    let keySet = (key): any => ['education', educationDialogIndex, key];
+    let educationDegreeLevel = _.get(profile, keySet("degree_name"));
+    let id = _.get(profile, keySet("id"));
+    let title = id !== undefined ? 'Edit Education' : 'Add Education';
 
     let fieldOfStudy = () => {
       if (educationDegreeLevel !== HIGH_SCHOOL) {
@@ -285,7 +287,7 @@ class EducationForm extends ProfileFormFields {
 
     return <Grid className="profile-tab-grid">
       <Cell col={12} className="profile-form-title">
-        {EDUCATION_LEVEL_LABELS[educationDegreeLevel]}
+        {title}
       </Cell>
       { levelForm() }
       { fieldOfStudy() }

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -26,7 +26,6 @@ import { educationEntriesByDate } from '../util/sorting';
 import {
   EDUCATION_LEVELS,
   HIGH_SCHOOL,
-  BACHELORS,
 } from '../constants';
 import type { Option } from '../flow/generalTypes';
 import type {

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -95,12 +95,15 @@ class EmploymentForm extends ProfileFormFields {
   };
 
   editWorkHistoryForm(): React$Element<*> {
-    const { ui } = this.props;
-    let keySet = (key) => ['work_history', ui.workDialogIndex, key];
+    const { ui, profile } = this.props;
+    let keySet = (key): any => ['work_history', ui.workDialogIndex, key];
+    let id = _.get(profile, keySet("id"));
+    let title = id !== undefined ? 'Edit Employment' : 'Add Employment';
+
     return (
       <Grid className="profile-tab-grid">
         <Cell col={12} className="profile-form-title">
-          Add Employment
+          {title}
         </Cell>
         <Cell col={12}>
           {this.boundTextField(keySet('company_name'), 'Company Name')}

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -448,6 +448,8 @@ describe("UserPage", function() {
             SET_EDUCATION_DEGREE_LEVEL,
           ], () => {
             TestUtils.Simulate.click(editButton);
+
+            assert.equal(document.querySelector(".profile-form-title").innerHTML, "Edit Education");
           });
         });
       });
@@ -505,6 +507,8 @@ describe("UserPage", function() {
 
           return listenForActions(expectedActions, () => {
             TestUtils.Simulate.click(addButton);
+
+            assert.equal(document.querySelector(".profile-form-title").innerHTML, "Add Education");
 
             let dialog = document.querySelector('.education-dialog');
             let grid = dialog.getElementsByClassName('profile-tab-grid')[0];
@@ -633,6 +637,8 @@ describe("UserPage", function() {
             SET_WORK_DIALOG_VISIBILITY
           ], () => {
             TestUtils.Simulate.click(editButton);
+
+            assert.equal(document.querySelector(".profile-form-title").innerHTML, "Edit Employment");
           });
         });
       });
@@ -693,6 +699,8 @@ describe("UserPage", function() {
 
           return listenForActions(expectedActions, () => {
             TestUtils.Simulate.click(addButton);
+
+            assert.equal(document.querySelector(".profile-form-title").innerHTML, "Add Employment");
             let dialog = document.querySelector('.employment-dialog');
             let grid = dialog.querySelector('.profile-tab-grid');
             let inputs = grid.getElementsByTagName('input');


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1498

#### What's this PR do?
Changes the education dialog titles to 'Add Education' and 'Edit Education' and changes the employment title to 'Edit Employment' when the employment is being edited

#### How should this be manually tested?
Edit and add employment and education entries
