### PR TITLE
Hide email from UserInfoCard if it is not present

### DIFF
--- a/static/js/components/UserInfoCard.js
+++ b/static/js/components/UserInfoCard.js
@@ -19,6 +19,13 @@ export default class UserInfoCard extends React.Component {
     toggleShowPersonalDialog: () => void
   };
 
+  email = (email: string): React$Element<*> => (
+    <div>
+      <Icon name="email" className="email-icon" />
+      <span className="profile-email">{email}</span>
+    </div>
+  );
+
   render() {
     const { profile, toggleShowPersonalDialog } = this.props;
 
@@ -29,10 +36,7 @@ export default class UserInfoCard extends React.Component {
           <div className="col user-info">
             <div className="profile-title">{getPreferredName(profile)}</div>
             <div className="profile-company-name">{mstr(getEmployer(profile))}</div>
-            <div>
-              <Icon name="email" className="email-icon" />
-              <span className="profile-email">{profile.email}</span>
-            </div>
+            { profile.email ? this.email(profile.email) : null }
           </div>
           <div className="edit-profile-holder">
             {userPrivilegeCheck(profile, () => <IconButton name="edit" onClick={toggleShowPersonalDialog}/>)}

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -216,6 +216,7 @@ export const USER_PROFILE_RESPONSE = {
   "filled_out": true,
   "agreed_to_terms_of_service": true,
   "account_privacy": "all_users",
+  "email": "jane@foobar.baz",
   "email_optin": false,
   "first_name": "Jane",
   "last_name": "Garris",

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -771,6 +771,30 @@ describe("UserPage", function() {
         });
       });
 
+      it('should show an email, if present', () => {
+        const username = SETTINGS.user ? SETTINGS.user.username : null;
+        return renderComponent(`/learner/${username}`, userActions).then(([, div]) => {
+          let email = div.querySelector('.profile-email').textContent;
+          assert.deepEqual(email, USER_PROFILE_RESPONSE.email);
+        });
+      });
+
+      it('should not show an email, if not present', () => {
+        helper.profileGetStub.
+          withArgs(SETTINGS.user.username).
+          returns(
+            Promise.resolve(Object.assign({}, USER_PROFILE_RESPONSE, {
+              username: SETTINGS.user.username,
+              email: null,
+            }))
+          );
+
+        const username = SETTINGS.user ? SETTINGS.user.username : null;
+        return renderComponent(`/learner/${username}`, userActions).then(([, div]) => {
+          assert.isNull(div.querySelector('.profile-email'));
+        });
+      });
+
       it('should let you edit personal info', () => {
         const username = SETTINGS.user ? SETTINGS.user.username : null;
         return renderComponent(`/learner/${username}`, userActions).then(([, div]) => {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1604 

#### What's this PR do?

This ensures that if the `UserInfoCard` receives a `Profile` which lacks an email it will not show the email icon.

#### Where should the reviewer start?

Read over the changes and ensure they make sense.

#### How should this be manually tested?

If you visit your own profile you should see an email icon and your email. If you visit another user's profile you shouldn't see an email icon (given that you have a student role).

#### Any background context you want to provide?

#### Screenshots (if appropriate)

before:

![before_email](https://cloud.githubusercontent.com/assets/6207644/20493535/4580ff9c-afe7-11e6-8df6-37ad77550a1d.png)

after:

![after_email](https://cloud.githubusercontent.com/assets/6207644/20493544/4948a2ec-afe7-11e6-9616-ca1a9e5a4fc8.png)



#### What GIF best describes this PR or how it makes you feel?
