### PR TITLE
Fixed use of /src in docker images

### DIFF
--- a/travis/Dockerfile-travis-watch-build
+++ b/travis/Dockerfile-travis-watch-build
@@ -21,5 +21,3 @@ USER mitodl
 COPY package.json npm-shrinkwrap.json ./webpack_if_prod.sh /src/
 
 RUN npm install
-
-COPY . /src

--- a/travis/Dockerfile-travis-web
+++ b/travis/Dockerfile-travis-web
@@ -8,6 +8,10 @@ COPY requirements.txt /tmp/requirements.txt
 COPY test_requirements.txt /tmp/test_requirements.txt
 RUN pip install -r requirements.txt && pip install -r test_requirements.txt
 
+# mm_web_travis comes with a copy of the source which may not match the current copy, so we need to copy it again
+RUN rm -rf /src
+RUN mkdir /src
+
 WORKDIR /src
 
 COPY . /src


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1698 

#### What's this PR do?
The travis build failure for the release was caused by the Python source shipping in the base docker image not matching the source in the git checkout. To fix this this PR removes the source from `/src` before the new source is checked out

#### How should this be manually tested?
After the new docker images are uploaded, restart the travis build for the release. It should pass without errors.
