### PR TITLE
fix Virgin Islands labels

### DIFF
--- a/static/js/components/inputs/CountrySelectField.js
+++ b/static/js/components/inputs/CountrySelectField.js
@@ -2,17 +2,33 @@
 import React from 'react';
 import _ from 'lodash';
 import iso3166 from 'iso-3166-2';
+import R from 'ramda';
+
 import SelectField from './SelectField';
 import type { Profile, UpdateProfileFunc, ValidationErrors } from '../../flow/profileTypes';
 import type { Validator, UIValidator } from '../../lib/validation/profile';
 import type { Option } from '../../flow/generalTypes';
+import { labelSort } from '../../util/util';
 
-let countryOptions = _(iso3166.data)
-  .map((countryInfoObj, countryCode) => ({
-    value: countryCode,
-    label: countryInfoObj.name
-  }))
-  .sortBy('label').value();
+// VI is US Virgin Islands, VG is British
+const adjustVIEntries = R.compose(
+  R.set(R.lensProp('VI'), 'US Virgin Islands'),
+  R.set(R.lensProp('VG'), 'British Virgin Islands')
+);
+
+const countryOption = (name, code) => (
+  { value: code, label: name }
+);
+
+const makeCountryOptions = R.compose(
+  labelSort,
+  R.values,
+  R.mapObjIndexed(countryOption),
+  adjustVIEntries,
+  R.map(R.prop('name')),
+);
+
+const countryOptions = makeCountryOptions(iso3166.data);
 
 export default class CountrySelectField extends React.Component {
   props: {

--- a/static/js/components/inputs/inputs_test.js
+++ b/static/js/components/inputs/inputs_test.js
@@ -229,6 +229,11 @@ describe('Profile inputs', () => {
       mount(<CountrySelectField {...inputProps} />)
     );
 
+    const checkFieldText = text => {
+      let countryField = renderCountrySelect();
+      assert.include(countryField.text(), text);
+    };
+
     it('shows a list of countries', () => {
       inputProps.profile.country_key = null;
       inputProps.profile.country = null;
@@ -248,6 +253,14 @@ describe('Profile inputs', () => {
       countryField.find(SelectField).props().onChange({ value: 'AL' });
       assert.equal(inputProps.profile.country_key, 'AL');
       assert.equal(inputProps.profile.state_key, null);
+    });
+
+    it('should have different labels for the different virgin islands', () => {
+      inputProps.profile.country_key = 'VI';
+      checkFieldText('US Virgin Islands');
+
+      inputProps.profile.country_key = 'VG';
+      checkFieldText('British Virgin Islands');
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?

closes #541 

#### What's this PR do?

Makes sure that the label is different for the US and the British virgin islands.


#### How should this be manually tested?

Go to `/profile` or similar and make sure that two distinct options come up if you type in 'Virgin Islands' into a country select field

Check that the values updated in the profile are the correct country code for the US and British islands.

helpful:

https://en.wikipedia.org/wiki/United_States_Virgin_Islands

https://en.wikipedia.org/wiki/British_Virgin_Islands

#### Screenshots (if appropriate)

![country_stuff_vi](https://cloud.githubusercontent.com/assets/6207644/20678779/094816e4-b566-11e6-83ed-b2ff14013052.png)

