### PR TITLE
Allow to use save button only if photo is selected on 'photo upload dialog'

### DIFF
--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -74,7 +74,7 @@ const ProfileImageUploader = ({
       </Button>,
       <Button
         type='button'
-        className={photo ? 'primary-button save-button' : 'secondary-button save-button disabled'}
+        className={`save-button ${photo ? 'primary-button' : 'secondary-button disabled'}`}
         key="save"
         onClick={updateUserPhoto}>
         Save

--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -74,7 +74,7 @@ const ProfileImageUploader = ({
       </Button>,
       <Button
         type='button'
-        className='primary-button save-button'
+        className={photo ? 'primary-button save-button' : 'secondary-button save-button disabled'}
         key="save"
         onClick={updateUserPhoto}>
         Save

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -433,6 +433,10 @@
       color: #616161;
     }
 
+    &:disabled {
+      opacity: 0.3;
+      cursor: not-allowed;
+    }
   }
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?
- fixes https://github.com/mitodl/micromasters/issues/1427

#### What's this PR do?
- when user selects photo then updates ``save button`` classes. so that user can save photo. 

@pdpinch @roberthouse54 @aliceriot 
#### Screenshots (if appropriate)
<img width="569" alt="screen shot 2016-11-04 at 4 18 24 pm" src="https://cloud.githubusercontent.com/assets/10431250/20003916/e90830c6-a2aa-11e6-9faf-b5e0b165c3f6.png">

<img width="592" alt="screen shot 2016-11-04 at 4 18 36 pm" src="https://cloud.githubusercontent.com/assets/10431250/20003917/e90aef46-a2aa-11e6-8183-8e4bea6fca23.png">

