### PR TITLE
Turned on webpack stats generation, use stats for filenames, use templatetags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,9 @@ static/scss/material.css
 
 # Local settings
 micromasters.yml
+
+# Webpack
+webpack-stats.json
+
+# Celery Beat
+celerybeat-schedule

--- a/cms/models.py
+++ b/cms/models.py
@@ -19,7 +19,6 @@ from micromasters.serializers import serialize_maybe_user
 from micromasters.utils import webpack_dev_server_host
 from profiles.api import get_social_username
 from roles.models import Instructor, Staff
-from ui.views import get_bundle_url
 
 
 class HomePage(Page):
@@ -43,16 +42,12 @@ class HomePage(Page):
         context = super(HomePage, self).get_context(request)
 
         context["programs"] = programs
-        context["style_src"] = get_bundle_url(request, "style.js")
-        context["public_src"] = get_bundle_url(request, "public.js")
-        context["style_public_src"] = get_bundle_url(request, "style_public.js")
+        context["is_public"] = True
         context["authenticated"] = not request.user.is_anonymous()
         context["is_staff"] = has_role(request.user, [Staff.ROLE_ID, Instructor.ROLE_ID])
         context["username"] = username
         context["js_settings_json"] = json.dumps(js_settings)
         context["title"] = self.title
-        context["common_src"] = get_bundle_url(request, "common.js")
-        context["sentry_client"] = get_bundle_url(request, "sentry_client.js")
         context["tracking_id"] = ""
 
         return context
@@ -209,17 +204,12 @@ def get_program_page_context(programpage, request):
     username = get_social_username(request.user)
     context = super(ProgramPage, programpage).get_context(request)
 
-    context["zendesk_widget"] = get_bundle_url(request, "zendesk_widget.js")
-    context["style_src"] = get_bundle_url(request, "style.js")
-    context["public_src"] = get_bundle_url(request, "public.js")
-    context["style_public_src"] = get_bundle_url(request, "style_public.js")
+    context["is_public"] = True
     context["authenticated"] = not request.user.is_anonymous()
     context["username"] = username
     context["js_settings_json"] = json.dumps(js_settings)
     context["title"] = programpage.title
     context["courses"] = courses_query
-    context["common_src"] = get_bundle_url(request, "common.js")
-    context["sentry_client"] = get_bundle_url(request, "sentry_client.js")
     context["tracking_id"] = programpage.program.ga_tracking_id
 
     return context

--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -292,7 +292,8 @@
 
   </div>
 </div>
-<script type="text/javascript" src="{{ public_src }}"></script>
+{% load render_bundle %}
+{% render_bundle "public" %}
 {% endblock %}
 
 </a>div>

--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -294,6 +294,5 @@
 </div>
 {% load render_bundle %}
 {% render_bundle "public" %}
+</div>
 {% endblock %}
-
-</a>div>

--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -146,6 +146,7 @@
 <div id="signup-dialog">
   <!-- signup dialog React component injected here -->
 </div>
-<script type="text/javascript" src="{{ public_src }}"></script>
+{% load render_bundle %}
+{% render_bundle "public" %}
 <script defer src="https://code.getmdl.io/1.2.1/material.min.js"></script>
 {% endblock %}

--- a/financialaid/templates/review_financial_aid.html
+++ b/financialaid/templates/review_financial_aid.html
@@ -276,5 +276,6 @@
     window.CSRF_TOKEN = "{{ csrf_token }}";
     window.BASE_PATH = "{{ request.path }}?sort_by={{ current_sort_field }}&search_query="
   </script>
-  <script src="{{ financial_aid_src }}"></script>
+  {% load render_bundle %}
+  {% render_bundle "financial_aid" %}
 {% endblock %}

--- a/financialaid/views.py
+++ b/financialaid/views.py
@@ -47,7 +47,6 @@ from financialaid.serializers import (
 )
 from mail.serializers import FinancialAidMailSerializer
 from roles.roles import Permissions
-from ui.views import get_bundle_url
 
 
 class FinancialAidRequestView(CreateAPIView):
@@ -223,9 +222,6 @@ class ReviewFinancialAidView(UserPassesTestMixin, ListView):
         context["sort_fields"] = self.sort_fields
 
         # Required for styling
