### PR TITLE
Style the react select field to look like material ui field

### DIFF
--- a/static/scss/profile.scss
+++ b/static/scss/profile.scss
@@ -200,15 +200,15 @@
   align-items: center;
 }
 
-.profile-form, .profile-form.collapsed {
+.profile-form.collapsed {
   padding: 20px 24px 20px;
 }
 
 .program-select {
   z-index: 2;
   overflow: visible;
-  font-weight: 500;
-  font-size: 16px;
+  font-weight: 400;
+  font-size: 15px;
   padding-top: 30px;
 }
 

--- a/static/scss/select-field.scss
+++ b/static/scss/select-field.scss
@@ -23,3 +23,36 @@
     border-top-left-radius: 4px!important;
   }
 }
+
+/* React Select styling */
+
+.Select--single > .Select-control {
+
+  border-radius: 0;
+  border: none;
+  border-bottom: 1px solid #dcdcdc;
+
+  .Select-value {
+    padding-left: 2px;
+    top: 4px;
+  }
+  .Select-input {
+    padding-left: 3px;
+  }
+}
+
+.Select-placeholder {
+  top: 4px;
+  padding-left: 2px;
+}
+
+.select-field {
+  .select-label {
+    font-size: 12px;
+    font-weight: 400;
+    color: rgba(0,0,0,.5);
+    position: relative;
+    top: 4px;
+    left: 2px;
+  }
+}

--- a/static/scss/select-field.scss
+++ b/static/scss/select-field.scss
@@ -36,8 +36,13 @@
     padding-left: 2px;
     top: 4px;
   }
+
   .Select-input {
     padding-left: 3px;
+  }
+
+  .Select-arrow-zone {
+    top: 2px;
   }
 }
 

--- a/static/scss/select-field.scss
+++ b/static/scss/select-field.scss
@@ -10,8 +10,12 @@
 
 .select-field {
   .select-label {
-    font-size: 13px;
-    font-weight: 700;
+    font-size: 12px;
+    font-weight: 400;
+    color: rgba(0,0,0,.5);
+    position: relative;
+    top: 4px;
+    left: 2px;
   }
 
   .menu-outer-top .Select-menu-outer {
@@ -23,8 +27,6 @@
     border-top-left-radius: 4px!important;
   }
 }
-
-/* React Select styling */
 
 .Select--single > .Select-control {
 
@@ -49,15 +51,4 @@
 .Select-placeholder {
   top: 4px;
   padding-left: 2px;
-}
-
-.select-field {
-  .select-label {
-    font-size: 12px;
-    font-weight: 400;
-    color: rgba(0,0,0,.5);
-    position: relative;
-    top: 4px;
-    left: 2px;
-  }
 }


### PR DESCRIPTION
#### What's this PR do?

This PR styles the react select field to look more-or-less like the material UI fields. So I changed the react select label, the spacing and margins of the field, the color of the bottom-border. I also removed the bold style for the program selector on page 1 of the sign up, and removed the "x" icon to clear the selection. This last one is pending discussion with Ferdi who said he thought having the x was useful.

![image](https://cloud.githubusercontent.com/assets/20047260/20275242/ce9ceb1a-aa65-11e6-8263-487fa46c13e4.png)

