### PR TITLE
Implemented auto approve for TierProgram where discount is $0

### DIFF
--- a/financialaid/api.py
+++ b/financialaid/api.py
@@ -42,12 +42,13 @@ def determine_tier_program(program, income):
     return tier_program
 
 
-def determine_auto_approval(financial_aid):
+def determine_auto_approval(financial_aid, tier_program):
     """
     Takes income and country code and returns a boolean if auto-approved. Logs an error if the country of
     financial_aid does not exist in CountryIncomeThreshold.
     Args:
         financial_aid (FinancialAid): the financial aid object to determine auto-approval
+        tier_program (TierProgram): the TierProgram for the user's income level
     Returns:
         boolean: True if auto-approved, False if not
     """
@@ -61,8 +62,14 @@ def determine_auto_approval(financial_aid):
             financial_aid.id
         )
         income_threshold = DEFAULT_INCOME_THRESHOLD
-    # The income_threshold == 0 is because in all cases BUT threshold == 0, it's strictly > instead of >=
-    return financial_aid.income_usd > income_threshold or income_threshold == 0
+    if tier_program.discount_amount == 0:
+        # There is no discount so no reason to go through the financial aid workflow
+        return True
+    elif income_threshold == 0:
+        # There is no income which we need to check the financial aid application
+        return True
+    else:
+        return financial_aid.income_usd > income_threshold
 
 
 def determine_income_usd(original_income, original_currency):

--- a/financialaid/api_test.py
+++ b/financialaid/api_test.py
@@ -120,7 +120,7 @@ class FinancialAidBaseTestCase(TestCase):
         )
 
     @staticmethod
-    def assert_http_status(method, url, status, data=None, content_type="application/json", **kwargs):
+    def make_http_request(method, url, status, data=None, content_type="application/json", **kwargs):
         """
         Helper method for asserting an HTTP status. Returns the response for further tests if needed.
         Args:

--- a/financialaid/api_test.py
+++ b/financialaid/api_test.py
@@ -202,7 +202,8 @@ class FinancialAidAPITests(FinancialAidBaseTestCase):
             income_usd=income_usd,
             country_of_income=country_code,
         )
-        assert determine_auto_approval(financial_aid) is expected
+        tier_program = determine_tier_program(self.program, income_usd)
+        assert determine_auto_approval(financial_aid, tier_program) is expected
 
     def test_determine_income_usd_from_not_usd(self):
         """

--- a/financialaid/api_test.py
+++ b/financialaid/api_test.py
@@ -110,11 +110,11 @@ class FinancialAidBaseTestCase(TestCase):
                 discount_amount=0
             ),
         }
-        cls.country_income_threshold_0 = CountryIncomeThreshold.objects.create(
+        CountryIncomeThreshold.objects.create(
             country_code="0",
             income_threshold=0,
         )
-        cls.country_income_threshold_50000 = CountryIncomeThreshold.objects.create(
+        CountryIncomeThreshold.objects.create(
             country_code=cls.profile.country,
             income_threshold=50000,
         )

--- a/financialaid/serializers.py
+++ b/financialaid/serializers.py
@@ -78,7 +78,7 @@ class FinancialAidRequestSerializer(serializers.Serializer):
             country_of_residence=user.profile.country,
         )
 
-        if determine_auto_approval(financial_aid) is True or tier_program.discount_amount == 0:
+        if determine_auto_approval(financial_aid, tier_program) is True:
             financial_aid.status = FinancialAidStatus.AUTO_APPROVED
         else:
             financial_aid.status = FinancialAidStatus.PENDING_DOCS

--- a/financialaid/serializers.py
+++ b/financialaid/serializers.py
@@ -78,7 +78,7 @@ class FinancialAidRequestSerializer(serializers.Serializer):
             country_of_residence=user.profile.country,
         )
 
-        if determine_auto_approval(financial_aid) is True:
+        if determine_auto_approval(financial_aid) is True or tier_program.discount_amount == 0:
             financial_aid.status = FinancialAidStatus.AUTO_APPROVED
         else:
             financial_aid.status = FinancialAidStatus.PENDING_DOCS

