### PR TITLE
add error display to financial aid calculator

### DIFF
--- a/static/js/actions/financial_aid.js
+++ b/static/js/actions/financial_aid.js
@@ -18,7 +18,7 @@ export const clearCalculatorEdit = createAction(CLEAR_CALCULATOR_EDIT);
 export const UPDATE_CALCULATOR_EDIT = 'UPDATE_CALCULATOR_EDIT';
 export const updateCalculatorEdit = createAction(UPDATE_CALCULATOR_EDIT);
 
-export const UPDATE_CALCULATOR_VALIDATION = 'UPDATE_PROFILE_VALIDATION';
+export const UPDATE_CALCULATOR_VALIDATION = 'UPDATE_CALCULATOR_VALIDATION';
 export const updateCalculatorValidation = createAction(UPDATE_CALCULATOR_VALIDATION);
 
 export const REQUEST_ADD_FINANCIAL_AID = 'REQUEST_ADD_FINANCIAL_AID';
@@ -40,8 +40,11 @@ export const addFinancialAid = (income: number, currency: string, programId: num
         dispatch(fetchDashboard());
         return Promise.resolve();
       },
-      () => {
-        dispatch(receiveAddFinancialAidFailure());
+      err => {
+        dispatch(receiveAddFinancialAidFailure({
+          message: err[0],
+          code: err.errorStatusCode
+        }));
         return Promise.reject();
       });
   };

--- a/static/js/reducers/financial_aid.js
+++ b/static/js/reducers/financial_aid.js
@@ -17,6 +17,7 @@ import {
   FETCH_SUCCESS,
 } from '../actions';
 import type { Action } from '../flow/reduxTypes';
+import _ from 'lodash';
 
 export const INITIAL_FINANCIAL_AID_STATE = {};
 
@@ -27,6 +28,7 @@ export const FINANCIAL_AID_EDIT = {
   fetchStatus:  null,
   programId:    null,
   validation:   {},
+  fetchError:   null,
 };
 
 export type FinancialAidValidation = {
@@ -35,6 +37,12 @@ export type FinancialAidValidation = {
   checkBox?: string,
 };
 
+export type FetchError = {
+  message?:  string,
+  code?:     number,
+};
+
+
 export type FinancialAidState = {
   income?:      string,
   currency?:    string,
@@ -42,6 +50,7 @@ export type FinancialAidState = {
   fetchStatus?: string,
   programId?:   number,
   validation?:  FinancialAidValidation,
+  fetchError?:  FetchError,
 };
 
 export const financialAid = (state: FinancialAidState = INITIAL_FINANCIAL_AID_STATE, action: Action) => {
@@ -52,20 +61,28 @@ export const financialAid = (state: FinancialAidState = INITIAL_FINANCIAL_AID_ST
     return FINANCIAL_AID_EDIT;
   case UPDATE_CALCULATOR_EDIT:
     return { ...state, ...action.payload };
-  case UPDATE_CALCULATOR_VALIDATION:
-    return { ...state, validation: action.payload };
+  case UPDATE_CALCULATOR_VALIDATION: {
+    let clone = _.clone(state);
+    clone.validation = action.payload;
+    return clone;
+  }
   case REQUEST_ADD_FINANCIAL_AID:
-    return { ...state, fetchStatus: FETCH_PROCESSING };
+    return {
+      ...state,
+      fetchStatus: FETCH_PROCESSING,
+      fetchError: null,
+      validation: {},
+    };
   case RECEIVE_ADD_FINANCIAL_AID_SUCCESS:
     return { ...state, fetchStatus: FETCH_SUCCESS };
   case RECEIVE_ADD_FINANCIAL_AID_FAILURE:
-    return { ...state, fetchStatus: FETCH_FAILURE };
+    return { ...state, fetchStatus: FETCH_FAILURE, fetchError: action.payload };
   case REQUEST_SKIP_FINANCIAL_AID:
     return { ...state, fetchStatus: FETCH_PROCESSING };
   case RECEIVE_SKIP_FINANCIAL_AID_SUCCESS:
     return { ...state, fetchStatus: FETCH_SUCCESS };
   case RECEIVE_SKIP_FINANCIAL_AID_FAILURE:
-    return { ...state, fetchStatus: FETCH_FAILURE };
+    return { ...state, fetchStatus: FETCH_FAILURE};
   default:
     return state;
   }

--- a/static/js/reducers/financial_aid_test.js
+++ b/static/js/reducers/financial_aid_test.js
@@ -122,7 +122,8 @@ describe('financial aid reducers', () => {
   });
 
   it('should fail to add a financial aid', () => {
-    addFinancialAidStub.returns(Promise.reject());
+    let err = {'0': 'an error message', errorStatusCode: 500};
+    addFinancialAidStub.returns(Promise.reject(err));
     let income = 100000;
     let currency = 'USD';
     let programId = 1;
@@ -133,7 +134,11 @@ describe('financial aid reducers', () => {
     ]).then(state => {
       let expectation = Object.assign({}, FINANCIAL_AID_EDIT, {
         programId: programId,
-        fetchStatus: FETCH_FAILURE
+        fetchStatus: FETCH_FAILURE,
+        fetchError: {
+          message: 'an error message',
+          code: 500
+        }
       });
       assert.deepEqual(state, expectation);
       assert.ok(addFinancialAidStub.calledWith(income, currency, programId));

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -20,6 +20,7 @@ $bg-light-blue: #cbe6f3;
 $bg-light-tan: #f1efe0;
 $bg-light-gray: #f5f5f5;
 $bg-med-gray: #ececec;
+$bg-error: #f9a9a9;
 $black-transparent: rgba(0, 0, 0, 0.9);
 $button-color: #ca213b;
 $button-color-hover: #dc102f;

--- a/static/scss/calculator.scss
+++ b/static/scss/calculator.scss
@@ -26,6 +26,14 @@
     display:  flex;
   }
 
+  .api-error {
+    background-color: $bg-error;
+    color: $link-text;
+    padding: 15px 25px;
+    margin-top: 25px;
+    border-radius: 5px;
+  }
+
   .salary-input {
     background-color: $lightgrey;
     padding: 30px;


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1285 

#### What's this PR do?

This adds a little error message display to the financial aid calculator!

![errrorororor](https://cloud.githubusercontent.com/assets/6207644/20277620/4d54c712-aa6f-11e6-860c-394f037d8c7b.png)

#### How should this be manually tested?

The easiest way to generate error messages is to not have have the currency conversion set-up on your computer. Then submitting the form with anything other than USD will result in a 400 error.