### PR TITLE
make sure that the JS bundles are included on the page everywhere we

### DIFF
--- a/ui/views.py
+++ b/ui/views.py
@@ -137,6 +137,8 @@ def standard_error_page(request, status_code, template_filename):
             "dashboard_src": get_bundle_url(request, "dashboard.js"),
             "common_src": get_bundle_url(request, "common.js"),
             "sentry_client": get_bundle_url(request, "sentry_client.js"),
+            "style_public_src": get_bundle_url(request, "style_public.js"),
+            "public_src": get_bundle_url(request, "public.js"),
             "js_settings_json": json.dumps({
                 "release_version": settings.VERSION,
                 "environment": settings.ENVIRONMENT,
@@ -166,6 +168,8 @@ def terms_of_service(request):
             "zendesk_widget": get_bundle_url(request, "zendesk_widget.js"),
             "style_src": get_bundle_url(request, "style.js"),
             "common_src": get_bundle_url(request, "common.js"),
+            "public_src": get_bundle_url(request, "public.js"),
+            "style_public_src": get_bundle_url(request, "style_public.js"),
             "sentry_client": get_bundle_url(request, "sentry_client.js"),
             "js_settings_json": json.dumps({
                 "release_version": settings.VERSION,


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1749 

#### What's this PR do?

When I merged #1719 I didn't get things correct on the ToS page - should have been including the `style_public` and `public` bundles there.

#### How should this be manually tested?

Make sure you can open the login popup and stuff like that on the terms of service page.