### PR TITLE
Added setting to configure Cloudfront

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -14,6 +14,7 @@ import ast
 import logging
 import os
 import platform
+from urllib.parse import urljoin
 
 import dj_database_url
 import yaml
@@ -293,6 +294,10 @@ USE_TZ = True
 
 # Serve static files with dj-static
 STATIC_URL = '/static/'
+CLOUDFRONT_DIST = get_var('CLOUDFRONT_DIST', None)
+if CLOUDFRONT_DIST:
+    STATIC_URL = urljoin('https://{dist}.cloudfront.net'.format(dist=CLOUDFRONT_DIST), STATIC_URL)
+
 STATIC_ROOT = 'staticfiles'
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1661 
Fixes #1681 

#### What's this PR do?
Adds configuration allowing the use of Cloudfront for static assets (this does not currently include S3 hosted assets)

#### How should this be manually tested?
To make sure the URLs are configured properly, set the `CLOUDFRONT_DIST` environment variable to something random in the PR build. Refresh the page and note that the URLs to JS files are coming from cloudfront. (These URLs will not work for the PR build)

On micromasters-rc set the `CLOUDFRONT_DIST` environment variable. Everything should work as it did before, except that the static assets are fetched from cloudfront.net.