### PR TITLE
Allow all hosts while in DEBUG mode

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -70,7 +70,14 @@ SECRET_KEY = get_var(
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = get_var('DEBUG', False)
 
-ALLOWED_HOSTS = get_var('ALLOWED_HOSTS', [])
+if DEBUG:
+    # Disabling the protection added in 1.10.3 against a DNS rebinding vulnerability:
+    # https://docs.djangoproject.com/en/1.10/releases/1.10.3/#dns-rebinding-vulnerability-when-debug-true
+    # Because we never debug against production data, we are not vulnerable
+    # to this problem.
+    ALLOWED_HOSTS = ['*']
+else:
+    ALLOWED_HOSTS = get_var('ALLOWED_HOSTS', [])
 
 SECURE_SSL_REDIRECT = get_var('MICROMASTERS_SECURE_SSL_REDIRECT', True)
 


### PR DESCRIPTION
I discovered a problem when running Django 1.10.3 via Docker: it forbids access based on the IP address, even while `DEBUG=True`. [This change to Django was introduced in 1.10.3.](https://docs.djangoproject.com/en/1.10/releases/1.10.3/#dns-rebinding-vulnerability-when-debug-true)

Because we never debug against production data, we can safely disable this protection. Doing so will allow us to run within Docker and use [Docker-Machine](https://docs.docker.com/machine/overview/).