### PR TITLE
Docker Compose version 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN curl --silent --location https://bootstrap.pypa.io/get-pip.py | python3 -
 # Add, and run as, non-root user.
 RUN mkdir /src
 RUN adduser --disabled-password --gecos "" mitodl
+RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 
 # Install project packages
 COPY requirements.txt /tmp/requirements.txt
@@ -30,8 +31,6 @@ RUN chown -R mitodl:mitodl /src
 RUN ./manage.py collectstatic --noinput
 RUN apt-get clean && apt-get purge
 USER mitodl
-
-RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 
 # Set pip cache folder, as it is breaking pip when it is on a shared volume
 ENV XDG_CACHE_HOME /tmp/.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN ./manage.py collectstatic --noinput
 RUN apt-get clean && apt-get purge
 USER mitodl
 
+RUN mkdir /var/media
+RUN chown -R mitodl:mitodl /var/media
+
 # Set pip cache folder, as it is breaking pip when it is on a shared volume
 ENV XDG_CACHE_HOME /tmp/.cache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,7 @@ RUN ./manage.py collectstatic --noinput
 RUN apt-get clean && apt-get purge
 USER mitodl
 
-RUN mkdir /var/media
-RUN chown -R mitodl:mitodl /var/media
+RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 
 # Set pip cache folder, as it is breaking pip when it is on a shared volume
 ENV XDG_CACHE_HOME /tmp/.cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,79 +1,86 @@
-db:
-  image: postgres
-  ports:
-    - "5432"
+version: '2'
+services:
+  db:
+    image: postgres
+    ports:
+      - "5432"
 
-redis:
-  image: redis
-  ports:
-    - "6379"
+  redis:
+    image: redis
+    ports:
+      - "6379"
 
-elastic:
-  image: elasticsearch:2.4.1
-  command: elasticsearch -Des.network.host=0.0.0.0 -Des.http.cors.enabled=true -Des.http.cors.allow-origin=*
-  ports:
-    - "9100:9200"
+  elastic:
+    image: elasticsearch:2.4.1
+    command: elasticsearch -Des.network.host=0.0.0.0 -Des.http.cors.enabled=true -Des.http.cors.allow-origin=*
+    ports:
+      - "9100:9200"
 
-web:
-  build: .
-  command: >
-    /bin/bash -c '
-    sleep 3 &&
-    python3 manage.py migrate &&
-    uwsgi uwsgi.ini'
-  volumes:
-    - .:/src
-  environment:
-    DEBUG: 'True'
-    DEV_ENV: 'True'
-    NODE_ENV: 'development'
-    PORT: 8079
-    COVERAGE_DIR: htmlcov
-    DATABASE_URL: postgres://postgres@db:5432/postgres
-    MICROMASTERS_USE_WEBPACK_DEV_SERVER: 'True'
-    MICROMASTERS_SECURE_SSL_REDIRECT: 'False'
-    MICROMASTERS_DB_DISABLE_SSL: 'True'
-    ELASTICSEARCH_URL: elastic:9200
-  env_file: .env
-  ports:
-    - "8079:8079"
-  links:
-    - db
-    - elastic
+  web:
+    build: .
+    command: >
+      /bin/bash -c '
+      sleep 3 &&
+      python3 manage.py migrate &&
+      uwsgi uwsgi.ini'
+    volumes:
+      - .:/src
+      - django_media:/var/media
+    environment:
+      DEBUG: 'True'
+      DEV_ENV: 'True'
+      NODE_ENV: 'development'
+      PORT: 8079
+      COVERAGE_DIR: htmlcov
+      DATABASE_URL: postgres://postgres@db:5432/postgres
+      MICROMASTERS_USE_WEBPACK_DEV_SERVER: 'True'
+      MICROMASTERS_SECURE_SSL_REDIRECT: 'False'
+      MICROMASTERS_DB_DISABLE_SSL: 'True'
+      ELASTICSEARCH_URL: elastic:9200
+    env_file: .env
+    ports:
+      - "8079:8079"
+    links:
+      - db
+      - elastic
 
-watch:
-  build: .
-  dockerfile: Dockerfile-node
-  working_dir: /src
-  command: >
-    /bin/bash -c './webpack_dev_server.sh --install'
-  ports:
-    - "8078:8078"
-  volumes:
-    - .:/src
-  environment:
-    NODE_ENV: 'development'
-  env_file: .env
+  watch:
+    build:
+      context: .
+      dockerfile: Dockerfile-node
+    working_dir: /src
+    command: >
+      /bin/bash -c './webpack_dev_server.sh --install'
+    ports:
+      - "8078:8078"
+    volumes:
+      - .:/src
+    environment:
+      NODE_ENV: 'development'
+    env_file: .env
 
