### PR TITLE
Set learners name on search to first and last name pair

### DIFF
--- a/static/js/components/search/LearnerResult.js
+++ b/static/js/components/search/LearnerResult.js
@@ -4,7 +4,7 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 import _ from 'lodash';
 import ProfileImage from '../../containers/ProfileImage';
 import UserChip from '../UserChip';
-import { getPreferredName, getLocation } from '../../util/util';
+import { getUserDisplayName, getLocation } from '../../util/util';
 import type { SearchResult } from '../../flow/searchTypes';
 
 export default class LearnerResult extends React.Component {
@@ -25,7 +25,7 @@ export default class LearnerResult extends React.Component {
         </Cell>
         <Cell col={3} className="learner-name centered">
           <span>
-            { getPreferredName(profile) }
+            { getUserDisplayName(profile) }
           </span>
           <UserChip profile={profile} />
         </Cell>

--- a/static/js/components/search/LearnerResult_test.js
+++ b/static/js/components/search/LearnerResult_test.js
@@ -9,7 +9,10 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
 import LearnerResult from './LearnerResult';
 import { configureMainTestStore } from '../../store/configureStore';
-import { makeStrippedHtml } from '../../util/util';
+import {
+  getUserDisplayName,
+  makeStrippedHtml,
+} from '../../util/util';
 import {
   USER_PROFILE_RESPONSE,
   USER_PROGRAM_RESPONSE
@@ -43,7 +46,7 @@ describe('LearnerResult', () => {
 
   it("should include the user's name", () => {
     let result = renderLearnerResult(elasticHit);
-    assert.include(result, USER_PROFILE_RESPONSE.preferred_name);
+    assert.include(result, getUserDisplayName(USER_PROFILE_RESPONSE));
   });
 
   it("should include the user's location", () => {

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -451,7 +451,9 @@ export const labelSort = R.sortBy(R.compose(R.toLower, R.prop('label')));
  * Return first and last names if available else username
  */
 export function getUserDisplayName(profile: Profile): string {
-  return (
-    profile.first_name && profile.last_name ? `${profile.first_name} ${profile.last_name}` : profile.username
-  );
+  let first = profile.first_name || profile.username;
+  let last =  profile.last_name || '';
+  let preferred_name = profile.preferred_name ? `(${profile.preferred_name})` : '';
+
+  return `${first} ${last} ${preferred_name}`;
 }

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -446,3 +446,12 @@ export const classify: (s: string) => string = (
 );
 
 export const labelSort = R.sortBy(R.compose(R.toLower, R.prop('label')));
+
+/**
+ * Return first and last names if available else username
+ */
+export function getUserDisplayName(profile: Profile): string {
+  return (
+    profile.first_name && profile.last_name ? `${profile.first_name} ${profile.last_name}` : profile.username
+  );
+}

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -448,12 +448,12 @@ export const classify: (s: string) => string = (
 export const labelSort = R.sortBy(R.compose(R.toLower, R.prop('label')));
 
 /**
- * Return first and last names if available else username
+ * Return first, last, preferred_name names if available else username
  */
 export function getUserDisplayName(profile: Profile): string {
   let first = profile.first_name || profile.username;
   let last =  profile.last_name || '';
-  let preferred_name = profile.preferred_name ? `(${profile.preferred_name})` : '';
+  let preferred_name = profile.preferred_name ? ` (${profile.preferred_name})` : '';
 
-  return `${first} ${last} ${preferred_name}`;
+  return `${first} ${last}${preferred_name}`;
 }

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -453,7 +453,8 @@ export const labelSort = R.sortBy(R.compose(R.toLower, R.prop('label')));
 export function getUserDisplayName(profile: Profile): string {
   let first = profile.first_name || profile.username;
   let last =  profile.last_name || '';
-  let preferred_name = profile.preferred_name ? ` (${profile.preferred_name})` : '';
+  let preferred_name = (profile.preferred_name && (profile.preferred_name !== first)) ?
+    ` (${profile.preferred_name})` : '';
 
   return `${first} ${last}${preferred_name}`;
 }

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -620,5 +620,10 @@ describe('utility functions', () => {
       profile.preferred_name = null;
       assert.equal('jane doe', getUserDisplayName(profile));
     });
+
+    it('does not show preferred name when first name has same value', () => {
+      profile.first_name = 'test';
+      assert.equal('test doe', getUserDisplayName(profile));
+    });
   });
 });

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -603,16 +603,22 @@ describe('utility functions', () => {
         username: 'jane_username',
         first_name: 'jane',
         last_name: 'doe',
+        preferred_name: 'test'
       };
     });
 
     it('assert first and last name', () => {
-      assert.equal('jane doe', getUserDisplayName(profile));
+      assert.equal('jane doe (test)', getUserDisplayName(profile));
     });
 
-    it('returns username when first or last name not available', () => {
+    it('returns username when first not available', () => {
       profile.first_name = null;
-      assert.equal('jane_username', getUserDisplayName(profile));
+      assert.equal('jane_username doe (test)', getUserDisplayName(profile));
+    });
+
+    it('not return preferred_name when preferred_name not available', () => {
+      profile.preferred_name = null;
+      assert.equal('jane doe ', getUserDisplayName(profile));
     });
   });
 });

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -607,18 +607,18 @@ describe('utility functions', () => {
       };
     });
 
-    it('assert first and last name', () => {
+    it('shows first, last, and preferred names', () => {
       assert.equal('jane doe (test)', getUserDisplayName(profile));
     });
 
-    it('returns username when first not available', () => {
+    it('shows username when first name is blank', () => {
       profile.first_name = null;
       assert.equal('jane_username doe (test)', getUserDisplayName(profile));
     });
 
-    it('not return preferred_name when preferred_name not available', () => {
+    it('does not show preferred name when that value is blank', () => {
       profile.preferred_name = null;
-      assert.equal('jane doe ', getUserDisplayName(profile));
+      assert.equal('jane doe', getUserDisplayName(profile));
     });
   });
 });

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -28,6 +28,7 @@ import {
   labelSort,
   classify,
   currentOrFirstIncompleteStep,
+  getUserDisplayName,
 } from '../util/util';
 import {
   EDUCATION_LEVELS,
@@ -592,6 +593,26 @@ describe('utility functions', () => {
         input[1],
       ];
       assert.deepEqual(expected, labelSort(input));
+    });
+  });
+
+  describe('getUserDisplayName', () => {
+    let profile;
+    beforeEach(() => {
+      profile = {
+        username: 'jane_username',
+        first_name: 'jane',
+        last_name: 'doe',
+      };
+    });
+
+    it('assert first and last name', () => {
+      assert.equal('jane doe', getUserDisplayName(profile));
+    });
+
+    it('returns username when first or last name not available', () => {
+      profile.first_name = null;
+      assert.equal('jane_username', getUserDisplayName(profile));
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
- fixes https://github.com/mitodl/micromasters/issues/1712

#### What's this PR do?
- On search page, instead of showing preferred name of learners, it shows first and last name pair.

@pdpinch @giocalitri 
#### Screenshots (if appropriate)