-        context["style_src"] = get_bundle_url(self.request, "style.js")
-        context["dashboard_src"] = get_bundle_url(self.request, "dashboard.js")
-        context["zendesk_widget"] = get_bundle_url(self.request, "zendesk_widget.js")
         js_settings = {
             "gaTrackingID": settings.GA_TRACKING_ID,
             "reactGaDebug": settings.REACT_GA_DEBUG,
@@ -234,10 +230,7 @@ class ReviewFinancialAidView(UserPassesTestMixin, ListView):
         }
         context["js_settings_json"] = json.dumps(js_settings)
         context["authenticated"] = not self.request.user.is_anonymous()
-        context["financial_aid_src"] = get_bundle_url(self.request, "financial_aid.js")
-        context["common_src"] = get_bundle_url(self.request, "common.js")
-        context["public_src"] = get_bundle_url(self.request, "public.js")
-        context["style_public_src"] = get_bundle_url(self.request, "style_public.js")
+        context["is_public"] = True
         return context
 
     def get_queryset(self):

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -90,8 +90,8 @@ WEBPACK_LOADER = {
         'POLL_INTERVAL': 0.1,
         'TIMEOUT': None,
         'IGNORE': [
-            '.+\.hot-update\.+',
-            '.+\.js\.map'
+            r'.+\.hot-update\.+',
+            r'.+\.js\.map'
         ]
     }
 }

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -82,6 +82,21 @@ else:
 SECURE_SSL_REDIRECT = get_var('MICROMASTERS_SECURE_SSL_REDIRECT', True)
 
 
+WEBPACK_LOADER = {
+    'DEFAULT': {
+        'CACHE': not DEBUG,
+        'BUNDLE_DIR_NAME': 'bundles/',
+        'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats.json'),
+        'POLL_INTERVAL': 0.1,
+        'TIMEOUT': None,
+        'IGNORE': [
+            '.+\.hot-update\.+',
+            '.+\.js\.map'
+        ]
+    }
+}
+
+
 # Application definition
 
 INSTALLED_APPS = (
@@ -114,6 +129,7 @@ INSTALLED_APPS = (
     # other third party APPS
     'rolepermissions',
     'raven.contrib.django.raven_compat',
+    'webpack_loader',
 
     # Our INSTALLED_APPS
     'backends',

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6092,6 +6092,23 @@
         }
       }
     },
+    "webpack-bundle-tracker": {
+      "version": "0.1.0",
+      "from": "webpack-bundle-tracker@latest",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-tracker/-/webpack-bundle-tracker-0.1.0.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "1.1.1",
+          "from": "ansi-regex@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+        },
+        "strip-ansi": {
+          "version": "2.0.1",
+          "from": "strip-ansi@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+        }
+      }
+    },
     "webpack-core": {
       "version": "0.6.8",
       "from": "webpack-core@>=0.6.0 <0.7.0",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "url-loader": "0.5.7",
     "warning": "2.1.0",
     "webpack": "1.13.0",
+    "webpack-bundle-tracker": "^0.1.0",
     "webpack-dev-middleware": "^1.8.4",
     "webpack-hot-middleware": "^2.13.2"
   },

--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,7 @@ dj-static==0.0.6
 django-role-permissions==1.2
 django-server-status==0.3.2
 django-storages-redux==1.3.2
+django-webpack-loader==0.4.1
 djangorestframework==3.5.2
 edx-api-client==0.3.0
 elasticsearch-dsl==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ django-server-status==0.3.2
 django-storages-redux==1.3.2
 django-taggit==0.18.3     # via wagtail
 django-treebeard==4.0.1   # via wagtail
+django-webpack-loader==0.4.1
 django==1.10.3
 djangorestframework==3.5.2
 edx-api-client==0.3.0

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -12,14 +12,15 @@
     var SETTINGS = {{ js_settings_json|safe }};
     var CURRENT_PAGE_URL = '{{ request.build_absolute_uri }}';
     </script>
-    <script type="text/javascript" src="{{ common_src }}"></script>
-    <script type="text/javascript" src="{{ sentry_client }}"></script>
-    {% if style_public_src %}
-    <script type="text/javascript" src="{{ style_public_src }}"></script>
+    {% load render_bundle %}
+    {% render_bundle "common" %}
+    {% render_bundle "sentry_client" %}
+    {% if is_public %}
+      {% render_bundle "style_public" %}
     {% endif %}
-    <script type="text/javascript" src="{{ style_src }}"></script>
-    {% if zendesk_widget %}
-      <script type="text/javascript" src="{{ zendesk_widget }}"></script>
+    {% render_bundle "style" %}
+    {% if has_zendesk_widget %}
+      {% render_bundle "zendesk_widget" %}
     {% endif %}
     <title>{% block title %}{% endblock %}</title>
     <meta name="description" content="{% block description %}{% endblock %}">

