### PR TITLE
Upgrade Pillow to 3.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ faker==0.7.3
 html5lib==0.999999
 jsonfield==1.0.3
 newrelic==2.72.1.53
-Pillow==3.1.1
+Pillow==3.4.2
 psycopg2==2.6
 python-dateutil==2.5.2
 python-social-auth==0.2.14


### PR DESCRIPTION
Wagtail 1.7 (#1635) updates the version of [Willow](https://pypi.python.org/pypi/Willow) that it depends on. I figured it would make sense to also make sure that the underlying Pillow library was up to date. [ChangeLog is here.](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst)