### PR TITLE
Refactor user edx data fetching

### DIFF
--- a/dashboard/api_edx_cache.py
+++ b/dashboard/api_edx_cache.py
@@ -16,6 +16,45 @@ log = logging.getLogger(__name__)
 
 
 class CachedEdxUserData:
+    """Represents all edx data related to a User"""
+    # pylint: disable=too-many-instance-attributes
+
+    enrollments = None
+    certificates = None
+    current_grades = None
+    raw_enrollments = None
+    raw_certificates = None
+    raw_current_grades = None
+
+    def __init__(self, user, program=None, include_raw_data=False):
+        """
+        Fetches the given User's edx data and sets object properties
+
+        Args:
+            user (User): a User object
+            program (Program): an optional Program to filter on
+            include_raw_data (bool): Set to True if raw edx data is needed (in addition to actual edX objects)
+        """
+        self.user = user
+        self.program = program
+        self.fetch_and_set_edx_data()
+        if include_raw_data:
+            self.fetch_and_set_raw_data()
+
+    def fetch_and_set_edx_data(self):
+        """Fetches edx data and sets object properties"""
+        self.enrollments = models.CachedEnrollment.get_edx_data(self.user, program=self.program)
+        self.certificates = models.CachedCertificate.get_edx_data(self.user, program=self.program)
+        self.current_grades = models.CachedCurrentGrade.get_edx_data(self.user, program=self.program)
+
+    def fetch_and_set_raw_data(self):
+        """Fetches raw cached data and sets object properties"""
+        self.raw_enrollments = list(models.CachedEnrollment.data_qset(self.user, program=self.program))
+        self.raw_certificates = list(models.CachedCertificate.data_qset(self.user, program=self.program))
+        self.raw_current_grades = list(models.CachedCurrentGrade.data_qset(self.user, program=self.program))
+
+
+class CachedEdxDataApi:
     """
     Class to handle the retrieval and update of the users' cached edX information
     """

--- a/dashboard/api_edx_cache_test.py
+++ b/dashboard/api_edx_cache_test.py
@@ -10,9 +10,9 @@ from edx_api.certificates.models import Certificate, Certificates
 from edx_api.enrollments.models import Enrollment, Enrollments
 from edx_api.grades.models import CurrentGrade, CurrentGrades
 
-from courses.factories import CourseRunFactory
+from courses.factories import ProgramFactory, CourseFactory, CourseRunFactory
 from dashboard import models
