### PR TITLE
make profile photo required during signup

### DIFF
--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import _ from 'lodash';
 import Card from 'react-mdl/lib/Card/Card';
+import CardTitle from 'react-mdl/lib/Card/CardTitle';
 import R from 'ramda';
 import Select from 'react-select';
 
@@ -12,9 +13,11 @@ import {
   combineValidators,
   personalValidation,
   programValidation,
+  profileImageValidation,
 } from '../lib/validation/profile';
 import type {
   Profile,
+  ProfileFetchResponse,
   SaveProfileFunc,
   ValidationErrors,
   UpdateProfileFunc,
@@ -28,7 +31,13 @@ import {  validationErrorSelector } from '../util/util';
 import type { Option } from '../flow/generalTypes';
 import { setProfileStep } from '../actions/ui';
 import { PERSONAL_STEP } from '../constants';
+import ProfileImage from '../containers/ProfileImage';
 
+const personalTabValidator = combineValidators(
+  personalValidation,
+  programValidation,
+  profileImageValidation,
+);
 
 export default class PersonalTab extends React.Component {
   props: {
@@ -38,6 +47,7 @@ export default class PersonalTab extends React.Component {
     nextStep:                 () => void,
     prevStep:                 () => void,
     profile:                  Profile,
+    uneditedProfile:          Profile,
     programs:                 AvailablePrograms,
     saveProfile:              SaveProfileFunc,
     setProgram:               Function,
@@ -89,8 +99,16 @@ export default class PersonalTab extends React.Component {
     );
   };
 
+  afterImageUpload = (fetchResponse: ProfileFetchResponse): void => {
+    const { profile, updateProfile } = this.props;
+    let editState = _.cloneDeep(profile);
+    let { payload: { profile: { image } }} = fetchResponse;
+    let newEditState = Object.assign({}, editState, { image });
+    updateProfile(newEditState, personalTabValidator);
+  };
+
   render() {
-    const { ui: { selectedProgram }, errors } = this.props;
+    const { ui: { selectedProgram }, errors, uneditedProfile } = this.props;
 
     return (
       <div>
@@ -104,6 +122,21 @@ export default class PersonalTab extends React.Component {
             {_.get(errors, ['program'])}
           </span>
         </Card>
+        <Card shadow={1} className="profile-image">
+          <CardTitle>
+            Upload a Profile Photo
+          </CardTitle>
+          <ProfileImage
+            profile={uneditedProfile}
+            editable={true}
+            showLink={true}
+            linkText="Click here to add a profile photo"
+            afterImageUpload={this.afterImageUpload}
+          />
+          <span className="validation-error-text">
+            {_.get(errors, ['image'])}
+          </span>
+        </Card>
         <Card shadow={1} className="profile-form">
           <PersonalForm {...this.props} validator={personalValidation} />
         </Card>
@@ -113,12 +146,7 @@ export default class PersonalTab extends React.Component {
           nextBtnLabel="Next"
           programIdForEnrollment={selectedProgram ? selectedProgram.id : null}
           isLastTab={false}
-          validator={
-            combineValidators(
-              personalValidation,
-              programValidation
-            )
-          }
+          validator={personalTabValidator}
         />
       </div>
     );

--- a/static/js/components/PersonalTab_test.js
+++ b/static/js/components/PersonalTab_test.js
@@ -9,6 +9,7 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import PersonalTab from './PersonalTab';
 import { PROGRAMS } from '../constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
+import { USER_PROFILE_RESPONSE } from '../constants';
 
 describe("PersonalTab", () => {
   let helper;
@@ -21,6 +22,7 @@ describe("PersonalTab", () => {
             programs={PROGRAMS}
             ui={{selectedProgram: selectedProgram}}
             dispatch={store.dispatch}
+            uneditedProfile={USER_PROFILE_RESPONSE}
             {...props}
           />
         </Provider>

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -223,6 +223,7 @@ export const ELASTICSEARCH_RESPONSE = {
 };
 
 export const USER_PROFILE_RESPONSE = {
+  "image": "some_sort_of_image.png",
   "username": SETTINGS.user ? SETTINGS.user.username : null,
   "filled_out": true,
   "agreed_to_terms_of_service": true,

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -108,7 +108,7 @@ class ProfileFormContainer extends React.Component {
 
   startProfileEdit: Function = () => {
     const { dispatch } = this.props;
-    const username = SETTINGS.username;
+    const username = SETTINGS.user.username;
     dispatch(startProfileEdit(username));
   };
 
@@ -183,19 +183,22 @@ class ProfileFormContainer extends React.Component {
       dispatch,
       currentProgramEnrollment
     } = this.props;
-    let errors, isEdit, profile;
+    let errors, isEdit, profile, uneditedProfile;
 
     if ( profileFromStore === undefined ) {
       profile = {};
+      uneditedProfile = {};
       errors = {};
       isEdit = false;
     } else {
       if (profileFromStore.edit !== undefined) {
         errors = profileFromStore.edit.errors;
         profile = profileFromStore.edit.profile;
+        uneditedProfile = profileFromStore.profile;
         isEdit = true;
       } else {
         profile = profileFromStore.profile;
+        uneditedProfile = profileFromStore.profile;
         errors = {};
         isEdit = false;
       }
@@ -207,6 +210,7 @@ class ProfileFormContainer extends React.Component {
       errors: errors,
       fetchProfile: this.fetchProfile,
       profile: profile,
+      uneditedProfile: uneditedProfile,
       programs: programs.availablePrograms,
       saveProfile: this.saveProfile.bind(this, isEdit),
       currentProgramEnrollment: currentProgramEnrollment,

--- a/static/js/containers/ProfileImage_test.js
+++ b/static/js/containers/ProfileImage_test.js
@@ -1,26 +1,31 @@
 /* global SETTINGS: false */
-import '../global_init';
-
 import React from 'react';
 import { mount } from 'enzyme';
 import { assert } from 'chai';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import { Provider } from 'react-redux';
 
 import ProfileImage from './ProfileImage';
 import IntegrationTestHelper from '../util/integration_test_helper';
+import ProfileImageUploader from '../components/ProfileImageUploader';
+import * as api from '../lib/api';
+import { startPhotoEdit, updatePhotoEdit } from '../actions/image_upload';
+import { USER_PROFILE_RESPONSE } from '../constants';
 
 describe('ProfileImage', () => {
-  let helper;
+  let helper, sandbox, updateProfileImageStub;
 
-  const renderProfileImage = (profile, editable=true) => (
+  const renderProfileImage = (editable=true, props = {}) => (
     mount(
       <MuiThemeProvider muiTheme={getMuiTheme()}>
-        <ProfileImage
-          profile={profile} 
-          store={helper.store}
-          editable={editable}
-        />
+        <Provider store={helper.store}>
+          <ProfileImage
+            editable={editable}
+            profile={USER_PROFILE_RESPONSE}
+            {...props}
+          />
+        </Provider>
       </MuiThemeProvider>
     )
   );
@@ -35,6 +40,9 @@ describe('ProfileImage', () => {
 
   beforeEach(() => {
     helper = new IntegrationTestHelper();
+    sandbox = helper.sandbox;
+    updateProfileImageStub = sandbox.stub(api, 'updateProfileImage');
+    updateProfileImageStub.returns(Promise.resolve());
   });
 
   afterEach(() => {
@@ -43,29 +51,27 @@ describe('ProfileImage', () => {
 
   describe('upload button', () => {
     it('should be hidden if not editable', () => {
-      let image = renderProfileImage(SETTINGS.user, false);
+      let image = renderProfileImage(false);
 
       assert.lengthOf(
         image.find('.open-photo-dialog'),
         0,
         'image should contain a button to upload a profile photo'
       );
-
     });
 
     it('should be visible if editable and is users own profile', () => {
-      let image = renderProfileImage(SETTINGS.user);
+      let image = renderProfileImage();
 
       assert.lengthOf(
         image.find('.open-photo-dialog'),
         1,
         'image should contain a button to upload a profile photo'
       );
-
     });
 
     it('should be hidden if editable and another users profile', () => {
-      let image = renderProfileImage(thatProfile);
+      let image = renderProfileImage();
 
       assert(
         image.find('.open-photo-dialog'),
@@ -74,5 +80,37 @@ describe('ProfileImage', () => {
       );
     });
 
+    it("should display a 'open' link with the correct link text if passed the right props", () => {
+      let image = renderProfileImage(true, {
+        profile: thatProfile,
+        showLink: true,
+        linkText: 'some link text'
+      });
+
+      let link = image.find('a');
+      assert.equal(link.text(), 'some link text');
+      link.simulate('click');
+      assert.ok(
+        helper.store.getState().ui.photoDialogVisibility,
+        'should be open now'
+      );
+    });
+
+    it('should call an afterImageUpload prop after success, if it is present', () => {
+      let afterImageUpload = sandbox.stub();
+      let image = renderProfileImage(true, {
+        profile: thatProfile,
+        afterImageUpload: afterImageUpload,
+      });
+      helper.store.dispatch(startPhotoEdit({ name: 'a name' }));
+      helper.store.dispatch(updatePhotoEdit({ name: 'a name'}));
+      let uploader = image.find(ProfileImageUploader);
+      return uploader.props().updateUserPhoto().then(() => {
+        assert.ok(
+          afterImageUpload.called,
+          'afterImageUpload callback should have been called'
+        );
+      });
+    });
   });
 });

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -218,8 +218,6 @@ describe("UserPage", function() {
               UPDATE_PROFILE_VALIDATION,
               UPDATE_VALIDATION_VISIBILITY,
               UPDATE_VALIDATION_VISIBILITY,
-              UPDATE_VALIDATION_VISIBILITY,
-              START_PROFILE_EDIT,
             ]),
             preferredName,
             { preferred_name: 'Nickname / Preferred name is required' },
@@ -233,7 +231,6 @@ describe("UserPage", function() {
               UPDATE_PROFILE_VALIDATION,
               UPDATE_VALIDATION_VISIBILITY,
               UPDATE_VALIDATION_VISIBILITY,
-              START_PROFILE_EDIT,
             ]),
             preferredName,
           );
@@ -247,7 +244,6 @@ describe("UserPage", function() {
             userProfileActions.concat([
               UPDATE_PROFILE_VALIDATION,
               UPDATE_VALIDATION_VISIBILITY,
-              START_PROFILE_EDIT,
             ]),
             dobMonth,
             { date_of_birth: "Please enter a valid date of birth" },
@@ -260,7 +256,6 @@ describe("UserPage", function() {
             scrollActions.concat([
               UPDATE_PROFILE_VALIDATION,
               UPDATE_VALIDATION_VISIBILITY,
-              START_PROFILE_EDIT,
             ]),
             dobMonth,
           );
@@ -281,7 +276,6 @@ describe("UserPage", function() {
         it('should clearValidationErrors when filling out a required select field', () => {
           return clearValidation(
             userProfileActions.concat([
-              START_PROFILE_EDIT,
               UPDATE_PROFILE_VALIDATION,
               UPDATE_VALIDATION_VISIBILITY,
             ]),
@@ -294,7 +288,6 @@ describe("UserPage", function() {
         it('should scrollIntoView when filling out a required select field', () => {
           return scrollIntoView(
             scrollActions.concat([
-              START_PROFILE_EDIT,
               UPDATE_PROFILE_VALIDATION,
               UPDATE_VALIDATION_VISIBILITY,
             ]),
@@ -335,7 +328,6 @@ describe("UserPage", function() {
           return scrollIntoView(
             scrollActions.concat([
               UPDATE_PROFILE_VALIDATION,
-              START_PROFILE_EDIT,
               UPDATE_VALIDATION_VISIBILITY,
               UPDATE_VALIDATION_VISIBILITY,
             ]),

--- a/static/js/flow/profileTypes.js
+++ b/static/js/flow/profileTypes.js
@@ -78,5 +78,9 @@ export type ProfileGetResult = {
 
 export type ProfilePatchResult = ProfileGetResult;
 
+export type ProfileFetchResponse = {
+  payload: ProfileGetResult
+};
+
 export type SaveProfileFunc = (validator: Validator|UIValidator, profile: Profile, ui: UIState) => Promise<Profile>;
 export type UpdateProfileFunc = (profile: Profile, validator: Validator|UIValidator) => void;

--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -57,6 +57,10 @@ export function programValidation(_: Profile, ui: UIState): ValidationErrors {
   return errors;
 }
 
+export const profileImageValidation = (profile: Profile) => (
+  profile.image ? {} : { image: 'Please upload a profile image' }
+);
+
 export function personalValidation(profile: Profile): ValidationErrors {
   let requiredFields = [
     ['first_name'],

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -12,6 +12,7 @@ import {
   combineValidators,
   emailValidation,
   validateFinancialAid,
+  profileImageValidation,
 } from './profile';
 import {
   USER_PROFILE_RESPONSE,
@@ -83,6 +84,21 @@ describe('Profile validation functions', () => {
         date_of_birth: "Please enter a valid date of birth"
       };
       assert.deepEqual(personalValidation(profile), errors);
+    });
+  });
+
+
+  describe('profileImageValidation', () => {
+    it('should return an error if no image', () => {
+      assert.deepEqual(profileImageValidation({}), {
+        image: 'Please upload a profile image'
+      });
+    });
+
+    it('should return no errors if image is present', () => {
+      assert.deepEqual(profileImageValidation({
+        image: 'some-image.png'
+      }), {});
     });
   });
 

--- a/static/scss/profile-image.scss
+++ b/static/scss/profile-image.scss
@@ -1,27 +1,38 @@
-.avatar {
-  position: relative;
+.profile-image {
+  display: flex;
 
-  .open-photo-dialog {
+  .avatar {
+    position: relative;
+
+    .open-photo-dialog {
+      cursor: pointer;
+      width: 34px;
+      height: 34px;
+      border: 0;
+      border-radius: 50%;
+      background-color: rgba(0, 0, 0, 0.3);
+      position: absolute;
+      top: 0;
+      right: -2px;
+      text-align: center;
+      line-height: 46px;
+
+      img {
+        width: 22px;
+        height: auto;
+      }
+
+      i.material-icons {
+        color: white;
+        font-size: 22px;
+      }
+    }
+  }
+
+  a {
+    margin-left: 25px;
+    margin-top: auto;
+    margin-bottom: auto;
     cursor: pointer;
-    width: 34px;
-    height: 34px;
-    border: 0;
-    border-radius: 50%;
-    background-color: rgba(0, 0, 0, 0.3);
-    position: absolute;
-    top: 0;
-    right: -2px;
-    text-align: center;
-    line-height: 46px;
-
-    img {
-      width: 22px;
-      height: auto;
-    }
-
-    i.material-icons {
-      color: white;
-      font-size: 22px;
-    }
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1762 

#### What's this PR do?

This PR adds a new requirement to the signup process, which is that the user add a profile image.

#### How should this be manually tested?

First,check that the validation is working correctly:

1. use the django shell or similar to delete your user's profile image (if present)
2. visit `/profile/personal`
3. click 'next'

there should be a validation error, which will disappear when you add a profile image. Then you should be able to proceed with the rest of the signup flow.

The other thing to check is that the edit state for the personal form is persisted when updating the profile image. This was a bit tricky to get working, because the currently edited `profile` is what we check via validation, and the user may have started editing the form before adding an image.

1. visit `/profile/personal`
2. make some edit to the form which results in a validation error (for instance removing your last name) and also an unsaved change to the form (like changing your first name to 'Salmon' or something).
3. Go through the profile image update process.
4. The form should still be the same.

In particular, if you're doing the above _without_ a profile image the validation error for the missing image should go away, while the rest of the edit state is persisted.

I think that's it, besides generally checking I didn't clobber any other profile functionality.

#### Screenshots (if appropriate)

![add_a_photo_error](https://cloud.githubusercontent.com/assets/6207644/20575911/628433e0-b189-11e6-87f1-a6bc01d44af2.png)

![add_a_photo](https://cloud.githubusercontent.com/assets/6207644/20575915/660b3ac2-b189-11e6-9218-18a477446a85.png)
