### PR TITLE
Hide icon text from screenreaders

### DIFF
--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -98,26 +98,26 @@ export default class Navbar extends React.Component {
             </div>
             <div className="links">
               <div className="link">
-                <Icon name="dashboard" />
+                <Icon name="dashboard" aria-hidden="true" />
                 <Link to="/dashboard" onClick={closeDrawer} >
                   Dashboard
                 </Link>
               </div>
               <div className="link">
-                <Icon name="person" />
+                <Icon name="person" aria-hidden="true" />
                 <Link to={`/learner/${SETTINGS.user.username}`}
                   onClick={closeDrawer} >
                   View Profile
                 </Link>
               </div>
               <div className="link">
-                <Icon name="camera_alt" />
-                <a onClick={R.compose(() => setPhotoDialogVisibility(true), closeDrawer)}>
+                <Icon name="camera_alt" aria-hidden="true" />
+                <button onClick={R.compose(() => setPhotoDialogVisibility(true), closeDrawer)}>
                   Edit Photo
-                </a>
+                </button>
               </div>
               <div className="link">
-                <Icon name="settings" />
+                <Icon name="settings" aria-hidden="true" />
                 <Link to="/settings" onClick={closeDrawer} >
                   Settings
                 </Link>
@@ -125,7 +125,7 @@ export default class Navbar extends React.Component {
             </div>
             <div className="logout-link">
               <div className="link">
-                <Icon name="exit_to_app" />
+                <Icon name="exit_to_app" aria-hidden="true" />
                 <a href="/logout">
                   Logout
                 </a>

--- a/static/js/containers/ProfileImage.js
+++ b/static/js/containers/ProfileImage.js
@@ -71,7 +71,7 @@ class ProfileImage extends React.Component {
     if ( editable ) {
       return (
         <button className="open-photo-dialog" onClick={() => setDialogVisibility(true)}>
-          <Icon name="camera_alt" />
+          <Icon name="camera_alt" aria-hidden="true" />
           <span className="sr-only">Update user photo</span>
         </button>
       );

--- a/static/scss/navbar.scss
+++ b/static/scss/navbar.scss
@@ -92,9 +92,19 @@
         align-items: center;
         padding: 10px 0;
 
-        a {
+        a, button {
           color: $font-black;
           width: 100%;
+          font-weight: 500;
+          border: 0;
+          padding: 0;
+          background: inherit;
+          text-align: left;
+
+          &:hover, &:focus {
+            text-decoration: none;
+            cursor: pointer;
+          }
         }
 
         i {


### PR DESCRIPTION
#### What are the relevant tickets?
Better fix for #1684

#### What's this PR do?
Sets `aria-hidden="true"` on the Material Icon tags. This will cause screen readers to not read out "camera_alt" when encountering the camera icon, for example. This is OK because we already have alternate text labels set using the `sr-only` class.

#### How should this be manually tested?
Load up [ChromeVox](http://www.chromevox.com/) or [VoiceOver](https://help.apple.com/voiceover/info/guide/10.12/), tab to the icons in the application, and verify that the screen reader reads text that is helpful and understandable. There is a camera icon as a badge on the user's profile image when viewing their own profile, and there are images in the menu drawer when the application is in a mobile layout.
