### PR TITLE
Upgrade NewRelic to 2.72.1.53

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ factory_boy==2.7.0
 faker==0.7.3
 html5lib==0.999999
 jsonfield==1.0.3
-newrelic==2.54.0.41
+newrelic==2.72.1.53
 Pillow==3.1.1
 psycopg2==2.6
 python-dateutil==2.5.2


### PR DESCRIPTION
The latest version of the [New Relic Agent for Python](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes) has some nice features, including better integration with Postgres via `psycopg2`, and better integration with Django 1.10 (#1636). This might make it easier to do performance testing. [Release notes are here.](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes)