### PR TITLE
Increased coverage reporting precision to 2

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,7 @@
 branch = True
 source = .
 data_file=/tmp/coverage
-omit = 
+omit =
     micromasters/wsgi.py
     manage.py
     ./.tox/*
@@ -14,6 +14,7 @@ omit =
 exclude_lines =
     pragma: no cover
 show_missing = True
+precision = 2
 
 [html]
 directory = ${COVERAGE_DIR}


### PR DESCRIPTION
#### What's this PR do?

This increases the precision of the reports generated by `coverage` from 0 to 2 (87% => 87.25%). We have enough code now that unless you're adding a huge the lack of precision hides any delta short of passing a rounding threshold.

#### How should this be manually tested?

Run `docker-compose run web tox` and verify you see the extra precision in `htmlcov/index.html`.

#### Screenshots (if appropriate)

![selection_006](https://cloud.githubusercontent.com/assets/28598/20573680/0e9b8422-b17f-11e6-954f-23201edb6d74.png)

