### PR TITLE
Very small PR- changes link color

### DIFF
--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -5,8 +5,8 @@ $font-black: rgba(0,0,0,.87);
 $font-gray: #6f6f6f;
 $font-gray-light: #9c9c9c;
 $font-gray-disabled: rgba(0,0,0,.2);
-$link-text: #a31f34;
-$link-hover: #a31f34;
+$link-text: #0054c3;
+$link-hover: #0054c3;
 
 // MIT brand colors palette
 $mm-brand-bg: #a31f34;


### PR DESCRIPTION
#### What's this PR do?

This is a one-lie change that only changes the link color. Just look to see that all links use this color. (I made this change as the previous maroon link was too close to the error text color, so going back to blue.)