### PR TITLE
Fix red border around calculator salary on Firefox

### DIFF
--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -62,7 +62,7 @@ const salaryUpdate = R.curry((update, current, e) => {
 const salaryField = (update, current) => (
   <TextField
     name="salary"
-    required="true"
+    aria-required="true"
     aria-invalid={_.has(current, ['validation', 'income'])}
     label="income (yearly)"
     id="user-salary-input"

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -160,7 +160,7 @@ describe('FinancialAidCalculator', () => {
           'income': 'Income is required',
           'currency': 'Please select a currency'
         });
-        checkInvalidInput('.salary-field input', 'required');
+        checkInvalidInput('.salary-field input', 'aria-required');
         checkInvalidInput('.checkbox input', 'required');
         checkInvalidInput('.currency .Select-input input', 'aria-required');
       });


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1850 

#### What's this PR do?

Firefox puts a red border around `<input>` tags which are targeted by the `:required` pseudo selector. This switches from `required` to `aria-required` to remove the effect.

Make sure that the red border is gone!

Before:

![required](https://cloud.githubusercontent.com/assets/6207644/20719473/062171bc-b62a-11e6-9b05-89835422efe8.png)

after:

![required_after](https://cloud.githubusercontent.com/assets/6207644/20719480/0bc31bca-b62a-11e6-9e4c-64746d88dc7d.png)