--- a/financialaid/views_test.py
+++ b/financialaid/views_test.py
@@ -110,7 +110,7 @@ class RequestAPITests(FinancialAidBaseTestCase, APIClient):
         }
         assert FinancialAid.objects.count() == 0
         assert FinancialAidAudit.objects.count() == 0
-        self.assert_http_status(self.client.post, self.request_url, status.HTTP_201_CREATED, data=data)
+        self.make_http_request(self.client.post, self.request_url, status.HTTP_201_CREATED, data=data)
         assert FinancialAid.objects.count() == 1
         assert FinancialAidAudit.objects.count() == 1
         financial_aid = FinancialAid.objects.first()
@@ -136,7 +136,7 @@ class RequestAPITests(FinancialAidBaseTestCase, APIClient):
         """
         for missing_key in self.data:
             data = {key: value for key, value in self.data.items() if key != missing_key}
-            self.assert_http_status(self.client.post, self.request_url, status.HTTP_400_BAD_REQUEST, data=data)
+            self.make_http_request(self.client.post, self.request_url, status.HTTP_400_BAD_REQUEST, data=data)
 
     def test_income_validation_no_financial_aid_availability(self):
         """
@@ -144,14 +144,14 @@ class RequestAPITests(FinancialAidBaseTestCase, APIClient):
         """
         self.program.financial_aid_availability = False
         self.program.save()
-        self.assert_http_status(self.client.post, self.request_url, status.HTTP_400_BAD_REQUEST, data=self.data)
+        self.make_http_request(self.client.post, self.request_url, status.HTTP_400_BAD_REQUEST, data=self.data)
 
     def test_income_validation_user_not_enrolled(self):
         """
         Tests FinancialAidRequestView post when User not enrolled in program
         """
         ProgramEnrollment.objects.all().delete()
-        self.assert_http_status(self.client.post, self.request_url, status.HTTP_400_BAD_REQUEST, data=self.data)
+        self.make_http_request(self.client.post, self.request_url, status.HTTP_400_BAD_REQUEST, data=self.data)
 
     def test_income_validation_currency_not_supported(self):
         """
@@ -182,24 +182,24 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
         Not allowed for default logged-in user
         """
         self.client.force_login(self.profile.user)
-        self.assert_http_status(self.client.get, self.review_url, status.HTTP_403_FORBIDDEN)
+        self.make_http_request(self.client.get, self.review_url, status.HTTP_403_FORBIDDEN)
 
     def test_staff_of_different_program(self):
         """Not allowed for staff of different program"""
         program = create_program()
         staff_user = create_enrolled_profile(program, role=Staff.ROLE_ID).user
         self.client.force_login(staff_user)
-        self.assert_http_status(self.client.get, self.review_url, status.HTTP_403_FORBIDDEN)
+        self.make_http_request(self.client.get, self.review_url, status.HTTP_403_FORBIDDEN)
 
     def test_instructor(self):
         """Not allowed for instructors"""
         self.client.force_login(self.instructor_user_profile.user)
-        self.assert_http_status(self.client.get, self.review_url, status.HTTP_403_FORBIDDEN)
+        self.make_http_request(self.client.get, self.review_url, status.HTTP_403_FORBIDDEN)
 
     def test_anonymous(self):
         """Not allowed for not logged in users"""
         self.client.logout()
-        self.assert_http_status(self.client.get, self.review_url, status.HTTP_403_FORBIDDEN)
+        self.make_http_request(self.client.get, self.review_url, status.HTTP_403_FORBIDDEN)
 
     def test_unavailable_financial_aid(self):
         """
@@ -207,7 +207,7 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
         """
         self.program.financial_aid_availability = False
         self.program.save()
-        self.assert_http_status(self.client.get, self.review_url, status.HTTP_404_NOT_FOUND)
+        self.make_http_request(self.client.get, self.review_url, status.HTTP_404_NOT_FOUND)
 
     def test_not_live(self):
         """
