### PR TITLE
Small PR - styles mm-minor-action button to look like a link

### DIFF
--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -171,7 +171,14 @@
   font-size: 15px;
   font-weight: 400;
   cursor: pointer;
+  background: none;
+  border: none;
+  padding: 3px 0;
 }
+
+.mm-minor-action:hover {
+  text-decoration: underline;
+  }
 
 .dashboard-button {
   font-size: 13px;

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -178,7 +178,7 @@
 
 .mm-minor-action:hover {
   text-decoration: underline;
-  }
+}
 
 .dashboard-button {
   font-size: 13px;

--- a/static/scss/navbar.scss
+++ b/static/scss/navbar.scss
@@ -265,6 +265,8 @@
 
   .Select-placeholder {
     font-weight: 300;
+    top: 0;
+    padding-left: 10px;
   }
 }
 


### PR DESCRIPTION
#### What's this PR do?

This is a very small PR that styles the mm-minor-action button on the learner profile to look like a link.  I also fixed a very minor spacing bug that was introduced with yesterday's PR styling the react select component. This fixes the program selector in the navbar, which uses the react select component.

Closes #1757 