-celery:
-  image: micromasters_web
-  mem_limit: 384m
-  command: >
-    /bin/bash -c '
-    sleep 3;
-    celery -A micromasters worker -B -l debug'
-  volumes_from:
-    - web
-  environment:
-    DEBUG: 'True'
-    MICROMASTERS_DB_DISABLE_SSL: 'True'
-    DJANGO_LOG_LEVEL: INFO
-    DATABASE_URL: postgres://postgres@db:5432/postgres
-    BROKER_URL: redis://redis:6379/4
-    CELERY_RESULT_BACKEND: redis://redis:6379/4
-    ELASTICSEARCH_URL: elastic:9200
-  env_file: .env
-  links:
-    - db
-    - elastic
-    - redis
+  celery:
+    image: micromasters_web
+    mem_limit: 384m
+    command: >
+      /bin/bash -c '
+      sleep 3;
+      celery -A micromasters worker -B -l debug'
+    volumes_from:
+      - web
+    environment:
+      DEBUG: 'True'
+      MICROMASTERS_DB_DISABLE_SSL: 'True'
+      DJANGO_LOG_LEVEL: INFO
+      DATABASE_URL: postgres://postgres@db:5432/postgres
+      BROKER_URL: redis://redis:6379/4
+      CELERY_RESULT_BACKEND: redis://redis:6379/4
+      ELASTICSEARCH_URL: elastic:9200
+    env_file: .env
+    links:
+      - db
+      - elastic
+      - redis
+
+volumes:
+  django_media: {}

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -432,7 +432,7 @@ SL_TRACKING_ID = get_var("SL_TRACKING_ID", "")
 
 # Wagtail
 WAGTAIL_SITE_NAME = "MIT MicroMasters"
-MEDIA_ROOT = get_var('MEDIA_ROOT', '/tmp/')
+MEDIA_ROOT = get_var('MEDIA_ROOT', '/var/media/')
 MEDIA_URL = '/media/'
 MICROMASTERS_USE_S3 = get_var('MICROMASTERS_USE_S3', False)
 AWS_ACCESS_KEY_ID = get_var('AWS_ACCESS_KEY_ID', False)

--- a/travis-docker-compose.yml
+++ b/travis-docker-compose.yml
@@ -1,34 +1,36 @@
-db:
-  image: postgres
-  ports:
-    - "5432"
+version: '2'
+services:
+  db:
+    image: postgres
+    ports:
+      - "5432"
 
-web:
-  build: .
-  dockerfile: ./travis/Dockerfile-travis-web
-  command: >
-    /bin/bash -c '
-    sleep 3 &&
-    python3 manage.py migrate &&
-    ./with_host.sh python3 manage.py runserver 0.0.0.0:8079'
-  environment:
-    DEBUG: 'False'
-    COVERAGE_DIR: htmlcov
-    PORT: 8079
-    NODE_ENV: 'production'
-    DATABASE_URL: postgres://postgres@db:5432/postgres
-    MICROMASTERS_SECURE_SSL_REDIRECT: 'False'
-    MICROMASTERS_DB_DISABLE_SSL: 'True'
-    ELASTICSEARCH_URL: elastic:9200
-  ports:
-    - "8079:8079"
-  links:
-    - db
-    - elastic
+  web:
+    build:
+      context: .
+      dockerfile: ./travis/Dockerfile-travis-web
+    command: >
+      /bin/bash -c '
+      sleep 3 &&
+      python3 manage.py migrate &&
+      ./with_host.sh python3 manage.py runserver 0.0.0.0:8079'
+    environment:
+      DEBUG: 'False'
+      COVERAGE_DIR: htmlcov
+      PORT: 8079
+      NODE_ENV: 'production'
+      DATABASE_URL: postgres://postgres@db:5432/postgres
+      MICROMASTERS_SECURE_SSL_REDIRECT: 'False'
+      MICROMASTERS_DB_DISABLE_SSL: 'True'
+      ELASTICSEARCH_URL: elastic:9200
+    ports:
+      - "8079:8079"
+    links:
+      - db
+      - elastic
 
-elastic:
-  image: elasticsearch:2.4.1
-  command: elasticsearch -Des.network.host=0.0.0.0
-  ports:
-    - "9200"
-
+  elastic:
+    image: elasticsearch:2.4.1
+    command: elasticsearch -Des.network.host=0.0.0.0
+    ports:
+      - "9200"

--- a/travis/Dockerfile-travis-web
+++ b/travis/Dockerfile-travis-web
@@ -13,6 +13,5 @@ WORKDIR /src
 COPY . /src
 
 RUN chown -R mitodl:mitodl /src
-RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 
 USER mitodl

--- a/travis/Dockerfile-travis-web
+++ b/travis/Dockerfile-travis-web
@@ -13,5 +13,6 @@ WORKDIR /src
 COPY . /src
 
 RUN chown -R mitodl:mitodl /src
+RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 
 USER mitodl


### PR DESCRIPTION
This upgrades our [Docker Compose](https://www.docker.com/products/docker-compose) file to the [version 2 syntax](https://docs.docker.com/compose/compose-file/#/versioning). This new syntax allows you to specify named volumes and mount them onto containers. This pull request creates a named volume for holding Django media and mounts it onto the `web` container. Previously, every time the `web` container was rebuilt, Wagtail lost all of its uploaded images; with this change, uploaded images live in this named volume, and will persist even if the developer rebuilds the `web` container.

There should be no user-visible changes from this pull request.