### PR TITLE
Fixed javascript links

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -43,6 +43,7 @@ class HomePage(Page):
 
         context["programs"] = programs
         context["is_public"] = True
+        context["has_zendesk_widget"] = False
         context["authenticated"] = not request.user.is_anonymous()
         context["is_staff"] = has_role(request.user, [Staff.ROLE_ID, Instructor.ROLE_ID])
         context["username"] = username
@@ -205,6 +206,7 @@ def get_program_page_context(programpage, request):
     context = super(ProgramPage, programpage).get_context(request)
 
     context["is_public"] = True
+    context["has_zendesk_widget"] = True
     context["authenticated"] = not request.user.is_anonymous()
     context["username"] = username
     context["js_settings_json"] = json.dumps(js_settings)

--- a/financialaid/views.py
+++ b/financialaid/views.py
@@ -231,6 +231,7 @@ class ReviewFinancialAidView(UserPassesTestMixin, ListView):
         context["js_settings_json"] = json.dumps(js_settings)
         context["authenticated"] = not self.request.user.is_anonymous()
         context["is_public"] = True
+        context["has_zendesk_widget"] = True
         return context
 
     def get_queryset(self):

--- a/financialaid/views_test.py
+++ b/financialaid/views_test.py
@@ -248,7 +248,6 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
             assert response.context['has_zendesk_widget'] is True
             assert response.context['is_public'] is True
             self.assertContains(response, 'Share this page')
