### PR TITLE
Fix 'save photo' exception

### DIFF
--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -76,7 +76,7 @@ const ProfileImageUploader = ({
         type='button'
         className={`save-button ${photo ? 'primary-button' : 'secondary-button disabled'}`}
         key="save"
-        onClick={updateUserPhoto}>
+        onClick={photo ? updateUserPhoto : undefined}>
         Save
       </Button>
     ]}


### PR DESCRIPTION
#### What are the relevant tickets?

#1875 

#### What's this PR do?

Basically just ensures that if there isn't a photo selected we don't try to call the function to issue the request.

#### How should this be manually tested?

Open the photo upload dialog, and click 'save' without selecting a photo. You shouldn't see any errors in the JS console.