### PR TITLE
fixes program thumbnail title wrapping on home page

### DIFF
--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -434,7 +434,7 @@ body.app-media {
         width: 100%;
         height: 95px;
         bottom: -1px;
-        padding: 25px 0 25px 22px;
+        padding: 25px 0 25px 16px;
         background: linear-gradient(to bottom,  rgba(0,0,0,0), rgba(0,0,0,1)); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
         filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00000000', endColorstr='#000000',GradientType=0 ); /* IE6-9 */
         z-index: 1;

--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -434,7 +434,7 @@ body.app-media {
         width: 100%;
         height: 95px;
         bottom: -1px;
-        padding: 25px 22px;
+        padding: 25px 0 25px 22px;
         background: linear-gradient(to bottom,  rgba(0,0,0,0), rgba(0,0,0,1)); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
         filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00000000', endColorstr='#000000',GradientType=0 ); /* IE6-9 */
         z-index: 1;
@@ -447,7 +447,8 @@ body.app-media {
 
         .program-title {
           color: white;
-          font-size: 19px;
+          font-size: 17px;
+          font-weight: 400;
         }
 
         .program-num-courses {

--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -432,7 +432,7 @@ body.app-media {
       .program-info {
         position: absolute;
         width: 100%;
-        height: 95px;
+        height: 94px;
         bottom: -1px;
         padding: 25px 0 25px 16px;
         background: linear-gradient(to bottom,  rgba(0,0,0,0), rgba(0,0,0,1)); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
@@ -440,9 +440,9 @@ body.app-media {
         z-index: 1;
 
         .program-title, .program-num-courses {
-          margin: 0 0 8px;
+          margin: 0 0 3px;
           font-weight: 300;
-          line-height: 1.4em;
+          line-height: 1.2em;
         }
 
         .program-title {
@@ -453,7 +453,7 @@ body.app-media {
 
         .program-num-courses {
           color: rgba(255,255,255,.7);
-          font-size: 15px;
+          font-size: 14px;
         }
       }
 


### PR DESCRIPTION
#### What's this PR do?

The DEDP program thumbnail caption currently wraps on the home page. This will hopefully fix that. Note on the live site (herokuapp) the name has been changed to "Data, Economics & Development Policy", using "&" instead of "and"
