### PR TITLE
CSS fallbacks for home page

### DIFF
--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -111,10 +111,10 @@
               {% endif %}
             </div>
             <div class="program-description">
-              <p id="program-{{ program.id }}-description">{{ program.description|default:"No description available for this program." }}</p>
+              <p class="program-description-text" id="program-{{ program.id }}-description">{{ program.description|default:"No description available for this program." }}</p>
 
               {% if program.programpage %}
-                <p>
+                <p class="program-description-link">
                 {% if program.programpage.external_program_page_url %}
                   <a href="{{ program.programpage.external_program_page_url }}" class="program-link">
                 {% else %}

--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -416,6 +416,10 @@ body.app-media {
     max-width: 1400px;
     margin: 0 auto;
 
+    li {
+      padding-bottom: 1em;
+    }
+
     .program-thumbnail {
       position: relative;
       background-color: black;
@@ -464,10 +468,14 @@ body.app-media {
     .program-description {
       padding: 20px 10px;
       height: 20em;
-      overflow: auto;
 
       @include breakpoint(phone) {
         padding: 20px 3px 30px;
+      }
+
+      p.program-description-text {
+        max-height: 15em;
+        overflow: auto;
       }
 
       p {

--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -417,7 +417,7 @@ body.app-media {
     margin: 0 auto;
 
     li {
-      padding-bottom: 1em;
+      padding-bottom: 2.5em;
     }
 
     .program-thumbnail {

--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -453,6 +453,7 @@ body.app-media {
 
       img {
         width: 100%;
+        min-height: 23vw;
 
         &.program-default-image {
           opacity: .4;
@@ -461,7 +462,9 @@ body.app-media {
     }
 
     .program-description {
-      padding: 20px 10px 30px 15px;
+      padding: 20px 10px;
+      height: 20em;
+      overflow: auto;
 
       @include breakpoint(phone) {
         padding: 20px 3px 30px;


### PR DESCRIPTION
Fixes #1559. Changes the CSS so that course cards tile correctly, even without course images and with variable course description lengths.
![home-page-tiles](https://cloud.githubusercontent.com/assets/132355/20361218/c7f3a664-ac04-11e6-8fe6-46b6f77f9c53.png)
