### PR TITLE
Filtered out reset FinancialAid statuses

### DIFF
--- a/financialaid/api_test.py
+++ b/financialaid/api_test.py
@@ -121,6 +121,13 @@ class FinancialAidBaseTestCase(TestCase):
             income_threshold=50000,
         )
 
+        # Create a FinancialAid with a reset status to verify that it is ignored
+        FinancialAidFactory.create(
+            user=cls.profile.user,
+            tier_program=cls.tier_programs['75k'],
+            status=FinancialAidStatus.RESET,
+        )
+
     @staticmethod
     def make_http_request(method, url, status, data=None, content_type="application/json", **kwargs):
         """

--- a/financialaid/serializers.py
+++ b/financialaid/serializers.py
@@ -87,28 +87,6 @@ class FinancialAidRequestSerializer(serializers.Serializer):
         return financial_aid
 
 
-class FinancialAidSkipSerializer(serializers.Serializer):
-    """
-    Serializer for skipping financial aid
-    """
-    def validate(self, data):
-        """
-        Validators for this serializer
-        """
-        if self.instance.status in FinancialAidStatus.TERMINAL_STATUSES:
-            raise ValidationError("Financial aid cannot be skipped once it has been approved or skipped.")
-        return data
-
-    def save(self):
-        """
-        Updates and logs status change of FinancialAid object to "skipped"
-        """
-        self.instance.status = FinancialAidStatus.SKIPPED
-        self.instance.tier_program = get_no_discount_tier_program(self.instance.tier_program.program.id)
-        self.instance.save_and_log(self.context["request"].user)
-        return self.instance
-
-
 class FinancialAidActionSerializer(serializers.Serializer):
     """
     Serializer for financial aid actions

