### PR TITLE
Clean up unnecessary JS references in program page

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -15,23 +15,11 @@ from wagtail.wagtailcore.models import Orderable, Page
 from wagtail.wagtailimages.models import Image
 
 from courses.models import Program
-from courses.serializers import CourseSerializer
 from micromasters.serializers import serialize_maybe_user
 from micromasters.utils import webpack_dev_server_host
 from profiles.api import get_social_username
 from roles.models import Instructor, Staff
 from ui.views import get_bundle_url
-
-
-def faculty_for_carousel(faculty):
-    """formats faculty info for the carousel"""
-    from cms.serializers import FacultySerializer
-    return FacultySerializer(faculty, many=True).data
-
-
-def courses_for_popover(courses):
-    """formats course info for the popover"""
-    return CourseSerializer(courses, many=True).data
 
 
 class HomePage(Page):
@@ -212,9 +200,6 @@ def get_program_page_context(programpage, request):
     js_settings = {
         "gaTrackingID": settings.GA_TRACKING_ID,
         "host": webpack_dev_server_host(request),
-        "programId": programpage.program.id,
-        "faculty": faculty_for_carousel(programpage.faculty_members.all()),
-        "courses": courses_for_popover(courses_query),
         "environment": settings.ENVIRONMENT,
         "sentry_dsn": sentry.get_public_dsn(),
         "release_version": settings.VERSION,

--- a/static/js/entry/public.js
+++ b/static/js/entry/public.js
@@ -21,22 +21,30 @@ import SignupDialog from '../containers/SignupDialog';
 
 // Program Page course list
 const courseListEl = document.querySelector('#course-list');
+let courseList = null;
+if (SETTINGS.program) {
+  courseList = SETTINGS.program.courses;
+}
 
-if ( courseListEl ) {
+if ( courseList && courseListEl ) {
   ReactDOM.render(
     <MuiThemeProvider muiTheme={getMuiTheme()}>
-      <CourseListWithPopover courses={SETTINGS.courses} />
+      <CourseListWithPopover courses={courseList} />
     </MuiThemeProvider>,
     courseListEl
   );
 }
 
 // Program Page carousel div
-const carouselDiv = document.querySelector('#faculty-carousel');
+const carousel = document.querySelector('#faculty-carousel');
+let facultyList = null;
+if (SETTINGS.program) {
+  facultyList = SETTINGS.program.faculty;
+}
 
-if ( carouselDiv ) {
+if ( facultyList && carouselDiv ) {
   ReactDOM.render(
-    <FacultyCarousel faculty={SETTINGS.faculty}/>,
+    <FacultyCarousel faculty={facultyList}/>,
     carouselDiv
   );
 }

--- a/static/js/entry/public.js
+++ b/static/js/entry/public.js
@@ -3,6 +3,7 @@ __webpack_public_path__ = `http://${SETTINGS.host}:8078/`;  // eslint-disable-li
 import "rrssb/js/rrssb.js";
 import "bootstrap";
 import "ajaxchimp";
+import _ from 'lodash';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
@@ -26,7 +27,7 @@ if (SETTINGS.program) {
   courseList = SETTINGS.program.courses;
 }
 
-if ( courseList && courseListEl ) {
+if ( courseListEl && !_.isEmpty(courseList) ) {
   ReactDOM.render(
     <MuiThemeProvider muiTheme={getMuiTheme()}>
       <CourseListWithPopover courses={courseList} />
@@ -42,7 +43,7 @@ if (SETTINGS.program) {
   facultyList = SETTINGS.program.faculty;
 }
 
-if ( facultyList && carouselDiv ) {
+if ( carouselDiv && !_.isEmpty(facultyList) ) {
   ReactDOM.render(
     <FacultyCarousel faculty={facultyList}/>,
     carouselDiv

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -406,10 +406,11 @@ class TestProgramPage(ViewsTests):
         response = self.client.get(self.program_page.url)
         js_settings = json.loads(response.context['js_settings_json'])
         # check that the courses are in the response
-        self.assertIn("courses", js_settings)
-        self.assertEqual(len(js_settings["courses"]), 5)
+        self.assertIn("program", js_settings)
+        self.assertIn("courses", js_settings["program"])
+        self.assertEqual(len(js_settings["program"]["courses"]), 5)
         # check that they're in the correct order
-        for course, js_course in zip(courses, js_settings["courses"]):
+        for course, js_course in zip(courses, js_settings["program"]["courses"]):
             self.assertEqual(course.title, js_course["title"])
             self.assertEqual(course.description, js_course["description"])
             self.assertEqual(course.url, js_course["url"])


### PR DESCRIPTION
Follow-up from #1628. Removes unnecessary, duplicated content from the `SETTINGS` Javascript object on the programs page.