### PR TITLE
Fix bug with custom entry

### DIFF
--- a/static/js/components/inputs/SelectField.js
+++ b/static/js/components/inputs/SelectField.js
@@ -95,7 +95,7 @@ class SelectField extends React.Component {
     </label>
   );
 
-  componentDidUpdate () {
+  addCustomOptions = () => {
     const { keySet, profile, allowCreate, options } = this.props;
     const { customOptions } = this.state;
 
@@ -106,6 +106,14 @@ class SelectField extends React.Component {
         customOptions: customOptions.concat({ value: value, label: value })
       });
     }
+  }
+
+  componentDidUpdate () {
+    this.addCustomOptions();
+  }
+
+  componentDidMount () {
+    this.addCustomOptions();
   }
 
   renderSelect = (): React$Element<*> => {

--- a/static/js/components/inputs/inputs_test.js
+++ b/static/js/components/inputs/inputs_test.js
@@ -155,6 +155,23 @@ describe('Profile inputs', () => {
         ]
       });
     });
+
+    it('should add a previously saved custom option to this.state', () => {
+      selectField = renderGenderSelectField({
+        allowCreate: true,
+        profile: {
+          gender: 'agender'
+        }
+      });
+      assert.include(selectField.text(), 'agender');
+      let expectedCustomOption = {
+        value: 'agender', label: 'agender'
+      };
+      assert.deepEqual(selectField.state(), {
+        customOptions: [ expectedCustomOption ]
+      });
+      assert.include(selectField.find(VirtualizedSelect).props().options, expectedCustomOption);
+    });
   });
 
   describe("State select field", () => {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1854 

#### What's this PR do?

This ensures that when opening an existing education or work history entry (which has a custom entry) the user will see the value in the field.

#### How should this be manually tested?

1. edit work history -> industry or educatoin -> field of study
2. save a custom option (e.g. 'Salmon psychology' or something)
3. open the entry again (w/ the edit button)
4. confirm that the custom entry is in the field still