### PR TITLE
Changed seed_db requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,6 +12,8 @@ djangorestframework==3.5.2
 edx-api-client==0.3.0
 elasticsearch-dsl==2.1.0
 elasticsearch==2.3.0
+factory_boy
+faker
 html5lib==0.999999
 jsonfield==1.0.3
 newrelic

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,19 +21,22 @@ django-server-status==0.3.2
 django-storages-redux==1.3.2
 django-taggit==0.18.3     # via wagtail
 django-treebeard==4.0.1   # via wagtail
-Django==1.10.3            # via django-role-permissions, django-server-status, django-treebeard, jsonfield, wagtail
+django==1.10.3
 djangorestframework==3.5.2
 edx-api-client==0.3.0
 elasticsearch-dsl==2.1.0
 elasticsearch==2.3.0
+factory-boy==2.7.0
+fake-factory==0.7.2       # via factory-boy
+faker==0.7.3
 html5lib==0.999999
 jsonfield==1.0.3
 kombu==3.0.37             # via celery, django-server-status
 newrelic==2.72.1.53
 oauthlib==2.0.0           # via python-social-auth, requests-oauthlib
-Pillow==3.4.2             # via wagtail
+pillow==3.4.2
 psycopg2==2.6
-PyJWT==1.4.2              # via python-social-auth
+pyjwt==1.4.2              # via python-social-auth
 python-dateutil==2.5.3
 python-social-auth==0.2.21
 python3-openid==3.0.10    # via python-social-auth
@@ -43,10 +46,10 @@ raven==5.31.0
 redis==2.10.5
 requests-oauthlib==0.7.0  # via python-social-auth
 requests==2.11.1
-six==1.10.0               # via django-role-permissions, django-server-status, edx-api-client, elasticsearch-dsl, html5lib, python-dateutil, python-social-auth
+six==1.10.0               # via django-role-permissions, django-server-status, edx-api-client, elasticsearch-dsl, fake-factory, faker, html5lib, python-dateutil, python-social-auth
 static3==0.5.1
-Unidecode==0.4.19         # via wagtail
+unidecode==0.4.19         # via wagtail
 urllib3==1.19             # via elasticsearch
 uwsgi==2.0.14
 wagtail==1.7
-Willow==0.4               # via wagtail
+willow==0.4               # via wagtail

--- a/test_requirements.in
+++ b/test_requirements.in
@@ -1,8 +1,6 @@
 bpython
 ddt
 django-debug-toolbar
-factory_boy
-faker
 ipdb
 ipython
 mock

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,6 +5,7 @@
 #    pip-compile --output-file test_requirements.txt test_requirements.in
 #
 apipkg==1.4               # via execnet
+appnope==0.1.0            # via ipython
 astroid==1.4.8            # via pylint, pylint-plugin-utils
 blessings==1.6            # via curtsies
 blinker==1.4              # via nplusone
@@ -15,10 +16,8 @@ curtsies==0.2.11          # via bpython
 ddt==1.1.1
 decorator==4.0.10         # via ipython, traitlets
 django-debug-toolbar==1.6
+Django==1.10.3            # via django-debug-toolbar
 execnet==1.4.1            # via pytest-cache
-factory-boy==2.7.0
-fake-factory==0.7.2       # via factory-boy
-faker==0.7.3
 fancycompleter==0.5       # via pdbpp
 first==2.0.1              # via pip-tools
 greenlet==0.4.10          # via bpython
@@ -51,11 +50,10 @@ pytest-django==3.0.0
 pytest-pep8==1.0.6
 pytest-pylint==0.6.0
 pytest==3.0.3
-python-dateutil==2.5.3    # via fake-factory, faker
 requests==2.11.1          # via bpython
 semantic-version==2.6.0
 simplegeneric==0.8.1      # via ipython
-six==1.10.0               # via astroid, bpython, fake-factory, faker, mock, nplusone, pip-tools, prompt-toolkit, pylint, pytest-pylint, python-dateutil, traitlets
+six==1.10.0               # via astroid, bpython, mock, nplusone, pip-tools, prompt-toolkit, pylint, pytest-pylint, traitlets
 sqlparse==0.2.2           # via django-debug-toolbar
 testfixtures==4.13.1
 tox==2.4.1
@@ -65,6 +63,5 @@ wcwidth==0.1.7            # via curtsies, prompt-toolkit
 wmctrl==0.3               # via pdbpp
 wrapt==1.10.8             # via astroid
 
-# The following packages are commented out because they are
-# considered to be unsafe in a requirements file:
+# The following packages are considered to be unsafe in a requirements file:
 # setuptools                # via ipdb, ipython


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #1745 

#### What's this PR do?

Changes `factory-boy` and `faker` to be normal app requirements rather than test requirements

#### How should this be manually tested?

Check to see that the `seed_db` or `unseed_db` management commands work on the PR builds

#### Any background context you want to provide?

I moved the `factory-boy` and `faker` requirements from `test_requirements.in` to `requirements.in` and ran `pip-compile` on both files
