### PR TITLE
Employment Form: make space for date field error

### DIFF
--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -94,6 +94,12 @@ class EmploymentForm extends ProfileFormFields {
     setShowWorkDeleteDialog(true);
   };
 
+  addSpaceForError(keySet: string[]){
+    const { errors } = this.props;
+    let value = _.get(errors, keySet);
+    return value === undefined ? "": "top-space";
+  }
+
   editWorkHistoryForm(): React$Element<*> {
     const { ui, profile } = this.props;
     let keySet = (key): any => ['work_history', ui.workDialogIndex, key];
@@ -143,7 +149,7 @@ class EmploymentForm extends ProfileFormFields {
         </Cell>
         <Cell col={6}>
           {this.boundDateField(keySet('end_date'), 'End Date', true)}
-          <span className="end-date-hint">
+          <span className={`end-date-hint ${this.addSpaceForError(keySet('end_date'))}`}>
             Leave blank if this is a current position
           </span>
         </Cell>

--- a/static/scss/profile.scss
+++ b/static/scss/profile.scss
@@ -249,6 +249,11 @@
     font-size: 12px;
   }
 
+  .top-space {
+    top: 10px;
+    position: relative;
+  }
+
   .profile-tab-card-greyed {
     min-height: 70px !important;
     padding-bottom: 0;


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #1458
#### What's this PR do?
If error is present for end date, push the 'end date hint' down to make space for the error.
![screen shot 2016-11-08 at 11 19 45 am](https://cloud.githubusercontent.com/assets/7574259/20107308/0ac1b856-a5a6-11e6-88b8-b187cbd675dc.png)

