### PR TITLE
Improve accessibility text for edit profile button

### DIFF
--- a/static/js/components/UserInfoCard.js
+++ b/static/js/components/UserInfoCard.js
@@ -79,7 +79,9 @@ export default class UserInfoCard extends React.Component {
             { profile.email ? this.email(profile.email) : null }
           </div>
           <div className="edit-profile-holder">
-            {userPrivilegeCheck(profile, () => <IconButton name="edit" onClick={toggleShowPersonalDialog}/>)}
+            {userPrivilegeCheck(profile, () => (
+              <IconButton name="edit personal information" onClick={toggleShowPersonalDialog}/>
+            ))}
           </div>
         </div>
         {this.renderAboutMeSection(profile, toggleShowAboutMeDialog)}


### PR DESCRIPTION
Improve accessibility text for edit profile button

#### How should this be manually tested?
Activate VoiceOver or ChromeVox, and tab to the edit buttons on your user profile page. The screen reader should clearly explain what these buttons do.