--- a/ui/templates/base_error.html
+++ b/ui/templates/base_error.html
@@ -39,5 +39,6 @@
   <div id="signup-dialog">
   <!-- signup dialog React component injected here -->
   </div>
-  <script type="text/javascript" src="{{ public_src }}"></script>
+  {% load render_bundle %}
+  {% render_bundle "public" %}
 {% endblock %}

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -7,5 +7,7 @@
 {% block content %}
 <div id="dashboard"></div>
 {% include "footer.html" %}
-<script type="text/javascript" src="{{ dashboard_src }}"></script>
+
+{% load render_bundle %}
+{% render_bundle 'dashboard' %}
 {% endblock %}

--- a/ui/templates/terms_of_service.html
+++ b/ui/templates/terms_of_service.html
@@ -126,6 +126,7 @@
   <div id="signup-dialog">
     <!-- signup dialog React component injected here -->
   </div>
-  <script type="text/javascript" src="{{ public_src }}"></script>
+  {% load render_bundle %}
+  {% render_bundle "public" %}
   {% include "footer.html" %}
 {% endblock %}

--- a/ui/templatetags/render_bundle.py
+++ b/ui/templatetags/render_bundle.py
@@ -31,4 +31,7 @@ def _get_bundle(request, bundle_name):
 
 @register.simple_tag(takes_context=True)
 def render_bundle(context, bundle_name):
+    """
+    Render the script tags for a Webpack bundle
+    """
     return render_as_tags(_get_bundle(context['request'], bundle_name), '')

--- a/ui/templatetags/render_bundle.py
+++ b/ui/templatetags/render_bundle.py
@@ -1,0 +1,34 @@
+"""Templatetags for rendering script tags"""
+
+from django import template
+from django.conf import settings
+from django.contrib.staticfiles.templatetags.staticfiles import static
+
+from webpack_loader.templatetags.webpack_loader import render_as_tags
+from webpack_loader.utils import get_loader
+
+from micromasters.utils import webpack_dev_server_url
+
+
+register = template.Library()
+
+
+def _get_bundle(request, bundle_name):
+    """
+    Update bundle URLs to handle webpack hot reloading correctly if DEBUG=True
+    """
+    for chunk in get_loader('DEFAULT').get_bundle(bundle_name):
+        chunk_copy = dict(chunk)
+        if settings.DEBUG and settings.USE_WEBPACK_DEV_SERVER:
+            chunk_copy['url'] = "{host_url}/{bundle}".format(
+                host_url=webpack_dev_server_url(request),
+                bundle=chunk['name'],
+            )
+        else:
+            chunk_copy['url'] = static("bundles/{bundle}".format(bundle=chunk['name']))
+        yield chunk_copy
+
+
+@register.simple_tag(takes_context=True)
+def render_bundle(context, bundle_name):
+    return render_as_tags(_get_bundle(context['request'], bundle_name), '')

--- a/ui/templatetags/render_bundle.py
+++ b/ui/templatetags/render_bundle.py
@@ -34,4 +34,8 @@ def render_bundle(context, bundle_name):
     """
     Render the script tags for a Webpack bundle
     """
-    return render_as_tags(_get_bundle(context['request'], bundle_name), '')
+    try:
+        return render_as_tags(_get_bundle(context['request'], bundle_name), '')
+    except OSError:
+        # webpack-stats.json doesn't exist
+        return ''

