### PR TITLE
Add repository and license fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "micromasters",
   "version": "0.0.0",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mitodl/micromasters.git"
+  },
   "dependencies": {
     "ajaxchimp": "^1.3.0",
     "babel": "6.5.2",


### PR DESCRIPTION
Because I'm tired of `npm install` complaining every single time.