### PR TITLE
Moved dashboard API call to DashboardPage

### DIFF
--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -4,13 +4,6 @@ import TestUtils from 'react-addons-test-utils';
 import { assert } from 'chai';
 import _ from 'lodash';
 
-import {
-  REQUEST_DASHBOARD,
-  REQUEST_COURSE_PRICES,
-  RECEIVE_DASHBOARD_FAILURE,
-  RECEIVE_DASHBOARD_SUCCESS,
-  RECEIVE_COURSE_PRICES_SUCCESS,
-} from '../actions';
 import { SET_USER_PAGE_DIALOG_VISIBILITY } from '../actions/ui';
 import {
   RECEIVE_GET_USER_PROFILE_SUCCESS,
@@ -34,6 +27,10 @@ import {
 import IntegrationTestHelper from '../util/integration_test_helper';
 import { makeStrippedHtml } from '../util/util';
 import * as api from '../lib/api';
+import {
+  DASHBOARD_SUCCESS_ACTIONS,
+  DASHBOARD_ERROR_ACTIONS,
+} from '../containers/DashboardPage_test';
 import ErrorMessage from './ErrorMessage';
 
 describe("ErrorMessage", () => {
@@ -108,32 +105,10 @@ describe("ErrorMessage", () => {
     });
 
     describe('dashboard page', () => {
-      const dashboardSuccessActions = [
-        REQUEST_DASHBOARD,
-        RECEIVE_DASHBOARD_SUCCESS,
-        REQUEST_COURSE_PRICES,
-        RECEIVE_COURSE_PRICES_SUCCESS,
-        REQUEST_GET_USER_PROFILE,
-        RECEIVE_GET_USER_PROFILE_SUCCESS,
-        REQUEST_GET_PROGRAM_ENROLLMENTS,
-        RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
-      ];
-
-      const dashboardErrorActions = [
-        REQUEST_DASHBOARD,
-        RECEIVE_DASHBOARD_FAILURE,
-        REQUEST_COURSE_PRICES,
-        RECEIVE_COURSE_PRICES_SUCCESS,
-        REQUEST_GET_USER_PROFILE,
-        RECEIVE_GET_USER_PROFILE_SUCCESS,
-        REQUEST_GET_PROGRAM_ENROLLMENTS,
-        RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
-      ];
-
       it('error from the backend triggers error message in dashboard', () => {
         helper.dashboardStub.returns(Promise.reject(ERROR_RESPONSE));
 
-        return renderComponent("/dashboard", dashboardErrorActions).then(([, div]) => {
+        return renderComponent("/dashboard", DASHBOARD_ERROR_ACTIONS).then(([, div]) => {
           confirmErrorMessage(div, `AB123 ${errorString}`, 'Additional info: custom error message for the user.');
         });
       });
@@ -143,7 +118,7 @@ describe("ErrorMessage", () => {
         delete response.user_message;
         helper.dashboardStub.returns(Promise.reject(response));
 
-        return renderComponent("/dashboard", dashboardErrorActions).then(([, div]) => {
+        return renderComponent("/dashboard", DASHBOARD_ERROR_ACTIONS).then(([, div]) => {
           confirmErrorMessage(div, `AB123 ${errorString}`);
         });
       });
@@ -153,7 +128,7 @@ describe("ErrorMessage", () => {
           errorStatusCode: 500
         }));
 
-        return renderComponent("/dashboard", dashboardErrorActions).then(([, div]) => {
+        return renderComponent("/dashboard", DASHBOARD_ERROR_ACTIONS).then(([, div]) => {
           confirmErrorMessage(div, `500 ${errorString}`);
         });
       });
@@ -161,7 +136,7 @@ describe("ErrorMessage", () => {
       it('a regular response does not show the error', () => {
         helper.dashboardStub.returns(Promise.resolve(DASHBOARD_RESPONSE));
 
-        return renderComponent("/dashboard", dashboardSuccessActions).then(([, div]) => {
+        return renderComponent("/dashboard", DASHBOARD_SUCCESS_ACTIONS).then(([, div]) => {
           let message = div.getElementsByClassName('alert-message')[0];
           assert.equal(message, undefined);
         });
@@ -170,7 +145,7 @@ describe("ErrorMessage", () => {
       it('shows an error if there are no programs', () => {
         helper.dashboardStub.returns(Promise.resolve([]));
 
-        return renderComponent("/dashboard", dashboardSuccessActions).then(([wrapper]) => {
+        return renderComponent("/dashboard", DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
           let message = wrapper.find('.page-content').text();
           assert(message.includes("Additional info: No program enrollment is available."));
         });
@@ -179,7 +154,7 @@ describe("ErrorMessage", () => {
       it('shows an error if there is no matching current program enrollment', () => {
         helper.programsGetStub.returns(Promise.resolve([]));
 
-        return renderComponent("/dashboard", dashboardSuccessActions).then(([wrapper]) => {
+        return renderComponent("/dashboard", DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
           let message = wrapper.find('.page-content').text();
           assert(message.includes("Additional info: No program enrollment is available."));
         });

--- a/static/js/components/NewEnrollmentDialog_test.js
+++ b/static/js/components/NewEnrollmentDialog_test.js
@@ -7,7 +7,7 @@ import { shallow } from 'enzyme';
 import Dialog from 'material-ui/Dialog';
 import SelectField from 'material-ui/SelectField';
 
-import { SUCCESS_ACTIONS } from '../containers/DashboardPage_test';
+import { DASHBOARD_SUCCESS_ACTIONS } from '../containers/DashboardPage_test';
 import * as enrollmentActions from '../actions/programs';
 import * as uiActions from '../actions/ui';
 
@@ -39,7 +39,7 @@ describe("NewEnrollmentDialog", () => {
   };
 
   it('renders a dialog', () => {
-    return helper.renderComponent("/dashboard", SUCCESS_ACTIONS).then(([wrapper]) => {
+    return helper.renderComponent("/dashboard", DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
       let dialog = wrapper.find(NewEnrollmentDialog).at(0);
       let props = dialog.props();
 
@@ -54,7 +54,7 @@ describe("NewEnrollmentDialog", () => {
   ]) {
     it(`dispatches ${funcName}`, () => {
       let stub = helper.sandbox.spy(uiActions, funcName);
-      return helper.renderComponent("/dashboard", SUCCESS_ACTIONS).then(([wrapper]) => {
+      return helper.renderComponent("/dashboard", DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
         let handler = wrapper.find(NewEnrollmentDialog).at(0).props()[funcName];
         handler(value);
         assert(stub.calledWith(value));
@@ -64,7 +64,7 @@ describe("NewEnrollmentDialog", () => {
     it(`the prop ${propName} comes from the state`, () => {
       helper.store.dispatch(uiActions[funcName](value));
 
-      return helper.renderComponent("/dashboard", SUCCESS_ACTIONS).then(([wrapper]) => {
+      return helper.renderComponent("/dashboard", DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
         let actual = wrapper.find(NewEnrollmentDialog).at(0).props()[propName];
         assert.equal(actual, value);
       });
@@ -74,7 +74,7 @@ describe("NewEnrollmentDialog", () => {
   it('dispatches addProgramEnrollment', () => {
     let stub = helper.sandbox.stub(enrollmentActions, 'addProgramEnrollment');
     stub.returns({type: "fake"});
-    return helper.renderComponent("/dashboard", SUCCESS_ACTIONS).then(([wrapper]) => {
+    return helper.renderComponent("/dashboard", DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
       let handler = wrapper.find(NewEnrollmentDialog).at(0).props().addProgramEnrollment;
       handler(3);
       assert(stub.calledWith(3));

--- a/static/js/components/NewEnrollmentDialog_test.js
+++ b/static/js/components/NewEnrollmentDialog_test.js
@@ -7,21 +7,8 @@ import { shallow } from 'enzyme';
 import Dialog from 'material-ui/Dialog';
 import SelectField from 'material-ui/SelectField';
 
-import {
-  REQUEST_DASHBOARD,
-  RECEIVE_DASHBOARD_SUCCESS,
-  REQUEST_COURSE_PRICES,
-  RECEIVE_COURSE_PRICES_SUCCESS,
-} from '../actions';
-import {
-  REQUEST_GET_USER_PROFILE,
-  RECEIVE_GET_USER_PROFILE_SUCCESS,
-} from '../actions/profile';
+import { SUCCESS_ACTIONS } from '../containers/DashboardPage_test';
 import * as enrollmentActions from '../actions/programs';
-import {
-  REQUEST_GET_PROGRAM_ENROLLMENTS,
-  RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
-} from '../actions/programs';
 import * as uiActions from '../actions/ui';
 
 import {
@@ -33,16 +20,6 @@ import IntegrationTestHelper from '../util/integration_test_helper';
 
 describe("NewEnrollmentDialog", () => {
   let helper;
-  const successActions = [
-    REQUEST_GET_PROGRAM_ENROLLMENTS,
-    RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
-    REQUEST_GET_USER_PROFILE,
-    RECEIVE_GET_USER_PROFILE_SUCCESS,
-    REQUEST_COURSE_PRICES,
-    RECEIVE_COURSE_PRICES_SUCCESS,
-    REQUEST_DASHBOARD,
-    RECEIVE_DASHBOARD_SUCCESS,
-  ];
   beforeEach(() => {
     helper = new IntegrationTestHelper();
   });
@@ -62,7 +39,7 @@ describe("NewEnrollmentDialog", () => {
   };
 
   it('renders a dialog', () => {
-    return helper.renderComponent("/dashboard", successActions).then(([wrapper]) => {
+    return helper.renderComponent("/dashboard", SUCCESS_ACTIONS).then(([wrapper]) => {
       let dialog = wrapper.find(NewEnrollmentDialog).at(0);
       let props = dialog.props();
 
@@ -77,7 +54,7 @@ describe("NewEnrollmentDialog", () => {
   ]) {
     it(`dispatches ${funcName}`, () => {
       let stub = helper.sandbox.spy(uiActions, funcName);
-      return helper.renderComponent("/dashboard", successActions).then(([wrapper]) => {
+      return helper.renderComponent("/dashboard", SUCCESS_ACTIONS).then(([wrapper]) => {
         let handler = wrapper.find(NewEnrollmentDialog).at(0).props()[funcName];
         handler(value);
         assert(stub.calledWith(value));
@@ -87,7 +64,7 @@ describe("NewEnrollmentDialog", () => {
     it(`the prop ${propName} comes from the state`, () => {
       helper.store.dispatch(uiActions[funcName](value));
 
-      return helper.renderComponent("/dashboard", successActions).then(([wrapper]) => {
+      return helper.renderComponent("/dashboard", SUCCESS_ACTIONS).then(([wrapper]) => {
         let actual = wrapper.find(NewEnrollmentDialog).at(0).props()[propName];
         assert.equal(actual, value);
       });
@@ -97,7 +74,7 @@ describe("NewEnrollmentDialog", () => {
   it('dispatches addProgramEnrollment', () => {
     let stub = helper.sandbox.stub(enrollmentActions, 'addProgramEnrollment');
     stub.returns({type: "fake"});
-    return helper.renderComponent("/dashboard", successActions).then(([wrapper]) => {
+    return helper.renderComponent("/dashboard", SUCCESS_ACTIONS).then(([wrapper]) => {
       let handler = wrapper.find(NewEnrollmentDialog).at(0).props().addProgramEnrollment;
       handler(3);
       assert(stub.calledWith(3));

--- a/static/js/components/NewEnrollmentDialog_test.js
+++ b/static/js/components/NewEnrollmentDialog_test.js
@@ -7,7 +7,21 @@ import { shallow } from 'enzyme';
 import Dialog from 'material-ui/Dialog';
 import SelectField from 'material-ui/SelectField';
 
+import {
+  REQUEST_DASHBOARD,
+  RECEIVE_DASHBOARD_SUCCESS,
+  REQUEST_COURSE_PRICES,
+  RECEIVE_COURSE_PRICES_SUCCESS,
+} from '../actions';
+import {
+  REQUEST_GET_USER_PROFILE,
+  RECEIVE_GET_USER_PROFILE_SUCCESS,
+} from '../actions/profile';
 import * as enrollmentActions from '../actions/programs';
+import {
+  REQUEST_GET_PROGRAM_ENROLLMENTS,
+  RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+} from '../actions/programs';
 import * as uiActions from '../actions/ui';
 
 import {
@@ -19,6 +33,16 @@ import IntegrationTestHelper from '../util/integration_test_helper';
 
 describe("NewEnrollmentDialog", () => {
   let helper;
+  const successActions = [
+    REQUEST_GET_PROGRAM_ENROLLMENTS,
+    RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+    REQUEST_GET_USER_PROFILE,
+    RECEIVE_GET_USER_PROFILE_SUCCESS,
+    REQUEST_COURSE_PRICES,
+    RECEIVE_COURSE_PRICES_SUCCESS,
+    REQUEST_DASHBOARD,
+    RECEIVE_DASHBOARD_SUCCESS,
+  ];
   beforeEach(() => {
     helper = new IntegrationTestHelper();
   });
@@ -38,7 +62,7 @@ describe("NewEnrollmentDialog", () => {
   };
 
   it('renders a dialog', () => {
-    return helper.renderComponent("/dashboard").then(([wrapper]) => {
+    return helper.renderComponent("/dashboard", successActions).then(([wrapper]) => {
       let dialog = wrapper.find(NewEnrollmentDialog).at(0);
       let props = dialog.props();
 
@@ -53,7 +77,7 @@ describe("NewEnrollmentDialog", () => {
   ]) {
     it(`dispatches ${funcName}`, () => {
       let stub = helper.sandbox.spy(uiActions, funcName);
-      return helper.renderComponent("/dashboard").then(([wrapper]) => {
+      return helper.renderComponent("/dashboard", successActions).then(([wrapper]) => {
         let handler = wrapper.find(NewEnrollmentDialog).at(0).props()[funcName];
         handler(value);
         assert(stub.calledWith(value));
@@ -63,7 +87,7 @@ describe("NewEnrollmentDialog", () => {
     it(`the prop ${propName} comes from the state`, () => {
       helper.store.dispatch(uiActions[funcName](value));
 
-      return helper.renderComponent("/dashboard").then(([wrapper]) => {
+      return helper.renderComponent("/dashboard", successActions).then(([wrapper]) => {
         let actual = wrapper.find(NewEnrollmentDialog).at(0).props()[propName];
         assert.equal(actual, value);
       });
@@ -73,7 +97,7 @@ describe("NewEnrollmentDialog", () => {
   it('dispatches addProgramEnrollment', () => {
     let stub = helper.sandbox.stub(enrollmentActions, 'addProgramEnrollment');
     stub.returns({type: "fake"});
-    return helper.renderComponent("/dashboard").then(([wrapper]) => {
+    return helper.renderComponent("/dashboard", successActions).then(([wrapper]) => {
       let handler = wrapper.find(NewEnrollmentDialog).at(0).props().addProgramEnrollment;
       handler(3);
       assert(stub.calledWith(3));

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -15,10 +15,6 @@ import Toast from '../components/Toast';
 import {
   FETCH_SUCCESS,
   FETCH_FAILURE,
-  fetchDashboard,
-  clearDashboard,
-  fetchCoursePrices,
-  clearCoursePrices,
 } from '../actions';
 import {
   fetchUserProfile,
@@ -44,7 +40,6 @@ import {
   setProgram,
 } from '../actions/ui';
 import { validateProfileComplete } from '../lib/validation/profile';
-import type { DashboardState, CoursePricesState } from '../flow/dashboardTypes';
 import type {
   AvailableProgram,
   AvailableProgramsState,
@@ -62,8 +57,6 @@ class App extends React.Component {
     location:                 Object,
     currentProgramEnrollment: AvailableProgram,
     dispatch:                 Dispatch,
-    dashboard:                DashboardState,
-    prices:                   CoursePricesState,
     programs:                 AvailableProgramsState,
     history:                  Object,
     ui:                       UIState,
@@ -78,8 +71,6 @@ class App extends React.Component {
     if (SETTINGS.user) {
       this.fetchUserProfile(SETTINGS.user.username);
     }
-    this.fetchDashboard();
-    this.fetchCoursePrices();
     this.fetchEnrollments();
     this.requireProfileFilledOut();
     this.requireCompleteProfile();
@@ -97,8 +88,6 @@ class App extends React.Component {
     const { dispatch } = this.props;
     const username = SETTINGS.user ? SETTINGS.user.username : null;
     dispatch(clearProfile(username));
-    dispatch(clearDashboard());
-    dispatch(clearCoursePrices());
     dispatch(clearUI());
     dispatch(clearEnrollments());
   }
@@ -111,20 +100,6 @@ class App extends React.Component {
           dispatch(startProfileEdit(SETTINGS.username));
         }
       });
-    }
-  }
-
-  fetchDashboard() {
-    const { dashboard, dispatch } = this.props;
-    if (dashboard.fetchStatus === undefined) {
-      dispatch(fetchDashboard());
-    }
-  }
-
-  fetchCoursePrices() {
-    const { prices, dispatch } = this.props;
-    if (prices.fetchStatus === undefined) {
-      dispatch(fetchCoursePrices());
     }
   }
 
@@ -302,8 +277,6 @@ const mapStateToProps = (state) => {
   }
   return {
     userProfile:              profile,
-    dashboard:                state.dashboard,
-    prices:                   state.prices,
     ui:                       state.ui,
     currentProgramEnrollment: state.currentProgramEnrollment,
     programs:                 state.programs,

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -39,30 +39,29 @@ import {
 } from '../constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
 
+export const SUCCESS_ACTIONS = [
+  REQUEST_GET_PROGRAM_ENROLLMENTS,
+  RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+  REQUEST_GET_USER_PROFILE,
+  RECEIVE_GET_USER_PROFILE_SUCCESS,
+];
+const EDIT_PROFILE_ACTIONS = SUCCESS_ACTIONS.concat([
+  START_PROFILE_EDIT,
+  START_PROFILE_EDIT,
+  UPDATE_PROFILE_VALIDATION,
+  SET_PROFILE_STEP,
+]);
+const REDIRECT_ACTIONS = SUCCESS_ACTIONS.concat([
+  START_PROFILE_EDIT
+]);
+
 describe('App', () => {
   let listenForActions, renderComponent, helper;
-  let editProfileActions, redirectActions;
 
   beforeEach(() => {
     helper = new IntegrationTestHelper();
     listenForActions = helper.listenForActions.bind(helper);
     renderComponent = helper.renderComponent.bind(helper);
-
-    const successActions = [
-      REQUEST_GET_PROGRAM_ENROLLMENTS,
-      RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
-      REQUEST_GET_USER_PROFILE,
-      RECEIVE_GET_USER_PROFILE_SUCCESS,
-    ];
-    editProfileActions = successActions.concat([
-      START_PROFILE_EDIT,
-      START_PROFILE_EDIT,
-      UPDATE_PROFILE_VALIDATION,
-      SET_PROFILE_STEP,
-    ]);
-    redirectActions = successActions.concat([
-      START_PROFILE_EDIT,
-    ]);
   });
 
   afterEach(() => {
@@ -90,7 +89,7 @@ describe('App', () => {
       });
       helper.profileGetStub.returns(Promise.resolve(response));
 
-      return renderComponent('/', editProfileActions).then(() => {
+      return renderComponent('/', EDIT_PROFILE_ACTIONS).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile");
         assert.equal(checkStep(), PERSONAL_STEP);
       });
@@ -102,7 +101,7 @@ describe('App', () => {
       });
       helper.profileGetStub.returns(Promise.resolve(response));
 
-      return renderComponent('/', redirectActions).then(() => {
+      return renderComponent('/', REDIRECT_ACTIONS).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile");
         assert.equal(checkStep(), PERSONAL_STEP);
       });
@@ -113,7 +112,7 @@ describe('App', () => {
       profile.work_history[1].city = "";
 
       helper.profileGetStub.returns(Promise.resolve(profile));
-      return renderComponent('/', editProfileActions).then(() => {
+      return renderComponent('/', EDIT_PROFILE_ACTIONS).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile");
         assert.equal(checkStep(), EMPLOYMENT_STEP);
       });
@@ -124,7 +123,7 @@ describe('App', () => {
       response.education[0].school_name = '';
       helper.profileGetStub.returns(Promise.resolve(response));
 
-      return renderComponent('/', editProfileActions).then(() => {
+      return renderComponent('/', EDIT_PROFILE_ACTIONS).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile");
         assert.equal(checkStep(), EDUCATION_STEP);
       });

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -7,12 +7,13 @@ import _ from 'lodash';
 
 import Navbar from '../components/Navbar';
 import {
-  CLEAR_DASHBOARD,
-  CLEAR_COURSE_PRICES,
+  REQUEST_DASHBOARD,
   RECEIVE_DASHBOARD_SUCCESS,
+  REQUEST_COURSE_PRICES,
   RECEIVE_COURSE_PRICES_SUCCESS,
 } from '../actions';
 import {
+  REQUEST_GET_USER_PROFILE,
   RECEIVE_GET_USER_PROFILE_SUCCESS,
   CLEAR_PROFILE,
   START_PROFILE_EDIT,
@@ -20,6 +21,8 @@ import {
 } from '../actions/profile';
 import {
   CLEAR_ENROLLMENTS,
+  REQUEST_GET_PROGRAM_ENROLLMENTS,
+  RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
   RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE,
 } from '../actions/programs';
 import * as enrollmentActions from '../actions/programs';
@@ -38,29 +41,37 @@ import IntegrationTestHelper from '../util/integration_test_helper';
 
 describe('App', () => {
   let listenForActions, renderComponent, helper;
-  let editProfileActions;
+  let editProfileActions, redirectActions;
 
   beforeEach(() => {
     helper = new IntegrationTestHelper();
     listenForActions = helper.listenForActions.bind(helper);
     renderComponent = helper.renderComponent.bind(helper);
-    editProfileActions = [
+
+    const successActions = [
+      REQUEST_GET_PROGRAM_ENROLLMENTS,
+      RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+      REQUEST_GET_USER_PROFILE,
+      RECEIVE_GET_USER_PROFILE_SUCCESS,
+    ];
+    editProfileActions = successActions.concat([
       START_PROFILE_EDIT,
       START_PROFILE_EDIT,
       UPDATE_PROFILE_VALIDATION,
       SET_PROFILE_STEP,
-    ];
+    ]);
+    redirectActions = successActions.concat([
+      START_PROFILE_EDIT,
+    ]);
   });
 
   afterEach(() => {
     helper.cleanup();
   });
 
-  it('clears profile, ui, enrollments, and dashboard after unmounting', () => {
-    return renderComponent("/dashboard").then(([, div]) => {
+  it('clears profile, ui, and enrollments after unmounting', () => {
+    return renderComponent('/').then(([, div]) => {
       return listenForActions([
-        CLEAR_DASHBOARD,
-        CLEAR_COURSE_PRICES,
         CLEAR_PROFILE,
         CLEAR_UI,
         CLEAR_ENROLLMENTS
@@ -69,6 +80,7 @@ describe('App', () => {
       });
     });
   });
+
   describe('profile completeness', () => {
     let checkStep = () => helper.store.getState().ui.profileStep;
 
@@ -78,7 +90,7 @@ describe('App', () => {
       });
       helper.profileGetStub.returns(Promise.resolve(response));
 
-      return renderComponent("/dashboard", editProfileActions).then(() => {
+      return renderComponent('/', editProfileActions).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile");
         assert.equal(checkStep(), PERSONAL_STEP);
       });
@@ -90,7 +102,7 @@ describe('App', () => {
       });
       helper.profileGetStub.returns(Promise.resolve(response));
 
-      return renderComponent("/dashboard", [START_PROFILE_EDIT]).then(() => {
+      return renderComponent('/', redirectActions).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile");
         assert.equal(checkStep(), PERSONAL_STEP);
       });
@@ -101,7 +113,7 @@ describe('App', () => {
       profile.work_history[1].city = "";
 
       helper.profileGetStub.returns(Promise.resolve(profile));
-      return renderComponent("/dashboard", editProfileActions).then(() => {
+      return renderComponent('/', editProfileActions).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile");
         assert.equal(checkStep(), EMPLOYMENT_STEP);
       });
@@ -112,7 +124,7 @@ describe('App', () => {
       response.education[0].school_name = '';
       helper.profileGetStub.returns(Promise.resolve(response));
 
-      return renderComponent("/dashboard", editProfileActions).then(() => {
+      return renderComponent('/', editProfileActions).then(() => {
         assert.equal(helper.currentLocation.pathname, "/profile");
         assert.equal(checkStep(), EDUCATION_STEP);
       });
@@ -123,19 +135,23 @@ describe('App', () => {
     it('shows an error message if the enrollments GET fetch fails', () => {
       helper.programsGetStub.returns(Promise.reject());
       let types = [
+        REQUEST_DASHBOARD,
         RECEIVE_DASHBOARD_SUCCESS,
+        REQUEST_COURSE_PRICES,
         RECEIVE_COURSE_PRICES_SUCCESS,
+        REQUEST_GET_USER_PROFILE,
         RECEIVE_GET_USER_PROFILE_SUCCESS,
+        REQUEST_GET_PROGRAM_ENROLLMENTS,
         RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE,
       ];
-      return renderComponent("/dashboard", types, false).then(([wrapper]) => {
+      return renderComponent('/dashboard', types).then(([wrapper]) => {
         let text = wrapper.find('.page-content').text();
         assert(text.includes("Sorry, we were unable to load the data"));
       });
     });
 
     it('setEnrollDialogVisibility dispatches the value to the action with the same name', () => {
-      return renderComponent("/dashboard").then(([wrapper]) => {
+      return renderComponent('/').then(([wrapper]) => {
         let props = wrapper.find(Navbar).props();
         let stub = helper.sandbox.stub(uiActions, 'setEnrollDialogVisibility');
         stub.returns({type: "fake"});
@@ -145,7 +161,7 @@ describe('App', () => {
     });
 
     it('setEnrollSelectedProgram dispatches the value to the action with the same name', () => {
-      return renderComponent("/dashboard").then(([wrapper]) => {
+      return renderComponent('/').then(([wrapper]) => {
         let props = wrapper.find(Navbar).props();
         let stub = helper.sandbox.stub(uiActions, 'setEnrollSelectedProgram');
         stub.returns({type: "fake"});
@@ -155,7 +171,7 @@ describe('App', () => {
     });
 
     it('setCurrentProgramEnrollment dispatches the value to the action with the same name', () => {
-      return renderComponent("/dashboard").then(([wrapper]) => {
+      return renderComponent('/').then(([wrapper]) => {
         let props = wrapper.find(Navbar).props();
         let stub = helper.sandbox.stub(enrollmentActions, 'setCurrentProgramEnrollment');
         stub.returns({type: "fake"});

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -12,6 +12,9 @@ import {
   checkout,
   updateCourseStatus,
   fetchDashboard,
+  clearDashboard,
+  fetchCoursePrices,
+  clearCoursePrices,
 } from '../actions';
 import {
   TOAST_SUCCESS,
@@ -77,11 +80,17 @@ class DashboardPage extends React.Component {
   };
 
   componentDidMount() {
-    this.handleOrderStatus();
+    this.updateRequirements();
   }
 
   componentDidUpdate() {
-    this.handleOrderStatus();
+    this.updateRequirements();
+  }
+
+  componentWillUnmount() {
+    const { dispatch } = this.props;
+    dispatch(clearDashboard());
+    dispatch(clearCoursePrices());
   }
 
   handleOrderSuccess = (course: Course): void => {
@@ -125,6 +134,26 @@ class DashboardPage extends React.Component {
       dispatch(setTimeoutActive(true));
     }
   };
+
+  updateRequirements = () => {
+    this.fetchDashboard();
+    this.fetchCoursePrices();
+    this.handleOrderStatus();
+  };
+
+  fetchDashboard() {
+    const { dashboard, dispatch } = this.props;
+    if (dashboard.fetchStatus === undefined) {
+      dispatch(fetchDashboard());
+    }
+  }
+
+  fetchCoursePrices() {
+    const { prices, dispatch } = this.props;
+    if (prices.fetchStatus === undefined) {
+      dispatch(fetchCoursePrices());
+    }
+  }
 
   handleOrderStatus = () => {
     const { dashboard, location: { query } } = this.props;

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -3,21 +3,38 @@ import '../global_init';
 
 import { assert } from 'chai';
 import moment from 'moment';
+import ReactDOM from 'react-dom';
 
 import CourseAction from '../components/dashboard/CourseAction';
 import IntegrationTestHelper from '../util/integration_test_helper';
 import {
   REQUEST_DASHBOARD,
+  RECEIVE_DASHBOARD_SUCCESS,
+  REQUEST_COURSE_PRICES,
+  RECEIVE_COURSE_PRICES_SUCCESS,
   UPDATE_COURSE_STATUS,
+  CLEAR_COURSE_PRICES,
+  CLEAR_DASHBOARD,
 } from '../actions';
 import * as actions from '../actions';
 import {
   SET_TOAST_MESSAGE,
+  CLEAR_UI,
 } from '../actions/ui';
 import {
   SET_TIMEOUT_ACTIVE,
   setInitialTime,
 } from '../actions/order_receipt';
+import {
+  REQUEST_GET_USER_PROFILE,
+  RECEIVE_GET_USER_PROFILE_SUCCESS,
+  CLEAR_PROFILE,
+} from '../actions/profile';
+import {
+  REQUEST_GET_PROGRAM_ENROLLMENTS,
+  RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+  CLEAR_ENROLLMENTS,
+} from '../actions/programs';
 import { findCourseRun } from '../util/util';
 import * as util from '../util/util';
 import {
@@ -35,6 +52,17 @@ import { findCourse } from '../util/test_utils';
 describe('DashboardPage', () => {
   let renderComponent, helper;
 
+  const dashboardSuccessActions = [
+    REQUEST_DASHBOARD,
+    RECEIVE_DASHBOARD_SUCCESS,
+    REQUEST_COURSE_PRICES,
+    RECEIVE_COURSE_PRICES_SUCCESS,
+    REQUEST_GET_USER_PROFILE,
+    RECEIVE_GET_USER_PROFILE_SUCCESS,
+    REQUEST_GET_PROGRAM_ENROLLMENTS,
+    RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+  ];
+
   beforeEach(() => {
     helper = new IntegrationTestHelper();
     renderComponent = helper.renderComponent.bind(helper);
@@ -45,7 +73,7 @@ describe('DashboardPage', () => {
   });
 
   it('shows a spinner when dashboard get is processing', () => {
-    return renderComponent('/dashboard').then(([, div]) => {
+    return renderComponent('/dashboard', dashboardSuccessActions).then(([, div]) => {
       assert.notOk(div.querySelector(".loader"), "Found spinner but no fetch in progress");
       helper.store.dispatch({ type: REQUEST_DASHBOARD, payload: { noSpinner: false } });
 
@@ -54,7 +82,7 @@ describe('DashboardPage', () => {
   });
 
   it('has all the cards we expect', () => {
-    return renderComponent('/dashboard').then(([wrapper]) => {
+    return renderComponent('/dashboard', dashboardSuccessActions).then(([wrapper]) => {
       assert.lengthOf(wrapper.find(".dashboard-user-card"), 1);
       assert.lengthOf(wrapper.find(".course-list"), 1);
       assert.lengthOf(wrapper.find(".progress-widget"), 1);
@@ -76,7 +104,7 @@ describe('DashboardPage', () => {
       let promise = Promise.resolve(EDX_CHECKOUT_RESPONSE);
       let checkoutStub = helper.sandbox.stub(actions, 'checkout').returns(() => promise);
 
-      return renderComponent('/dashboard').then(([wrapper]) => {
+      return renderComponent('/dashboard', dashboardSuccessActions).then(([wrapper]) => {
         wrapper.find(CourseAction).first().props().checkout('course_id');
 
         assert.equal(checkoutStub.callCount, 1);
@@ -97,7 +125,7 @@ describe('DashboardPage', () => {
       fakeForm.submit = submitStub;
       let createFormStub = helper.sandbox.stub(util, 'createForm').returns(fakeForm);
 
-      return renderComponent('/dashboard').then(([wrapper]) => {
+      return renderComponent('/dashboard', dashboardSuccessActions).then(([wrapper]) => {
         wrapper.find(CourseAction).first().props().checkout('course_id');
 
         assert.equal(checkoutStub.callCount, 1);
@@ -117,8 +145,14 @@ describe('DashboardPage', () => {
   });
 
   describe('order receipt and cancellation pages', () => {
+    const successWithToastActions = dashboardSuccessActions.concat([SET_TOAST_MESSAGE]);
+    const successWithTimeoutActions = dashboardSuccessActions.concat([
+      SET_TIMEOUT_ACTIVE,
+      UPDATE_COURSE_STATUS,
+    ]);
+
     it('shows the order status toast when the query param is set for a cancellation', () => {
-      return renderComponent('/dashboard?status=cancel', [SET_TOAST_MESSAGE]).then(() => {
+      return renderComponent('/dashboard?status=cancel', successWithToastActions).then(() => {
         assert.deepEqual(helper.store.getState().ui.toastMessage, {
           message: "Order was cancelled",
           icon: TOAST_FAILURE
@@ -133,7 +167,10 @@ describe('DashboardPage', () => {
       );
       let run = course.runs[0];
       let encodedKey = encodeURIComponent(run.course_id);
-      return renderComponent(`/dashboard?status=receipt&course_key=${encodedKey}`, [SET_TOAST_MESSAGE]).then(() => {
+      return renderComponent(
+        `/dashboard?status=receipt&course_key=${encodedKey}`,
+        successWithToastActions
+      ).then(() => {
         assert.deepEqual(helper.store.getState().ui.toastMessage, {
           title: "Order Complete!",
           message: `You are now enrolled in ${course.title}`,
@@ -149,9 +186,10 @@ describe('DashboardPage', () => {
       );
       let run = course.runs[0];
       let encodedKey = encodeURIComponent(run.course_id);
-      return renderComponent(`/dashboard?status=receipt&course_key=${encodedKey}`, [
-        UPDATE_COURSE_STATUS, SET_TIMEOUT_ACTIVE
-      ]).then(() => {
+      return renderComponent(
+        `/dashboard?status=receipt&course_key=${encodedKey}`,
+        successWithTimeoutActions
+      ).then(() => {
         let [ courseRun ] = findCourseRun(
           helper.store.getState().dashboard.programs,
           _run => _run.course_id === run.course_id
@@ -174,9 +212,10 @@ describe('DashboardPage', () => {
         );
         let run = course.runs[0];
         let encodedKey = encodeURIComponent(run.course_id);
-        return renderComponent(`/dashboard?status=receipt&course_key=${encodedKey}`, [
-          UPDATE_COURSE_STATUS, SET_TIMEOUT_ACTIVE
-        ]).then(() => {
+        return renderComponent(
+          `/dashboard?status=receipt&course_key=${encodedKey}`,
+          successWithTimeoutActions
+        ).then(() => {
           let fetchDashboardStub = helper.sandbox.stub(actions, 'fetchDashboard').returns(() => ({
             type: 'fake'
           }));
@@ -192,9 +231,10 @@ describe('DashboardPage', () => {
         );
         let run = course.runs[0];
         let encodedKey = encodeURIComponent(run.course_id);
-        return renderComponent(`/dashboard?status=receipt&course_key=${encodedKey}`, [
-          UPDATE_COURSE_STATUS, SET_TIMEOUT_ACTIVE
-        ]).then(() => {
+        return renderComponent(
+          `/dashboard?status=receipt&course_key=${encodedKey}`,
+          successWithTimeoutActions
+        ).then(() => {
           let future = moment().add(-35, 'seconds').toISOString();
           helper.store.dispatch(setInitialTime(future));
           clock.tick(3500);
@@ -203,6 +243,20 @@ describe('DashboardPage', () => {
             icon: TOAST_FAILURE
           });
         });
+      });
+    });
+  });
+
+  it('dispatches actions to clean up after unmounting', () => {
+    return renderComponent('/dashboard', dashboardSuccessActions).then(([, div]) => {
+      return helper.listenForActions([
+        CLEAR_PROFILE,
+        CLEAR_UI,
+        CLEAR_ENROLLMENTS,
+        CLEAR_DASHBOARD,
+        CLEAR_COURSE_PRICES,
+      ], () => {
+        ReactDOM.unmountComponentAtNode(div);
       });
     });
   });

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -23,14 +23,8 @@ import {
   RECEIVE_ADD_FINANCIAL_AID_FAILURE,
 } from '../actions/financial_aid';
 import {
-  REQUEST_GET_USER_PROFILE,
-  RECEIVE_GET_USER_PROFILE_SUCCESS,
-} from '../actions/profile';
-import {
   receiveGetProgramEnrollmentsSuccess,
   setCurrentProgramEnrollment,
-  REQUEST_GET_PROGRAM_ENROLLMENTS,
-  RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
 } from '../actions/programs';
 import {
   SET_CALCULATOR_DIALOG_VISIBILITY,
@@ -42,20 +36,10 @@ import {
   REQUEST_COURSE_PRICES,
   RECEIVE_COURSE_PRICES_SUCCESS,
 } from '../actions/index';
+import { DASHBOARD_SUCCESS_ACTIONS } from '../containers/DashboardPage_test';
 
 describe('FinancialAidCalculator', () => {
   let listenForActions, renderComponent, helper, addFinancialAidStub, skipFinancialAidStub;
-  const dashboardSuccessActions = [
-    REQUEST_DASHBOARD,
-    RECEIVE_DASHBOARD_SUCCESS,
-    REQUEST_COURSE_PRICES,
-    RECEIVE_COURSE_PRICES_SUCCESS,
-    REQUEST_GET_USER_PROFILE,
-    RECEIVE_GET_USER_PROFILE_SUCCESS,
-    REQUEST_GET_PROGRAM_ENROLLMENTS,
-    RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
-  ];
-
   let financialAidDashboard = _.clone(DASHBOARD_RESPONSE);
   let program = financialAidDashboard.find(program => (
     program.title === "Not passed program"
@@ -80,7 +64,7 @@ describe('FinancialAidCalculator', () => {
   });
 
   it('should let you open and close the financial aid calculator', () => {
-    return renderComponent('/dashboard', dashboardSuccessActions).then(([wrapper]) => {
+    return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
       wrapper.find('.pricing-actions').find('.dashboard-button').simulate('click');
       assert.equal(helper.store.getState().ui.calculatorDialogVisibility, true);
       let calculator = document.querySelector('.financial-aid-calculator');
@@ -92,7 +76,7 @@ describe('FinancialAidCalculator', () => {
 
   it('should let you skip and pay full price', () => {
     skipFinancialAidStub.returns(Promise.resolve(FINANCIAL_AID_PARTIAL_RESPONSE));
-    return renderComponent('/dashboard', dashboardSuccessActions).then(([wrapper]) => {
+    return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
       return listenForActions([
         START_CALCULATOR_EDIT,
         UPDATE_CALCULATOR_EDIT,
@@ -124,7 +108,7 @@ describe('FinancialAidCalculator', () => {
   });
 
   it('should let you enter your income', () => {
-    return renderComponent('/dashboard', dashboardSuccessActions).then(([wrapper]) => {
+    return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
       return listenForActions([
         START_CALCULATOR_EDIT,
         UPDATE_CALCULATOR_EDIT,
@@ -158,7 +142,7 @@ describe('FinancialAidCalculator', () => {
       assert.isNotNull(input.attributes.getNamedItem(reqdAttr));
     };
 
-    return renderComponent('/dashboard').then(([wrapper]) => {
+    return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
       return listenForActions([
         START_CALCULATOR_EDIT,
         UPDATE_CALCULATOR_EDIT,
@@ -184,7 +168,7 @@ describe('FinancialAidCalculator', () => {
   });
 
   it('should let you enter your preferred currency', () => {
-    return renderComponent('/dashboard', dashboardSuccessActions).then(([wrapper]) => {
+    return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
       return listenForActions([
         START_CALCULATOR_EDIT,
         UPDATE_CALCULATOR_EDIT,
@@ -214,7 +198,7 @@ describe('FinancialAidCalculator', () => {
 
   it('should let you submit a financial aid request', () => {
     addFinancialAidStub.returns(Promise.resolve(FINANCIAL_AID_PARTIAL_RESPONSE));
-    return renderComponent('/dashboard', dashboardSuccessActions).then(([wrapper]) => {
+    return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
       return listenForActions([
         START_CALCULATOR_EDIT,
         UPDATE_CALCULATOR_EDIT,
@@ -250,7 +234,7 @@ describe('FinancialAidCalculator', () => {
       '0': 'an error message',
       errorStatusCode: 500
     }));
-    return renderComponent('/dashboard').then(([wrapper]) => {
+    return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
       return listenForActions([
         START_CALCULATOR_EDIT,
         UPDATE_CALCULATOR_EDIT,

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -23,8 +23,14 @@ import {
   RECEIVE_ADD_FINANCIAL_AID_FAILURE,
 } from '../actions/financial_aid';
 import {
+  REQUEST_GET_USER_PROFILE,
+  RECEIVE_GET_USER_PROFILE_SUCCESS,
+} from '../actions/profile';
+import {
   receiveGetProgramEnrollmentsSuccess,
   setCurrentProgramEnrollment,
+  REQUEST_GET_PROGRAM_ENROLLMENTS,
+  RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
 } from '../actions/programs';
 import {
   SET_CALCULATOR_DIALOG_VISIBILITY,
@@ -39,6 +45,16 @@ import {
 
 describe('FinancialAidCalculator', () => {
   let listenForActions, renderComponent, helper, addFinancialAidStub, skipFinancialAidStub;
+  const dashboardSuccessActions = [
+    REQUEST_DASHBOARD,
+    RECEIVE_DASHBOARD_SUCCESS,
+    REQUEST_COURSE_PRICES,
+    RECEIVE_COURSE_PRICES_SUCCESS,
+    REQUEST_GET_USER_PROFILE,
+    RECEIVE_GET_USER_PROFILE_SUCCESS,
+    REQUEST_GET_PROGRAM_ENROLLMENTS,
+    RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+  ];
 
   let financialAidDashboard = _.clone(DASHBOARD_RESPONSE);
   let program = financialAidDashboard.find(program => (
@@ -64,7 +80,7 @@ describe('FinancialAidCalculator', () => {
   });
 
   it('should let you open and close the financial aid calculator', () => {
-    return renderComponent('/dashboard').then(([wrapper]) => {
+    return renderComponent('/dashboard', dashboardSuccessActions).then(([wrapper]) => {
       wrapper.find('.pricing-actions').find('.dashboard-button').simulate('click');
       assert.equal(helper.store.getState().ui.calculatorDialogVisibility, true);
       let calculator = document.querySelector('.financial-aid-calculator');
@@ -76,7 +92,7 @@ describe('FinancialAidCalculator', () => {
 
   it('should let you skip and pay full price', () => {
     skipFinancialAidStub.returns(Promise.resolve(FINANCIAL_AID_PARTIAL_RESPONSE));
-    return renderComponent('/dashboard').then(([wrapper]) => {
+    return renderComponent('/dashboard', dashboardSuccessActions).then(([wrapper]) => {
       return listenForActions([
         START_CALCULATOR_EDIT,
         UPDATE_CALCULATOR_EDIT,
@@ -108,7 +124,7 @@ describe('FinancialAidCalculator', () => {
   });
 
   it('should let you enter your income', () => {
-    return renderComponent('/dashboard').then(([wrapper]) => {
+    return renderComponent('/dashboard', dashboardSuccessActions).then(([wrapper]) => {
       return listenForActions([
         START_CALCULATOR_EDIT,
         UPDATE_CALCULATOR_EDIT,
@@ -168,7 +184,7 @@ describe('FinancialAidCalculator', () => {
   });
 
   it('should let you enter your preferred currency', () => {
-    return renderComponent('/dashboard').then(([wrapper]) => {
+    return renderComponent('/dashboard', dashboardSuccessActions).then(([wrapper]) => {
       return listenForActions([
         START_CALCULATOR_EDIT,
         UPDATE_CALCULATOR_EDIT,
@@ -198,7 +214,7 @@ describe('FinancialAidCalculator', () => {
 
   it('should let you submit a financial aid request', () => {
     addFinancialAidStub.returns(Promise.resolve(FINANCIAL_AID_PARTIAL_RESPONSE));
-    return renderComponent('/dashboard').then(([wrapper]) => {
+    return renderComponent('/dashboard', dashboardSuccessActions).then(([wrapper]) => {
       return listenForActions([
         START_CALCULATOR_EDIT,
         UPDATE_CALCULATOR_EDIT,

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -6,9 +6,12 @@ import _ from 'lodash';
 import {
   REQUEST_ADD_PROGRAM_ENROLLMENT,
   RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS,
+  REQUEST_GET_PROGRAM_ENROLLMENTS,
+  RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
 } from '../actions/programs';
 import {
   REQUEST_GET_USER_PROFILE,
+  RECEIVE_GET_USER_PROFILE_SUCCESS,
   REQUEST_PATCH_USER_PROFILE,
   RECEIVE_PATCH_USER_PROFILE_SUCCESS,
   START_PROFILE_EDIT,
@@ -43,6 +46,14 @@ describe("ProfilePage", function() {
   ];
   let prevButtonSelector = '.prev';
   let nextButtonSelector = '.next';
+
+  const successActions = [
+    REQUEST_GET_USER_PROFILE,
+    RECEIVE_GET_USER_PROFILE_SUCCESS,
+    REQUEST_GET_PROGRAM_ENROLLMENTS,
+    RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+    START_PROFILE_EDIT,
+  ];
 
   const setStep = step => helper.store.dispatch(setProfileStep(step));
 
@@ -106,7 +117,7 @@ describe("ProfilePage", function() {
         activeDialog('education-dialog-wrapper');
       };
       setStep(EDUCATION_STEP);
-      return renderComponent('/profile', [START_PROFILE_EDIT]).then(dialogTest);
+      return renderComponent('/profile', successActions).then(dialogTest);
     });
 
     it('should launch a dialog to add an entry when an employment switch is set to Yes', () => {
@@ -116,14 +127,14 @@ describe("ProfilePage", function() {
         activeDialog('employment-dialog-wrapper');
       };
       setStep(EMPLOYMENT_STEP);
-      return renderComponent('/profile', [START_PROFILE_EDIT]).then(dialogTest);
+      return renderComponent('/profile', successActions).then(dialogTest);
     });
   });
 
   it('navigates backward when Previous button is clicked', () => {
     setStep(EDUCATION_STEP);
     const checkStep = () => helper.store.getState().ui.profileStep;
-    return renderComponent('/profile', [START_PROFILE_EDIT]).then(([, div]) => {
+    return renderComponent('/profile', successActions).then(([, div]) => {
       let button = div.querySelector(prevButtonSelector);
       assert.equal(checkStep(), EDUCATION_STEP);
       TestUtils.Simulate.click(button);
@@ -141,7 +152,7 @@ describe("ProfilePage", function() {
           education: []
         });
         helper.profileGetStub.returns(Promise.resolve(updatedProfile));
-        return renderComponent('/profile', [START_PROFILE_EDIT]).then(([, div]) => {
+        return renderComponent('/profile', successActions).then(([, div]) => {
           // close all switches
           if (`${step}` === 'personal') {
             return confirmSaveButtonBehavior(updatedProfile, {div: div}, true);
@@ -153,7 +164,7 @@ describe("ProfilePage", function() {
   }
 
   it('shows a spinner when profile get is processing', () => {
-    return renderComponent('/profile', [START_PROFILE_EDIT]).then(([, div]) => {
+    return renderComponent('/profile', successActions).then(([, div]) => {
       assert.notOk(div.querySelector(".loader"), "Found spinner but no fetch in progress");
       helper.store.dispatch({
         type: REQUEST_GET_USER_PROFILE,
@@ -174,7 +185,7 @@ describe("ProfilePage", function() {
     patchUserProfileStub.returns(Promise.resolve(USER_PROFILE_RESPONSE));
 
     helper.store.dispatch(setProgram(program));
-    return renderComponent(`/profile`, [START_PROFILE_EDIT]).then(([wrapper]) => {
+    return renderComponent(`/profile`, successActions).then(([wrapper]) => {
       assert.isFalse(addEnrollmentStub.called);
 
       return helper.listenForActions([
@@ -202,7 +213,7 @@ describe("ProfilePage", function() {
   ]) {
     it(`sends the right props to tab components for step ${step}`, () => {
       setStep(step);
-      return renderComponent('/profile', [START_PROFILE_EDIT]).then(([wrapper]) => {
+      return renderComponent('/profile', successActions).then(([wrapper]) => {
         let props = wrapper.find(component).props();
         assert.deepEqual(props['ui'], helper.store.getState().ui);
         assert.deepEqual(props['programs'], helper.store.getState().programs.availablePrograms);

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -68,12 +68,13 @@ describe("ProfilePage", function() {
     helper.cleanup();
   });
 
-  let confirmSaveButtonBehavior = (updatedProfile, pageElements, validationFailure=false, actions = []) => {
+  let confirmSaveButtonBehavior = (updatedProfile, pageElements, validationFailure=false) => {
     let { div, button } = pageElements;
     button = button || div.querySelector(nextButtonSelector);
     patchUserProfileStub.throws("Invalid arguments");
     patchUserProfileStub.withArgs(SETTINGS.user.username, updatedProfile).returns(Promise.resolve(updatedProfile));
 
+    let actions = [];
     if ( actions.length === 0 ) {
       if (!validationFailure) {
         actions.push(

--- a/static/js/containers/SettingsPage_test.js
+++ b/static/js/containers/SettingsPage_test.js
@@ -5,6 +5,14 @@ import { assert } from 'chai';
 import _ from 'lodash';
 
 import {
+  REQUEST_GET_USER_PROFILE,
+  RECEIVE_GET_USER_PROFILE_SUCCESS,
+} from '../actions/profile';
+import {
+  REQUEST_GET_PROGRAM_ENROLLMENTS,
+  RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+} from '../actions/programs';
+import {
   START_PROFILE_EDIT,
   UPDATE_PROFILE_VALIDATION,
   REQUEST_PATCH_USER_PROFILE,
@@ -22,7 +30,13 @@ describe("SettingsPage", function() {
   this.timeout(5000);
   let nextButtonSelector = '.next';
   let listenForActions, renderComponent, helper, patchUserProfileStub;
-  let userActions = [START_PROFILE_EDIT];
+  let userActions = [
+    REQUEST_GET_PROGRAM_ENROLLMENTS,
+    RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+    REQUEST_GET_USER_PROFILE,
+    RECEIVE_GET_USER_PROFILE_SUCCESS,
+    START_PROFILE_EDIT,
+  ];
 
   beforeEach(() => {
     helper = new IntegrationTestHelper();

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -20,6 +20,10 @@ import {
   updateProfile,
 } from '../actions/profile';
 import {
+  REQUEST_GET_PROGRAM_ENROLLMENTS,
+  RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+} from '../actions/programs';
+import {
   SET_WORK_DIALOG_VISIBILITY,
   SET_WORK_DIALOG_INDEX,
   SET_EDUCATION_DEGREE_LEVEL,
@@ -50,7 +54,14 @@ describe("UserPage", function() {
   this.timeout(10000);
 
   let listenForActions, renderComponent, helper, patchUserProfileStub;
-  let userActions = [RECEIVE_GET_USER_PROFILE_SUCCESS, REQUEST_GET_USER_PROFILE];
+  let userActions = [
+    REQUEST_GET_PROGRAM_ENROLLMENTS,
+    RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+    REQUEST_GET_USER_PROFILE,
+    RECEIVE_GET_USER_PROFILE_SUCCESS,
+    REQUEST_GET_USER_PROFILE,
+    RECEIVE_GET_USER_PROFILE_SUCCESS,
+  ];
 
   const confirmResumeOrder = (
     editButton,

--- a/static/js/flow/reduxTypes.js
+++ b/static/js/flow/reduxTypes.js
@@ -1,8 +1,13 @@
 // @flow
-import type { Dispatch, State } from 'redux';
+import type {
+  Dispatch,
+  Reducer,
+  State,
+} from 'redux';
 
+export type ActionType = string;
 export type Action = {
-  type: string;
+  type: ActionType;
   payload: any
 };
 
@@ -17,3 +22,10 @@ export type AsyncActionCreator<T> = (...a: any) => Dispatcher<T>;
 export type AssertReducerResultState<T> = (
   actionFunc: () => Action, stateFunc: ((reducerState: State) => T), defaultValue: any
 ) => void;
+
+export type TestStore = {
+  dispatch: Dispatch,
+  getState: () => State,
+  subscribe: (listener: () => void) => () => void,
+  replaceReducer: (reducer: Reducer<any, any>) => void,
+};

--- a/static/js/flow/sinonTypes.js
+++ b/static/js/flow/sinonTypes.js
@@ -1,0 +1,4 @@
+export type Sandbox = {
+
+};
+

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -13,12 +13,6 @@ import {
   USER_PROFILE_RESPONSE,
 } from '../constants';
 import {
-  REQUEST_DASHBOARD,
-  RECEIVE_DASHBOARD_SUCCESS,
-  REQUEST_COURSE_PRICES,
-  RECEIVE_COURSE_PRICES_SUCCESS,
-} from '../actions';
-import {
   REQUEST_GET_USER_PROFILE,
   RECEIVE_GET_USER_PROFILE_SUCCESS,
 } from '../actions/profile';
@@ -30,8 +24,17 @@ import rootReducer from '../reducers';
 import { makeDashboardRoutes } from '../dashboard_routes';
 import { localStorageMock } from '../util/test_utils';
 import { configureMainTestStore } from '../store/configureStore';
+import type { Action } from '../flow/reduxTypes';
+import type { TestStore } from '../flow/reduxTypes';
+import type { Sandbox } from '../flow/sinonTypes';
 
-class IntegrationTestHelper {
+export default class IntegrationTestHelper {
+  listenForActions: (a: Array<string>, f: Function) => Promise<*>;
+  dispatchThen: (a: Action) => Promise<*>;
+  sandbox: Sandbox;
+  store: TestStore;
+  browserHistory: History;
+
   constructor() {
     if ( ! window.localStorage ) {
       window.localStorage = localStorageMock();
@@ -71,25 +74,25 @@ class IntegrationTestHelper {
     window.localStorage.reset();
   }
 
-  renderComponent(url = "/", extraTypesToAssert = [], isSuccessExpected = true) {
-    let expectedTypes = [
-      REQUEST_DASHBOARD,
-      REQUEST_COURSE_PRICES,
-      REQUEST_GET_USER_PROFILE,
-      REQUEST_GET_PROGRAM_ENROLLMENTS,
-    ];
-    let expectedSuccessTypes = [
-      RECEIVE_DASHBOARD_SUCCESS,
-      RECEIVE_GET_USER_PROFILE_SUCCESS,
-      RECEIVE_COURSE_PRICES_SUCCESS,
-      RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
-    ];
-
-    // if the success is expected  update the list with the success types
-    if (isSuccessExpected) {
-      expectedTypes.push(...expectedSuccessTypes);
+  /**
+   * Renders the components using the given URL.
+   * @param url {String} The react-router URL
+   * @param typesToAssert {Array<String>|null} A list of redux actions to listen for.
+   * If null, actions types for the success case is assumed.
+   * @returns {Promise<*>} A promise which provides [wrapper, div] on success
+   */
+  renderComponent(url: string = "/", typesToAssert: Array<string>|null = null): Promise<*> {
+    let expectedTypes = [];
+    if (typesToAssert === null) {
+      expectedTypes = [
+        REQUEST_GET_USER_PROFILE,
+        REQUEST_GET_PROGRAM_ENROLLMENTS,
+        RECEIVE_GET_USER_PROFILE_SUCCESS,
+        RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+      ];
+    } else {
+      expectedTypes = typesToAssert;
     }
-    expectedTypes.push(...extraTypesToAssert);
 
     let wrapper, div;
 
@@ -109,5 +112,3 @@ class IntegrationTestHelper {
     });
   }
 }
-
-export default IntegrationTestHelper;


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1655

#### What's this PR do?
Delays loading the dashboard API until the user looks at the dashboard page. The user will load the dashboard API when they click next and enroll in a program, but this shouldn't block anything on their end.

#### How should this be manually tested?
Load `/profile` and verify that no request to `/api/v0/dashboard/` is loaded and that the user still sees programs they can enroll in.

Also, go to `/settings` and refresh the browser. Verify that `/api/v0/dashboard/` is not loaded. Then click the logo on the upper left to direct you to the dashboard. Verify that the dashboard loaded properly.