### PR TITLE
Fixed footer display while JS loads

### DIFF
--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -57,5 +57,11 @@
   <body class="{% block bodyclass %}{% endblock %}">
     {% block content %}
     {% endblock %}
+    <script type="text/javascript">
+      var footer = document.querySelector("#footer");
+      if (footer) {
+        footer.style.display = "";
+      }
+    </script>
   </body>
 </html>

--- a/ui/templates/footer.html
+++ b/ui/templates/footer.html
@@ -1,5 +1,5 @@
 {% load static %}
-<footer>
+<footer style="display: none" id="footer">
   <div class="container">
     <div class="row">
       <div class="col-md-8">


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1563

#### What's this PR do?
Makes the footer disappear while the javascript loads, then adds it back afterwards by toggling the display of the footer element.

#### How should this be manually tested?
Refresh the browser and see if you notice the footer during the refresh

#### Any background context you want to provide?
I'm not sure if there's a better way to toggle visibility but it seems simple enough
