### PR TITLE
[learners profile] Allow period in url param

### DIFF
--- a/profiles/views.py
+++ b/profiles/views.py
@@ -28,6 +28,7 @@ class ProfileViewSet(RetrieveModelMixin, UpdateModelMixin, GenericViewSet):
     permission_classes = (CanEditIfOwner, CanSeeIfNotPrivate, )
     lookup_field = 'user__social_auth__uid'
     lookup_url_kwarg = 'user'
+    lookup_value_regex = '[-\w.]+'  # pylint: disable=anomalous-backslash-in-string
     queryset = Profile.objects.all()
 
     # possible serializers

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -78,7 +78,7 @@ class ProfileBaseTests(ESTestCase):
         cls.url1 = reverse('profile-detail', kwargs={'user': username})
 
         with mute_signals(post_save):
-            cls.user2 = UserFactory.create()
+            cls.user2 = UserFactory.create(username="test.dev.example")
             username = "{}_edx".format(cls.user2.username)
             cls.user2.social_auth.create(
                 provider=EdxOrgOAuth2.name,

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -33,6 +33,6 @@ urlpatterns = [
     url(r'^logout/$', auth_views.logout, {'next_page': '/'}),
     url(r'^404/$', page_404, name='ui-404'),
     url(r'^500/$', page_500, name='ui-500'),
-    url(r'^learner/(?P<user>[-\w]+)?/?', UsersView.as_view(), name='ui-users'),
+    url(r'^learner/(?P<user>[-\w.]+)?/?', UsersView.as_view(), name='ui-users'),
     url(r'^{}$'.format(TERMS_OF_SERVICE_URL.lstrip("/")), terms_of_service, name='terms_of_service'),
 ] + dashboard_urlpatterns


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/1731

#### How should this be manually tested?
- create fake data ``docker-compose run web ./manage.py gen_realistic_search_data --staff-user <staff user name>
``
- Open admin panel,  go to profile of user e.g``fake.blanca.rojas`` and make profile public.
- Copy same user name e.g ``fake.blanca.rojas``
- Go to url ``http://192.168.99.100:8079/learner/fake.blanca.rojas`` as staff or learner and see profile.

@pdpinch @giocalitri 
#### Screenshots (if appropriate)
<img width="640" alt="screen shot 2016-11-15 at 6 30 30 pm" src="https://cloud.githubusercontent.com/assets/10431250/20307526/a9bf0d8a-ab61-11e6-88a8-9d388d430f2e.png">

