### PR TITLE
Upgrade python-social-auth to 0.2.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ newrelic==2.54.0.41
 Pillow==3.1.1
 psycopg2==2.6
 python-dateutil==2.5.2
-python-social-auth==0.2.14
+python-social-auth==0.2.21
 PyYAML==3.11
 raven==5.24.3
 redis==2.10.5


### PR DESCRIPTION
[ChangeLog is here.](https://github.com/omab/python-social-auth/blob/master/CHANGELOG.md) Based on a quick skim, there seem to be some security-related updates -- not sure if we're vulnerable, but probably a good idea to upgrade regardless.

In addition, Django 1.10 (#1636) depends on this upgrade.