### PR TITLE
Update selector for Zendesk launcher button

### DIFF
--- a/static/js/entry/zendesk_widget.js
+++ b/static/js/entry/zendesk_widget.js
@@ -74,7 +74,7 @@ const zendeskCallbacks = {
 
   launcherLoaded: () => {
     const iframe = document.querySelector("iframe.zEWidget-launcher");
-    const btn = iframe.contentDocument.querySelector(".Button--launcher");
+    const btn = iframe.contentDocument.querySelector(".u-userBackgroundColor");
 
     const regularBackgroundColor = "rgba(0, 0, 0, .14)";
     const hoverBackgroundColor = window.getComputedStyle(btn).backgroundColor;


### PR DESCRIPTION
Zendesk changed the HTML that they use for their launcher button. As a result, the JS that I wrote to change the background color of the button broke. This pull request restores the background color that we want for the launcher button.