-from dashboard.api_edx_cache import CachedEdxUserData
+from dashboard.api_edx_cache import CachedEdxUserData, CachedEdxDataApi
 from dashboard.factories import (
     CachedEnrollmentFactory,
     CachedCertificateFactory,
@@ -34,6 +34,66 @@ from search.base import ESTestCase
 class CachedEdxUserDataTests(ESTestCase):
     """
     Tests for the CachedEdxUserData class
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory.create()
+        # Create Programs, Courses, CourseRuns...
+        cls.p1_course_run_keys = ['p1_course_run']
+        cls.p2_course_run_keys = ['p2_course_run_1', 'p2_course_run_2']
+        cls.p1_course_run = CourseRunFactory.create(edx_course_key=cls.p1_course_run_keys[0])
+        p2 = ProgramFactory.create(full=True)
+        first_course = p2.course_set.first()
+        extra_course = CourseFactory.create(program=p2)
+        cls.p2_course_run_1 = CourseRunFactory.create(course=first_course, edx_course_key=cls.p2_course_run_keys[0])
+        cls.p2_course_run_2 = CourseRunFactory.create(course=extra_course, edx_course_key=cls.p2_course_run_keys[1])
+        all_course_runs = [cls.p1_course_run, cls.p2_course_run_1, cls.p2_course_run_2]
+        # Create cached edX data
+        cls.enrollments = [
+            CachedEnrollmentFactory.create(user=cls.user, course_run=course_run) for course_run in all_course_runs
+        ]
+        cls.certificates = [
+            CachedCertificateFactory.create(user=cls.user, course_run=course_run) for course_run in all_course_runs
+        ]
+        cls.current_grades = [
+            CachedCurrentGradeFactory.create(user=cls.user, course_run=course_run) for course_run in all_course_runs
+        ]
+
+    def assert_edx_data_has_given_ids(self, edx_user_data, ids):
+        """Asserts that all edX object course id sets match the given list of ids"""
+        assert sorted(edx_user_data.enrollments.get_enrolled_course_ids()) == ids
+        assert sorted(edx_user_data.certificates.all_courses_verified_certs) == ids
+        assert sorted(edx_user_data.current_grades.all_course_ids) == ids
+
+    def test_edx_data_fetch_and_set(self):
+        """Test that a user's edX data is properly fetched and set onto object properties"""
+        edx_user_data = CachedEdxUserData(self.user)
+        assert isinstance(edx_user_data.enrollments, Enrollments)
+        assert isinstance(edx_user_data.certificates, Certificates)
+        assert isinstance(edx_user_data.current_grades, CurrentGrades)
+        self.assert_edx_data_has_given_ids(edx_user_data, self.p1_course_run_keys + self.p2_course_run_keys)
+
+    def test_edx_data_with_program(self):
+        """Test that a user's edX data is filtered by program when specified"""
+        p1_course_run_program = self.p1_course_run.course.program
+        edx_user_data = CachedEdxUserData(self.user, program=p1_course_run_program)
+        self.assert_edx_data_has_given_ids(edx_user_data, self.p1_course_run_keys)
+        p2_course_run_program = self.p2_course_run_1.course.program
+        edx_user_data = CachedEdxUserData(self.user, program=p2_course_run_program)
+        self.assert_edx_data_has_given_ids(edx_user_data, self.p2_course_run_keys)
+
+    def test_raw_data_fetch_and_set(self):
+        """Test that a user's raw edX data is properly fetched and set onto object properties"""
+        edx_user_data = CachedEdxUserData(self.user, include_raw_data=True)
+        assert edx_user_data.raw_enrollments == [obj.data for obj in self.enrollments]
+        assert edx_user_data.raw_certificates == [obj.data for obj in self.certificates]
+        assert edx_user_data.raw_current_grades == [obj.data for obj in self.current_grades]
+
+
+class CachedEdxDataApiTests(ESTestCase):
+    """
+    Tests for the CachedEdxDataApi class
     """
 
     @classmethod
@@ -82,29 +142,29 @@ class CachedEdxUserDataTests(ESTestCase):
         enrollment_keys = enrollment_keys or []
         certificate_keys = certificate_keys or []
         grades_keys = grades_keys or []
-        enrollments = CachedEdxUserData.get_cached_edx_data(self.user, CachedEdxUserData.ENROLLMENT)
-        certificates = CachedEdxUserData.get_cached_edx_data(self.user, CachedEdxUserData.CERTIFICATE)
-        grades = CachedEdxUserData.get_cached_edx_data(self.user, CachedEdxUserData.CURRENT_GRADE)
+        enrollments = CachedEdxDataApi.get_cached_edx_data(self.user, CachedEdxDataApi.ENROLLMENT)
+        certificates = CachedEdxDataApi.get_cached_edx_data(self.user, CachedEdxDataApi.CERTIFICATE)
+        grades = CachedEdxDataApi.get_cached_edx_data(self.user, CachedEdxDataApi.CURRENT_GRADE)
         assert sorted(list(enrollments.enrollments.keys())) == sorted(enrollment_keys)
         assert sorted(list(certificates.certificates.keys())) == sorted(certificate_keys)
         assert sorted(list(grades.current_grades.keys())) == sorted(grades_keys)
 
     def test_constants(self):
         """Tests class constants"""
-        assert CachedEdxUserData.SUPPORTED_CACHES == (
-            CachedEdxUserData.ENROLLMENT,
-            CachedEdxUserData.CERTIFICATE,
-            CachedEdxUserData.CURRENT_GRADE,
+        assert CachedEdxDataApi.SUPPORTED_CACHES == (
+            CachedEdxDataApi.ENROLLMENT,
+            CachedEdxDataApi.CERTIFICATE,
+            CachedEdxDataApi.CURRENT_GRADE,
         )
-        assert CachedEdxUserData.CACHED_EDX_MODELS == {
-            CachedEdxUserData.ENROLLMENT: models.CachedEnrollment,
-            CachedEdxUserData.CERTIFICATE: models.CachedCertificate,
-            CachedEdxUserData.CURRENT_GRADE: models.CachedCurrentGrade,
+        assert CachedEdxDataApi.CACHED_EDX_MODELS == {
+            CachedEdxDataApi.ENROLLMENT: models.CachedEnrollment,
+            CachedEdxDataApi.CERTIFICATE: models.CachedCertificate,
+            CachedEdxDataApi.CURRENT_GRADE: models.CachedCurrentGrade,
         }
-        assert CachedEdxUserData.CACHE_EXPIRATION_DELTAS == {
-            CachedEdxUserData.ENROLLMENT:  timedelta(minutes=5),
-            CachedEdxUserData.CERTIFICATE: timedelta(hours=6),
-            CachedEdxUserData.CURRENT_GRADE: timedelta(hours=1),
+        assert CachedEdxDataApi.CACHE_EXPIRATION_DELTAS == {
+            CachedEdxDataApi.ENROLLMENT:  timedelta(minutes=5),
+            CachedEdxDataApi.CERTIFICATE: timedelta(hours=6),
+            CachedEdxDataApi.CURRENT_GRADE: timedelta(hours=1),
         }
 
     def test_get_cached_edx_data(self):
@@ -112,7 +172,7 @@ class CachedEdxUserDataTests(ESTestCase):
         Test for get_cached_edx_data
         """
         with self.assertRaises(ValueError):
-            CachedEdxUserData.get_cached_edx_data(self.user, 'footype')
+            CachedEdxDataApi.get_cached_edx_data(self.user, 'footype')
 
         self.assert_cache_in_db()
         for run in self.all_runs:
@@ -124,28 +184,28 @@ class CachedEdxUserDataTests(ESTestCase):
     def test_update_cache_last_access(self):
         """Test for update_cache_last_access"""
         with self.assertRaises(ValueError):
-            CachedEdxUserData.update_cache_last_access(self.user, 'footype')
+            CachedEdxDataApi.update_cache_last_access(self.user, 'footype')
         assert UserCacheRefreshTime.objects.filter(user=self.user).exists() is False
 
-        CachedEdxUserData.update_cache_last_access(self.user, CachedEdxUserData.ENROLLMENT)
+        CachedEdxDataApi.update_cache_last_access(self.user, CachedEdxDataApi.ENROLLMENT)
         cache_time = UserCacheRefreshTime.objects.get(user=self.user)
         assert cache_time.enrollment <= datetime.now(tz=pytz.UTC)
         assert cache_time.certificate is None
         assert cache_time.current_grade is None
 
         old_timestamp = datetime.now(tz=pytz.UTC) - timedelta(days=1)
-        CachedEdxUserData.update_cache_last_access(self.user, CachedEdxUserData.ENROLLMENT, old_timestamp)
+        CachedEdxDataApi.update_cache_last_access(self.user, CachedEdxDataApi.ENROLLMENT, old_timestamp)
         cache_time.refresh_from_db()
         assert cache_time.enrollment == old_timestamp
 
     def test_is_cache_fresh(self):
         """Test for is_cache_fresh"""
         with self.assertRaises(ValueError):
-            CachedEdxUserData.is_cache_fresh(self.user, 'footype')
+            CachedEdxDataApi.is_cache_fresh(self.user, 'footype')
         # if there is no entry in the table, the cache is not fresh
         assert UserCacheRefreshTime.objects.filter(user=self.user).exists() is False
-        for cache_type in CachedEdxUserData.SUPPORTED_CACHES:
-            assert CachedEdxUserData.is_cache_fresh(self.user, cache_type) is False
+        for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
+            assert CachedEdxDataApi.is_cache_fresh(self.user, cache_type) is False
         now = datetime.now(tz=pytz.UTC)
         user_cache = UserCacheRefreshTimeFactory.create(
             user=self.user,
@@ -153,16 +213,16 @@ class CachedEdxUserDataTests(ESTestCase):
             certificate=now,
             current_grade=now,
         )
-        for cache_type in CachedEdxUserData.SUPPORTED_CACHES:
-            assert CachedEdxUserData.is_cache_fresh(self.user, cache_type) is True
+        for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
+            assert CachedEdxDataApi.is_cache_fresh(self.user, cache_type) is True
         # moving back the timestamp of one day, makes the cache not fresh again
         yesterday = now - timedelta(days=1)
         user_cache.enrollment = yesterday
         user_cache.certificate = yesterday
         user_cache.current_grade = yesterday
         user_cache.save()
-        for cache_type in CachedEdxUserData.SUPPORTED_CACHES:
-            assert CachedEdxUserData.is_cache_fresh(self.user, cache_type) is False
+        for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
+            assert CachedEdxDataApi.is_cache_fresh(self.user, cache_type) is False
 
     @patch('search.tasks.index_users', autospec=True)
     def test_update_cached_enrollment(self, mocked_index):
@@ -172,7 +232,7 @@ class CachedEdxUserDataTests(ESTestCase):
         self.assert_cache_in_db()
 
         # normal update that creates also the entry
-        CachedEdxUserData.update_cached_enrollment(self.user, enrollment, course_id, False)
+        CachedEdxDataApi.update_cached_enrollment(self.user, enrollment, course_id, False)
         self.assert_cache_in_db(enrollment_keys=[course_id])
         cached_enr = CachedEnrollment.objects.get(user=self.user, course_run__edx_course_key=course_id)
         assert cached_enr.data == enrollment.json
@@ -187,7 +247,7 @@ class CachedEdxUserDataTests(ESTestCase):
             "user": self.user.username
         }
         enrollment_new = Enrollment(enr_json)
-        CachedEdxUserData.update_cached_enrollment(self.user, enrollment_new, course_id, True)
+        CachedEdxDataApi.update_cached_enrollment(self.user, enrollment_new, course_id, True)
         self.assert_cache_in_db(enrollment_keys=[course_id])
         cached_enr.refresh_from_db()
         assert cached_enr.data == enr_json
@@ -198,7 +258,7 @@ class CachedEdxUserDataTests(ESTestCase):
         """Test for update_cached_enrollments."""
         self.assert_cache_in_db()
         assert UserCacheRefreshTime.objects.filter(user=self.user).exists() is False
-        CachedEdxUserData.update_cached_enrollments(self.user, self.edx_client)
+        CachedEdxDataApi.update_cached_enrollments(self.user, self.edx_client)
         self.assert_cache_in_db(enrollment_keys=self.enrollment_ids)
         cache_time = UserCacheRefreshTime.objects.get(user=self.user)
         now = datetime.now(tz=pytz.UTC)
@@ -209,7 +269,7 @@ class CachedEdxUserDataTests(ESTestCase):
         # add another cached element for another course that will be removed by the refresh
         cached_enr = CachedEnrollmentFactory.create(user=self.user)
         self.assert_cache_in_db(enrollment_keys=list(self.enrollment_ids) + [cached_enr.course_run.edx_course_key])
-        CachedEdxUserData.update_cached_enrollments(self.user, self.edx_client)
+        CachedEdxDataApi.update_cached_enrollments(self.user, self.edx_client)
         self.assert_cache_in_db(enrollment_keys=self.enrollment_ids)
         cache_time.refresh_from_db()
         assert cache_time.enrollment >= now
@@ -221,7 +281,7 @@ class CachedEdxUserDataTests(ESTestCase):
         assert self.verified_certificates_ids.issubset(self.certificates_ids)
         self.assert_cache_in_db()
         assert UserCacheRefreshTime.objects.filter(user=self.user).exists() is False
-        CachedEdxUserData.update_cached_certificates(self.user, self.edx_client)
+        CachedEdxDataApi.update_cached_certificates(self.user, self.edx_client)
         self.assert_cache_in_db(certificate_keys=self.verified_certificates_ids)
         cache_time = UserCacheRefreshTime.objects.get(user=self.user)
         now = datetime.now(tz=pytz.UTC)
@@ -233,7 +293,7 @@ class CachedEdxUserDataTests(ESTestCase):
         cached_cert = CachedCertificateFactory.create(user=self.user)
         self.assert_cache_in_db(
             certificate_keys=list(self.verified_certificates_ids) + [cached_cert.course_run.edx_course_key])
-        CachedEdxUserData.update_cached_certificates(self.user, self.edx_client)
+        CachedEdxDataApi.update_cached_certificates(self.user, self.edx_client)
         self.assert_cache_in_db(certificate_keys=self.verified_certificates_ids)
         cache_time.refresh_from_db()
         assert cache_time.certificate >= now
@@ -244,7 +304,7 @@ class CachedEdxUserDataTests(ESTestCase):
         """Test for update_cached_current_grades."""
         self.assert_cache_in_db()
         assert UserCacheRefreshTime.objects.filter(user=self.user).exists() is False
-        CachedEdxUserData.update_cached_current_grades(self.user, self.edx_client)
+        CachedEdxDataApi.update_cached_current_grades(self.user, self.edx_client)
         self.assert_cache_in_db(grades_keys=self.grades_ids)
         cache_time = UserCacheRefreshTime.objects.get(user=self.user)
         now = datetime.now(tz=pytz.UTC)
@@ -255,27 +315,27 @@ class CachedEdxUserDataTests(ESTestCase):
         # add another cached element for another course that will be removed by the refresh
         cached_grade = CachedCurrentGradeFactory.create(user=self.user)
         self.assert_cache_in_db(grades_keys=list(self.grades_ids) + [cached_grade.course_run.edx_course_key])
-        CachedEdxUserData.update_cached_current_grades(self.user, self.edx_client)
+        CachedEdxDataApi.update_cached_current_grades(self.user, self.edx_client)
         self.assert_cache_in_db(grades_keys=self.grades_ids)
         cache_time.refresh_from_db()
         assert cache_time.current_grade >= now
         mocked_index.delay.assert_called_once_with([self.user])
 
-    @patch('dashboard.api_edx_cache.CachedEdxUserData.update_cached_current_grades')
-    @patch('dashboard.api_edx_cache.CachedEdxUserData.update_cached_certificates')
-    @patch('dashboard.api_edx_cache.CachedEdxUserData.update_cached_enrollments')
+    @patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cached_current_grades')
+    @patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cached_certificates')
+    @patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cached_enrollments')
     def test_update_cache_if_expired(self, mock_enr, mock_cert, mock_grade):
         """Test for update_cache_if_expired"""
         all_mocks = (mock_enr, mock_cert, mock_grade, )
 
         with self.assertRaises(ValueError):
-            CachedEdxUserData.update_cache_if_expired(self.user, self.edx_client, 'footype')
+            CachedEdxDataApi.update_cache_if_expired(self.user, self.edx_client, 'footype')
 
         # if there is no entry in the UserCacheRefreshTime the cache is not fresh and needs to be refreshed
-        for cache_type in CachedEdxUserData.SUPPORTED_CACHES:
+        for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
             # the following is possible only because a mocked function is called
             assert UserCacheRefreshTime.objects.filter(user=self.user).exists() is False
-            CachedEdxUserData.update_cache_if_expired(self.user, self.edx_client, cache_type)
+            CachedEdxDataApi.update_cache_if_expired(self.user, self.edx_client, cache_type)
         for mock_func in all_mocks:
             assert mock_func.called is True
             mock_func.reset_mock()
@@ -288,8 +348,8 @@ class CachedEdxUserDataTests(ESTestCase):
             certificate=now,
             current_grade=now,
         )
-        for cache_type in CachedEdxUserData.SUPPORTED_CACHES:
-            CachedEdxUserData.update_cache_if_expired(self.user, self.edx_client, cache_type)
+        for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
+            CachedEdxDataApi.update_cache_if_expired(self.user, self.edx_client, cache_type)
         for mock_func in all_mocks:
             assert mock_func.called is False
             mock_func.reset_mock()
@@ -300,7 +360,7 @@ class CachedEdxUserDataTests(ESTestCase):
         user_cache.certificate = yesterday
         user_cache.current_grade = yesterday
         user_cache.save()
-        for cache_type in CachedEdxUserData.SUPPORTED_CACHES:
-            CachedEdxUserData.update_cache_if_expired(self.user, self.edx_client, cache_type)
+        for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
+            CachedEdxDataApi.update_cache_if_expired(self.user, self.edx_client, cache_type)
         for mock_func in all_mocks:
             assert mock_func.called is True

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -16,7 +16,7 @@ from dashboard import (
     api,
     models,
 )
-from dashboard.api_edx_cache import CachedEdxUserData
+from dashboard.api_edx_cache import CachedEdxDataApi
 from dashboard.factories import CachedEnrollmentFactory, CachedCurrentGradeFactory, UserCacheRefreshTimeFactory
 from dashboard.utils import MMTrack
 from micromasters.factories import UserFactory
@@ -750,17 +750,14 @@ class UserProgramInfoIntegrationTest(ESTestCase):
         self.expected_programs = [self.program_non_fin_aid, self.program_fin_aid]
         self.edx_client = MagicMock()
 
-    @patch('dashboard.api_edx_cache.CachedEdxUserData.update_cache_if_expired', new_callable=MagicMock)
-    @patch('dashboard.api_edx_cache.CachedEdxUserData.get_cached_edx_data', new_callable=MagicMock)
-    def test_format(self, mock_cache_get, mock_cache_refresh):
+    @patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cache_if_expired', new_callable=MagicMock)
+    def test_format(self, mock_cache_refresh):
         """Test that get_user_program_info fetches edx data and returns a list of Program data"""
         result = api.get_user_program_info(self.user, self.edx_client)
 
-        assert mock_cache_refresh.call_count == len(CachedEdxUserData.SUPPORTED_CACHES)
-        assert mock_cache_get.call_count == len(CachedEdxUserData.SUPPORTED_CACHES)
-        for cache_type in CachedEdxUserData.SUPPORTED_CACHES:
+        assert mock_cache_refresh.call_count == len(CachedEdxDataApi.SUPPORTED_CACHES)
+        for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
             mock_cache_refresh.assert_any_call(self.user, self.edx_client, cache_type)
-            mock_cache_get.assert_any_call(self.user, cache_type)
 
         assert len(result) == 2
         for i in range(2):

--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -3,11 +3,7 @@ Provides functionality for serializing a ProgramEnrollment for the ES index
 """
 from decimal import Decimal
 
-from edx_api.certificates.models import Certificate, Certificates
-from edx_api.grades.models import CurrentGrade, CurrentGrades
-from edx_api.enrollments.models import Enrollments
-
-from dashboard.models import CachedEnrollment, CachedCertificate, CachedCurrentGrade
+from dashboard.api_edx_cache import CachedEdxUserData
 from dashboard.utils import MMTrack
 from roles.models import (
     NON_LEARNERS,
@@ -35,22 +31,18 @@ class UserProgramSearchSerializer:
         """
         user = program_enrollment.user
         program = program_enrollment.program
-        enrollments = list(CachedEnrollment.active_data(user, program))
-        certificates = list(CachedCertificate.active_data(user, program))
-        current_grades = list(CachedCurrentGrade.active_data(user, program))
+        edx_user_data = CachedEdxUserData(user, program=program, include_raw_data=True)
 
         mmtrack = MMTrack(
             user,
             program,
-            Enrollments(enrollments),
-            CurrentGrades([CurrentGrade(grade) for grade in current_grades]),
-            Certificates([Certificate(cert) for cert in certificates])
+            edx_user_data
         )
         return {
             'id': program.id,
-            'enrollments': enrollments,
-            'certificates': certificates,
-            'current_grades': current_grades,
+            'enrollments': edx_user_data.raw_enrollments,
+            'certificates': edx_user_data.raw_certificates,
+            'current_grades': edx_user_data.raw_current_grades,
             'grade_average': cls.calculate_final_grade_average(mmtrack),
             'is_learner': cls.is_learner(user, program),
             'email_optin': user.profile.email_optin,

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -137,9 +137,9 @@ class UserProgramSearchSerializerTests(TestCase):
         program = self.program_enrollment.program
         assert UserProgramSearchSerializer.serialize(self.program_enrollment) == {
             'id': program.id,
-            'enrollments': list(CachedEnrollment.active_data(self.user, program)),
-            'certificates': list(CachedCertificate.active_data(self.user, program)),
-            'current_grades': list(CachedCurrentGrade.active_data(self.user, program)),
+            'enrollments': list(CachedEnrollment.data_qset(self.user, program=program)),
+            'certificates': list(CachedCertificate.data_qset(self.user, program=program)),
+            'current_grades': list(CachedCurrentGrade.data_qset(self.user, program=program)),
             'grade_average': 75,
             'is_learner': True,
             'email_optin': True
@@ -155,9 +155,9 @@ class UserProgramSearchSerializerTests(TestCase):
         program = self.program_enrollment.program
         assert UserProgramSearchSerializer.serialize(self.program_enrollment) == {
             'id': program.id,
-            'enrollments': list(CachedEnrollment.active_data(self.user, program)),
-            'certificates': list(CachedCertificate.active_data(self.user, program)),
-            'current_grades': list(CachedCurrentGrade.active_data(self.user, program)),
+            'enrollments': list(CachedEnrollment.data_qset(self.user, program=program)),
+            'certificates': list(CachedCertificate.data_qset(self.user, program=program)),
+            'current_grades': list(CachedCurrentGrade.data_qset(self.user, program=program)),
             'grade_average': 75,
             'is_learner': True,
             'email_optin': email_optin_flag
@@ -174,9 +174,9 @@ class UserProgramSearchSerializerTests(TestCase):
         self.profile.refresh_from_db()
         expected_result = {
             'id': self.fa_program.id,
-            'enrollments': list(CachedEnrollment.active_data(self.user, self.fa_program)),
+            'enrollments': list(CachedEnrollment.data_qset(self.user, program=self.fa_program)),
             'certificates': [],
-            'current_grades': list(CachedCurrentGrade.active_data(self.user, self.fa_program)),
+            'current_grades': list(CachedCurrentGrade.data_qset(self.user, program=self.fa_program)),
             'grade_average': 95,
             'is_learner': True,
             'email_optin': True
@@ -198,9 +198,9 @@ class UserProgramSearchSerializerTests(TestCase):
 
         assert UserProgramSearchSerializer.serialize(self.program_enrollment) == {
             'id': program.id,
-            'enrollments': list(CachedEnrollment.active_data(self.user, program)),
-            'certificates': list(CachedCertificate.active_data(self.user, program)),
-            'current_grades': list(CachedCurrentGrade.active_data(self.user, program)),
+            'enrollments': list(CachedEnrollment.data_qset(self.user, program=program)),
+            'certificates': list(CachedCertificate.data_qset(self.user, program=program)),
+            'current_grades': list(CachedCurrentGrade.data_qset(self.user, program=program)),
             'grade_average': 75,
             'is_learner': False,
             'email_optin': True

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -17,7 +17,7 @@ from social.apps.django_app.default.models import UserSocialAuth
 from backends import utils
 from backends.edxorg import EdxOrgOAuth2
 from dashboard.models import UserCacheRefreshTime
-from dashboard.api_edx_cache import CachedEdxUserData
+from dashboard.api_edx_cache import CachedEdxDataApi
 from micromasters.celery import async
 
 
@@ -119,8 +119,8 @@ def batch_update_user_data_subtasks(students):
 
                 edx_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL)
 
-                for cache_type in CachedEdxUserData.SUPPORTED_CACHES:
-                    CachedEdxUserData.update_cache_if_expired(user, edx_client, cache_type)
+                for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
+                    CachedEdxDataApi.update_cache_if_expired(user, edx_client, cache_type)
 
         except Exception as e:
             log.exception(

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -39,20 +39,18 @@ class MMTrack:
     financial_aid_max_price = None
     financial_aid_date_documents_sent = None
 
-    def __init__(self, user, program, enrollments, current_grades, certificates):
+    def __init__(self, user, program, edx_user_data):
         """
         Args:
             user (User): a Django user
             program (programs.models.Program): program where the user is enrolled
-            enrollments (edx_api.enrollment.models.Enrollments): User's enrollments
-            current_grades (edx_api.grades.models.CurrentGrades): User's current grades
-            certificates (edx_api.certificates.models.Certificates): User's certificates
+            edx_user_data (dashboard.api_edx_cache.CachedEdxUserData): A CachedEdxUserData object
         """
         self.user = user
         self.program = program
-        self.enrollments = enrollments
-        self.current_grades = current_grades
-        self.certificates = certificates
+        self.enrollments = edx_user_data.enrollments
+        self.current_grades = edx_user_data.current_grades
+        self.certificates = edx_user_data.certificates
         self.financial_aid_available = program.financial_aid_availability
 
         with transaction.atomic():

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -18,7 +18,7 @@ from rest_framework.response import Response
 from backends import utils
 from backends.edxorg import EdxOrgOAuth2
 from dashboard.api import get_user_program_info
-from dashboard.api_edx_cache import CachedEdxUserData
+from dashboard.api_edx_cache import CachedEdxDataApi
 from micromasters.exceptions import PossiblyImproperlyConfigured
 from profiles.api import get_social_username
 
@@ -123,7 +123,7 @@ class UserCourseEnrollment(APIView):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 data={'error': str(exc)}
             )
-        CachedEdxUserData.update_cached_enrollment(request.user, enrollment, enrollment.course_id, index_user=True)
+        CachedEdxDataApi.update_cached_enrollment(request.user, enrollment, enrollment.course_id, index_user=True)
         return Response(
             data=enrollment.json
         )

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -19,7 +19,7 @@ from rest_framework.exceptions import ValidationError
 
 from backends.edxorg import EdxOrgOAuth2
 from courses.models import CourseRun
-from dashboard.api_edx_cache import CachedEdxUserData
+from dashboard.api_edx_cache import CachedEdxDataApi
 from dashboard.models import ProgramEnrollment
 from ecommerce.exceptions import (
     EcommerceEdxApiException,
@@ -300,7 +300,7 @@ def enroll_user_on_success(order):
             exceptions.append(ex)
 
     for enrollment in enrollments:
-        CachedEdxUserData.update_cached_enrollment(
+        CachedEdxDataApi.update_cached_enrollment(
             order.user,
             enrollment,
             enrollment.course_id,

--- a/seed_data/lib.py
+++ b/seed_data/lib.py
@@ -7,7 +7,7 @@ from functools import wraps
 
 from django.contrib.auth.models import User
 from courses.models import Program, Course
-from dashboard.api_edx_cache import CachedEdxUserData
+from dashboard.api_edx_cache import CachedEdxDataApi
 from dashboard.models import CachedCertificate, CachedEnrollment, CachedCurrentGrade, UserCacheRefreshTime
 from financialaid.factories import TierProgramFactory
 from financialaid.models import TierProgram
@@ -165,7 +165,7 @@ class CachedHandler(object):
         if not created:
             obj.data = data
             obj.save()
-        CachedEdxUserData.update_cache_last_access(self.user, self.cache_type, timestamp=datetime.utcnow())
+        CachedEdxDataApi.update_cache_last_access(self.user, self.cache_type, timestamp=datetime.utcnow())
         return obj
 
     def find(self, course_run):
@@ -252,7 +252,7 @@ def ensure_cached_data_freshness(user):
     Ensure that all cached edX data will be considered 'fresh' for a User
     """
     future = future_date()
-    updated_values = {cache: future for cache in CachedEdxUserData.SUPPORTED_CACHES}
+    updated_values = {cache: future for cache in CachedEdxDataApi.SUPPORTED_CACHES}
     updated_values['user'] = user
     UserCacheRefreshTime.objects.update_or_create(user=user, defaults=updated_values)
 


### PR DESCRIPTION
#### What are the relevant tickets?

No issue - done as a precursor to #933 
**Rebased on #1890 (to help with testing)**

#### What's this PR do?

Streamlines user edX data fetching and avoids potential bugs 

#### Where should the reviewer start?

dashboard/api_edx_cache.py and dashboard/models.py

Most of these changes are naming changes and repetitive changes to parameters, etc. The most significant functional change is the addition of [CachedEdxUserData](https://github.com/mitodl/micromasters/compare/master...refactor_user_edx_data_fetching#diff-54f823943ee528710d6f9d178443a994L18) and 

#### How should this be manually tested?

To test that the dashboard API still works correctly:

1. Unseed and seed the database, specifying `--staff-user=YOUR_USERNAME` when you run `seed_db`
1. Check the /dashboard page and make sure 'Digital Learning' and 'Analog Learning' look right
1. Enroll in a non-FA course using the `alter_data` commands. Example: `manage.py alter_data --action=set_course_to_enrolled --username=YOUR_USERNAME --program-title='Analog' --course-title='100'`
1. Reload the /dashboard page and check that the enrolled course shows up correctly

To test that serialization for search results still works:

1. Look at the /learners page and pick one of the fake 'Analog Learning' program users
1. Set one or more courses to passed for that user. Example: `alter_data --action=set_course_to_passed --email=roberto.cortes --program-title='Analog' --course-title='100' --grade=100`
1. Run recreate_index: `manage.py recreate_index`
1. Reload the page and confirm that the user's average grade has been changed