--- a/ui/templatetags/render_bundle_test.py
+++ b/ui/templatetags/render_bundle_test.py
@@ -1,0 +1,97 @@
+"""
+Tests for render_bundle
+"""
+from unittest.mock import (
+    patch,
+    Mock,
+)
+
+from django.test.client import RequestFactory
+from django.test import (
+    override_settings,
+    TestCase,
+)
+from micromasters.utils import webpack_dev_server_url
+
+from ui.templatetags.render_bundle import render_bundle
+
+
+FAKE_COMMON_BUNDLE = [
+    {
+        "name": "common-1f11431a92820b453513.js",
+        "path": "/project/static/bundles/common-1f11431a92820b453513.js"
+    },
+]
+
+
+# pylint: disable=no-self-use
+class TestRenderBundle(TestCase):
+    """
+    Tests for render_bundle
+    """
+
+    @override_settings(DEBUG=True, USE_WEBPACK_DEV_SERVER=True)
+    def test_debug(self):
+        """
+        If DEBUG=True and USE_WEBPACK_DEV_SERVER=True, return a hot reload URL
+        """
+        request = RequestFactory().get('/')
+        context = {"request": request}
+
+        # convert to generator
+        common_bundle = (chunk for chunk in FAKE_COMMON_BUNDLE)
+        get_bundle = Mock(return_value=common_bundle)
+        loader = Mock(get_bundle=get_bundle)
+        bundle_name = 'bundle_name'
+        with patch('ui.templatetags.render_bundle.get_loader', return_value=loader) as get_loader:
+            assert render_bundle(context, bundle_name) == (
+                '<script type="text/javascript" src="{base}/{filename}" >'
+                '</script>'.format(
+                    base=webpack_dev_server_url(request),
+                    filename=FAKE_COMMON_BUNDLE[0]['name'],
+                )
+            )
+
+            get_bundle.assert_called_with(bundle_name)
+            get_loader.assert_called_with('DEFAULT')
+
+    @override_settings(DEBUG=True, USE_WEBPACK_DEV_SERVER=False)
+    def test_production(self):
+        """
+        If USE_WEBPACK_DEV_SERVER=False, return a static URL for production
+        """
+        request = RequestFactory().get('/')
+        context = {"request": request}
+
+        # convert to generator
+        common_bundle = (chunk for chunk in FAKE_COMMON_BUNDLE)
+        get_bundle = Mock(return_value=common_bundle)
+        loader = Mock(get_bundle=get_bundle)
+        bundle_name = 'bundle_name'
+        with patch('ui.templatetags.render_bundle.get_loader', return_value=loader) as get_loader:
+            assert render_bundle(context, bundle_name) == (
+                '<script type="text/javascript" src="{base}/{filename}" >'
+                '</script>'.format(
+                    base="/static/bundles",
+                    filename=FAKE_COMMON_BUNDLE[0]['name'],
+                )
+            )
+
+            get_bundle.assert_called_with(bundle_name)
+            get_loader.assert_called_with('DEFAULT')
+
+    def test_missing_file(self):
+        """
+        If webpack-stats.json is missing, return an empty string
+        """
+        request = RequestFactory().get('/')
+        context = {"request": request}
+
+        get_bundle = Mock(side_effect=OSError)
+        loader = Mock(get_bundle=get_bundle)
+        bundle_name = 'bundle_name'
+        with patch('ui.templatetags.render_bundle.get_loader', return_value=loader) as get_loader:
+            assert render_bundle(context, bundle_name) == ''
+
+            get_bundle.assert_called_with(bundle_name)
+            get_loader.assert_called_with('DEFAULT')

--- a/ui/views.py
+++ b/ui/views.py
@@ -6,7 +6,6 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.urlresolvers import reverse
 from django.shortcuts import Http404, redirect, render
 from django.utils.decorators import method_decorator
@@ -16,7 +15,7 @@ from raven.contrib.django.raven_compat.models import client as sentry
 from rolepermissions.shortcuts import available_perm_status
 from rolepermissions.verifications import has_role
 
-from micromasters.utils import webpack_dev_server_host, webpack_dev_server_url
+from micromasters.utils import webpack_dev_server_host
 from micromasters.serializers import serialize_maybe_user
 from profiles.api import get_social_username
 from profiles.permissions import CanSeeIfNotPrivate
@@ -24,19 +23,6 @@ from roles.models import Instructor, Staff
 from ui.decorators import require_mandatory_urls
 
 log = logging.getLogger(__name__)
-
-
-def get_bundle_url(request, bundle_name):
-    """
-    Create a URL for the webpack bundle.
-    """
-    if settings.DEBUG and settings.USE_WEBPACK_DEV_SERVER:
-        return "{host_url}/{bundle}".format(
-            host_url=webpack_dev_server_url(request),
-            bundle=bundle_name
-        )
-    else:
-        return static("bundles/{bundle}".format(bundle=bundle_name))
 
 
 class ReactView(View):  # pylint: disable=unused-argument
@@ -77,11 +63,7 @@ class ReactView(View):  # pylint: disable=unused-argument
             request,
             "dashboard.html",
             context={
-                "common_src": get_bundle_url(request, "common.js"),
-                "sentry_client": get_bundle_url(request, "sentry_client.js"),
-                "zendesk_widget": get_bundle_url(request, "zendesk_widget.js"),
-                "style_src": get_bundle_url(request, "style.js"),
-                "dashboard_src": get_bundle_url(request, "dashboard.js"),
+                "has_zendesk_widget": True,
                 "js_settings_json": json.dumps(js_settings),
                 "tracking_id": "",
             }
