### PR TITLE
Removed empty education and work history cards on learners page

### DIFF
--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -129,12 +129,8 @@ class EducationForm extends ProfileFormFields {
     </Cell>;
   }
 
-  renderEducationLevelEntries(level: any): Array<React$Element<*>|void>|void|null {
+  renderEducationLevelEntries(level: any): Array<React$Element<*>|void>|void {
     const { profile } = this.props;
-    if (!isProfileOfLoggedinUser(profile) && (!profile.education || profile.education.length === 0)) {
-      return null;
-    }
-
     let levelValue = HIGH_SCHOOL;
     let filterDegreeName = () => true;
     let title;
@@ -169,7 +165,7 @@ class EducationForm extends ProfileFormFields {
     ];
   }
 
-  renderEducationLevel(level: Option): Array<React$Element<*>|void>|React$Element<*>|void|null {
+  renderEducationLevel(level: Option): Array<React$Element<*>|void>|React$Element<*>|void {
     if (this.hasEducationAtLevel(level.value)) {
       return this.renderEducationLevelEntries(level);
     } else {
@@ -341,21 +337,20 @@ class EducationForm extends ProfileFormFields {
         </Card>;
       });
     } else if (profile !== undefined) {
-      let educationLevelEntries = this.renderEducationLevelEntries(null);
-      if (educationLevelEntries) {
-        return (
-          <Card shadow={1} className="profile-form" id="education-card">
-            <Grid className="profile-form-grid">
-              <Cell col={12} className="profile-form-row profile-card-header">
-                <span className="title">
-                  Education
-                </span>
-              </Cell>
-              { this.renderEducationLevelEntries(null) }
-            </Grid>
-          </Card>
-        );
+      if (!isProfileOfLoggedinUser(profile) && (!profile.education || profile.education.length === 0)) {
+        return null;
       }
+
+      return <Card shadow={1} className="profile-form" id="education-card">
+        <Grid className="profile-form-grid">
+          <Cell col={12} className="profile-form-row profile-card-header">
+            <span className="title">
+              Education
+            </span>
+          </Cell>
+        { this.renderEducationLevelEntries(null) }
+        </Grid>
+      </Card>;
     } else {
       return null;
     }

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -10,7 +10,10 @@ import Dialog from 'material-ui/Dialog';
 import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
 
 import { educationValidation } from '../lib/validation/profile';
-import { userPrivilegeCheck } from '../util/util';
+import {
+  userPrivilegeCheck,
+  profileOfLoggedinUser
+} from '../util/util';
 import ProfileFormFields from '../util/ProfileFormFields';
 import ConfirmDeletion from './ConfirmDeletion';
 import FieldsOfStudySelectField from './inputs/FieldsOfStudySelectField';
@@ -126,8 +129,12 @@ class EducationForm extends ProfileFormFields {
     </Cell>;
   }
 
-  renderEducationLevelEntries(level: any): Array<React$Element<*>|void>|void {
+  renderEducationLevelEntries(level: any): Array<React$Element<*>|void>|void|null {
     const { profile } = this.props;
+    if (!profileOfLoggedinUser(profile) && (!profile.education || profile.education.length === 0)) {
+      return null;
+    }
+
     let levelValue = HIGH_SCHOOL;
     let filterDegreeName = () => true;
     let title;
@@ -334,16 +341,21 @@ class EducationForm extends ProfileFormFields {
         </Card>;
       });
     } else if (profile !== undefined) {
-      return <Card shadow={1} className="profile-form" id="education-card">
-        <Grid className="profile-form-grid">
-          <Cell col={12} className="profile-form-row profile-card-header">
-            <span className="title">
-              Education
-            </span>
-          </Cell>
-        { this.renderEducationLevelEntries(null) }
-        </Grid>
-      </Card>;
+      let educationLevelEntries = this.renderEducationLevelEntries(null);
+      if (educationLevelEntries) {
+        return (
+          <Card shadow={1} className="profile-form" id="education-card">
+            <Grid className="profile-form-grid">
+              <Cell col={12} className="profile-form-row profile-card-header">
+                <span className="title">
+                  Education
+                </span>
+              </Cell>
+              { this.renderEducationLevelEntries(null) }
+            </Grid>
+          </Card>
+        );
+      }
     } else {
       return null;
     }

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -12,7 +12,7 @@ import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
 import { educationValidation } from '../lib/validation/profile';
 import {
   userPrivilegeCheck,
-  profileOfLoggedinUser
+  isProfileOfLoggedinUser
 } from '../util/util';
 import ProfileFormFields from '../util/ProfileFormFields';
 import ConfirmDeletion from './ConfirmDeletion';
@@ -131,7 +131,7 @@ class EducationForm extends ProfileFormFields {
 
   renderEducationLevelEntries(level: any): Array<React$Element<*>|void>|void|null {
     const { profile } = this.props;
-    if (!profileOfLoggedinUser(profile) && (!profile.education || profile.education.length === 0)) {
+    if (!isProfileOfLoggedinUser(profile) && (!profile.education || profile.education.length === 0)) {
       return null;
     }
 
@@ -169,7 +169,7 @@ class EducationForm extends ProfileFormFields {
     ];
   }
 
-  renderEducationLevel(level: Option): Array<React$Element<*>|void>|React$Element<*>|void {
+  renderEducationLevel(level: Option): Array<React$Element<*>|void>|React$Element<*>|void|null {
     if (this.hasEducationAtLevel(level.value)) {
       return this.renderEducationLevelEntries(level);
     } else {

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -8,7 +8,10 @@ import IconButton from 'react-mdl/lib/IconButton';
 import _ from 'lodash';
 import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
 
-import { userPrivilegeCheck } from '../util/util';
+import {
+  userPrivilegeCheck,
+  profileOfLoggedinUser
+} from '../util/util';
 import { workEntriesByDate } from '../util/sorting';
 import { employmentValidation } from '../lib/validation/profile';
 import ProfileFormFields from '../util/ProfileFormFields';
@@ -157,8 +160,12 @@ class EmploymentForm extends ProfileFormFields {
     );
   }
 
-  renderWorkHistory(): Array<React$Element<*>|void>|void {
+  renderWorkHistory(): Array<React$Element<*>|void>|void|null {
     const { ui, profile, profile: { work_history } } = this.props;
+    if (!profileOfLoggedinUser(profile) && (!profile.work_history || profile.work_history.length === 0)) {
+      return null;
+    }
+
     if ( ui.workHistoryEdit === true ) {
       let workHistoryRows = [];
       if ( !_.isUndefined(work_history) ) {
@@ -293,6 +300,12 @@ class EmploymentForm extends ProfileFormFields {
       ui: { workHistoryEdit }
     } = this.props;
     let cardClass = workHistoryEdit ? '' : 'profile-tab-card-greyed';
+    let cardBody = this.renderCardBody();
+
+    if (!cardBody) {
+      return null;
+    }
+
     return <Card shadow={1} className={`profile-form ${cardClass}`} id={`work-history-card`}>
       <Grid className="profile-form-grid">
         { this.renderCardBody() }

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -10,7 +10,7 @@ import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
 
 import {
   userPrivilegeCheck,
-  profileOfLoggedinUser
+  isProfileOfLoggedinUser
 } from '../util/util';
 import { workEntriesByDate } from '../util/sorting';
 import { employmentValidation } from '../lib/validation/profile';
@@ -162,7 +162,7 @@ class EmploymentForm extends ProfileFormFields {
 
   renderWorkHistory(): Array<React$Element<*>|void>|void|null {
     const { ui, profile, profile: { work_history } } = this.props;
-    if (!profileOfLoggedinUser(profile) && (!profile.work_history || profile.work_history.length === 0)) {
+    if (!isProfileOfLoggedinUser(profile) && (!profile.work_history || profile.work_history.length === 0)) {
       return null;
     }
 

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -160,12 +160,8 @@ class EmploymentForm extends ProfileFormFields {
     );
   }
 
-  renderWorkHistory(): Array<React$Element<*>|void>|void|null {
+  renderWorkHistory(): Array<React$Element<*>|void>|void {
     const { ui, profile, profile: { work_history } } = this.props;
-    if (!isProfileOfLoggedinUser(profile) && (!profile.work_history || profile.work_history.length === 0)) {
-      return null;
-    }
-
     if ( ui.workHistoryEdit === true ) {
       let workHistoryRows = [];
       if ( !_.isUndefined(work_history) ) {
@@ -297,15 +293,15 @@ class EmploymentForm extends ProfileFormFields {
 
   renderCard () {
     const {
-      ui: { workHistoryEdit }
+      ui: { workHistoryEdit },
+      profile
     } = this.props;
-    let cardClass = workHistoryEdit ? '' : 'profile-tab-card-greyed';
-    let cardBody = this.renderCardBody();
 
-    if (!cardBody) {
+    if (!isProfileOfLoggedinUser(profile) && (!profile.work_history || profile.work_history.length === 0)) {
       return null;
     }
 
+    let cardClass = workHistoryEdit ? '' : 'profile-tab-card-greyed';
     return <Card shadow={1} className={`profile-form ${cardClass}`} id={`work-history-card`}>
       <Grid className="profile-form-grid">
         { this.renderCardBody() }

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -40,9 +40,9 @@ export function sendGoogleAnalyticsEvent(category: any, action: any, label: any,
   ga.event(event);
 }
 
-export function profileOfLoggedinUser(profile: Profile): boolean {
-  return (SETTINGS.user && profile.username === SETTINGS.user.username);
-}
+export const isProfileOfLoggedinUser = (profile: Profile): boolean => (
+  SETTINGS.user && profile.username === SETTINGS.user.username
+);
 
 export function userPrivilegeCheck (profile: Profile, privileged: any, unPrivileged: any): any {
   if ( SETTINGS.user && profile.username === SETTINGS.user.username ) {

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -40,6 +40,10 @@ export function sendGoogleAnalyticsEvent(category: any, action: any, label: any,
   ga.event(event);
 }
 
+export function profileOfLoggedinUser(profile: Profile): boolean {
+  return (SETTINGS.user && profile.username === SETTINGS.user.username);
+}
+
 export function userPrivilegeCheck (profile: Profile, privileged: any, unPrivileged: any): any {
   if ( SETTINGS.user && profile.username === SETTINGS.user.username ) {
     return _.isFunction(privileged) ? privileged() : privileged;

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -24,6 +24,7 @@ import {
   formatPrice,
   programCourseInfo,
   findCourseRun,
+  isProfileOfLoggedinUser
 } from '../util/util';
 import {
   EDUCATION_LEVELS,
@@ -221,6 +222,34 @@ describe('utility functions', () => {
     });
   });
 
+  describe('Profile of logged in user check', () => {
+    let settingsBackup;
+
+    beforeEach(() => {
+      settingsBackup = SETTINGS;
+    });
+
+    afterEach(() => {
+      SETTINGS = settingsBackup;
+    });
+
+    it('when user is not logged in', () => {
+      SETTINGS = Object.assign({}, SETTINGS, {user: null});
+      let profile = { username: "another_user" };
+      assert.isNotTrue(isProfileOfLoggedinUser(profile));
+    });
+
+    it("when other user's profile", () => {
+      let profile = { username: "another_user" };
+      assert.isNotTrue(isProfileOfLoggedinUser(profile));
+    });
+
+    it("when loggedin user's profile", () => {
+      let profile = { username: SETTINGS.user.username };
+      assert.isTrue(isProfileOfLoggedinUser(profile));
+    });
+  });
+
   describe('User privilege check', () => {
     let settingsBackup;
 
@@ -258,7 +287,7 @@ describe('utility functions', () => {
       assert.equal(userPrivilegeCheck(profile, privilegedCallback, unprivilegedString), "emacs");
     });
 
-    it('should return the value of the second function if user is not login', () => {
+    it('should return the value of the second function if user is not logged in', () => {
       SETTINGS = Object.assign({}, SETTINGS, {user: null});
       let profile = { username: "another_user" };
       let privilegedCallback = () => "vim";


### PR DESCRIPTION
#### What are the relevant tickets?
- fixes https://github.com/mitodl/micromasters/issues/1605

#### How to test:
- open your profile ``/learner``.
- open other user profile with no work history and education``/learner``.
- open other user profile with work history and education ``/learner``.
- open your ``/profile`` and see education and work tabs

@pdpinch @noisecapella 
#### Screenshots (if appropriate)
#### Logged in user profile
<img width="1280" alt="screen shot 2016-11-08 at 7 54 20 pm" src="https://cloud.githubusercontent.com/assets/10431250/20103839/63536612-a5ed-11e6-9d03-74b862f16c37.png">

#### Other user profile
<img width="1280" alt="screen shot 2016-11-08 at 7 54 17 pm" src="https://cloud.githubusercontent.com/assets/10431250/20103858/72b1fee8-a5ed-11e6-8faa-c4b6e41a2733.png">