@@ -215,7 +215,7 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
         """
         self.program.live = False
         self.program.save()
-        self.assert_http_status(self.client.get, self.review_url, status.HTTP_404_NOT_FOUND)
+        self.make_http_request(self.client.get, self.review_url, status.HTTP_404_NOT_FOUND)
 
     def test_not_valid(self):
         """No valid course_price will raise ImproperlyConfigured"""
@@ -229,7 +229,7 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
         Tests ReviewFinancialAidView that are allowed
         """
         # Allowed for staff of program
-        self.assert_http_status(self.client.get, self.review_url, status.HTTP_200_OK)
+        self.make_http_request(self.client.get, self.review_url, status.HTTP_200_OK)
 
     def test_filter(self):
         """
@@ -241,7 +241,7 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
                 status=FinancialAidStatus.AUTO_APPROVED
             )
         # Should work with a filter
-        resp = self.assert_http_status(self.client.get, self.review_url_with_filter, status.HTTP_200_OK)
+        resp = self.make_http_request(self.client.get, self.review_url_with_filter, status.HTTP_200_OK)
         resp_obj_id_list = resp.context_data["financial_aid_objects"].values_list("id", flat=True)
         expected_obj_id_list = FinancialAid.objects.filter(
             tier_program__program_id=self.program.id,
@@ -257,7 +257,7 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
                 status=FinancialAidStatus.AUTO_APPROVED
             )
         url_with_sorting = "{url}?sort_by=-last_name".format(url=self.review_url)
-        resp = self.assert_http_status(self.client.get, url_with_sorting, status.HTTP_200_OK)
+        resp = self.make_http_request(self.client.get, url_with_sorting, status.HTTP_200_OK)
         resp_obj_id_list = resp.context_data["financial_aid_objects"].values_list("id", flat=True)
         expected_obj_id_list = FinancialAid.objects.filter(
             tier_program__program_id=self.program.id,
@@ -273,7 +273,7 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
                 status=FinancialAidStatus.AUTO_APPROVED
             )
         url_with_filter_and_sorting = "{url}?sort_by=-last_name".format(url=self.review_url_with_filter)
-        resp = self.assert_http_status(self.client.get, url_with_filter_and_sorting, status.HTTP_200_OK)
+        resp = self.make_http_request(self.client.get, url_with_filter_and_sorting, status.HTTP_200_OK)
         resp_obj_id_list = resp.context_data["financial_aid_objects"].values_list("id", flat=True)
         expected_obj_id_list = FinancialAid.objects.filter(
             tier_program__program_id=self.program.id,
@@ -287,7 +287,7 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
         """
         FinancialAidFactory.create(tier_program=self.tier_programs["0k"])
         url_with_bad_sort_field = "{url}?sort_by=-askjdf".format(url=self.review_url_with_filter)
-        self.assert_http_status(self.client.get, url_with_bad_sort_field, status.HTTP_200_OK)
+        self.make_http_request(self.client.get, url_with_bad_sort_field, status.HTTP_200_OK)
 
     def test_invalid_filter(self):
         """
@@ -301,7 +301,7 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
                 "status": "aksdjfk"
             }
         )
-        self.assert_http_status(self.client.get, url_with_bad_filter, status.HTTP_200_OK)
+        self.make_http_request(self.client.get, url_with_bad_filter, status.HTTP_200_OK)
 
     def test_invalid_sorting_and_filter(self):
         """
@@ -316,7 +316,7 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
             }
         )
         url_with_bad_filter_and_bad_sorting = "{url}?sort_by=-askjdf".format(url=url_with_bad_filter)
