### PR TITLE
Make camera icon accessible

### DIFF
--- a/static/js/containers/ProfileImage.js
+++ b/static/js/containers/ProfileImage.js
@@ -65,9 +65,12 @@ class ProfileImage extends React.Component {
   cameraIcon: Function = (editable: bool): React$Element<*>|null => {
     const { setDialogVisibility } = this.props;
     if ( editable ) {
-      return <span className="img">
-        <Icon name="camera_alt" onClick={() => setDialogVisibility(true)} />
-        </span>;
+      return (
+        <button className="open-photo-dialog" onClick={() => setDialogVisibility(true)}>
+          <Icon name="camera_alt" />
+          <span className="sr-only">Update user photo</span>
+        </button>
+      );
     } else {
       return null;
     }

--- a/static/scss/profile-image.scss
+++ b/static/scss/profile-image.scss
@@ -1,13 +1,11 @@
 .avatar {
   position: relative;
 
-  i {
-    cursor: pointer
-  }
-
-  span.img {
+  .open-photo-dialog {
+    cursor: pointer;
     width: 34px;
     height: 34px;
+    border: 0;
     border-radius: 50%;
     background-color: rgba(0, 0, 0, 0.3);
     position: absolute;


### PR DESCRIPTION
Fixes #1684. Sets an accessible description for the camera icon on the user profile page, and uses a `<button>` element to indicate that clicking on the camera will open a dialog.