### PR TITLE
Correct buttons on cost calculator

### DIFF
--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -127,7 +127,7 @@ export default class CourseAction extends React.Component {
   renderPayLaterLink(run: CourseRun): React$Element<*> {
     return (
       <button
-        className="text-link enroll-pay-later"
+        className="mm-minor-action enroll-pay-later"
         onClick={e => this.handleAddCourseEnrollment(e, run)} key="2"
       >
         Enroll and pay later

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -126,12 +126,12 @@ export default class CourseAction extends React.Component {
 
   renderPayLaterLink(run: CourseRun): React$Element<*> {
     return (
-      <a href="#"
-        className="enroll-pay-later"
+      <button
+        className="text-link enroll-pay-later"
         onClick={e => this.handleAddCourseEnrollment(e, run)} key="2"
       >
         Enroll and pay later
-      </a>
+      </button>
     );
   }
 

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -59,7 +59,7 @@ describe('CourseAction', () => {
     }
     let description = renderedComponent.find(".description");
     let descriptionText = description.length === 1 ? description.text() : undefined;
-    let link = renderedComponent.find("a");
+    let link = renderedComponent.find("button.text-link");
     let linkText = link.length === 1 ? link.text() : undefined;
     return {
       button: button,

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -59,7 +59,7 @@ describe('CourseAction', () => {
     }
     let description = renderedComponent.find(".description");
     let descriptionText = description.length === 1 ? description.text() : undefined;
-    let link = renderedComponent.find("button.text-link");
+    let link = renderedComponent.find("button.enroll-pay-later");
     let linkText = link.length === 1 ? link.text() : undefined;
     return {
       button: button,

--- a/static/js/components/dashboard/CourseSubRow_test.js
+++ b/static/js/components/dashboard/CourseSubRow_test.js
@@ -76,7 +76,7 @@ describe('CourseSubRow', () => {
     assert.equal(wrapper.find(".course-grade").text().trim(), "");
     let actionCell = wrapper.find(".course-action");
     assert.equal(actionCell.find("button.dashboard-button").text(), "Calculate Cost");
-    assert.equal(actionCell.find("button.text-link").text(), "Enroll and pay later");
+    assert.equal(actionCell.find("button.enroll-pay-later").text(), "Enroll and pay later");
   });
 
   it('indicates future enrollment and if a future course run is offered', () => {

--- a/static/js/components/dashboard/CourseSubRow_test.js
+++ b/static/js/components/dashboard/CourseSubRow_test.js
@@ -75,8 +75,8 @@ describe('CourseSubRow', () => {
     assert.include(wrapper.find(".course-description").html(), "Enrollment open");
     assert.equal(wrapper.find(".course-grade").text().trim(), "");
     let actionCell = wrapper.find(".course-action");
-    assert.equal(actionCell.find("button").text(), "Calculate Cost");
-    assert.equal(actionCell.find("a").text(), "Enroll and pay later");
+    assert.equal(actionCell.find("button.dashboard-button").text(), "Calculate Cost");
+    assert.equal(actionCell.find("button.text-link").text(), "Enroll and pay later");
   });
 
   it('indicates future enrollment and if a future course run is offered', () => {

--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -128,9 +128,9 @@ export default class FinancialAidCard extends React.Component {
         >
           Calculate your cost
         </button>
-        <a className="full-price" onClick={() => setConfirmSkipDialogVisibility(true)}>
+        <button className="text-link full-price" onClick={() => setConfirmSkipDialogVisibility(true)}>
           Skip this and Pay Full Price
-        </a>
+        </button>
       </div>
     </div>;
   }
@@ -161,9 +161,9 @@ export default class FinancialAidCard extends React.Component {
             <div>
               Your cost is {price(coursePrice.price)} per course.
             </div>
-            <a className="full-price" onClick={() => setConfirmSkipDialogVisibility(true)}>
+            <button className="text-link full-price" onClick={() => setConfirmSkipDialogVisibility(true)}>
               Skip this and Pay Full Price
-            </a>
+            </button>
           </Cell>
         </Grid>
 

--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -128,7 +128,7 @@ export default class FinancialAidCard extends React.Component {
         >
           Calculate your cost
         </button>
-        <button className="text-link full-price" onClick={() => setConfirmSkipDialogVisibility(true)}>
+        <button className="mm-minor-action full-price" onClick={() => setConfirmSkipDialogVisibility(true)}>
           Skip this and Pay Full Price
         </button>
       </div>
@@ -161,7 +161,7 @@ export default class FinancialAidCard extends React.Component {
             <div>
               Your cost is {price(coursePrice.price)} per course.
             </div>
-            <button className="text-link full-price" onClick={() => setConfirmSkipDialogVisibility(true)}>
+            <button className="mm-minor-action full-price" onClick={() => setConfirmSkipDialogVisibility(true)}>
               Skip this and Pay Full Price
             </button>
           </Cell>

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -109,7 +109,7 @@ const calculatorActions = (openSkipDialog, cancel, save) => {
   ];
 
   return <div className="actions">
-    <button className="text-link full-price" onClick={openSkipDialog}>
+    <button className="mm-minor-action full-price" onClick={openSkipDialog}>
       Skip this and Pay Full Price
     </button>
     <div className="buttons">

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -92,10 +92,10 @@ const checkBox = (update, current) => (
   />
 );
 
-const actionButtons = R.map(({ name, onClick, label}) => (
+const actionButtons = R.map(({ name, primary, onClick, label}) => (
   <Button
     type='button'
-    className={`${name}-button mm-button`}
+    className={`${name}-button ${primary ? 'primary' : 'secondary'}-button mm-button`}
     key={name}
     onClick={onClick}>
     { label }
@@ -104,14 +104,14 @@ const actionButtons = R.map(({ name, onClick, label}) => (
 
 const calculatorActions = (openSkipDialog, cancel, save) => {
   const buttonManifest = [
-    { name: 'cancel', onClick: cancel, label: 'Cancel' },
-    { name: 'main-action save', onClick: save, label: 'Calculate' },
+    { name: 'cancel', primary: false, onClick: cancel, label: 'Cancel' },
+    { name: 'save', primary: true, onClick: save, label: 'Calculate' },
   ];
 
   return <div className="actions">
-    <a className="full-price" onClick={openSkipDialog}>
+    <button className="text-link full-price" onClick={openSkipDialog}>
       Skip this and Pay Full Price
-    </a>
+    </button>
     <div className="buttons">
       { actionButtons(buttonManifest) }
     </div>

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -162,10 +162,11 @@
   background: none;
   border: none;
   padding: 3px 0;
-}
 
-.mm-minor-action:hover {
-  text-decoration: underline;
+  &:hover {
+    color: $link-hover;
+    text-decoration: underline;
+  }
 }
 
 .dashboard-button {
@@ -183,18 +184,6 @@
   cursor: not-allowed;
 }
 
-
-
 a.btn {
   text-decoration: none;
-}
-
-button.text-link {
-  border: 0;
-  background-color: inherit;
-  color: $link-text;
-
-  &:hover {
-    color: $link-hover;
-  }
 }

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -188,3 +188,13 @@
 a.btn {
   text-decoration: none;
 }
+
+button.text-link {
+  border: 0;
+  background-color: inherit;
+  color: $link-text;
+
+  &:hover {
+    color: $link-hover;
+  }
+}


### PR DESCRIPTION
Adds `primary-button` and `secondary-button` CSS classes, and uses `<button>` for accessibility (#1222) 