### PR TITLE
Replace mock with unittest.mock

### DIFF
--- a/backends/pipeline_api_test.py
+++ b/backends/pipeline_api_test.py
@@ -4,7 +4,7 @@ Tests for the pipeline APIs
 
 from urllib.parse import urljoin
 
-import mock
+from unittest import mock
 
 from backends import pipeline_api, edxorg
 from backends.pipeline_api import update_from_linkedin

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -2,8 +2,8 @@
 Tests for serializers
 """
 
+from unittest.mock import Mock
 from django.test import override_settings
-from mock import Mock
 
 from cms.factories import ProgramPageFactory
 from cms.models import HomePage

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -1,7 +1,7 @@
 """Tests for the API"""
 # pylint: disable=no-self-use
 
-from mock import Mock
+from unittest.mock import Mock
 
 from django.core.urlresolvers import reverse
 from rest_framework import status

--- a/ecommerce/admin_test.py
+++ b/ecommerce/admin_test.py
@@ -1,7 +1,7 @@
 """
 Tests for ecommerce admin interface
 """
-from mock import Mock
+from unittest.mock import Mock
 
 from search.base import ESTestCase
 

--- a/mail/utils_test.py
+++ b/mail/utils_test.py
@@ -2,9 +2,9 @@
 Tests for mail utils
 """
 
+from unittest.mock import Mock
 from django.core.exceptions import ValidationError, ImproperlyConfigured
 from django.test import TestCase
-from mock import Mock
 from requests import Response
 from rest_framework import status
 

--- a/micromasters/serializers_test.py
+++ b/micromasters/serializers_test.py
@@ -1,7 +1,7 @@
 """
 Tests for serializing Django User objects
 """
-import mock
+from unittest import mock
 from django.test import TestCase
 from django.contrib.auth.models import AnonymousUser
 from django.db.models.signals import post_save

--- a/profiles/api_test.py
+++ b/profiles/api_test.py
@@ -2,7 +2,7 @@
 Tests for profile functions
 """
 
-from mock import Mock
+from unittest.mock import Mock
 
 from django.db.models.signals import post_save
 from factory.django import mute_signals

--- a/profiles/permissions_test.py
+++ b/profiles/permissions_test.py
@@ -1,7 +1,7 @@
 """
 Tests for profile permissions
 """
-from mock import Mock
+from unittest.mock import Mock
 from django.http import Http404
 from django.db.models.signals import post_save
 from factory.django import mute_signals

--- a/test_requirements.in
+++ b/test_requirements.in
@@ -4,7 +4,6 @@ ddt
 django-debug-toolbar
 ipdb
 ipython
-mock
 nplusone
 pdbpp
 pip-tools

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -17,7 +17,7 @@ curtsies==0.2.11          # via bpython
 ddt==1.1.1
 decorator==4.0.10         # via ipython, traitlets
 django-debug-toolbar==1.6
-Django==1.10.3            # via django-debug-toolbar
+django==1.10.3            # via django-debug-toolbar
 execnet==1.4.1            # via pytest-cache
 fancycompleter==0.5       # via pdbpp
 first==2.0.1              # via pip-tools
@@ -28,10 +28,8 @@ ipython==5.1.0
 isort==4.2.5              # via pylint
 lazy-object-proxy==1.2.2  # via astroid
 mccabe==0.5.2             # via pylint
-mock==2.0.0
 nplusone==0.7.3
 ordereddict==1.1          # via pdbpp
-pbr==1.10.0               # via mock
 pdbpp==0.8.3
 pep8==1.7.0               # via pytest-pep8
 pexpect==4.2.1            # via ipython
@@ -54,7 +52,7 @@ pytest==3.0.3
 requests==2.11.1          # via bpython, codecov
 semantic-version==2.6.0
 simplegeneric==0.8.1      # via ipython
-six==1.10.0               # via astroid, bpython, mock, nplusone, pip-tools, prompt-toolkit, pylint, pytest-pylint, traitlets
+six==1.10.0               # via astroid, bpython, nplusone, pip-tools, prompt-toolkit, pylint, pytest-pylint, traitlets
 sqlparse==0.2.2           # via django-debug-toolbar
 testfixtures==4.13.1
 tox==2.4.1
@@ -64,6 +62,5 @@ wcwidth==0.1.7            # via curtsies, prompt-toolkit
 wmctrl==0.3               # via pdbpp
 wrapt==1.10.8             # via astroid
 
-# The following packages are commented out because they are
-# considered to be unsafe in a requirements file:
+# The following packages are considered to be unsafe in a requirements file:
 # setuptools                # via ipdb, ipython


### PR DESCRIPTION
The [`mock`](http://www.voidspace.org.uk/python/mock/) library is bundled in Python 3 as [`unittest.mock`](https://docs.python.org/3/library/unittest.mock.html), so we don't need to install the library from PyPI.