### PR TITLE
Fixed future course start date display

### DIFF
--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -152,8 +152,9 @@ export default class CourseAction extends React.Component {
       break;
     }
     case STATUS_WILL_ATTEND: {
-      let startDate = moment(run.course_start_date);
-      let text = ifValidDate('', date => `Course starts in ${date.diff(now, 'days')} days`, startDate);
+      let startDate = moment(run.course_start_date).startOf('day');
+      let nowDate = moment(now).startOf('day');
+      let text = ifValidDate('', date => `Course starts in ${date.diff(nowDate, 'days')} days`, startDate);
       description = this.renderBoxedDescription(text);
       break;
     }

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -241,11 +241,35 @@ describe('CourseAction', () => {
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_WILL_ATTEND
     ));
-    let startDate = moment(now).add(10, 'days').toISOString();
-    let firstRun = alterFirstRun(course, {course_start_date: startDate});
+    let startDate = moment(now).add(10, 'days');
+    let firstRun = alterFirstRun(course, {course_start_date: startDate.toISOString()});
     const wrapper = shallow(<CourseAction courseRun={firstRun} {...defaultParamsNow} />);
     let elements = getElements(wrapper);
 
+    assert.include(elements.descriptionText, 'Course starts in 10 days');
+  });
+
+  it('ignores time of day when showing the number of days until a future course starts', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_WILL_ATTEND
+    ));
+
+    let currentDate = moment(now).set('hour', 12);
+    let startDate = moment(currentDate).add(10, 'days');
+
+    // Set the course to start in 10 days + 10 minutes
+    startDate.add(10, 'minutes');
+    let firstRun = alterFirstRun(course, {course_start_date: startDate.toISOString()});
+    let wrapper = shallow(<CourseAction courseRun={firstRun} {...defaultParamsNow} />);
+    let elements = getElements(wrapper);
+    assert.include(elements.descriptionText, 'Course starts in 10 days');
+
+    // Set the course to start in 10 days - 10 minutes
+    startDate.add(-20, 'minutes');
+    firstRun = alterFirstRun(course, {course_start_date: startDate.toISOString()});
+    wrapper = shallow(<CourseAction courseRun={firstRun} {...defaultParamsNow} />);
+    elements = getElements(wrapper);
     assert.include(elements.descriptionText, 'Course starts in 10 days');
   });
 


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #1676 

#### What's this PR do?

Makes sure that the day countdown to a future course run ignores the time of day. For example, if a course starts in 3 calendar days, but the time of day for the start date is less than the current time of day, the countdown will still show 3

#### How should this be manually tested?

You can use the `alter_data` command to set a course to be enrolled and in the future:

`alter_data --action=set_course_to_enrolled --email=YOUR_EMAIL --program-title='Analog' --course-title='100' --in-future`

After that, you can run a django shell and edit the course run's `start_date` to set the time behind/ahead of the current time. The `Course starts in X days` message on the dashboard should show the same number.