@@ -132,13 +114,8 @@ def standard_error_page(request, status_code, template_filename):
         request,
         template_filename,
         context={
-            "zendesk_widget": get_bundle_url(request, "zendesk_widget.js"),
-            "style_src": get_bundle_url(request, "style.js"),
-            "dashboard_src": get_bundle_url(request, "dashboard.js"),
-            "common_src": get_bundle_url(request, "common.js"),
-            "sentry_client": get_bundle_url(request, "sentry_client.js"),
-            "style_public_src": get_bundle_url(request, "style_public.js"),
-            "public_src": get_bundle_url(request, "public.js"),
+            "has_zendesk_widget": True,
+            "is_public": True,
             "js_settings_json": json.dumps({
                 "release_version": settings.VERSION,
                 "environment": settings.ENVIRONMENT,
@@ -165,12 +142,8 @@ def terms_of_service(request):
         request,
         "terms_of_service.html",
         context={
-            "zendesk_widget": get_bundle_url(request, "zendesk_widget.js"),
-            "style_src": get_bundle_url(request, "style.js"),
-            "common_src": get_bundle_url(request, "common.js"),
-            "public_src": get_bundle_url(request, "public.js"),
-            "style_public_src": get_bundle_url(request, "style_public.js"),
-            "sentry_client": get_bundle_url(request, "sentry_client.js"),
+            "has_zendesk_widget": True,
+            "is_public": True,
             "js_settings_json": json.dumps({
                 "release_version": settings.VERSION,
                 "environment": settings.ENVIRONMENT,

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -2,6 +2,7 @@ var webpack = require('webpack');
 var path = require("path");
 var sharedConfig = require(path.resolve("./webpack.config.shared.js"));
 var R = require('ramda');
+var BundleTracker = require('webpack-bundle-tracker');
 
 const hotEntry = (host, port) => (
   `webpack-hot-middleware/client?path=http://${host}:${port}/__webpack_hmr&timeout=20000&reload=true`
@@ -13,7 +14,10 @@ const insertHotReload = (host, port, entries) => (
 
 const devConfig = {
   context: __dirname,
-  output: sharedConfig.output,
+  output: {
+    path: path.resolve('./static/bundles/'),
+    filename: "[name].js"
+  },
   module: sharedConfig.module,
   sassLoader: sharedConfig.sassLoader,
   resolve: sharedConfig.resolve,
@@ -29,7 +33,8 @@ const devConfig = {
     }),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.NoErrorsPlugin(),
+    new BundleTracker({filename: './webpack-stats.json'})
   ],
   devtool: 'source-map'
 };

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,11 +1,15 @@
 var webpack = require('webpack');
 var path = require("path");
 var sharedConfig = require(path.resolve("./webpack.config.shared.js"));
+var BundleTracker = require('webpack-bundle-tracker');
 
 module.exports = {
   context: __dirname,
   entry: sharedConfig.entry,
-  output: sharedConfig.output,
+  output: {
+    path: path.resolve('./static/bundles/'),
+    filename: "[name]-[chunkhash].js"
+  },
   module: sharedConfig.module,
   sassLoader: sharedConfig.sassLoader,
   resolve: sharedConfig.resolve,
@@ -27,6 +31,9 @@ module.exports = {
       name: 'common',
       minChunks: 2,
     }),
+    new BundleTracker({
+      filename: './webpack-stats.json'
+    })
   ],
   devtool: 'source-map'
 };

--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -15,10 +15,6 @@ module.exports = {
     'style_public': './static/js/entry/style_public',
     'zendesk_widget': './static/js/entry/zendesk_widget.js',
   },
-  output: {
-    path: path.resolve('./static/bundles/'),
-    filename: "[name].js"
-  },
   module: {
     loaders: [
       {


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1662

#### What's this PR do?
Bundles now have a hash concatenated on the filename for production builds. This will allow us to set a far future expiration header for these assets which will make it easier to deploy on a CDN.

This also removes `get_bundle_url` and uses a template tag in its place

#### Where should the reviewer start?
ui/templatetags/render_bundle.py

#### How should this be manually tested?
Make sure that the JS bundles are still properly rendered for each page, for both development and production builds. Nothing should break. Hot reloading should still work.

