### PR TITLE
pass validator into PrivacyForm

### DIFF
--- a/static/js/components/PrivacyForm.js
+++ b/static/js/components/PrivacyForm.js
@@ -6,6 +6,7 @@ import { Card } from 'react-mdl/lib/Card';
 import ProfileFormFields from '../util/ProfileFormFields';
 import type { Profile, ValidationErrors, UpdateProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
+import type { Validator } from '../lib/validation/profile';
 
 class PrivacyForm extends ProfileFormFields {
   props: {
@@ -13,6 +14,7 @@ class PrivacyForm extends ProfileFormFields {
     ui:             UIState,
     updateProfile:  UpdateProfileFunc,
     errors:         ValidationErrors,
+    validator:      Validator,
   };
 
   privacyOptions: Array<{value: string, label: string, helper: string}> = [

--- a/static/js/containers/SettingsPage.js
+++ b/static/js/containers/SettingsPage.js
@@ -39,7 +39,7 @@ class SettingsPage extends ProfileFormContainer {
       <Loader loaded={loaded}>
         <div className="single-column privacy-form">
           <h4 className="privacy-form-heading">Settings</h4>
-          <PrivacyForm {...props} />
+          <PrivacyForm {...props} validator={privacyValidation} />
           <ProfileProgressControls
             nextBtnLabel="Save"
             {...props}


### PR DESCRIPTION
The privacy form has to have a `validator` on `this.props` in order for the `boundRadioGroupField` to pull it out.