### PR TITLE
add scroll-to-error functionality to the profile image requirement

### DIFF
--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -122,7 +122,7 @@ export default class PersonalTab extends React.Component {
             {_.get(errors, ['program'])}
           </span>
         </Card>
-        <Card shadow={1} className="profile-image">
+        <Card shadow={1} className={`profile-image ${validationErrorSelector(errors, ['image'])}`}>
           <CardTitle>
             Upload a Profile Photo
           </CardTitle>


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1895 

#### What's this PR do?

Just ensures that we put the right class name on the profile image card if it is invalid, so that the `scrollIntoView` function which finds invalid fields will work.

#### How should this be manually tested?

- Delete your user's profile image (set `user.profile.image` to `None` in the django shell) and visit `/profile/personal`. 
- either use the browser dev tools or squash the window to make the viewport short (so you won't be able to see the image field when scrolled down)
- scroll down and click on 'next'

it should scroll you up to the image card.