-        self.assert_http_status(self.client.get, url_with_bad_filter_and_bad_sorting, status.HTTP_200_OK)
+        self.make_http_request(self.client.get, url_with_bad_filter_and_bad_sorting, status.HTTP_200_OK)
 
     def test_review_financial_aid_view_with_search(self):
         """
@@ -338,7 +338,7 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
             path=self.review_url_with_filter,
             search_query=search_query
         )
-        resp = self.assert_http_status(self.client.get, search_url, status.HTTP_200_OK)
+        resp = self.make_http_request(self.client.get, search_url, status.HTTP_200_OK)
         resp_obj_id_list = resp.context_data["financial_aid_objects"].values_list("id", flat=True)
         expected_obj_id_list = FinancialAid.objects.filter(
             Q(user__profile__first_name__icontains=search_query) | Q(user__profile__last_name__icontains=search_query),
@@ -378,30 +378,30 @@ class FinancialAidActionTests(FinancialAidBaseTestCase, APIClient):
         Not allowed for default logged-in user
         """
         self.client.force_login(self.profile.user)
-        self.assert_http_status(self.client.patch, self.action_url, status.HTTP_403_FORBIDDEN, data=self.data)
+        self.make_http_request(self.client.patch, self.action_url, status.HTTP_403_FORBIDDEN, data=self.data)
 
     def test_not_allowed_staff_of_different_program(self):
         """Not allowed for staff of different program"""
         program = create_program()
         staff_user = create_enrolled_profile(program, role=Staff.ROLE_ID).user
         self.client.force_login(staff_user)
-        self.assert_http_status(self.client.patch, self.action_url, status.HTTP_403_FORBIDDEN, data=self.data)
+        self.make_http_request(self.client.patch, self.action_url, status.HTTP_403_FORBIDDEN, data=self.data)
 
     def test_not_allowed_instructors(self):
         """Not allowed for instructors (regardless of program)"""
         self.client.force_login(self.instructor_user_profile.user)
-        self.assert_http_status(self.client.patch, self.action_url, status.HTTP_403_FORBIDDEN, data=self.data)
+        self.make_http_request(self.client.patch, self.action_url, status.HTTP_403_FORBIDDEN, data=self.data)
 
     def test_anonymous(self):
         """Not allowed for logged-out user"""
         self.client.logout()
-        self.assert_http_status(self.client.patch, self.action_url, status.HTTP_403_FORBIDDEN, data=self.data)
+        self.make_http_request(self.client.patch, self.action_url, status.HTTP_403_FORBIDDEN, data=self.data)
 
     def test_no_action(self):
         """
         If no action is present, there should be a ValidationError
         """
