### PR TITLE
Use external URL if one exists

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -25,7 +25,10 @@ class ProgramSerializer(serializers.ModelSerializer):
         """
         from cms.models import ProgramPage
         try:
-            return program.programpage.url
+            page = program.programpage
+            if page.external_program_page_url:
+                return page.external_program_page_url
+            return page.url
         except ProgramPage.DoesNotExist:
             return
 

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -98,6 +98,26 @@ class ProgramSerializerTests(ESTestCase):
         }
         assert len(programpage.url) > 0
 
+    def test_program_with_external_url(self):
+        """
+        Test ProgramSerializer with a program page that has an external url
+        """
+        url = 'http://example.com/external-url/'
+        programpage = ProgramPageFactory.build(
+            program=self.program,
+            external_program_page_url=url,
+        )
+        homepage = HomePage.objects.first()
+        homepage.add_child(instance=programpage)
+        data = ProgramSerializer(self.program, context=self.context).data
+        assert data == {
+            'id': self.program.id,
+            'title': self.program.title,
+            'programpage_url': url,
+            'enrolled': False,
+        }
+        assert programpage.url != url
+
     def test_program_enrolled(self):
         """
         Test ProgramSerializer with an enrolled user


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1003

#### What's this PR do?
Changes the program serializer to return the external URL if it exists, instead of the CMS URL

#### How should this be manually tested?
Create a program page in the CMS and set the external URL to something. Go to `/api/v0/programs/` and confirm that the URL there is the one you typed in, not the link to the CMS page.
