### PR TITLE
Make footer use is_public template variable

### DIFF
--- a/ui/templates/footer.html
+++ b/ui/templates/footer.html
@@ -4,7 +4,7 @@
     <div class="row">
       <div class="col-md-8">
         <a href="http://www.mit.edu" target="_blank"><img src="{% static 'images/mit-logo-ltgray-white@72x38.svg' %}" alt="MIT" width="72" height="38"></a>
-        {% if public_src %}
+        {% if is_public %}
           <div class="footer-button footer-cta-left">
             <a href="https://giving.mit.edu/explore/campus-student-life/digital-learning" target="_blank"
               class="mdl-button footer-button">Give to MIT
@@ -20,7 +20,7 @@
         </div>
       </div>
       <div class="col-md-4">
-        {% if public_src %}
+        {% if is_public %}
           {% include "social_buttons.html" %}
         {% else %}
           <div class="footer-button footer-cta non-marketing-pages">


### PR DESCRIPTION
Fixes #1925. The `public_src` template variable was removed in #1897, and replaced with the `is_public` template variable. Looks like we missed a spot when making the change in the templates.
