### PR TITLE
Run celery tasks asynchronously

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,12 +37,16 @@ services:
       MICROMASTERS_SECURE_SSL_REDIRECT: 'False'
       MICROMASTERS_DB_DISABLE_SSL: 'True'
       ELASTICSEARCH_URL: elastic:9200
+      CELERY_ALWAYS_EAGER: 'False'
+      BROKER_URL: redis://redis:6379/4
+      CELERY_RESULT_BACKEND: redis://redis:6379/4
     env_file: .env
     ports:
       - "8079:8079"
     links:
       - db
       - elastic
+      - redis
 
   watch:
     build:
@@ -76,6 +80,7 @@ services:
       BROKER_URL: redis://redis:6379/4
       CELERY_RESULT_BACKEND: redis://redis:6379/4
       ELASTICSEARCH_URL: elastic:9200
+      CELERY_ALWAYS_EAGER: 'False'
     env_file: .env
     links:
       - db


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1909 

#### What's this PR do?
Runs Celery asynchronously on docker

#### How should this be manually tested?
Go into the Django shell and delete a `ProgramEnrollment`. There should be no exception regarding connecting to Celery
