### PR TITLE
Turn off querystring auth so we don't expire S3 asset links

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -445,6 +445,7 @@ MICROMASTERS_USE_S3 = get_var('MICROMASTERS_USE_S3', False)
 AWS_ACCESS_KEY_ID = get_var('AWS_ACCESS_KEY_ID', False)
 AWS_SECRET_ACCESS_KEY = get_var('AWS_SECRET_ACCESS_KEY', False)
 AWS_STORAGE_BUCKET_NAME = get_var('AWS_STORAGE_BUCKET_NAME', False)
+AWS_QUERYSTRING_AUTH = get_var('AWS_QUERYSTRING_AUTH', False)
 # Provide nice validation of the configuration
 if (
         MICROMASTERS_USE_S3 and


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1533 

#### What's this PR do?
Sets `AWS_QUERYSTRING_AUTH` to false. When query string auth is disabled it will no longer set an expiration in the URL.

#### How should this be manually tested?
In the attached PR build upload a profile image. Verify that the profile image comes from S3 without any query parameters
