### PR TITLE
Fixed browser history for profile tabs

### DIFF
--- a/static/js/DashboardRouter.js
+++ b/static/js/DashboardRouter.js
@@ -11,6 +11,9 @@ import App from './containers/App';
 import DashboardPage from './containers/DashboardPage';
 import SettingsPage from './containers/SettingsPage';
 import ProfilePage from './containers/ProfilePage';
+import PersonalTab from './components/PersonalTab';
+import EducationTab from './components/EducationTab';
+import EmploymentTab from './components/EmploymentTab';
 import UserPage from './containers/UserPage';
 import User from './components/User';
 import LearnerSearchPage from './containers/LearnerSearchPage';
@@ -36,7 +39,12 @@ export default class DashboardRouter extends React.Component {
           <Router history={browserHistory} onUpdate={onRouteUpdate}>
             <Route path="/" component={App}>
               <Route path="dashboard" component={DashboardPage} />
-              <Route path="profile" component={ProfilePage} />
+              <Route path="profile" component={ProfilePage}>
+                <IndexRedirect to="personal"/>
+                <Route path="personal" component={PersonalTab}/>
+                <Route path="education" component={EducationTab}/>
+                <Route path="professional" component={EmploymentTab}/>
+              </Route>
               <Route path="/settings" component={SettingsPage}  />
               <Route path="/learner" component={UserPage} >
                 <IndexRedirect to={username} />

--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -6,16 +6,22 @@ import EducationForm from './EducationForm';
 import { educationValidation } from '../lib/validation/profile';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
+import { setProfileStep } from '../actions/ui';
+import { EDUCATION_STEP } from '../constants';
 
 class EducationTab extends React.Component {
   props: {
-    nextStep:     () => void,
-    prevStep:     () => void,
     profile:      Profile,
     ui:           UIState,
     saveProfile:  SaveProfileFunc,
     addProgramEnrollment: Function,
+    dispatch:     Function,
   };
+
+  componentWillMount() {
+    const { dispatch } = this.props;
+    dispatch(setProfileStep(EDUCATION_STEP));
+  }
 
   render() {
     return (
@@ -23,6 +29,8 @@ class EducationTab extends React.Component {
         <EducationForm {...this.props} showSwitch={true} validator={educationValidation} />
         <ProfileProgressControls
           {...this.props}
+          prevUrl="/profile/personal"
+          nextUrl="/profile/professional"
           nextBtnLabel="Next"
           isLastTab={false}
           programIdForEnrollment={null}

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -11,16 +11,22 @@ import {
 } from '../lib/validation/profile';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
+import { setProfileStep } from '../actions/ui';
+import { EMPLOYMENT_STEP } from '../constants';
 
 class EmploymentTab extends React.Component {
   props: {
     saveProfile:  SaveProfileFunc,
     profile:      Profile,
     ui:           UIState,
-    nextStep:     () => void,
-    prevStep:     () => void,
     addProgramEnrollment: Function,
+    dispatch:     Function,
   };
+
+  componentWillMount() {
+    const { dispatch } = this.props;
+    dispatch(setProfileStep(EMPLOYMENT_STEP));
+  }
 
   render () {
     return (
@@ -29,6 +35,8 @@ class EmploymentTab extends React.Component {
         <ProfileProgressControls
           {...this.props}
           nextBtnLabel="I'm Done!"
+          prevUrl="/profile/education"
+          nextUrl="/dashboard"
           isLastTab={true}
           programIdForEnrollment={null}
           validator={

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -26,6 +26,9 @@ import type {
 } from '../flow/enrollmentTypes';
 import {  validationErrorSelector } from '../util/util';
 import type { Option } from '../flow/generalTypes';
+import { setProfileStep } from '../actions/ui';
+import { PERSONAL_STEP } from '../constants';
+
 
 export default class PersonalTab extends React.Component {
   props: {
@@ -40,6 +43,7 @@ export default class PersonalTab extends React.Component {
     setProgram:               Function,
     ui:                       UIState,
     updateProfile:            UpdateProfileFunc,
+    dispatch:                 Function,
   };
 
   sortPrograms = R.sortBy(R.compose(R.toLower, R.prop('title')));
@@ -47,6 +51,11 @@ export default class PersonalTab extends React.Component {
   programOptions = R.compose(
     R.map(program => ({value: program.id, label: program.title})), this.sortPrograms
   );
+
+  componentWillMount() {
+    const { dispatch } = this.props;
+    dispatch(setProfileStep(PERSONAL_STEP));
+  }
 
   onChange = (selection: Option): void => {
     const {
@@ -99,6 +108,7 @@ export default class PersonalTab extends React.Component {
         </Card>
         <ProfileProgressControls
           {...this.props}
+          nextUrl="/profile/education"
           nextBtnLabel="Next"
           programIdForEnrollment={selectedProgram ? selectedProgram.id : null}
           isLastTab={false}

--- a/static/js/components/PersonalTab_test.js
+++ b/static/js/components/PersonalTab_test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
 import { assert } from 'chai';
 import R from 'ramda';
@@ -7,16 +8,22 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
 import PersonalTab from './PersonalTab';
 import { PROGRAMS } from '../constants';
+import IntegrationTestHelper from '../util/integration_test_helper';
 
 describe("PersonalTab", () => {
+  let helper;
   let renderPersonalTab = (selectedProgram = null, props = {}) => {
+    let { store } = helper;
     return mount(
       <MuiThemeProvider muiTheme={getMuiTheme()}>
-        <PersonalTab
-          programs={PROGRAMS}
-          ui={{selectedProgram: selectedProgram}}
-          {...props}
-        />
+        <Provider store={store}>
+          <PersonalTab
+            programs={PROGRAMS}
+            ui={{selectedProgram: selectedProgram}}
+            dispatch={store.dispatch}
+            {...props}
+          />
+        </Provider>
       </MuiThemeProvider>,
       {
         context: { router: {}},
@@ -24,6 +31,14 @@ describe("PersonalTab", () => {
       }
     );
   };
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper();
+  });
+
+  afterEach(() => {
+    helper.cleanup();
+  });
 
   it('should show a list of programs to enroll in for the learner page', () => {
     let wrapper = renderPersonalTab();

--- a/static/js/components/ProfileProgressControls.js
+++ b/static/js/components/ProfileProgressControls.js
@@ -7,8 +7,8 @@ import type { UIState } from '../reducers/ui';
 
 export default class ProfileProgressControls extends React.Component {
   props: {
-    nextStep:     () => void,
-    prevStep:     () => void,
+    nextUrl?:      string,
+    prevUrl?:      string,
     nextBtnLabel: string,
     isLastTab:    boolean,
     validator:    Function,
@@ -19,9 +19,14 @@ export default class ProfileProgressControls extends React.Component {
     addProgramEnrollment: Function,
   };
 
+  stepBack: Function = (): void => {
+    const { prevUrl } = this.props;
+    this.context.router.push(prevUrl);
+  };
+
   saveAndContinue: Function = (): void => {
     const {
-      nextStep,
+      nextUrl,
       isLastTab,
       validator,
       programIdForEnrollment,
@@ -32,22 +37,22 @@ export default class ProfileProgressControls extends React.Component {
       if (programIdForEnrollment && addProgramEnrollment) {
         addProgramEnrollment(programIdForEnrollment);
       }
-      nextStep();
+      this.context.router.push(nextUrl);
     });
   };
 
   render() {
-    const { nextStep, prevStep, nextBtnLabel } = this.props;
+    const { nextUrl, prevUrl, nextBtnLabel } = this.props;
 
     let prevButton, nextButton;
-    if(prevStep) {
+    if (prevUrl) {
       prevButton = <button
         className="mdl-button gray-button go-back prev"
-        onClick={prevStep}>
+        onClick={this.stepBack}>
         <span>Go Back</span>
       </button>;
     }
-    if(nextStep) {
+    if (nextUrl) {
       nextButton = <button
         role="button"
         className="mdl-button next"

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -18,8 +18,9 @@ export const EDUCATION_LEVELS = [
   {value: DOCTORATE, label: "Doctorate"}
 ];
 
+// NOTE: these need to be kept in sync with ui/url_utils.py
 export const PERSONAL_STEP = 'personal';
-export const EMPLOYMENT_STEP = 'employment';
+export const EMPLOYMENT_STEP = 'professional';
 export const EDUCATION_STEP = 'education';
 
 export const YEAR_VALIDATION_CUTOFF = 120;
@@ -31,6 +32,12 @@ export const PROFILE_STEP_LABELS = new Map([
   [EDUCATION_STEP, "Education"],
   [EMPLOYMENT_STEP, "Professional"]
 ]);
+
+export const PROFILE_STEP_ORDER = [
+  PERSONAL_STEP,
+  EDUCATION_STEP,
+  EMPLOYMENT_STEP
+];
 
 export const DEFAULT_OPTION_LIMIT_COUNT = 10;
 

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -44,15 +44,16 @@ import { SUCCESS_ACTIONS } from './test_util';
 
 const EDIT_PROFILE_ACTIONS = SUCCESS_ACTIONS.concat([
   START_PROFILE_EDIT,
-  START_PROFILE_EDIT,
   UPDATE_PROFILE_VALIDATION,
   SET_PROFILE_STEP,
 ]);
 const REDIRECT_ACTIONS = SUCCESS_ACTIONS.concat([
-  START_PROFILE_EDIT
+  START_PROFILE_EDIT,
+  UPDATE_PROFILE_VALIDATION,
+  SET_PROFILE_STEP,
 ]);
 
-describe('App', () => {
+describe('App', function() {
   let listenForActions, renderComponent, helper;
 
   beforeEach(() => {
@@ -80,48 +81,48 @@ describe('App', () => {
   describe('profile completeness', () => {
     let checkStep = () => helper.store.getState().ui.profileStep;
 
-    it('redirects to /profile if profile is not complete', () => {
+    it('redirects to /profile/personal if profile is not complete', () => {
       let response = Object.assign(_.cloneDeep(USER_PROFILE_RESPONSE), {
         first_name: undefined
       });
       helper.profileGetStub.returns(Promise.resolve(response));
 
-      return renderComponent('/', EDIT_PROFILE_ACTIONS).then(() => {
-        assert.equal(helper.currentLocation.pathname, "/profile");
+      return renderComponent("/", EDIT_PROFILE_ACTIONS).then(() => {
+        assert.equal(helper.currentLocation.pathname, "/profile/personal");
         assert.equal(checkStep(), PERSONAL_STEP);
       });
     });
 
-    it('redirects to /profile if profile is not filled out', () => {
+    it('redirects to /profile/professional if profile is not filled out', () => {
       let response = Object.assign(_.cloneDeep(USER_PROFILE_RESPONSE), {
         filled_out: false
       });
       helper.profileGetStub.returns(Promise.resolve(response));
 
-      return renderComponent('/', REDIRECT_ACTIONS).then(() => {
-        assert.equal(helper.currentLocation.pathname, "/profile");
-        assert.equal(checkStep(), PERSONAL_STEP);
-      });
-    });
-
-    it('redirects to /profile and goes to the employment step if a field is missing there', () => {
-      let profile = _.cloneDeep(USER_PROFILE_RESPONSE);
-      profile.work_history[1].city = "";
-
-      helper.profileGetStub.returns(Promise.resolve(profile));
-      return renderComponent('/', EDIT_PROFILE_ACTIONS).then(() => {
-        assert.equal(helper.currentLocation.pathname, "/profile");
+      return renderComponent("/", REDIRECT_ACTIONS).then(() => {
+        assert.equal(helper.currentLocation.pathname, "/profile/professional");
         assert.equal(checkStep(), EMPLOYMENT_STEP);
       });
     });
 
-    it('redirects to /profile and goes to the education step if a field is missing there', () => {
+    it('redirects to /profile/professional if a field is missing there', () => {
+      let profile = _.cloneDeep(USER_PROFILE_RESPONSE);
+      profile.work_history[1].city = "";
+
+      helper.profileGetStub.returns(Promise.resolve(profile));
+      return renderComponent("/", EDIT_PROFILE_ACTIONS).then(() => {
+        assert.equal(helper.currentLocation.pathname, "/profile/professional");
+        assert.equal(checkStep(), EMPLOYMENT_STEP);
+      });
+    });
+
+    it('redirects to /profile/education if a field is missing there', () => {
       let response = _.cloneDeep(USER_PROFILE_RESPONSE);
       response.education[0].school_name = '';
       helper.profileGetStub.returns(Promise.resolve(response));
 
-      return renderComponent('/', EDIT_PROFILE_ACTIONS).then(() => {
-        assert.equal(helper.currentLocation.pathname, "/profile");
+      return renderComponent("/", EDIT_PROFILE_ACTIONS).then(() => {
+        assert.equal(helper.currentLocation.pathname, "/profile/education");
         assert.equal(checkStep(), EDUCATION_STEP);
       });
     });

--- a/static/js/containers/SettingsPage.js
+++ b/static/js/containers/SettingsPage.js
@@ -23,10 +23,7 @@ class SettingsPage extends ProfileFormContainer {
 
   render() {
     const { profiles } = this.props;
-    let props = Object.assign({}, this.profileProps(profiles[SETTINGS.user.username]), {
-      nextStep: () => this.context.router.push('/dashboard'),
-      prevStep: undefined
-    });
+    let props = Object.assign({}, this.profileProps(profiles[SETTINGS.user.username]));
     let loaded = false;
     const username = SETTINGS.user.username;
 
@@ -41,8 +38,9 @@ class SettingsPage extends ProfileFormContainer {
           <h4 className="privacy-form-heading">Settings</h4>
           <PrivacyForm {...props} validator={privacyValidation} />
           <ProfileProgressControls
-            nextBtnLabel="Save"
             {...props}
+            nextBtnLabel="Save"
+            nextUrl="/dashboard"
             isLastTab={true}
             validator={privacyValidation}
           />

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -40,7 +40,6 @@ import {
   SET_NAV_DRAWER_OPEN,
   SET_PROGRAM,
 } from '../actions/ui';
-import { PERSONAL_STEP } from '../constants';
 import type { ToastMessage } from '../flow/generalTypes';
 import type { Action } from '../flow/reduxTypes';
 import type { AvailableProgram } from '../flow/enrollmentTypes';
@@ -64,7 +63,7 @@ export type UIState = {
   showEducationDeleteDialog:    boolean;
   deletionIndex:                ?number;
   dialog:                       UIDialog;
-  profileStep:                  string;
+  profileStep:                  ?string;
   workDialogIndex:              ?number;
   userMenuOpen:                 boolean;
   searchFilterVisibility:       {[s: string]: boolean};
@@ -96,7 +95,7 @@ export const INITIAL_UI_STATE: UIState = {
   showEducationDeleteDialog: false,
   deletionIndex: null,
   dialog: {},
-  profileStep: PERSONAL_STEP,
+  profileStep: null,
   workDialogIndex:  null,
   userMenuOpen: false,
   searchFilterVisibility: {},

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -34,7 +34,6 @@ import {
   setNavDrawerOpen,
 } from '../actions/ui';
 import { INITIAL_UI_STATE } from '../reducers/ui';
-import { PERSONAL_STEP } from '../constants';
 import rootReducer from '../reducers';
 import { createAssertReducerResultState } from '../util/test_utils';
 import type { AssertReducerResultState } from '../flow/reduxTypes';
@@ -143,7 +142,7 @@ describe('ui reducers', () => {
 
   describe("profile step", () => {
     it(`should let you set the profile step`, () => {
-      assertReducerResultState(setProfileStep, ui => ui.profileStep, PERSONAL_STEP);
+      assertReducerResultState(setProfileStep, ui => ui.profileStep, null);
     });
   });
 

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -13,7 +13,8 @@ import R from 'ramda';
 import {
   STATUS_PASSED,
   EDUCATION_LEVELS,
-  PROFILE_STEP_LABELS
+  PROFILE_STEP_LABELS,
+  PROFILE_STEP_ORDER,
 } from '../constants';
 import type {
   Profile,
@@ -53,7 +54,7 @@ export function userPrivilegeCheck (profile: Profile, privileged: any, unPrivile
   }
 }
 
-export function makeProfileProgressDisplay(active: string) {
+export function makeProfileProgressDisplay(active: ?string) {
   const width = 750, height = 100, radius = 20, paddingX = 40, paddingY = 5;
   const numCircles = PROFILE_STEP_LABELS.size;
 
@@ -179,6 +180,21 @@ export function makeProfileProgressDisplay(active: string) {
     {elements}
   </svg>;
 }
+
+const getStepIndices = R.map(R.indexOf(R.__, PROFILE_STEP_ORDER));
+const lastStep = R.last(PROFILE_STEP_ORDER);
+
+/**
+ * Determine the lesser of the current step or the first incomplete step
+ */
+export const currentOrFirstIncompleteStep = R.compose(
+    R.nth(R.__, PROFILE_STEP_ORDER),
+    R.reduce(R.min, Infinity),
+    getStepIndices,
+    R.reject(R.isNil),
+    R.append(lastStep),
+    R.pair
+);
 
 /* eslint-disable camelcase */
 /**

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -27,6 +27,7 @@ import {
   isProfileOfLoggedinUser,
   labelSort,
   classify,
+  currentOrFirstIncompleteStep,
 } from '../util/util';
 import {
   EDUCATION_LEVELS,
@@ -39,6 +40,8 @@ import {
   PROFILE_STEP_LABELS,
   CYBERSOURCE_CHECKOUT_RESPONSE,
   DASHBOARD_RESPONSE,
+  PERSONAL_STEP,
+  EDUCATION_STEP,
 } from '../constants';
 import { assertMaybeEquality, assertIsNothing } from '../lib/sanctuary_test';
 import { program } from '../components/ProgressWidget_test';
@@ -221,6 +224,32 @@ describe('utility functions', () => {
           );
         }
       });
+    });
+  });
+
+  describe('currentOrFirstIncompleteStep', () => {
+    it('should return the validated step if current step is null', () => {
+      let step = currentOrFirstIncompleteStep(null, PERSONAL_STEP);
+
+      assert.equal(step, PERSONAL_STEP);
+    });
+
+    it('should return the current step if validated step is null', () => {
+      let step = currentOrFirstIncompleteStep(PERSONAL_STEP, null);
+
+      assert.equal(step, PERSONAL_STEP);
+    });
+
+    it('should return the current step if validated step is greater', () => {
+      let step = currentOrFirstIncompleteStep(PERSONAL_STEP, EDUCATION_STEP);
+
+      assert.equal(step, PERSONAL_STEP);
+    });
+
+    it('should return the validated step if current step is greater', () => {
+      let step = currentOrFirstIncompleteStep(EDUCATION_STEP, PERSONAL_STEP);
+
+      assert.equal(step, PERSONAL_STEP);
     });
   });
 

--- a/ui/url_utils.py
+++ b/ui/url_utils.py
@@ -4,6 +4,19 @@ Utils for URLs (to avoid circular imports)
 
 DASHBOARD_URL = '/dashboard/'
 PROFILE_URL = '/profile/'
+PROFILE_PERSONAL_URL = '{}personal/?'.format(PROFILE_URL)
+PROFILE_EDUCATION_URL = '{}education/?'.format(PROFILE_URL)
+PROFILE_EMPLOYMENT_URL = '{}professional/?'.format(PROFILE_URL)
 TERMS_OF_SERVICE_URL = '/terms_of_service/'
 SETTINGS_URL = "/settings/"
 SEARCH_URL = "/learners/"
+
+DASHBOARD_URLS = [
+    DASHBOARD_URL,
+    PROFILE_URL,
+    PROFILE_PERSONAL_URL,
+    PROFILE_EDUCATION_URL,
+    PROFILE_EMPLOYMENT_URL,
+    SETTINGS_URL,
+    SEARCH_URL,
+]

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -5,11 +5,8 @@ from django.conf.urls import url
 from django.contrib.auth import views as auth_views
 
 from ui.url_utils import (
-    DASHBOARD_URL,
-    PROFILE_URL,
+    DASHBOARD_URLS,
     TERMS_OF_SERVICE_URL,
-    SETTINGS_URL,
-    SEARCH_URL,
 )
 from ui.views import (
     DashboardView,
@@ -21,12 +18,7 @@ from ui.views import (
 
 dashboard_urlpatterns = [
     url(r'^{}$'.format(dashboard_url.lstrip("/")), DashboardView.as_view(), name='ui-dashboard')
-    for dashboard_url in [
-        DASHBOARD_URL,
-        PROFILE_URL,
-        SETTINGS_URL,
-        SEARCH_URL,
-    ]
+    for dashboard_url in DASHBOARD_URLS
 ]
 
 urlpatterns = [

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -22,7 +22,7 @@ from profiles.api import get_social_username
 from profiles.factories import ProfileFactory
 from roles.models import Role
 from search.base import ESTestCase
-from ui.urls import DASHBOARD_URL, TERMS_OF_SERVICE_URL
+from ui.url_utils import DASHBOARD_URL, TERMS_OF_SERVICE_URL
 
 
 class ViewsTests(ESTestCase):


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #1363 

#### What's this PR do?

Reintroduces named urls for the personal/education/professional tabs on the profile setup.

#### Where should the reviewer start?

Take a look at `PersonalTab` (other tabs are similar) and the routes in `dashboard_routes.js`. Also look at `currentOrFirstIncompleteStep()` in `util/util.js`.

#### How should this be manually tested?

Sign up with a new account, verify you're directed to /profile/personal by default and that you're redirected there, particularly if trying to reach one of the later steps (e.g. /profile/education or /profile/professional). You shouldn't be allowed into those later steps until you've completed the personal tab.

#### Any background context you want to provide?

We previously had named urls for each of these tabs, this PR reintroduces them, but also addresses the [original issue](https://github.com/mitodl/micromasters/issues/627) for the [PR that removed them](https://github.com/mitodl/micromasters/pull/657) so we don't have a regression on that.

#### What GIF best describes this PR or how it makes you feel?

![Moonwalk](https://cloud.githubusercontent.com/assets/28598/20491148/76023bda-afde-11e6-8fc9-5bd4280395d5.gif)
