### PR TITLE
Turn profile links into buttons

### DIFF
--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -159,12 +159,12 @@ class EducationForm extends ProfileFormFields {
       ...renderedEducationRows(profile.education),
       userPrivilegeCheck(profile, () =>
         <Cell col={12} className="profile-form-row add" key={`add-row`}>
-          <a
+          <button
             className="mm-minor-action"
             onClick={() => this.openNewEducationForm(levelValue, null)}
           >
             Add degree
-          </a>
+          </button>
         </Cell>, null
       ),
     ];

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -173,12 +173,12 @@ class EmploymentForm extends ProfileFormFields {
       userPrivilegeCheck(profile, () => {
         workHistoryRows.push(
         <Cell col={12} className="profile-form-row add" key={"I'm unique!"}>
-          <a
+          <button
             className="mm-minor-action"
             onClick={this.openNewWorkHistoryForm}
           >
             Add employment
-          </a>
+          </button>
         </Cell>
         );
       });


### PR DESCRIPTION
Fixes #1705. Right now, this is the simplest possible fix: changing the `<a>` tags into `<button>` tags. It's now much clearer that these are actions that the user can take, but it's not particularly pretty. @roberthouse54, do you want to style this up nicely?

![profile-with-buttons](https://cloud.githubusercontent.com/assets/132355/20283277/58c4022c-aa86-11e6-9785-38f40fe74399.png)