### PR TITLE
Add basic styleguide for wording

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
       "url": "https://github.com/heroku/heroku-buildpack-pgbouncer"
     }
   ],
-  "description": "Web Portal for Micromasters",
+  "description": "Web Portal for MicroMasters",
   "env": {
     "ALLOWED_HOSTS": {
       "default": "['*']",

--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -108,7 +108,7 @@
           <div class="reasons-images-wrap">
             <img src="{% static 'images/hiw4.png' %}" alt="">
           </div>
-          <h4>Pursue a Masters</h4>
+          <h4>Pursue a Master’s</h4>
           <p>Learners who complete the MicroMasters program can apply for the Master’s degree program at MIT or other universities .</p>
         </div>
         </div>

--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -6,7 +6,7 @@
 
 {% block title %}{{ page.title }} MicroMasters{% endblock %}
 {% block description %}{% if page.program.description %}{{ page.program.description }}{% endif %}{% endblock %}
-{% block keywords %}micromasters, MIT, {{ page.program.title }}, online masters, online courses, MOOC{% endblock %}
+{% block keywords %}micromasters, MIT, {{ page.program.title }}, online master's, online courses, MOOC{% endblock %}
 
 {% block social %}
   <meta property="og:site:name" content="{{ page.title }} MicroMasters">

--- a/docs/styleguide-wording.md
+++ b/docs/styleguide-wording.md
@@ -1,0 +1,35 @@
+# Styleguide: Wording & Phrasing
+
+We should be consistent in how we refer to key ideas and phrase key terms
+in this project. Inconsistency is confusing, expecially for students who are
+trying to learn! This styleguide will define how to refer to these key ideas
+and key terms correctly.
+
+Note that this styleguide only applies for text that is visible to users.
+Internal references, such as in code, do not need to conform to this styleguide
+(although they should, if possible).
+
+## Education Terms
+
+### MicroMasters
+
+Both "M"s should always be capitalized. No apostrophe before the final "s".
+
+### master's degree
+
+The "m" should not be capitalized unless it is the first word in a sentence.
+There should be an apostrophe before the final "s". It is acceptable to leave
+off the word "degree" and simply refer to a "master's", but you should still
+include the apostrophe before the final "s".
+
+## Companies
+
+### edX
+
+The "e" should not be capitalized unless it is the first word in a sentence.
+The "X" should always be capitalized.
+
+### MITx
+
+The letters "MIT" should always be capitalized. The letter "x" should never
+be capitalized.

--- a/static/js/components/ProgressWidget.js
+++ b/static/js/components/ProgressWidget.js
@@ -72,9 +72,9 @@ export default class ProgressWidget extends React.Component {
         <p className="text-course-complete">Courses complete</p>
         <p className="heading-paragraph">
           On completion, you can apply for
-          the Masters Degree Program</p>
+          the master’s degree program</p>
            <Button className="progress-button disabled">
-             Apply for Masters
+             Apply for Master’s
            </Button>
       </Card>
     );

--- a/static/js/components/ProgressWidget_test.js
+++ b/static/js/components/ProgressWidget_test.js
@@ -88,7 +88,7 @@ describe('ProgressWidget', () => {
     );
     assert.equal(
       wrapper.find(".heading-paragraph").text(),
-      "On completion, you can apply for the Masters Degree Program"
+      "On completion, you can apply for the master’s degree program"
     );
     assert.isTrue(wrapper.find(".progress-button").hasClass('disabled'), 'Button is disable');
   });


### PR DESCRIPTION
I've noticed that different parts of the website use different phrasing to refer to a "master's degree". We should be consistent in our phrasing, to avoid confusing students who are trying to figure out what a master's degree is.

I don't know if what I've put into this styleguide is correct, but if it isn't, we should decide on what *is* correct, and standardize on that instead.