### PR TITLE
Implemented sending emails on order errors

### DIFF
--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -1,5 +1,6 @@
 """Views from ecommerce"""
 import logging
+import traceback
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -23,6 +24,7 @@ from ecommerce.models import (
     Receipt,
 )
 from ecommerce.permissions import IsSignedByCyberSource
+from mail.api import MailgunClient
 
 log = logging.getLogger(__name__)
 
@@ -100,17 +102,51 @@ class OrderFulfillmentView(APIView):
         if request.data['decision'] != 'ACCEPT':
             # This may happen if the user clicks 'Cancel Order'
             order.status = Order.FAILED
+            log.warning(
+                "Order fulfillment failed: received a decision that wasn't ACCEPT for order %s",
+                order,
+            )
+            try:
+                MailgunClient().send_individual_email(
+                    "Order fulfillment failed",
+                    "Order fulfillment failed for order {order}".format(
+                        order=order,
+                    ),
+                    settings.EMAIL_SUPPORT
+                )
+            except:
+                log.exception(
+                    "Error occurred when sending the email to notify "
+                    "about order fulfillment failure for order %s",
+                    order,
+                )
         else:
-            # Do the verified enrollment with edX here
             order.status = Order.FULFILLED
         order.save_and_log(None)
 
         if order.status == Order.FULFILLED:
             try:
                 enroll_user_on_success(order)
-            except EcommerceEdxApiException:
+            except:
                 log.exception(
-                    "Error occurred when enrolling user in one or more courses. See other errors above for more info."
+                    "Error occurred when enrolling user in one or more courses. "
+                    "See other errors above for more info."
                 )
+                try:
+                    MailgunClient().send_individual_email(
+                        "Error occurred when enrolling user during order fulfillment",
+                        "Error occurred when enrolling user during order fulfillment for {order}. "
+                        "Exception: {exception}".format(
+                            order=order,
+                            exception=traceback.format_exc()
+                        ),
+                        settings.EMAIL_SUPPORT,
+                    )
+                except:
+                    log.exception(
+                        "Error occurred when sending the email to notify support "
+                        "of user enrollment error during order %s fulfillment",
+                        order,
+                    )
         # The response does not matter to CyberSource
         return Response()

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -18,7 +18,6 @@ from ecommerce.api import (
     generate_cybersource_sa_payload,
     get_new_order_by_reference_number,
 )
-from ecommerce.exceptions import EcommerceEdxApiException
 from ecommerce.models import (
     Order,
     Receipt,
@@ -114,7 +113,7 @@ class OrderFulfillmentView(APIView):
                     ),
                     settings.EMAIL_SUPPORT
                 )
-            except:
+            except:  # pylint: disable=bare-except
                 log.exception(
                     "Error occurred when sending the email to notify "
                     "about order fulfillment failure for order %s",
@@ -127,10 +126,11 @@ class OrderFulfillmentView(APIView):
         if order.status == Order.FULFILLED:
             try:
                 enroll_user_on_success(order)
-            except:
+            except:  # pylint: disable=bare-except
                 log.exception(
-                    "Error occurred when enrolling user in one or more courses. "
-                    "See other errors above for more info."
+                    "Error occurred when enrolling user in one or more courses for order %s. "
+                    "See other errors above for more info.",
+                    order
                 )
                 try:
                     MailgunClient().send_individual_email(
@@ -142,7 +142,7 @@ class OrderFulfillmentView(APIView):
                         ),
                         settings.EMAIL_SUPPORT,
                     )
-                except:
+                except:  # pylint: disable=bare-except
                     log.exception(
                         "Error occurred when sending the email to notify support "
                         "of user enrollment error during order %s fulfillment",


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1336

#### What's this PR do?
Sends emails if the order fulfillment failed, or if the enrollment failed afterwards

#### How should this be manually tested?
Set up mailgun's environment variables, in particular `MAILGUN_RECIPIENT_OVERRIDE` should point to an email address you control. Start a purchase of a course and in Cybersource click 'cancel'. You should get an email saying that there was an order fulfillment failure. Make sure the recipient email matches `EMAIL_SUPPORT` in `settings.py`.

Next, change the course key for the course run you purchased to something invalid. Go through a purchase workflow and you should see the order fulfillment fail in the UI due to the enrollment in the course not working. You should get an email saying that the enrollment failed and a stack trace.
