### PR TITLE
Upgrade Django REST Framework to 3.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ django-role-permissions==1.2
 django-server-status==0.3.2
 django-storages-redux==1.3.2
 Django==1.9.10
-djangorestframework==3.3.2
+djangorestframework==3.5.2
 edx-api-client==0.3.0
 elasticsearch==2.3.0
 elasticsearch-dsl==2.1.0


### PR DESCRIPTION
Django REST Framework is one of the core frameworks that this project uses. It's better to do smaller, more frequent upgrades than to wait until bugs or deprecations force us to do larger, infrequent upgrades. [ChangeLog is here.](http://www.django-rest-framework.org/topics/release-notes/)