### PR TITLE
Remove border between row and sub rows

### DIFF
--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -143,7 +143,6 @@
       font-size: 11pt;
       align-items: center;
       padding: 14px 20px;
-      border-bottom: 1px solid $lightgrey;
 
       &:last-child {
         border-bottom: none;

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -144,10 +144,6 @@
       align-items: center;
       padding: 14px 20px;
 
-      &:last-child {
-        border-bottom: none;
-      }
-
       .course-description {
         .course-title {
           font-weight: 500;


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1599 

#### What's this PR do?
Removes border between row and sub rows

#### How should this be manually tested?
I set up the PR build to have past runs, so you should be able to see the fix there, under Digital Learning. There should be no border between the past run message and the current run.
