### PR TITLE
Fixed education/employment deletion when uploading images

### DIFF
--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -199,10 +199,10 @@ class ProfileSerializer(ProfileBaseSerializer):
                 else:
                     setattr(instance, attr, value)
             instance.save()
-            if 'work_history' in validated_data:
+            if 'work_history' in self.initial_data:
                 update_work_history(validated_data['work_history'], instance.id)
 
-            if 'education' in validated_data:
+            if 'education' in self.initial_data:
                 update_education(validated_data['education'], instance.id)
             return instance
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1658

#### What's this PR do?
Fixes bug where education and employment entries were cleared when uploading a profile image

#### How should this be manually tested?
Create employment and education entries, then upload a profile image. The employment and education entries you created should still be there.
