### PR TITLE
fix gradient syntax error warning

### DIFF
--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -106,12 +106,12 @@
     font-size: 12px;
     color: #333333;
     border: 1px solid #d2d2d2;
-    background-image: linear-gradient(top, #fbfbfb   0%, #e2e2e2   100%);
+    background-image: linear-gradient(to bottom, #fbfbfb   0%, #e2e2e2   100%);
   }
 
   &.minor-action:hover, &.minor-action:focus, &.minor-action:active, &.minor-action:focus:not(:active) {
     color: #000;
-    background-image: linear-gradient(top, #f7f7f7   0%, #dadada   100%);
+    background-image: linear-gradient(to bottom, #f7f7f7   0%, #dadada   100%);
   }
 
   &:hover, &:focus, &:active, &:focus:not(:active) {


### PR DESCRIPTION
#### What are the relevant tickets?

Should have caught this in #1772 

#### What's this PR do?

Fixes a spot where we were using the old syntax for `linear-gradient`.

#### How should this be manually tested?

Just check there's no warning from `postcss` showing up in the JS console.
