### PR TITLE
Correctly handle faculty without images

### DIFF
--- a/static/js/components/FacultyTile.js
+++ b/static/js/components/FacultyTile.js
@@ -40,8 +40,8 @@ export default class FacultyTile extends React.Component {
       <div className="faculty-tile">
         {imgEl}
         <div className="faculty-copy">
-          <h4>{nameStr}</h4>
-          <p>{shortBio}</p>
+          <h4 className="faculty-name">{nameStr}</h4>
+          <p className="faculty-bio">{shortBio}</p>
         </div>
       </div>
     );

--- a/static/js/components/FacultyTile.js
+++ b/static/js/components/FacultyTile.js
@@ -14,28 +14,34 @@ export default class FacultyTile extends React.Component {
       name,
       title,
       short_bio: shortBio,
-      image: {
+      image,
+    } = this.props;
+    let nameStr, imgEl;
+    if (title) {
+      nameStr = `${name}, ${title}`;
+    } else {
+      nameStr = name;
+    }
+    if (image) {
+      const {
         alt,
         rendition: {
           width,
           height,
           file,
         }
-      }
-    } = this.props;
-    let nameStr;
-    if (title) {
-      nameStr = `${name}, ${title}`;
+      } = image;
+      imgEl = <img src={file} alt={alt} width={width} height={height} />;
     } else {
-      nameStr = name;
+      imgEl = null;
     }
 
     return (
       <div className="faculty-tile">
-        <img src={file} alt={alt} width={width} height={height} />
+        {imgEl}
         <div className="faculty-copy">
-        <h4>{nameStr}</h4>
-        <p>{shortBio}</p>
+          <h4>{nameStr}</h4>
+          <p>{shortBio}</p>
         </div>
       </div>
     );

--- a/static/js/components/FacultyTile_test.js
+++ b/static/js/components/FacultyTile_test.js
@@ -26,10 +26,10 @@ describe('FacultyTile', () => {
 
   it('can render itself', () => {
     const wrapper = renderFacultyTile();
-    const nameEl = wrapper.find("h4");
+    const nameEl = wrapper.find(".faculty-name");
     assert.lengthOf(nameEl, 1);
     assert.equal(nameEl.text(), "Frank Professor, Ph.D");
-    const bioEl = wrapper.find("p");
+    const bioEl = wrapper.find(".faculty-bio");
     assert.lengthOf(bioEl, 1);
     assert.equal(bioEl.text(), "He does things.");
     const imgEl = wrapper.find("img");
@@ -41,10 +41,10 @@ describe('FacultyTile', () => {
 
   it('can render without an image', () => {
     const wrapper = renderFacultyTile({image: null});
-    const nameEl = wrapper.find("h4");
+    const nameEl = wrapper.find(".faculty-name");
     assert.lengthOf(nameEl, 1);
     assert.equal(nameEl.text(), "Frank Professor, Ph.D");
-    const bioEl = wrapper.find("p");
+    const bioEl = wrapper.find(".faculty-bio");
     assert.lengthOf(bioEl, 1);
     assert.equal(bioEl.text(), "He does things.");
     const imgEl = wrapper.find("img");

--- a/static/js/components/FacultyTile_test.js
+++ b/static/js/components/FacultyTile_test.js
@@ -1,0 +1,53 @@
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import FacultyTile from './FacultyTile';
+
+describe('FacultyTile', () => {
+  let renderFacultyTile = (props) => {
+    return shallow(
+      <FacultyTile
+        name="Frank Professor"
+        title="Ph.D"
+        short_bio="He does things."
+        image={{
+          alt: "An impressive image",
+          rendition: {
+            width: "50",
+            height: "50",
+            file: "frank.jpg"
+          }
+        }}
+        {...props}
+      />
+    );
+  };
+
+  it('can render itself', () => {
+    const wrapper = renderFacultyTile();
+    const nameEl = wrapper.find("h4");
+    assert.lengthOf(nameEl, 1);
+    assert.equal(nameEl.text(), "Frank Professor, Ph.D");
+    const bioEl = wrapper.find("p");
+    assert.lengthOf(bioEl, 1);
+    assert.equal(bioEl.text(), "He does things.");
+    const imgEl = wrapper.find("img");
+    assert.lengthOf(imgEl, 1);
+    const imgElProps = imgEl.props();
+    assert.propertyVal(imgElProps, "src", "frank.jpg");
+    assert.propertyVal(imgElProps, "alt", "An impressive image");
+  });
+
+  it('can render without an image', () => {
+    const wrapper = renderFacultyTile({image: null});
+    const nameEl = wrapper.find("h4");
+    assert.lengthOf(nameEl, 1);
+    assert.equal(nameEl.text(), "Frank Professor, Ph.D");
+    const bioEl = wrapper.find("p");
+    assert.lengthOf(bioEl, 1);
+    assert.equal(bioEl.text(), "He does things.");
+    const imgEl = wrapper.find("img");
+    assert.lengthOf(imgEl, 0);
+  });
+});


### PR DESCRIPTION
Fixes #1560. The faculty carousel should now be able to display faculty even if some of them don't have an image set.

#### How should this be manually tested?
Create a ProgramPage in Wagtail with one or more faculty. Make sure that at least one of these faculty members does _not_ have an image set. View the program page in the browser, and verify that all faculty show up in the faculty carousel at the bottom.