### PR TITLE
Added SSL parameters to Elasticsearch connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,3 +283,25 @@ host machine isn't running Linux. If you are using a Mac, you'll need to run
 
     npm install
     npm run-script flow
+
+## Connecting to external services
+
+#### Elasticsearch
+
+If you want to connect to an ES cluster aside from the one created by Docker, you'll need to do the following:
+
+1. Add these variables to your `.env` file (without parentheses):
+
+
+        ELASTICSEARCH_INDEX=(your_index_name)
+        ELASTICSEARCH_URL=https://(your_elastic_search_url)
+        ELASTICSEARCH_HTTP_AUTH=(your_cluster_name):(key)
+
+1. If any of the above variables are set in the `web` configuration in `docker-compose.yml`, those
+ will override the values you have in `.env`. Delete them.
+1. Restart the `db` and `elastic` docker-compose services if they're running:
+ `docker-compose restart db elastic`
+ 
+You should now be able to connect to the external ES cluster. You
+can run `docker-compose run web ./manage.py recreate_index` to test
+that it's working.

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -43,10 +43,15 @@ def get_conn(verify=True):
 
     do_verify = False
     if _CONN is None:
-        http_auth = None
-        if settings.ELASTICSEARCH_HTTP_AUTH is not None:
-            http_auth = settings.ELASTICSEARCH_HTTP_AUTH
-        _CONN = connections.create_connection(hosts=[settings.ELASTICSEARCH_URL], http_auth=http_auth)
+        http_auth = settings.ELASTICSEARCH_HTTP_AUTH
+        use_ssl = http_auth is not None
+        _CONN = connections.create_connection(
+            hosts=[settings.ELASTICSEARCH_URL],
+            http_auth=http_auth,
+            use_ssl=use_ssl,
+            # make sure we verify SSL certificates (off by default)
+            verify_certs=use_ssl
+        )
         # Verify connection on first connect if verify=True.
         do_verify = verify
 


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #1742 

#### What's this PR do?

Adds SSL parameters to the ES connection (see [the docs](https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch) for details)

#### How should this be manually tested?

First, you'll need to delete the line in `docker-compose.yml` that sets `ELASTICSEARCH_URL` in the `web` service. I don't know why this is here instead of just getting it from `.env` like other settings vars. 

Make sure you can run the `recreate_index` command with no changes to .env and not see a warning. Then, in your `.env` file, set your `ELASTICSEARCH_URL` and `ELASTICSEARCH_HTTP_AUTH` variables to the values in micromasters-rc. You can find these by connecting to -rc via the `heroku` CLI command, running a django shell, and importing `settings`. Copy those values over to your local `.env` and make sure you can still run `recreate_index` with no warnings. You can also double-check in a django shell that your `ELASTICSEARCH_URL` is correct.

