### PR TITLE
Switch to `manage.py showmigrations`

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -11,7 +11,7 @@ MANAGE_FILE=${MANAGE_FILE:2}
 # Run migrations
 
 echo "-----> Running django migrations"
-python $MANAGE_FILE migrate --list 2>&1 | indent
+python $MANAGE_FILE showmigrations --list 2>&1 | indent
 python $MANAGE_FILE migrate --noinput 2>&1 | indent
 
 echo


### PR DESCRIPTION
The `manage.py migrate --list` command is removed in Django 1.10. It has been replaced with the `manage.py showmigrations` command. https://docs.djangoproject.com/en/1.10/ref/django-admin/#django-admin-showmigrations