### PR TITLE
Final grade serialization

### DIFF
--- a/courses/factories.py
+++ b/courses/factories.py
@@ -1,10 +1,11 @@
 """Factories for making test data"""
-import pytz
+from random import randint
 
+import faker
+import pytz
 import factory
 from factory import fuzzy
 from factory.django import DjangoModelFactory
-import faker
 
 from .models import Program, Course, CourseRun
 
@@ -75,7 +76,7 @@ class CourseRunFactory(DjangoModelFactory):
     course = factory.SubFactory(CourseFactory)
     # Try to make sure we escape this correctly
     edx_course_key = factory.LazyAttribute(
-        lambda x: "course:/()+&/" + FAKE.sentence()
+        lambda x: "course:/v{}/{}".format(randint(1, 100), FAKE.slug())
     )
     enrollment_start = factory.LazyAttribute(
         lambda x: FAKE.date_time_this_month(before_now=True, after_now=False, tzinfo=pytz.utc)
@@ -90,10 +91,10 @@ class CourseRunFactory(DjangoModelFactory):
         lambda x: FAKE.date_time_this_year(before_now=False, after_now=True, tzinfo=pytz.utc)
     )
     fuzzy_start_date = factory.LazyAttribute(
-        lambda x: "Starting " + FAKE.sentence()
+        lambda x: "Starting {}".format(FAKE.sentence())
     )
     fuzzy_enrollment_start_date = factory.LazyAttribute(
-        lambda x: "Enrollment starting " + FAKE.sentence()
+        lambda x: "Enrollment starting {}".format(FAKE.sentence())
     )
     enrollment_url = factory.LazyAttribute(
         lambda x: FAKE.url()

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -1,14 +1,12 @@
 """
 Test cases for the UserProgramSearchSerializer
 """
+import faker
+import pytz
 from django.test import TestCase
 from django.db.models.signals import post_save
 from factory.django import mute_signals
-from profiles.factories import (
-    EducationFactory,
-    EmploymentFactory,
-    ProfileFactory,
-)
+
 from courses.factories import (
     ProgramFactory,
     CourseFactory,
@@ -16,10 +14,28 @@ from courses.factories import (
 )
 from dashboard.factories import (
     CachedCertificateFactory,
+    CachedCurrentGradeFactory,
     CachedEnrollmentFactory,
 )
-from dashboard.models import ProgramEnrollment, CachedEnrollment, CachedCertificate
+from dashboard.models import (
+    CachedCertificate,
+    CachedCurrentGrade,
+    CachedEnrollment,
+    ProgramEnrollment,
+)
 from dashboard.serializers import UserProgramSearchSerializer
+from ecommerce.factories import (
+    OrderFactory,
+    LineFactory,
+)
+from financialaid.api_test import (
+    create_program,
+)
+from profiles.factories import (
+    EducationFactory,
+    EmploymentFactory,
+    ProfileFactory,
+)
 from roles.models import Role
 from roles.roles import Staff
 
@@ -28,13 +44,24 @@ class UserProgramSearchSerializerTests(TestCase):
     """
     Test cases for the UserProgramSearchSerializer
     """
+
     @staticmethod
     def _generate_cached_enrollments(user, program, num_course_runs=1, data=None):
         """
         Helper method to generate CachedEnrollments for test cases
         """
+        fake = faker.Factory.create()
         course = CourseFactory.create(program=program)
-        course_runs = [CourseRunFactory.create(course=course) for _ in range(num_course_runs)]
+        cours_run_params = dict(before_now=True, after_now=False, tzinfo=pytz.utc)
+        course_runs = [
+            CourseRunFactory.create(
+                course=course,
+                enrollment_start=fake.date_time_this_month(**cours_run_params),
+                start_date=fake.date_time_this_month(**cours_run_params),
+                enrollment_end=fake.date_time_this_month(**cours_run_params),
+                end_date=fake.date_time_this_year(**cours_run_params),
+            ) for _ in range(num_course_runs)
+        ]
         factory_kwargs = dict(user=user)
         if data is not None:
             factory_kwargs['data'] = data
@@ -44,47 +71,107 @@ class UserProgramSearchSerializerTests(TestCase):
     def setUpTestData(cls):
         with mute_signals(post_save):
             profile = ProfileFactory.create()
+        cls.user = profile.user
         EducationFactory.create(profile=profile)
         EmploymentFactory.create(profile=profile)
+        # create a normal program
         program = ProgramFactory.create()
-        cls.enrollments = cls._generate_cached_enrollments(profile.user, program, num_course_runs=2)
-        certificate_grades = [0.7, 0.8]
+        cls.enrollments = cls._generate_cached_enrollments(cls.user, program, num_course_runs=2)
+        certificate_grades_vals = [0.7, 0.8]
+        cls.current_grades_vals = [0.9, 1.0]
         cls.certificates = []
+        cls.current_grades = []
         for i, enrollment in enumerate(cls.enrollments):
             cls.certificates.append(
                 CachedCertificateFactory.create(
-                    user=profile.user,
+                    user=cls.user,
                     course_run=enrollment.course_run,
-                    data={'grade': certificate_grades[i]}
+                    data={
+                        "grade": certificate_grades_vals[i],
+                        "certificate_type": "verified",
+                        "course_id": enrollment.course_run.edx_course_key,
+                    }
                 )
             )
-        cls.program_enrollment = ProgramEnrollment.objects.create(user=profile.user, program=program)
+            cls.current_grades.append(
+                CachedCurrentGradeFactory.create(
+                    user=cls.user,
+                    course_run=enrollment.course_run,
+                    data={
+                        "passed": True,
+                        "percent": cls.current_grades_vals[i],
+                        "course_key": enrollment.course_run.edx_course_key,
+                    }
+                )
+            )
+        cls.program_enrollment = ProgramEnrollment.objects.create(user=cls.user, program=program)
+        # create a financial aid program
+        cls.fa_program, _ = create_program()
+        cls.fa_program_enrollment = ProgramEnrollment.objects.create(user=cls.user, program=cls.fa_program)
+        cls.fa_enrollments = cls._generate_cached_enrollments(cls.user, cls.fa_program, num_course_runs=2)
+        cls.current_grades = []
+        for i, enrollment in enumerate(cls.fa_enrollments):
+            order = OrderFactory.create(user=cls.user, status='fulfilled')
+            LineFactory.create(order=order, course_key=enrollment.course_run.edx_course_key)
+            cls.current_grades.append(
+                CachedCurrentGradeFactory.create(
+                    user=cls.user,
+                    course_run=enrollment.course_run,
+                    data={
+                        "passed": True,
+                        "percent": cls.current_grades_vals[i],
+                        "course_key": enrollment.course_run.edx_course_key,
+                    }
+                )
+            )
 
     def test_full_program_user_serialization(self):
         """
         Tests that full ProgramEnrollment serialization works as expected
         """
-        user = self.program_enrollment.user
         program = self.program_enrollment.program
         assert UserProgramSearchSerializer.serialize(self.program_enrollment) == {
             'id': program.id,
-            'enrollments': list(CachedEnrollment.active_data(user, program)),
-            'certificates': list(CachedCertificate.active_data(user, program)),
+            'enrollments': list(CachedEnrollment.active_data(self.user, program)),
+            'certificates': list(CachedCertificate.active_data(self.user, program)),
+            'current_grades': list(CachedCurrentGrade.active_data(self.user, program)),
             'grade_average': 75,
             'is_learner': True
         }
 
-        # when user has staff role, assert that he is not learner.
+    def test_full_program_user_serialization_financial_aid(self):
+        """
+        Tests that full ProgramEnrollment serialization works as expected
+        for financial aid programs.
+        the difference with test_full_program_user_serialization
+        is that the grade is calculated using the current grades
+        """
+        expected_result = {
+            'id': self.fa_program.id,
+            'enrollments': list(CachedEnrollment.active_data(self.user, self.fa_program)),
+            'certificates': [],
+            'current_grades': list(CachedCurrentGrade.active_data(self.user, self.fa_program)),
+            'grade_average': 95,
+            'is_learner': True
+        }
+        assert UserProgramSearchSerializer.serialize(self.fa_program_enrollment) == expected_result
+
+    def test_full_program_user_serialization_staff(self):
+        """
+        Tests that when user has staff role, the serialization shows that she is not a learner.
+        """
+        program = self.program_enrollment.program
         Role.objects.create(
-            user=user,
+            user=self.user,
             program=program,
             role=Staff.ROLE_ID
         )
 
         assert UserProgramSearchSerializer.serialize(self.program_enrollment) == {
             'id': program.id,
-            'enrollments': list(CachedEnrollment.active_data(user, program)),
-            'certificates': list(CachedCertificate.active_data(user, program)),
+            'enrollments': list(CachedEnrollment.active_data(self.user, program)),
+            'certificates': list(CachedCertificate.active_data(self.user, program)),
+            'current_grades': list(CachedCurrentGrade.active_data(self.user, program)),
             'grade_average': 75,
             'is_learner': False
         }
@@ -107,13 +194,12 @@ class UserProgramSearchSerializerTests(TestCase):
         Tests that the serialization for a ProgramEnrollment doesn't yield enrollment data for a different program
         """
         # Create an enrollment in a different program and make sure it is not part of the serialized version
-        user = self.program_enrollment.user
         enrolled_program = self.program_enrollment.program
         other_program = ProgramFactory.create()
-        self._generate_cached_enrollments(user, other_program, num_course_runs=1, data={'enroll': '1'})
+        self._generate_cached_enrollments(self.user, other_program, num_course_runs=1, data={'enroll': '1'})
         serialized_program_user = UserProgramSearchSerializer.serialize(self.program_enrollment)
         assert len([e for e in serialized_program_user['enrollments'] if e == {'enroll': '1'}]) == 0
         # Create an enrollment in the same program and make sure it is part of the serialized version
-        self._generate_cached_enrollments(user, enrolled_program, num_course_runs=1, data={'enroll': '2'})
+        self._generate_cached_enrollments(self.user, enrolled_program, num_course_runs=1, data={'enroll': '2'})
         serialized_program_user = UserProgramSearchSerializer.serialize(self.program_enrollment)
         assert len([e for e in serialized_program_user['enrollments'] if e == {'enroll': '2'}]) == 1

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -201,6 +201,20 @@ class MMTrack:
             current_grade = self.current_grades.get_current_grade(course_id)
             return float(current_grade.percent) * 100
 
+    def get_all_final_grades(self):
+        """
+        Returns a list of final grades for only the passed courses.
+
+        Returns:
+            dict: dictionary of course_ids: floats representing final grades for a course
+        """
+        final_grades = {}
+        for course_id in self.course_ids:
+            final_grade = self.get_final_grade(course_id)
+            if final_grade is not None:
+                final_grades[course_id] = final_grade
+        return final_grades
+
     def get_current_grade(self, course_id):
         """
         Returns the current grade number for the user in the course if enrolled.

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -464,6 +464,19 @@ class MMTrackTest(TestCase):
         assert mmtrack.get_final_grade(course_id) == 69.0
         assert mmtrack.get_final_grade("course-v1:edX+DemoX+Demo_Course") is None
 
+    def test_get_all_final_grades(self):
+        """
+        Test for get_all_final_grades
+        """
+        mmtrack = MMTrack(
+            user=self.user,
+            program=self.program,
+            enrollments=self.enrollments,
+            current_grades=self.current_grades,
+            certificates=self.certificates
+        )
+        assert mmtrack.get_all_final_grades() == {'course-v1:edX+DemoX+Demo_Course': 98.0}
+
     def test_get_current_grade(self):
         """
         Test for get_current_grade method

--- a/financialaid/views_test.py
+++ b/financialaid/views_test.py
@@ -186,7 +186,7 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
 
     def test_staff_of_different_program(self):
         """Not allowed for staff of different program"""
-        program = create_program()
+        program, _ = create_program()
         staff_user = create_enrolled_profile(program, role=Staff.ROLE_ID).user
         self.client.force_login(staff_user)
         self.make_http_request(self.client.get, self.review_url, status.HTTP_403_FORBIDDEN)
@@ -382,7 +382,7 @@ class FinancialAidActionTests(FinancialAidBaseTestCase, APIClient):
 
     def test_not_allowed_staff_of_different_program(self):
         """Not allowed for staff of different program"""
-        program = create_program()
+        program, _ = create_program()
         staff_user = create_enrolled_profile(program, role=Staff.ROLE_ID).user
         self.client.force_login(staff_user)
         self.make_http_request(self.client.patch, self.action_url, status.HTTP_403_FORBIDDEN, data=self.data)
@@ -704,7 +704,7 @@ class CoursePriceDetailViewTests(FinancialAidBaseTestCase, APIClient):
         Tests ReviewFinancialAidView that are not allowed
         """
         # Bad request if not enrolled
-        program = create_program()
+        program, _ = create_program()
         profile = create_enrolled_profile(program)
         self.client.force_login(profile.user)
         self.make_http_request(self.client.get, self.course_price_url, status.HTTP_404_NOT_FOUND)
@@ -865,7 +865,7 @@ class LearnerSkipsFinancialAid(FinancialAidBaseTestCase, APIClient):
         """
         Tests that a FinancialAid object cannot be skipped if the user is not enrolled in program
         """
-        program = create_program()
+        program, _ = create_program()
         url = reverse("financial_aid_skip", kwargs={"program_id": program.id})
         self.make_http_request(self.client.patch, url, status.HTTP_400_BAD_REQUEST)
 
@@ -897,7 +897,7 @@ class CoursePriceListViewTests(FinancialAidBaseTestCase, APIClient):
         super().setUpTestData()
         cls.course_price_url = reverse("course_price_list")
         # create a second program
-        program = create_program()
+        program, _ = create_program()
         ProgramEnrollment.objects.create(
             program=program,
             user=cls.profile.user,

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -145,7 +145,7 @@ class FinancialAidMailViewsTests(FinancialAidBaseTestCase, APITestCase):
 
     def test_different_programs_staff(self):
         """Different program's staff should not be allowed to send email for this program"""
-        program = create_program()
+        program, _ = create_program()
         staff_user = create_enrolled_profile(program, Staff.ROLE_ID).user
         self.client.force_login(staff_user)
         self.make_http_request(self.client.post, self.url, status.HTTP_403_FORBIDDEN, data=self.request_data)


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #1632

#### What's this PR do?
Adds support for the financial grade final grade serialization for the search.
It also refactors many factories because of specific needs for this PR

#### Where should the reviewer start?
`dashboard/serializers.py`

#### How should this be manually tested?
You need a course run in a financial aid program where the user is enrolled mmtrack (meaning is enrolled and paid for the course run).
Once this is done, the easiest way is to modify the course run CachedCurrentGrade object for the user to something like 
```
{
		"course_key": <course run edx key>,
		"passed": True,
		"percent": 0.77,
		"letter_grade": "Pass",
		"username": <your user's username>
}
```
Then recreate the index and you should be able to see the final grade in the search result.

#### Any background context you want to provide?
the `seed_db` command does not help much for the test: there is another issue open to add support for financial aid programs