### PR TITLE
Making profile form more accessible

### DIFF
--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -299,10 +299,10 @@ class EducationForm extends ProfileFormFields {
       </Cell>
       { levelForm() }
       { fieldOfStudy() }
-      <Cell col={7}>
+      <Cell col={12}>
         {this.boundTextField(keySet('school_name'), 'School Name')}
       </Cell>
-      <Cell col={5}>
+      <Cell col={12}>
         {this.boundDateField(keySet('graduation_date'), 'Graduation Date', true, true)}
       </Cell>
       <Cell col={4}>

--- a/static/js/components/PersonalForm.js
+++ b/static/js/components/PersonalForm.js
@@ -44,86 +44,89 @@ export default class PersonalForm extends ProfileFormFields {
       'to learners with specific backgrounds.';
 
     return (
-      <Grid className="profile-form-grid">
-        <Cell col={6}>
-          {this.boundTextField(["first_name"], "Given name")}
-        </Cell>
-        <Cell col={6}>
-          {this.boundTextField(["last_name"], "Family name")}
-        </Cell>
-        <Cell col={12}>
-          {this.boundTextField(["preferred_name"], "Nickname / Preferred name")}
-        </Cell>
-        <Cell col={12}>
-          {this.boundDateField(['date_of_birth'], 'Date of birth')}
-        </Cell>
-        <Cell col={12} className="profile-gender-group">
-          {this.boundRadioGroupField(['gender'], 'Gender', this.genderOptions)}
-        </Cell>
-        <Cell col={12}>
-          <SelectField
-            keySet={['preferred_language']}
-            label='Preferred language'
-            options={this.languageOptions}
-            {...this.defaultInputComponentProps()}
-          />
-        </Cell>
-        <Cell col={12}>
-          <div className="section-header">
-            Where are you currently living?
-          </div>
-        </Cell>
-        <Cell col={4}>
-          <CountrySelectField
-            stateKeySet={['state_or_territory']}
-            countryKeySet={['country']}
-            topMenu={true}
-            label='Country'
-            {...this.defaultInputComponentProps()}
-          />
-        </Cell>
-        <Cell col={4}>
-          <StateSelectField
-            stateKeySet={['state_or_territory']}
-            countryKeySet={['country']}
-            topMenu={true}
-            label='State or Territory'
-            {...this.defaultInputComponentProps()}
-          />
-        </Cell>
-        <Cell col={4}>
-          {this.boundTextField(['city'], 'City')}
-        </Cell>
-        <Cell col={12}>
-          <div className="section-header">
-            Where are you from? <span
-              className="tooltip-link"
-              data-tip
-              data-for='why-we-ask-this'
-              style={{"display": "inline-block"}}
-            >(Why we ask this)</span>
-            <ReactTooltip id="why-we-ask-this" effect="solid" event="click" globalEventOff="click">
-              {whyWeAskThis}
-            </ReactTooltip>
-          </div>
-        </Cell>
-        <Cell col={4}>
-          <CountrySelectField
-            countryKeySet={['birth_country']}
-            label='Country of birth'
-            topMenu={true}
-            {...this.defaultInputComponentProps()}
-          />
-        </Cell>
-        <Cell col={4}>
-          <CountrySelectField
-            countryKeySet={['nationality']}
-            label='Nationality'
-            topMenu={true}
-            {...this.defaultInputComponentProps()}
-          />
-        </Cell>
-      </Grid>
+      <section>
+        <h2 className="sr-only">Personal Information</h2>
+        <Grid className="profile-form-grid">
+          <Cell col={6}>
+            {this.boundTextField(["first_name"], "Given name")}
+          </Cell>
+          <Cell col={6}>
+            {this.boundTextField(["last_name"], "Family name")}
+          </Cell>
+          <Cell col={12}>
+            {this.boundTextField(["preferred_name"], "Nickname / Preferred name")}
+          </Cell>
+          <Cell col={12}>
+            {this.boundDateField(['date_of_birth'], 'Date of birth')}
+          </Cell>
+          <Cell col={12} className="profile-gender-group">
+            {this.boundRadioGroupField(['gender'], 'Gender', this.genderOptions)}
+          </Cell>
+          <Cell col={12}>
+            <SelectField
+              keySet={['preferred_language']}
+              label='Preferred language'
+              options={this.languageOptions}
+              {...this.defaultInputComponentProps()}
+            />
+          </Cell>
+        </Grid>
+        <section>
+          <h3>Where are you currently living?</h3>
+          <Grid className="profile-form-grid">
+            <Cell col={4}>
+              <CountrySelectField
+                stateKeySet={['state_or_territory']}
+                countryKeySet={['country']}
+                topMenu={true}
+                label='Country'
+                {...this.defaultInputComponentProps()}
+              />
+            </Cell>
+            <Cell col={4}>
+              <StateSelectField
+                stateKeySet={['state_or_territory']}
+                countryKeySet={['country']}
+                topMenu={true}
+                label='State or Territory'
+                {...this.defaultInputComponentProps()}
+              />
+            </Cell>
+            <Cell col={4}>
+              {this.boundTextField(['city'], 'City')}
+            </Cell>
+          </Grid>
+        </section>
+        <section>
+          <h3>Where are you from?</h3>
+          <span className="tooltip-link"
+            data-tip
+            data-for='why-we-ask-this'
+            style={{"display": "inline-block"}}
+          >(Why we ask this)</span>
+          <ReactTooltip id="why-we-ask-this" effect="solid" event="click" globalEventOff="click">
+            {whyWeAskThis}
+          </ReactTooltip>
+          <Grid className="profile-form-grid">
+            <Cell col={4}>
+              <CountrySelectField
+                countryKeySet={['birth_country']}
+                label='Country of birth'
+                topMenu={true}
+                {...this.defaultInputComponentProps()}
+              />
+            </Cell>
+            <Cell col={4}>
+              <CountrySelectField
+                countryKeySet={['nationality']}
+                label='Nationality'
+                topMenu={true}
+                {...this.defaultInputComponentProps()}
+              />
+            </Cell>
+          </Grid>
+        </section>
+      </section>
     );
   }
 }

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -85,9 +85,11 @@ export default class PersonalTab extends React.Component {
     return (
       <div>
         <Card shadow={1} className="program-select">
-          <div className="section-header">Which MicroMasters program are you signing up for?</div>
-          <br/>
-          { this.selectProgram() }
+          <h2>Program Selection</h2>
+          <label>
+            Which MicroMasters program are you signing up for?
+            { this.selectProgram() }
+          </label>
           <span className="validation-error-text">
             {_.get(errors, ['program'])}
           </span>

--- a/static/js/components/inputs/DateField.js
+++ b/static/js/components/inputs/DateField.js
@@ -144,10 +144,10 @@ export default class DateField extends React.Component {
       daySlash = <span className="slash"> / </span>;
       dayField = <TextField
         hintText="DD"
-        floatingLabelText=" "
+        floatingLabelText="Day"
         floatingLabelFixed={true}
         style={{
-          maxWidth: "2em"
+          maxWidth: "3em"
         }}
         fullWidth={true}
         value={edit.day !== undefined ? edit.day : ""}
@@ -155,40 +155,44 @@ export default class DateField extends React.Component {
       />;
     }
 
-    return <div className={validationErrorSelector(errors, keySet)}>
-      <TextField
-        floatingLabelText={label}
-        floatingLabelFixed={true}
-        floatingLabelStyle={{whiteSpace: "nowrap"}}
-        hintText="MM"
-        style={{
-          maxWidth: "2em"
-        }}
-        errorStyle={{
-          position: "absolute",
-          top: "100%",
-          whiteSpace: "nowrap"
-        }}
-        fullWidth={true}
-        value={edit.month !== undefined ? edit.month : ""}
-        onChange={e => setNewDate(undefined, e.target.value, undefined)}
-        errorText={_.get(errors, keySet)}
-      />
-      <span className="slash"> / </span>
-      {dayField}
-      {daySlash}
-      <TextField
-        hintText="YYYY"
-        floatingLabelFixed={true}
-        floatingLabelText=" "
-        style={{
-          maxWidth: "4em"
-        }}
-        fullWidth={true}
-        value={edit.year !== undefined ? edit.year : ""}
-        onChange={e => setNewDate(undefined, undefined, e.target.value)}
-        onBlur={onBlur}
-      />
-    </div>;
+    return (
+      <fieldset className={validationErrorSelector(errors, keySet)}>
+        <legend>{label}</legend>
+        {" "}
+        <TextField
+          hintText="MM"
+          floatingLabelText="Month"
+          floatingLabelFixed={true}
+          floatingLabelStyle={{whiteSpace: "nowrap"}}
+          style={{
+            maxWidth: "3em"
+          }}
+          errorStyle={{
+            position: "absolute",
+            top: "100%",
+            whiteSpace: "nowrap"
+          }}
+          fullWidth={true}
+          value={edit.month !== undefined ? edit.month : ""}
+          onChange={e => setNewDate(undefined, e.target.value, undefined)}
+          errorText={_.get(errors, keySet)}
+        />
+        <span className="slash"> / </span>
+        {dayField}
+        {daySlash}
+        <TextField
+          hintText="YYYY"
+          floatingLabelText="Year"
+          floatingLabelFixed={true}
+          style={{
+            maxWidth: "4em"
+          }}
+          fullWidth={true}
+          value={edit.year !== undefined ? edit.year : ""}
+          onChange={e => setNewDate(undefined, undefined, e.target.value)}
+          onBlur={onBlur}
+        />
+      </fieldset>
+    );
   }
 }

--- a/static/js/components/inputs/SelectField.js
+++ b/static/js/components/inputs/SelectField.js
@@ -91,7 +91,9 @@ class SelectField extends React.Component {
     );
     let labelledSelect;
     if (label) {
-      labelledSelect = <label>{label}{select}</label>;
+      labelledSelect = <label className="react-select-label">
+        {label}{select}
+      </label>;
     } else {
       labelledSelect = select;
     }

--- a/static/js/components/inputs/SelectField.js
+++ b/static/js/components/inputs/SelectField.js
@@ -28,6 +28,19 @@ class SelectField extends React.Component {
     validator:                  Validator|UIValidator,
   };
 
+  state: {
+    id: string,
+  };
+
+  componentWillMount: Function = (): void => {
+    const { label } = this.props;
+    let id = this.props.id;
+    if (!id) {
+      id = _.uniqueId(classify(label));
+    }
+    this.setState({id: id});
+  }
+
   onChange: Function = (selection: Option): void => {
     const {
       profile,
@@ -54,12 +67,6 @@ class SelectField extends React.Component {
     updateProfile(profile, validator);
   };
 
-  label: Function = (label: string): React$Element<*> => (
-    <div className="select-label">
-      { label }
-    </div>
-  );
-
   className = (): string => {
     const { className, label } = this.props;
     return `select-field ${classify(className)} ${classify(label)}`;
@@ -70,19 +77,27 @@ class SelectField extends React.Component {
     return `${validationErrorSelector(errors, keySet)} ${topMenu ? 'menu-outer-top' : ''}`;
   };
 
-
   render() {
-    const { errors, keySet, id, profile, label } = this.props;
+    const { errors, keySet, profile, label } = this.props;
+    const { id } = this.state;
+    const select = (
+      <VirtualizedSelect
+        value={_.get(profile, keySet, "")}
+        className={this.selectClassName()}
+        onChange={this.onChange}
+        onBlur={this.onBlur}
+        {...this.props}
+      />
+    );
+    let labelledSelect;
+    if (label) {
+      labelledSelect = <label>{label}{select}</label>;
+    } else {
+      labelledSelect = select;
+    }
     return (
-      <div className={this.className()} id={id ? id : ""}>
-        { label ? this.label(label) : null }
-        <VirtualizedSelect
-          value={_.get(profile, keySet, "")}
-          className={this.selectClassName()}
-          onChange={this.onChange}
-          onBlur={this.onBlur}
-          {...this.props}
-        />
+      <div className={this.className()} id={id}>
+        { labelledSelect }
         <span className="validation-error-text">
           {_.get(errors, keySet)}
         </span>

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -87,7 +87,7 @@ class ProfilePage extends ProfileFormContainer {
           <div className="profile-pagination">
             {makeProfileProgressDisplay(this.currentStep())}
           </div>
-          <section>
+          <section className="profile-form">
             {this.currentComponent(props)}
           </section>
         </div>;

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -241,7 +241,7 @@ describe("UserPage", function() {
       });
 
       describe('date field', () => {
-        const dobMonth = dialog => inputs(dialog).find(i => i.id.includes('Dateofbirth'));
+        const dobMonth = dialog => inputs(dialog).find(i => i.id.includes('MM-Month'));
         it('should clearValidation when filling out a required date field', () => {
           return clearValidation(
             userProfileActions.concat([

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -60,8 +60,9 @@ export default class IntegrationTestHelper {
     this.profileGetStub.returns(Promise.resolve(USER_PROFILE_RESPONSE));
     this.programsGetStub = this.sandbox.stub(api, 'getPrograms');
     this.programsGetStub.returns(Promise.resolve(PROGRAMS));
-    HTMLDivElement.prototype.scrollIntoView = this.sandbox.stub();
-    this.scrollIntoViewStub = HTMLDivElement.prototype.scrollIntoView;
+    this.scrollIntoViewStub = this.sandbox.stub();
+    HTMLDivElement.prototype.scrollIntoView = this.scrollIntoViewStub;
+    HTMLFieldSetElement.prototype.scrollIntoView = this.scrollIntoViewStub;
     this.browserHistory = createMemoryHistory();
     this.currentLocation = null;
     this.browserHistory.listen(url => {

--- a/static/js/util/profile_edit_test.js
+++ b/static/js/util/profile_edit_test.js
@@ -48,11 +48,11 @@ describe('Profile Editing utility functions', () => {
   describe('Bound radio group', () => {
     let radioGroup, labelSpan, errorSpan;
     let privacyOptions = [
-      { value: 'public', label: 'Public to the world', helper: `We will publish your Micromasters 
+      { value: 'public', label: 'Public to the world', helper: `We will publish your Micromasters
         profile on our website.` },
-      { value: 'public_to_mm', label: 'Public to other micromasters students', helper: `Your Micromasters profile 
+      { value: 'public_to_mm', label: 'Public to other micromasters students', helper: `Your Micromasters profile
         will only be viewable by other learners in your program, and by MIT faculity and staff.` },
-      { value: 'private', label: 'Private', helper: `Your Micromasters profile will be viewable only by 
+      { value: 'private', label: 'Private', helper: `Your Micromasters profile will be viewable only by
         MIT faculty and staff.` }
     ];
 
@@ -145,10 +145,11 @@ describe('Profile Editing utility functions', () => {
     });
 
     let rerender = omitDay => {
+      let legend, space;  // eslint-disable-line no-unused-vars
       if (omitDay) {
-        [monthTextField, , yearTextField] = renderDateField(true);
+        [legend, space, monthTextField, , yearTextField] = renderDateField(true);
       } else {
-        [monthTextField, , dayTextField, , yearTextField] = renderDateField(false);
+        [legend, space, monthTextField, , dayTextField, , yearTextField] = renderDateField(false);
       }
     };
 
@@ -162,14 +163,14 @@ describe('Profile Editing utility functions', () => {
         that.props.profile.date_of_birth = dateOfBirth;
         rerender(false);
 
-        assert.equal(monthTextField.props.floatingLabelText, "Date of birth");
+        assert.equal(monthTextField.props.floatingLabelText, "Month");
         assert.equal(monthTextField.props.hintText, "MM");
         assert.equal(monthTextField.props.value, "");
         assert.equal(monthTextField.props.errorText, "Date of birth is required");
-        assert.equal(dayTextField.props.floatingLabelText, " ");
+        assert.equal(dayTextField.props.floatingLabelText, "Day");
         assert.equal(dayTextField.props.hintText, "DD");
         assert.equal(dayTextField.props.value, "");
-        assert.equal(yearTextField.props.floatingLabelText, " ");
+        assert.equal(yearTextField.props.floatingLabelText, "Year");
         assert.equal(yearTextField.props.hintText, "YYYY");
         assert.equal(yearTextField.props.value, "");
       }
@@ -179,14 +180,14 @@ describe('Profile Editing utility functions', () => {
       that.props.profile.date_of_birth = "1985-12-31";
       rerender(false);
 
-      assert.equal(monthTextField.props.floatingLabelText, "Date of birth");
+      assert.equal(monthTextField.props.floatingLabelText, "Month");
       assert.equal(monthTextField.props.hintText, "MM");
       assert.equal(monthTextField.props.value, 12);
       assert.equal(monthTextField.props.errorText, "Date of birth is required");
-      assert.equal(dayTextField.props.floatingLabelText, " ");
+      assert.equal(dayTextField.props.floatingLabelText, "Day");
       assert.equal(dayTextField.props.hintText, "DD");
       assert.equal(dayTextField.props.value, 31);
-      assert.equal(yearTextField.props.floatingLabelText, " ");
+      assert.equal(yearTextField.props.floatingLabelText, "Year");
       assert.equal(yearTextField.props.hintText, "YYYY");
       assert.equal(yearTextField.props.value, 1985);
     });
@@ -195,11 +196,11 @@ describe('Profile Editing utility functions', () => {
       that.props.profile.date_of_birth = "1985-12-31";
       rerender(true);
 
-      assert.equal(monthTextField.props.floatingLabelText, "Date of birth");
+      assert.equal(monthTextField.props.floatingLabelText, "Month");
       assert.equal(monthTextField.props.hintText, "MM");
       assert.equal(monthTextField.props.value, 12);
       assert.equal(monthTextField.props.errorText, "Date of birth is required");
-      assert.equal(yearTextField.props.floatingLabelText, " ");
+      assert.equal(yearTextField.props.floatingLabelText, "Year");
       assert.equal(yearTextField.props.hintText, "YYYY");
       assert.equal(yearTextField.props.value, 1985);
     });

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -25,6 +25,7 @@
 @import "footer";
 @import "profile-image";
 @import "profile-image-uploader";
+@import "profile-form";
 @import "calculator";
 @import "docs-instructions";
 @import "toast";

--- a/static/scss/profile-form.scss
+++ b/static/scss/profile-form.scss
@@ -1,4 +1,4 @@
-.profile-form, .personal-dialog {
+.profile-form, .dialog {
   &.collapsed {
     padding: 20px 24px 20px;
     height: 100px;
@@ -20,15 +20,21 @@
     display: inline-block;
   }
 
-  label {
+  label.react-select-label {
     display: block;
-    line-height: 2;
+    font-size: 13px;
+    color: rgba(0, 0, 0, 0.5);
+    font-weight: 400;
+
+    .Select-value, .Select-multi-value-wrapper {
+      font-size: 16px;
+    }
   }
 
   legend {
     border: 0;
     display: inline-block;
-    margin: 0;
+    margin: 0 15px 0 0;
     width: auto;
     font-size: 16px;
   }

--- a/static/scss/profile-form.scss
+++ b/static/scss/profile-form.scss
@@ -1,0 +1,47 @@
+.profile-form, .personal-dialog {
+  &.collapsed {
+    padding: 20px 24px 20px;
+    height: 100px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  h2 {
+    font-size: 20px;
+    margin: 0;
+  }
+
+  h3 {
+    font-size: 16px;
+    font-weight: 500;
+    padding-top: 30px;
+    margin: 0;
+    display: inline-block;
+  }
+
+  label {
+    display: block;
+    line-height: 2;
+  }
+
+  legend {
+    border: 0;
+    display: inline-block;
+    margin: 0;
+    width: auto;
+    font-size: 16px;
+  }
+
+  [data-id='tooltip'] {
+    max-width: 450px;
+    font-size: 14px;
+  }
+
+  .tooltip-link {
+    color: $link-text;
+    cursor: pointer;
+    display: inline-block;
+    margin-left: .5em;
+  }
+}

--- a/static/scss/profile.scss
+++ b/static/scss/profile.scss
@@ -181,26 +181,6 @@
   margin-top: 0;
 }
 
-// for the Why we ask this tooltip
-// TODO: where should this go?
-[data-id='tooltip'] {
-  max-width: 450px;
-  font-size: 14px;
-}
-
-.tooltip-link {
-  color: $link-text;
-  cursor: pointer;
-}
-
-.profile-form.collapsed {
-  height: 100px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 20px 24px 20px;
-}
-
 .program-select {
   z-index: 2;
   overflow: visible;


### PR DESCRIPTION
This pull request does the following things, all related to the profile form:

* Replace `<div class="section-header">` elements with `<h3>` elements
* Add accessible `<label>` elements to the date fields and the select fields
* Ensure that every select field has a unique ID, so that we can use `aria-describedby` attributes to label error messages in a future pull request
* Pull Sass related to the profile form out into its own `profile-form.scss` file, for organizational purposes

To test this pull request, I suggest using [ChromeVox](http://www.chromevox.com/) or [VoiceOver](https://help.apple.com/voiceover/info/guide/10.12/). To activate/deactivate VoiceOver on a Mac, press Command + F5. Different browsers & screen readers work differently; for example, when reading the "Date of birth" fields, both ChromeVox and VoiceOver with Chrome read out "Day, edit text", "Month, edit text", "Year, edit text". However, VoiceOver with Safari reads out "Day, edit text, date of birth", "Month, edit text, date of birth", "Year, edit text, date of birth", which is much clearer for a non-sighted user. (This is related to #1683.)

A few concrete manual test cases:

* For every select field, try clicking the label, and ensure that the browser automatically focuses on the select field.
* Turn on ChromeVox or VoiceOver and tab through the profile form. All fields should announce themselves properly, with the following known exceptions:
  * the "Gender" radio fields are not properly labelled
  * error states, such as not filling in required fields, are not properly accessible

![screen shot 2016-11-17 at 11 49 12 am](https://cloud.githubusercontent.com/assets/132355/20398579/f085cdb6-acbb-11e6-8c20-ad214238ffe2.png)
![screen shot 2016-11-17 at 11 48 32 am](https://cloud.githubusercontent.com/assets/132355/20398584/f7e858b2-acbb-11e6-982a-75471d1b31fa.png)
![screen shot 2016-11-17 at 11 48 37 am](https://cloud.githubusercontent.com/assets/132355/20398589/fbe3d90a-acbb-11e6-847a-91ae49fc1b23.png)
