### PR TITLE
Use dicts for Python-Social-Auth instead of strings

### DIFF
--- a/backends/utils_test.py
+++ b/backends/utils_test.py
@@ -29,7 +29,10 @@ class RefreshTest(ESTestCase):
         cls.user.social_auth.create(
             provider=EdxOrgOAuth2.name,
             uid="{}_edx".format(cls.user.username),
-            extra_data='{"access_token": "fooooootoken", "refresh_token": "baaaarrefresh"}'
+            extra_data={
+                "access_token": "fooooootoken",
+                "refresh_token": "baaaarrefresh",
+            }
         )
 
     def setUp(self):

--- a/dashboard/tasks_test.py
+++ b/dashboard/tasks_test.py
@@ -34,7 +34,7 @@ class TasksTest(TestCase):
             user.social_auth.create(
                 provider=EdxOrgOAuth2.name,
                 uid="{}_edx".format(user.username),
-                extra_data='{"access_token": "fooooootoken"}'
+                extra_data={"access_token": "fooooootoken"}
             )
 
     def setUp(self):

--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -40,7 +40,7 @@ class DashboardTest(APITestCase):
         cls.user.social_auth.create(
             provider=EdxOrgOAuth2.name,
             uid="{}_edx".format(cls.user.username),
-            extra_data='{"access_token": "fooooootoken"}'
+            extra_data={"access_token": "fooooootoken"}
         )
 
         # create the programs
@@ -116,7 +116,10 @@ class DashboardTokensTest(APITestCase):
         cls.user.social_auth.create(
             provider=EdxOrgOAuth2.name,
             uid="{}_edx".format(cls.user.username),
-            extra_data='{"access_token": "fooooootoken", "refresh_token": "baaaarrefresh"}'
+            extra_data={
+                "access_token": "fooooootoken",
+                "refresh_token": "baaaarrefresh",
+            }
         )
 
         cls.enrollments = Enrollments([])
@@ -203,7 +206,7 @@ class UserCourseEnrollmentTest(ESTestCase, APITestCase):
         cls.user.social_auth.create(
             provider=EdxOrgOAuth2.name,
             uid="{}_edx".format(cls.user.username),
-            extra_data='{"access_token": "fooooootoken"}'
+            extra_data={"access_token": "fooooootoken"}
         )
 
         # create the course run


### PR DESCRIPTION
This is necessary to upgrade Django to 1.10 (#1636).