### PR TITLE
Script to update docker hub images

### DIFF
--- a/travis/update-docker-hub.sh
+++ b/travis/update-docker-hub.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eo pipefail
+
+docker build -t mitodl/mm_web_travis -f Dockerfile .
+docker build -t mitodl/mm_watch_travis -f travis/Dockerfile-travis-watch-build .
+
+docker push mitodl/mm_web_travis
+docker push mitodl/mm_watch_travis


### PR DESCRIPTION
This is just a little script to automate building new docker images and pushing them to the [mitodl organization](https://hub.docker.com/u/mitodl/dashboard/) on docker hub. In order to use it you'll need to be logged in to a docker hub account which has permissions to push to the mitodl organization.

I just used it to push new images, so I guess if the builds are still passing it works! hahaha.