### PR TITLE
Send ImproperlyConfigured exceptions to Sentry

### DIFF
--- a/micromasters/exceptions.py
+++ b/micromasters/exceptions.py
@@ -1,0 +1,11 @@
+"""
+Custom exceptions for the MicroMasters app
+"""
+
+from django.core.exceptions import ImproperlyConfigured
+
+
+class PossiblyImproperlyConfigured(ImproperlyConfigured):
+    """
+    Custom exception to be raised when the improper configuration is not certain
+    """

--- a/micromasters/utils.py
+++ b/micromasters/utils.py
@@ -9,6 +9,7 @@ import pytz
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers import serialize
+from raven.contrib.django.raven_compat.models import client
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
@@ -65,6 +66,9 @@ def custom_exception_handler(exc, context):
 
     # Otherwise format the exception only in specific cases
     if isinstance(exc, ImproperlyConfigured):
+        # send the exception to Sentry anyway
+        client.captureException()
+
         formatted_exception_string = "{0}: {1}".format(type(exc).__name__, str(exc))
         return Response(
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/tox.ini
+++ b/tox.ini
@@ -18,3 +18,4 @@ setenv =
     ELASTICSEARCH_INDEX=testindex
     DEBUG=False
     CELERY_ALWAYS_EAGER=True
+    SENTRY_DSN=


### PR DESCRIPTION
#### What are the relevant tickets?
closes #1817 

#### What's this PR do?
Sends `ImproperlyConfigured` exceptions (and subclasses of it) to Sentry even if they are handled.

#### Where should the reviewer start?
`dashboard/views.py`

#### How should this be manually tested?
configure the `SENTRY_DSN` environment variable, try to make an enrollment for a course with closed enrollments on edX but open on micromasters and verify that the exception appears on Sentry.