-        self.assert_http_status(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST)
+        self.make_http_request(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST)
 
     @ddt.data(
         *([
@@ -414,7 +414,7 @@ class FinancialAidActionTests(FinancialAidBaseTestCase, APIClient):
         """
         Tests FinancialAidActionView when invalid action is posted
         """
-        self.assert_http_status(
+        self.make_http_request(
             self.client.patch,
             self.action_url,
             status.HTTP_400_BAD_REQUEST,
@@ -427,17 +427,17 @@ class FinancialAidActionTests(FinancialAidBaseTestCase, APIClient):
         """
         not_current = TierProgramFactory.create(program=self.program, income_threshold=75000, current=False)
         self.data["tier_program_id"] = not_current.id
-        self.assert_http_status(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST, data=self.data)
+        self.make_http_request(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST, data=self.data)
 
     def test_invalid(self):
         """Not part of the same program"""
         self.data["tier_program_id"] = TierProgramFactory.create().id  # Will be part of a different program
-        self.assert_http_status(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST, data=self.data)
+        self.make_http_request(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST, data=self.data)
 
     def test_no_tier_program(self):
         """No tier program"""
         self.data.pop("tier_program_id")
-        self.assert_http_status(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST, data=self.data)
+        self.make_http_request(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST, data=self.data)
 
     @ddt.data(
         *([
@@ -452,19 +452,19 @@ class FinancialAidActionTests(FinancialAidBaseTestCase, APIClient):
         """
         self.financialaid.status = financial_aid_status
         self.financialaid.save()
-        self.assert_http_status(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST, data=self.data)
+        self.make_http_request(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST, data=self.data)
 
     def test_approve_invalid_justification(self):
         """
         Tests FinancialAidActionView when trying to approve a FinancialAid with an invalid justification
         """
         self.data["justification"] = "somerandomstring"
-        self.assert_http_status(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST, data=self.data)
+        self.make_http_request(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST, data=self.data)
 
     def test_approve_no_justification(self):
         """There should be a ValidationError if there is no justification"""
         self.data.pop("justification")
-        self.assert_http_status(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST, data=self.data)
+        self.make_http_request(self.client.patch, self.action_url, status.HTTP_400_BAD_REQUEST, data=self.data)
 
     @ddt.data(
         *([
@@ -480,7 +480,7 @@ class FinancialAidActionTests(FinancialAidBaseTestCase, APIClient):
         # FinancialAid object whose documents cannot received
         self.financialaid.status = financial_aid_status
         self.financialaid.save()
-        self.assert_http_status(
+        self.make_http_request(
             self.client.patch,
             self.action_url,
             status.HTTP_400_BAD_REQUEST,
@@ -499,7 +499,7 @@ class FinancialAidActionTests(FinancialAidBaseTestCase, APIClient):
         )
         assert self.financialaid.status != FinancialAidStatus.APPROVED
         assert self.financialaid.justification != FinancialAidJustification.NOT_NOTARIZED
-        self.assert_http_status(self.client.patch, self.action_url, status.HTTP_200_OK, data=self.data)
+        self.make_http_request(self.client.patch, self.action_url, status.HTTP_200_OK, data=self.data)
         # Application is approved for the tier program in the financial aid object
         self.financialaid.refresh_from_db()
         assert self.financialaid.tier_program == self.tier_programs["25k"]
@@ -526,7 +526,7 @@ class FinancialAidActionTests(FinancialAidBaseTestCase, APIClient):
         assert self.financialaid.tier_program != self.tier_programs["50k"]
         assert self.financialaid.status != FinancialAidStatus.APPROVED
         self.data["tier_program_id"] = self.tier_programs["50k"].id
-        self.assert_http_status(self.client.patch, self.action_url, status.HTTP_200_OK, data=self.data)
+        self.make_http_request(self.client.patch, self.action_url, status.HTTP_200_OK, data=self.data)
         # Application is approved for a different tier program
         self.financialaid.refresh_from_db()
         assert self.financialaid.tier_program == self.tier_programs["50k"]
@@ -554,7 +554,7 @@ class FinancialAidActionTests(FinancialAidBaseTestCase, APIClient):
         self.financialaid.status = FinancialAidStatus.PENDING_DOCS
         self.financialaid.save()
         # Set action to pending manual approval from pending-docs
-        self.assert_http_status(
+        self.make_http_request(
             self.client.patch,
             self.action_url,
             status.HTTP_200_OK,
@@ -587,7 +587,7 @@ class FinancialAidActionTests(FinancialAidBaseTestCase, APIClient):
         self.financialaid.status = FinancialAidStatus.DOCS_SENT
         self.financialaid.save()
         # Set action to pending manual approval from pending-docs
-        self.assert_http_status(
+        self.make_http_request(
             self.client.patch,
             self.action_url,
             status.HTTP_200_OK,
@@ -636,7 +636,7 @@ class FinancialAidDetailViewTests(FinancialAidBaseTestCase, APIClient):
         """
         Tests FinancialAidDetailView for user editing their own financial aid document status
         """
-        self.assert_http_status(self.client.patch, self.docs_sent_url, status.HTTP_200_OK, data=self.data)
+        self.make_http_request(self.client.patch, self.docs_sent_url, status.HTTP_200_OK, data=self.data)
         self.financialaid_pending_docs.refresh_from_db()
         assert self.financialaid_pending_docs.status == FinancialAidStatus.DOCS_SENT
         assert self.financialaid_pending_docs.date_documents_sent == datetime.date(2016, 9, 25)
@@ -652,14 +652,14 @@ class FinancialAidDetailViewTests(FinancialAidBaseTestCase, APIClient):
         ]
         for unpermitted_user in unpermitted_users_to_test:
             self.client.force_login(unpermitted_user)
-            self.assert_http_status(self.client.patch, self.docs_sent_url, status.HTTP_403_FORBIDDEN, data=self.data)
+            self.make_http_request(self.client.patch, self.docs_sent_url, status.HTTP_403_FORBIDDEN, data=self.data)
 
     def test_anonymous(self):
         """
         Anonymous users can't update status for docs sent
         """
         self.client.logout()
-        self.assert_http_status(self.client.patch, self.docs_sent_url, status.HTTP_403_FORBIDDEN, data=self.data)
+        self.make_http_request(self.client.patch, self.docs_sent_url, status.HTTP_403_FORBIDDEN, data=self.data)
 
     @ddt.data(
         *([
@@ -674,7 +674,7 @@ class FinancialAidDetailViewTests(FinancialAidBaseTestCase, APIClient):
         """
         self.financialaid_pending_docs.status = financial_aid_status
         self.financialaid_pending_docs.save()
-        self.assert_http_status(self.client.patch, self.docs_sent_url, status.HTTP_400_BAD_REQUEST, data=self.data)
+        self.make_http_request(self.client.patch, self.docs_sent_url, status.HTTP_400_BAD_REQUEST, data=self.data)
 
 
 class CoursePriceDetailViewTests(FinancialAidBaseTestCase, APIClient):
@@ -707,7 +707,7 @@ class CoursePriceDetailViewTests(FinancialAidBaseTestCase, APIClient):
         program = create_program()
         profile = create_enrolled_profile(program)
         self.client.force_login(profile.user)
-        self.assert_http_status(self.client.get, self.course_price_url, status.HTTP_404_NOT_FOUND)
+        self.make_http_request(self.client.get, self.course_price_url, status.HTTP_404_NOT_FOUND)
 
     def test_get_learner_price_for_enrolled_with_financial_aid(self):
         """
@@ -719,7 +719,7 @@ class CoursePriceDetailViewTests(FinancialAidBaseTestCase, APIClient):
             status=FinancialAidStatus.APPROVED,
         )
         course_price = self.program.course_set.first().courserun_set.first().courseprice_set.first()
-        resp = self.assert_http_status(self.client.get, self.course_price_url, status.HTTP_200_OK)
+        resp = self.make_http_request(self.client.get, self.course_price_url, status.HTTP_200_OK)
         expected_response = {
             "program_id": self.program.id,
             "price": course_price.price - financial_aid.tier_program.discount_amount,
@@ -738,7 +738,7 @@ class CoursePriceDetailViewTests(FinancialAidBaseTestCase, APIClient):
             status=FinancialAidStatus.PENDING_MANUAL_APPROVAL,
         )
         course_price = self.program.course_set.first().courserun_set.first().courseprice_set.first()
-        resp = self.assert_http_status(self.client.get, self.course_price_url, status.HTTP_200_OK)
+        resp = self.make_http_request(self.client.get, self.course_price_url, status.HTTP_200_OK)
         expected_response = {
             "program_id": self.program.id,
             "price": course_price.price - financial_aid.tier_program.discount_amount,
@@ -752,7 +752,7 @@ class CoursePriceDetailViewTests(FinancialAidBaseTestCase, APIClient):
         Tests ReviewFinancialAidView for enrolled user who has no financial aid request
         """
         course_price = self.program.course_set.first().courserun_set.first().courseprice_set.first()
-        resp = self.assert_http_status(self.client.get, self.course_price_url, status.HTTP_200_OK)
+        resp = self.make_http_request(self.client.get, self.course_price_url, status.HTTP_200_OK)
         expected_response = {
             "program_id": self.program.id,
             "price": course_price.price,
@@ -768,7 +768,7 @@ class CoursePriceDetailViewTests(FinancialAidBaseTestCase, APIClient):
         course_price = self.program.course_set.first().courserun_set.first().courseprice_set.first()
         self.program.financial_aid_availability = False
         self.program.save()
-        resp = self.assert_http_status(self.client.get, self.course_price_url, status.HTTP_200_OK)
+        resp = self.make_http_request(self.client.get, self.course_price_url, status.HTTP_200_OK)
         expected_response = {
             "program_id": self.program.id,
             "price": course_price.price,
@@ -804,7 +804,7 @@ class LearnerSkipsFinancialAid(FinancialAidBaseTestCase, APIClient):
         Tests that a FinancialAid object with the status "skipped" is created.
         """
         assert FinancialAidAudit.objects.count() == 0
-        self.assert_http_status(self.client.patch, self.skip_url, status.HTTP_200_OK)
+        self.make_http_request(self.client.patch, self.skip_url, status.HTTP_200_OK)
         assert FinancialAid.objects.count() == 1
         financial_aid = FinancialAid.objects.get(
             user=self.profile.user,
@@ -829,7 +829,7 @@ class LearnerSkipsFinancialAid(FinancialAidBaseTestCase, APIClient):
         )
 
         assert FinancialAidAudit.objects.count() == 0
-        self.assert_http_status(self.client.patch, self.skip_url, status.HTTP_200_OK)
+        self.make_http_request(self.client.patch, self.skip_url, status.HTTP_200_OK)
         assert FinancialAid.objects.count() == 1
         financial_aid.refresh_from_db()
         assert financial_aid.tier_program == self.tier_programs["75k"]
@@ -850,7 +850,7 @@ class LearnerSkipsFinancialAid(FinancialAidBaseTestCase, APIClient):
             tier_program=self.tier_programs["25k"],
             status=financial_aid_status,
         )
-        self.assert_http_status(self.client.patch, self.skip_url, status.HTTP_400_BAD_REQUEST)
+        self.make_http_request(self.client.patch, self.skip_url, status.HTTP_400_BAD_REQUEST)
 
     def test_financialaid_object_cannot_be_skipped_if_aid_not_available(self):
         """
@@ -859,7 +859,7 @@ class LearnerSkipsFinancialAid(FinancialAidBaseTestCase, APIClient):
         """
         self.program.financial_aid_availability = False
         self.program.save()
-        self.assert_http_status(self.client.patch, self.skip_url, status.HTTP_400_BAD_REQUEST)
+        self.make_http_request(self.client.patch, self.skip_url, status.HTTP_400_BAD_REQUEST)
 
     def test_financialaid_object_cannot_be_skipped_if_not_enrolled_in_program(self):
         """
@@ -867,7 +867,7 @@ class LearnerSkipsFinancialAid(FinancialAidBaseTestCase, APIClient):
         """
         program = create_program()
         url = reverse("financial_aid_skip", kwargs={"program_id": program.id})
-        self.assert_http_status(self.client.patch, url, status.HTTP_400_BAD_REQUEST)
+        self.make_http_request(self.client.patch, url, status.HTTP_400_BAD_REQUEST)
 
     def test_financialaid_object_cannot_be_skipped_for_nonexisting_program(self):
         """
@@ -875,16 +875,16 @@ class LearnerSkipsFinancialAid(FinancialAidBaseTestCase, APIClient):
         """
         Program.objects.all().delete()
         url = reverse("financial_aid_skip", kwargs={"program_id": 1})
-        self.assert_http_status(self.client.patch, url, status.HTTP_404_NOT_FOUND)
+        self.make_http_request(self.client.patch, url, status.HTTP_404_NOT_FOUND)
 
     def test_skip_financial_aid_only_put_allowed(self):
         """
         Tests that methods other than PUT/PATCH are not allowed for skipping financial aid
         """
-        self.assert_http_status(self.client.get, self.skip_url, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assert_http_status(self.client.post, self.skip_url, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assert_http_status(self.client.head, self.skip_url, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assert_http_status(self.client.delete, self.skip_url, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.make_http_request(self.client.get, self.skip_url, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.make_http_request(self.client.post, self.skip_url, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.make_http_request(self.client.head, self.skip_url, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.make_http_request(self.client.delete, self.skip_url, status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
 class CoursePriceListViewTests(FinancialAidBaseTestCase, APIClient):
@@ -912,7 +912,7 @@ class CoursePriceListViewTests(FinancialAidBaseTestCase, APIClient):
         Anonymous users are restricted
         """
         self.client.logout()
-        self.assert_http_status(self.client.get, self.course_price_url, status.HTTP_403_FORBIDDEN)
+        self.make_http_request(self.client.get, self.course_price_url, status.HTTP_403_FORBIDDEN)
 
     def test_not_live(self):
         """
@@ -922,7 +922,7 @@ class CoursePriceListViewTests(FinancialAidBaseTestCase, APIClient):
             program.live = False
             program.save()
 
-        resp = self.assert_http_status(self.client.get, self.course_price_url, status.HTTP_200_OK)
+        resp = self.make_http_request(self.client.get, self.course_price_url, status.HTTP_200_OK)
         assert resp.data == []
 
     def test_no_enrollments(self):
@@ -930,14 +930,14 @@ class CoursePriceListViewTests(FinancialAidBaseTestCase, APIClient):
         If there are no enrollments there should not be output in the course price API
         """
         ProgramEnrollment.objects.all().delete()
-        resp = self.assert_http_status(self.client.get, self.course_price_url, status.HTTP_200_OK)
+        resp = self.make_http_request(self.client.get, self.course_price_url, status.HTTP_200_OK)
         assert resp.data == []
 
     def test_get_all_course_prices(self):
         """
         Test that the course_price_list route will return a list of formatted course prices
         """
-        resp = self.assert_http_status(self.client.get, self.course_price_url, status.HTTP_200_OK)
+        resp = self.make_http_request(self.client.get, self.course_price_url, status.HTTP_200_OK)
         assert sorted(resp.data, key=lambda x: x['program_id']) == sorted([
             get_formatted_course_price(enrollment)
             for enrollment in ProgramEnrollment.objects.filter(user=self.profile.user)

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -148,24 +148,24 @@ class FinancialAidMailViewsTests(FinancialAidBaseTestCase, APITestCase):
         program = create_program()
         staff_user = create_enrolled_profile(program, Staff.ROLE_ID).user
         self.client.force_login(staff_user)
-        self.assert_http_status(self.client.post, self.url, status.HTTP_403_FORBIDDEN, data=self.request_data)
+        self.make_http_request(self.client.post, self.url, status.HTTP_403_FORBIDDEN, data=self.request_data)
 
     def test_instructor(self):
         """An instructor can't send email"""
         self.client.force_login(self.instructor_user_profile.user)
-        self.assert_http_status(self.client.post, self.url, status.HTTP_403_FORBIDDEN, data=self.request_data)
+        self.make_http_request(self.client.post, self.url, status.HTTP_403_FORBIDDEN, data=self.request_data)
 
     def test_learner(self):
         """A learner can't send email"""
         self.client.force_login(self.profile.user)
-        self.assert_http_status(self.client.post, self.url, status.HTTP_403_FORBIDDEN, data=self.request_data)
+        self.make_http_request(self.client.post, self.url, status.HTTP_403_FORBIDDEN, data=self.request_data)
 
     def test_anonymous(self):
         """
         Anonymous users can't send email
         """
         self.client.logout()
-        self.assert_http_status(self.client.post, self.url, status.HTTP_403_FORBIDDEN, data=self.request_data)
+        self.make_http_request(self.client.post, self.url, status.HTTP_403_FORBIDDEN, data=self.request_data)
 
     @patch('mail.views.MailgunClient')
     def test_send_financial_aid_view(self, mock_mailgun_client):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1341

#### What's this PR do?
Auto-approves the user if they are below the income threshold for their country but they are matched with a $0 discount anyway.

#### How should this be manually tested?
Configure the tier program to have a $0 discount level that's lower than the income threshold for your country of residence (this is $75k for US). Then apply for financial aid with an income slightly above the $0 discount tier program level