-            self.assertContains(response, 'Give to MIT')
             assert json.loads(response.context['js_settings_json']) == {
                 'gaTrackingID': ga_tracking_id,
                 'reactGaDebug': react_ga_debug,

--- a/financialaid/views_test.py
+++ b/financialaid/views_test.py
@@ -2,12 +2,14 @@
 Tests for financialaid view
 """
 import datetime
+import json
 from unittest.mock import Mock, patch
 
 import ddt
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.db.models import Q
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
@@ -229,6 +231,30 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
         """
         # Allowed for staff of program
         self.make_http_request(self.client.get, self.review_url, status.HTTP_200_OK)
+
+    def test_context(self):
+        """
+        Test context information for financial aid review page
+        """
+        ga_tracking_id = 'track'
+        react_ga_debug = True
+        base_url = 'edx_base_url'
+        with override_settings(
+            GA_TRACKING_ID=ga_tracking_id,
+            REACT_GA_DEBUG=react_ga_debug,
+            EDXORG_BASE_URL=base_url,
+        ):
+            response = self.client.get(self.review_url)
+            assert response.context['has_zendesk_widget'] is True
+            assert response.context['is_public'] is True
+            self.assertContains(response, 'Share this page')
+            self.assertContains(response, 'Give to MIT')
+            assert json.loads(response.context['js_settings_json']) == {
+                'gaTrackingID': ga_tracking_id,
+                'reactGaDebug': react_ga_debug,
+                'authenticated': True,
+                'edx_base_url': base_url,
+            }
 
     def test_filter(self):
         """

--- a/ui/templates/footer.html
+++ b/ui/templates/footer.html
@@ -4,7 +4,7 @@
     <div class="row">
       <div class="col-md-8">
         <a href="http://www.mit.edu" target="_blank"><img src="{% static 'images/mit-logo-ltgray-white@72x38.svg' %}" alt="MIT" width="72" height="38"></a>
-        {% if public_src %}
+        {% if is_public %}
           <div class="footer-button footer-cta-left">
             <a href="https://giving.mit.edu/explore/campus-student-life/digital-learning" target="_blank"
               class="mdl-button footer-button">Give to MIT
@@ -20,7 +20,7 @@
         </div>
       </div>
       <div class="col-md-4">
-        {% if public_src %}
+        {% if is_public %}
           {% include "social_buttons.html" %}
         {% else %}
           <div class="footer-button footer-cta non-marketing-pages">

--- a/ui/views.py
+++ b/ui/views.py
@@ -64,6 +64,7 @@ class ReactView(View):  # pylint: disable=unused-argument
             "dashboard.html",
             context={
                 "has_zendesk_widget": True,
+                "is_public": False,
                 "js_settings_json": json.dumps(js_settings),
                 "tracking_id": "",
             }

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -226,7 +226,7 @@ class DashboardTests(ViewsTests):
             }
             assert resp.context['is_public'] is False
             assert resp.context['has_zendesk_widget'] is True
-            self.assertContains(resp, 'Share this page')
+            self.assertNotContains(resp, 'Share this page')
 
     def test_roles_setting(self):
         """

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -284,24 +284,22 @@ class HandlerTests(ViewsTests):
         # case with specific page
         with override_settings(EMAIL_SUPPORT='support'):
             response = self.client.get('/404/')
-            assert response.status_code == status.HTTP_404_NOT_FOUND
             assert response.context['authenticated'] is True
             assert response.context['name'] == profile.preferred_name
             assert response.context['support_email'] == 'support'
             assert response.context['is_public'] is True
             assert response.context['has_zendesk_widget'] is True
-            self.assertContains(response, 'Share this page')
+            self.assertContains(response, 'Share this page', status_code=status.HTTP_404_NOT_FOUND)
 
             # case with a fake page
             with self.settings(DEBUG=False):
                 response = self.client.get('/gfh0o4n8741387jfmnub134fn348fr38f348f/')
-                assert response.status_code == status.HTTP_404_NOT_FOUND
                 assert response.context['authenticated'] is True
                 assert response.context['name'] == profile.preferred_name
                 assert response.context['support_email'] == 'support'
                 assert response.context['is_public'] is True
                 assert response.context['has_zendesk_widget'] is True
-                self.assertContains(response, 'Share this page')
+                self.assertContains(response, 'Share this page', status_code=status.HTTP_404_NOT_FOUND)
 
     def test_404_error_context_logged_out(self):
         """
@@ -309,22 +307,20 @@ class HandlerTests(ViewsTests):
         """
         # case with specific page
         response = self.client.get('/404/')
-        assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.context['authenticated'] is False
         assert response.context['name'] == ""
         assert response.context['is_public'] is True
         assert response.context['has_zendesk_widget'] is True
-        self.assertContains(response, 'Share this page')
+        self.assertContains(response, 'Share this page', status_code=status.HTTP_404_NOT_FOUND)
 
         # case with a fake page
         with self.settings(DEBUG=False):
             response = self.client.get('/gfh0o4n8741387jfmnub134fn348fr38f348f/')
-            assert response.status_code == status.HTTP_404_NOT_FOUND
             assert response.context['authenticated'] is False
             assert response.context['name'] == ""
             assert response.context['is_public'] is True
             assert response.context['has_zendesk_widget'] is True
-            self.assertContains(response, 'Share this page')
+            self.assertContains(response, 'Share this page', status_code=status.HTTP_404_NOT_FOUND)
 
     def test_500_error_context_logged_in(self):
         """
@@ -336,13 +332,12 @@ class HandlerTests(ViewsTests):
 
         with override_settings(EMAIL_SUPPORT='support'):
             response = self.client.get('/500/')
-            assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
             assert response.context['authenticated'] is True
             assert response.context['name'] == profile.preferred_name
             assert response.context['support_email'] == 'support'
             assert response.context['is_public'] is True
             assert response.context['has_zendesk_widget'] is True
-            self.assertContains(response, 'Share this page')
+            self.assertContains(response, 'Share this page', status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def test_500_error_context_logged_out(self):
         """
@@ -350,12 +345,11 @@ class HandlerTests(ViewsTests):
         """
         # case with specific page
         response = self.client.get('/500/')
-        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.context['authenticated'] is False
         assert response.context['name'] == ""
         assert response.context['is_public'] is True
         assert response.context['has_zendesk_widget'] is True
-        self.assertContains(response, 'Share this page')
+        self.assertContains(response, 'Share this page', status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 class TestProgramPage(ViewsTests):

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -116,6 +116,10 @@ class TestHomePage(ViewsTests):
             assert response.context['authenticated'] is False
             assert response.context['username'] is None
             assert response.context['title'] == HomePage.objects.first().title
+            assert response.context['is_public'] is True
+            assert response.context['has_zendesk_widget'] is False
+            self.assertContains(response, 'Share this page')
+            self.assertContains(response, 'Give to MIT')
             js_settings = json.loads(response.context['js_settings_json'])
             assert js_settings['gaTrackingID'] == ga_tracking_id
 
@@ -133,6 +137,10 @@ class TestHomePage(ViewsTests):
             assert response.context['authenticated'] is True
             assert response.context['username'] == get_social_username(user)
             assert response.context['title'] == HomePage.objects.first().title
+            assert response.context['is_public'] is True
+            assert response.context['has_zendesk_widget'] is False
+            self.assertContains(response, 'Share this page')
+            self.assertContains(response, 'Give to MIT')
             js_settings = json.loads(response.context['js_settings_json'])
             assert js_settings['gaTrackingID'] == ga_tracking_id
 
@@ -152,6 +160,10 @@ class TestHomePage(ViewsTests):
             assert response.context['authenticated'] is True
             assert response.context['username'] is None
             assert response.context['title'] == HomePage.objects.first().title
+            assert response.context['is_public'] is True
+            assert response.context['has_zendesk_widget'] is False
+            self.assertContains(response, 'Share this page')
+            self.assertContains(response, 'Give to MIT')
             js_settings = json.loads(response.context['js_settings_json'])
             assert js_settings['gaTrackingID'] == ga_tracking_id
 
@@ -215,6 +227,10 @@ class DashboardTests(ViewsTests):
                 'sentry_dsn': None,
                 'es_page_size': 10
             }
+            assert resp.context['is_public'] is False
+            assert resp.context['has_zendesk_widget'] is True
+            self.assertContains(resp, 'Share this page')
+            self.assertContains(resp, 'Give to MIT')
 
     def test_roles_setting(self):
         """
@@ -276,6 +292,10 @@ class HandlerTests(ViewsTests):
             assert response.context['authenticated'] is True
             assert response.context['name'] == profile.preferred_name
             assert response.context['support_email'] == 'support'
+            assert response.context['is_public'] is True
+            assert response.context['has_zendesk_widget'] is True
+            self.assertContains(response, 'Share this page')
+            self.assertContains(response, 'Give to MIT')
 
             # case with a fake page
             with self.settings(DEBUG=False):
@@ -284,6 +304,10 @@ class HandlerTests(ViewsTests):
                 assert response.context['authenticated'] is True
                 assert response.context['name'] == profile.preferred_name
                 assert response.context['support_email'] == 'support'
+                assert response.context['is_public'] is True
+                assert response.context['has_zendesk_widget'] is True
+                self.assertContains(response, 'Share this page')
+                self.assertContains(response, 'Give to MIT')
 
     def test_404_error_context_logged_out(self):
         """
@@ -294,6 +318,10 @@ class HandlerTests(ViewsTests):
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.context['authenticated'] is False
         assert response.context['name'] == ""
+        assert response.context['is_public'] is True
+        assert response.context['has_zendesk_widget'] is True
+        self.assertContains(response, 'Share this page')
+        self.assertContains(response, 'Give to MIT')
 
         # case with a fake page
         with self.settings(DEBUG=False):
@@ -301,6 +329,10 @@ class HandlerTests(ViewsTests):
             assert response.status_code == status.HTTP_404_NOT_FOUND
             assert response.context['authenticated'] is False
             assert response.context['name'] == ""
+            assert response.context['is_public'] is True
+            assert response.context['has_zendesk_widget'] is True
+            self.assertContains(response, 'Share this page')
+            self.assertContains(response, 'Give to MIT')
 
     def test_500_error_context_logged_in(self):
         """
@@ -316,6 +348,10 @@ class HandlerTests(ViewsTests):
             assert response.context['authenticated'] is True
             assert response.context['name'] == profile.preferred_name
             assert response.context['support_email'] == 'support'
+            assert response.context['is_public'] is True
+            assert response.context['has_zendesk_widget'] is True
+            self.assertContains(response, 'Share this page')
+            self.assertContains(response, 'Give to MIT')
 
     def test_500_error_context_logged_out(self):
         """
@@ -326,6 +362,10 @@ class HandlerTests(ViewsTests):
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.context['authenticated'] is False
         assert response.context['name'] == ""
+        assert response.context['is_public'] is True
+        assert response.context['has_zendesk_widget'] is True
+        self.assertContains(response, 'Share this page')
+        self.assertContains(response, 'Give to MIT')
 
 
 class TestProgramPage(ViewsTests):
@@ -353,6 +393,10 @@ class TestProgramPage(ViewsTests):
             assert response.context['authenticated'] is False
             assert response.context['username'] is None
             assert response.context['title'] == "Test Program"
+            assert response.context['is_public'] is True
+            assert response.context['has_zendesk_widget'] is True
+            self.assertContains(response, 'Share this page')
+            self.assertContains(response, 'Give to MIT')
             js_settings = json.loads(response.context['js_settings_json'])
             assert js_settings['gaTrackingID'] == ga_tracking_id
 
@@ -451,6 +495,8 @@ class TestUsersPage(ViewsTests):
             with patch('profiles.permissions.CanSeeIfNotPrivate.has_permission', has_permission):
                 resp = self.client.get(reverse('ui-users', kwargs={'user': username}))
                 assert resp.status_code == 200
+                assert resp.context['is_public'] is False
+                assert resp.context['has_zendesk_widget'] is False
                 js_settings = json.loads(resp.context['js_settings_json'])
                 assert js_settings == {
                     'gaTrackingID': ga_tracking_id,
@@ -503,6 +549,8 @@ class TestUsersPage(ViewsTests):
             with patch('profiles.permissions.CanSeeIfNotPrivate.has_permission', has_permission):
                 resp = self.client.get(reverse('ui-users', kwargs={'user': username}))
                 assert resp.status_code == 200
+                assert resp.context['is_public'] is False
+                assert resp.context['has_zendesk_widget'] is False
                 js_settings = json.loads(resp.context['js_settings_json'])
                 assert js_settings == {
                     'gaTrackingID': ga_tracking_id,
@@ -557,4 +605,8 @@ class TestTermsOfService(ViewsTests):
         """
         response = self.client.get(TERMS_OF_SERVICE_URL)
         js_settings = json.loads(response.context['js_settings_json'])
+        assert response.context['is_public'] is True
+        assert response.context['has_zendesk_widget'] is True
+        self.assertContains(response, 'Share this page')
+        self.assertContains(response, 'Give to MIT')
         assert {'environment', 'release_version', 'sentry_dsn'}.issubset(set(js_settings.keys()))

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -119,7 +119,6 @@ class TestHomePage(ViewsTests):
             assert response.context['is_public'] is True
             assert response.context['has_zendesk_widget'] is False
             self.assertContains(response, 'Share this page')
-            self.assertContains(response, 'Give to MIT')
             js_settings = json.loads(response.context['js_settings_json'])
             assert js_settings['gaTrackingID'] == ga_tracking_id
 
@@ -140,7 +139,6 @@ class TestHomePage(ViewsTests):
             assert response.context['is_public'] is True
             assert response.context['has_zendesk_widget'] is False
             self.assertContains(response, 'Share this page')
-            self.assertContains(response, 'Give to MIT')
             js_settings = json.loads(response.context['js_settings_json'])
             assert js_settings['gaTrackingID'] == ga_tracking_id
 
@@ -163,7 +161,6 @@ class TestHomePage(ViewsTests):
             assert response.context['is_public'] is True
             assert response.context['has_zendesk_widget'] is False
             self.assertContains(response, 'Share this page')
-            self.assertContains(response, 'Give to MIT')
             js_settings = json.loads(response.context['js_settings_json'])
             assert js_settings['gaTrackingID'] == ga_tracking_id
 
@@ -230,7 +227,6 @@ class DashboardTests(ViewsTests):
             assert resp.context['is_public'] is False
             assert resp.context['has_zendesk_widget'] is True
             self.assertContains(resp, 'Share this page')
-            self.assertContains(resp, 'Give to MIT')
 
     def test_roles_setting(self):
         """
@@ -295,7 +291,6 @@ class HandlerTests(ViewsTests):
             assert response.context['is_public'] is True
             assert response.context['has_zendesk_widget'] is True
             self.assertContains(response, 'Share this page')
-            self.assertContains(response, 'Give to MIT')
 
             # case with a fake page
             with self.settings(DEBUG=False):
@@ -307,7 +302,6 @@ class HandlerTests(ViewsTests):
                 assert response.context['is_public'] is True
                 assert response.context['has_zendesk_widget'] is True
                 self.assertContains(response, 'Share this page')
-                self.assertContains(response, 'Give to MIT')
 
     def test_404_error_context_logged_out(self):
         """
@@ -321,7 +315,6 @@ class HandlerTests(ViewsTests):
         assert response.context['is_public'] is True
         assert response.context['has_zendesk_widget'] is True
         self.assertContains(response, 'Share this page')
-        self.assertContains(response, 'Give to MIT')
 
         # case with a fake page
         with self.settings(DEBUG=False):
@@ -332,7 +325,6 @@ class HandlerTests(ViewsTests):
             assert response.context['is_public'] is True
             assert response.context['has_zendesk_widget'] is True
             self.assertContains(response, 'Share this page')
-            self.assertContains(response, 'Give to MIT')
 
     def test_500_error_context_logged_in(self):
         """
@@ -351,7 +343,6 @@ class HandlerTests(ViewsTests):
             assert response.context['is_public'] is True
             assert response.context['has_zendesk_widget'] is True
             self.assertContains(response, 'Share this page')
-            self.assertContains(response, 'Give to MIT')
 
     def test_500_error_context_logged_out(self):
         """
@@ -365,7 +356,6 @@ class HandlerTests(ViewsTests):
         assert response.context['is_public'] is True
         assert response.context['has_zendesk_widget'] is True
         self.assertContains(response, 'Share this page')
-        self.assertContains(response, 'Give to MIT')
 
 
 class TestProgramPage(ViewsTests):
@@ -396,7 +386,6 @@ class TestProgramPage(ViewsTests):
             assert response.context['is_public'] is True
             assert response.context['has_zendesk_widget'] is True
             self.assertContains(response, 'Share this page')
-            self.assertContains(response, 'Give to MIT')
             js_settings = json.loads(response.context['js_settings_json'])
             assert js_settings['gaTrackingID'] == ga_tracking_id
 
@@ -496,7 +485,8 @@ class TestUsersPage(ViewsTests):
                 resp = self.client.get(reverse('ui-users', kwargs={'user': username}))
                 assert resp.status_code == 200
                 assert resp.context['is_public'] is False
-                assert resp.context['has_zendesk_widget'] is False
+                assert resp.context['has_zendesk_widget'] is True
+                self.assertNotContains(resp, 'Share this page')
                 js_settings = json.loads(resp.context['js_settings_json'])
                 assert js_settings == {
                     'gaTrackingID': ga_tracking_id,
@@ -550,7 +540,8 @@ class TestUsersPage(ViewsTests):
                 resp = self.client.get(reverse('ui-users', kwargs={'user': username}))
                 assert resp.status_code == 200
                 assert resp.context['is_public'] is False
-                assert resp.context['has_zendesk_widget'] is False
+                assert resp.context['has_zendesk_widget'] is True
+                self.assertNotContains(resp, 'Share this page')
                 js_settings = json.loads(resp.context['js_settings_json'])
                 assert js_settings == {
                     'gaTrackingID': ga_tracking_id,
@@ -608,5 +599,4 @@ class TestTermsOfService(ViewsTests):
         assert response.context['is_public'] is True
         assert response.context['has_zendesk_widget'] is True
         self.assertContains(response, 'Share this page')
-        self.assertContains(response, 'Give to MIT')
         assert {'environment', 'release_version', 'sentry_dsn'}.issubset(set(js_settings.keys()))


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1923 
Fixes #1925 

#### What's this PR do?
- Sets `has_zendesk_widget` to true on program pages which will cause the zendesk script tag to be included again
- Changes checks for the removed `public_src` to use `is_public` instead
- Tests

#### How should this be manually tested?
Make sure the share links appear on the bottom of the pages where they should appear, and the zendesk widget should appear on program pages.
