### PR TITLE
Allow the user to create new entries in 'industry' and 'field of study'

### DIFF
--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -275,6 +275,7 @@ class EducationForm extends ProfileFormFields {
             options={fieldOfStudyOptions}
             keySet={keySet('field_of_study')}
             label='Field of Study'
+            allowCreate={true}
             {...this.defaultInputComponentProps()}
           />
         </Cell>;

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -141,6 +141,7 @@ class EmploymentForm extends ProfileFormFields {
             keySet={keySet('industry')}
             label='Industry'
             options={this.industryOptions}
+            allowCreate={true}
             {...this.defaultInputComponentProps()}
           />
         </Cell>

--- a/static/js/components/inputs/SelectField_test.js
+++ b/static/js/components/inputs/SelectField_test.js
@@ -1,0 +1,28 @@
+import { assert } from 'chai';
+
+import { CREATE_OPTION_REGEX } from './SelectField';
+
+describe('SelectField', () => {
+  describe('CREATE_OPTION_REGEX', () => {
+    [
+      'Create option ""',
+      'Create option "test"',
+      'Create option "My new option"',
+      'Create option "..asdf anything at all!!!! "',
+    ].forEach(string => {
+      it(`should match ${string}`, () => {
+        assert.match(string, CREATE_OPTION_REGEX);
+      });
+    });
+
+    [
+      'Crete option',
+      'Some other option with nothing in common',
+      ''
+    ].forEach(string => {
+      it(`should not match ${string}`, () => {
+        assert.notMatch(string, CREATE_OPTION_REGEX);
+      });
+    });
+  });
+});

--- a/static/js/components/inputs/StateSelectField.js
+++ b/static/js/components/inputs/StateSelectField.js
@@ -17,7 +17,7 @@ const stateOption = (stateInfo, code) => (
   { value: code, label: stateInfo.name }
 );
 
-const statesForCountry = code => R.prop('sub', R.defaultTo({}, iso3166.data[code]));
+const statesForCountry = code => R.propOr({}, 'sub', R.defaultTo({}, iso3166.data[code]));
 
 const stateOptions = R.compose(
   labelSort, R.values, R.mapObjIndexed(stateOption), statesForCountry

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -79,6 +79,13 @@ export const modifySelectField = (field: HTMLElement, text: string): void => {
   TestUtils.Simulate.keyDown(input, { keyCode: 9, key: 'Tab' });
 };
 
+export const modifyWrapperSelectField = (wrapper: Object, text: string): void => {
+  let input = wrapper.find('input');
+  input.simulate('focus');
+  input.simulate('change', { target: { value: text }});
+  input.simulate('keyDown', { keyCode: 9, key: 'Tab' });
+};
+
 export const clearSelectField = (field: HTMLElement): void => {
   let input = field.querySelector('.Select-input').querySelector('input');
   TestUtils.Simulate.focus(input);


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1519 

#### What's this PR do?

This adds support to adding a custom entry to our `SelectField` component. In order to turn this on, you just pass a boolean `allowCreate` prop.

#### Where should the reviewer start?

Read over the changes to `components/inpust/SelectField.js`.

#### How should this be manually tested?

On the profile everything should have all of it's normal functionality.

The new thing is if you're adding a work history or education history element. 

- If you type in something which is not in the list, you should see an option which says `'Create option "your input so far"'`.
- If you press tab or click on this your input should be the new selected value of the field.
- If you clear the field, the entry you entered should appear as an option you can re-select.
- If you reload the app and go to the same entry, the custom entry you saved should appear.

I think that's it?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

![potato_surgery](https://cloud.githubusercontent.com/assets/6207644/20489803/ce59924c-afd9-11e6-96aa-f39107aaebf8.png)


#### What GIF best describes this PR or how it makes you feel?