--- a/financialaid/serializers.py
+++ b/financialaid/serializers.py
@@ -19,7 +19,6 @@ from financialaid.api import (
     determine_auto_approval,
     determine_tier_program,
     determine_income_usd,
-    get_no_discount_tier_program
 )
 from financialaid.constants import (
     FinancialAidJustification,

--- a/financialaid/views.py
+++ b/financialaid/views.py
@@ -1,6 +1,7 @@
 """
 Views for financialaid
 """
+import datetime
 import json
 from functools import reduce
 
@@ -17,16 +18,20 @@ from rest_framework.generics import (
 )
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.status import HTTP_200_OK
 from rest_framework.views import APIView
 from rolepermissions.verifications import has_object_permission
 
 from courses.models import Program
 from dashboard.models import ProgramEnrollment
+from financialaid.api import (
+    get_formatted_course_price,
+    get_no_discount_tier_program,
+)
 from financialaid.constants import (
     FinancialAidJustification,
     FinancialAidStatus
 )
-from financialaid.api import get_formatted_course_price
 from financialaid.models import (
     FinancialAid,
     TierProgram
@@ -39,7 +44,6 @@ from financialaid.serializers import (
     FinancialAidActionSerializer,
     FinancialAidRequestSerializer,
     FinancialAidSerializer,
-    FinancialAidSkipSerializer
 )
 from mail.serializers import FinancialAidMailSerializer
 from roles.roles import Permissions
@@ -71,14 +75,13 @@ class FinancialAidSkipView(UpdateAPIView):
     aid object exists, and then either creates or updates a financial aid object to reflect
     the user skipping financial aid.
     """
-    serializer_class = FinancialAidSkipSerializer
     authentication_classes = (
         SessionAuthentication,
         TokenAuthentication,
     )
     permission_classes = (IsAuthenticated, )
 
-    def get_object(self):
+    def update(self, request, *args, **kwargs):
         """
         Overrides get_object in case financialaid object does not exist, as the learner may skip
         financial aid either after starting the process or in lieu of applying
@@ -86,18 +89,29 @@ class FinancialAidSkipView(UpdateAPIView):
         program = get_object_or_404(Program, id=self.kwargs["program_id"])
         if not program.financial_aid_availability:
             raise ValidationError("Financial aid not available for this program.")
-        if not ProgramEnrollment.objects.filter(program=program.id, user=self.request.user).exists():
+        if not ProgramEnrollment.objects.filter(program=program.id, user=request.user).exists():
             raise ValidationError("User not in program.")
 
-        # Look up a FinancialAid object for the user. The FinancialAidSkipSerializer
-        # will then change its status to skipped
+        user = request.user
         financialaid = FinancialAid.objects.filter(
-            user=self.request.user,
+            user=user,
             tier_program__program=program,
         ).exclude(status=FinancialAidStatus.RESET).first()
         if financialaid is None:
-            raise ValidationError("No financial aid application is available to mark as skipped")
-        return financialaid
+            financialaid = FinancialAid(
+                user=user,
+                country_of_income=user.profile.country,
+                date_exchange_rate=datetime.datetime.now(),
+                country_of_residence=user.profile.country,
+            )
+
+        if financialaid.status in FinancialAidStatus.TERMINAL_STATUSES:
+            raise ValidationError("Financial aid application cannot be skipped once it's been approved or skipped.")
+
+        financialaid.tier_program = get_no_discount_tier_program(program.id)
+        financialaid.status = FinancialAidStatus.SKIPPED
+        financialaid.save_and_log(self.request.user)
+        return Response(status=HTTP_200_OK)
 
 
 class ReviewFinancialAidView(UserPassesTestMixin, ListView):

--- a/financialaid/views.py
+++ b/financialaid/views.py
@@ -26,10 +26,7 @@ from financialaid.constants import (
     FinancialAidJustification,
     FinancialAidStatus
 )
-from financialaid.api import (
-    get_formatted_course_price,
-    get_no_discount_tier_program
-)
+from financialaid.api import get_formatted_course_price
 from financialaid.models import (
     FinancialAid,
     TierProgram

--- a/financialaid/views.py
+++ b/financialaid/views.py
@@ -95,6 +95,7 @@ class FinancialAidSkipView(UpdateAPIView):
         financialaid, _ = FinancialAid.objects.get_or_create(
             user=self.request.user,
             tier_program__program=program,
+            status__in=set(FinancialAidStatus.ALL_STATUSES) - {FinancialAidStatus.RESET},
             defaults={"tier_program": tier_program}
         )
         return financialaid

--- a/financialaid/views.py
+++ b/financialaid/views.py
@@ -86,13 +86,13 @@ class FinancialAidSkipView(UpdateAPIView):
         Overrides get_object in case financialaid object does not exist, as the learner may skip
         financial aid either after starting the process or in lieu of applying
         """
+        user = request.user
         program = get_object_or_404(Program, id=self.kwargs["program_id"])
         if not program.financial_aid_availability:
             raise ValidationError("Financial aid not available for this program.")
-        if not ProgramEnrollment.objects.filter(program=program.id, user=request.user).exists():
+        if not ProgramEnrollment.objects.filter(program=program.id, user=user).exists():
             raise ValidationError("User not in program.")
 
-        user = request.user
         financialaid = FinancialAid.objects.filter(
             user=user,
             tier_program__program=program,
@@ -110,7 +110,7 @@ class FinancialAidSkipView(UpdateAPIView):
 
         financialaid.tier_program = get_no_discount_tier_program(program.id)
         financialaid.status = FinancialAidStatus.SKIPPED
-        financialaid.save_and_log(self.request.user)
+        financialaid.save_and_log(user)
         return Response(status=HTTP_200_OK)
 
 

--- a/financialaid/views_test.py
+++ b/financialaid/views_test.py
@@ -801,19 +801,13 @@ class LearnerSkipsFinancialAid(FinancialAidBaseTestCase, APIClient):
 
     def test_skipped_financialaid_object_created(self):
         """
-        Tests that a FinancialAid object with the status "skipped" is created.
+        Tests that the user can't set skipped status unless a FinancialAid object already exists
         """
         assert FinancialAidAudit.objects.count() == 0
         assert FinancialAid.objects.exclude(status=FinancialAidStatus.RESET).count() == 0
-        self.make_http_request(self.client.patch, self.skip_url, status.HTTP_200_OK)
-        assert FinancialAid.objects.exclude(status=FinancialAidStatus.RESET).count() == 1
-        financial_aid = FinancialAid.objects.get(
-            user=self.profile.user,
-            status=FinancialAidStatus.SKIPPED,
-        )
-        assert financial_aid.tier_program == self.tier_programs["75k"]
-        # Check logging
-        assert FinancialAidAudit.objects.count() == 1
+        self.make_http_request(self.client.patch, self.skip_url, status.HTTP_400_BAD_REQUEST)
+        assert FinancialAidAudit.objects.count() == 0
+        assert FinancialAid.objects.exclude(status=FinancialAidStatus.RESET).count() == 0
 
     @ddt.data(
         *([status] for status in (

--- a/micromasters/utils.py
+++ b/micromasters/utils.py
@@ -5,10 +5,10 @@ import datetime
 import json
 import logging
 
+import pytz
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers import serialize
-import pytz
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import exception_handler

--- a/micromasters/utils.py
+++ b/micromasters/utils.py
@@ -1,12 +1,14 @@
 """
 General micromasters utility functions
 """
+import datetime
 import json
 import logging
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers import serialize
+import pytz
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
@@ -135,3 +137,19 @@ def is_subset_dict(dict_to_test, master_dict):
     except KeyError:
         return False
     return result
+
+
+def is_near_now(time):
+    """
+    Returns true if time is within five seconds or so of now
+
+    Args:
+        time (datetime.datetime):
+            The time to test
+    Returns:
+        bool:
+            True if near now, false otherwise
+    """
+    now = datetime.datetime.now(tz=pytz.UTC)
+    five_seconds = datetime.timedelta(0, 5)
+    return now - five_seconds < time < now + five_seconds

--- a/micromasters/utils_test.py
+++ b/micromasters/utils_test.py
@@ -1,6 +1,7 @@
 """
 Tests for the utils module
 """
+import datetime
 import unittest
 
 from django.core.exceptions import ImproperlyConfigured
@@ -10,6 +11,7 @@ from django.test import (
     RequestFactory,
     TestCase,
 )
+import pytz
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
 
@@ -26,6 +28,7 @@ from micromasters.utils import (
     get_field_names,
     serialize_model_object,
     first_matching_item,
+    is_near_now,
     is_subset_dict,
 )
 
@@ -185,3 +188,14 @@ class UtilTests(unittest.TestCase):
         new_dict = dict(d1)
         new_dict['c']['d'] = 123
         assert not is_subset_dict(new_dict, d2)
+
+    def test_is_near_now(self):
+        """
+        Test is_near_now for now
+        """
+        now = datetime.datetime.now(tz=pytz.UTC)
+        assert is_near_now(now) is True
+        later = now + datetime.timedelta(0, 6)
+        assert is_near_now(later) is False
+        earlier = now - datetime.timedelta(0, 6)
+        assert is_near_now(earlier) is False


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1777

#### What's this PR do?
Adds a filter to prevent reset `FinancialAid`s from being seen in `FinancialAidSkipView`

#### How should this be manually tested?
Create a financial aid, set it to `RESET` in the Django admin. Then attempt to skip financial aid in the UI.
