### PR TITLE
Add is_staff for program and financial aid review pages and other cleanup

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -29,7 +29,7 @@ class HomePage(Page):
     subpage_types = ['ProgramPage']
 
     def get_context(self, request):
-        programs = Program.objects.filter(live=True).order_by("id")
+        programs = Program.objects.filter(live=True).select_related('programpage').order_by("id")
         js_settings = {
             "gaTrackingID": settings.GA_TRACKING_ID,
             "host": webpack_dev_server_host(request),
@@ -41,7 +41,15 @@ class HomePage(Page):
         username = get_social_username(request.user)
         context = super(HomePage, self).get_context(request)
 
-        context["programs"] = programs
+        def get_program_page(program):
+            """Return a None if ProgramPage does not exist, to avoid template errors"""
+            try:
+                return program.programpage
+            except ProgramPage.DoesNotExist:
+                return
+
+        program_pairs = ((program, get_program_page(program)) for program in programs)
+        context["programs"] = program_pairs
         context["is_public"] = True
         context["has_zendesk_widget"] = False
         context["authenticated"] = not request.user.is_anonymous()
@@ -205,6 +213,7 @@ def get_program_page_context(programpage, request):
     username = get_social_username(request.user)
     context = super(ProgramPage, programpage).get_context(request)
 
+    context["is_staff"] = has_role(request.user, [Staff.ROLE_ID, Instructor.ROLE_ID])
     context["is_public"] = True
     context["has_zendesk_widget"] = True
     context["authenticated"] = not request.user.is_anonymous()

--- a/cms/models.py
+++ b/cms/models.py
@@ -48,7 +48,7 @@ class HomePage(Page):
             except ProgramPage.DoesNotExist:
                 return
 
-        program_pairs = ((program, get_program_page(program)) for program in programs)
+        program_pairs = [(program, get_program_page(program)) for program in programs]
         context["programs"] = program_pairs
         context["is_public"] = True
         context["has_zendesk_widget"] = False

--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -117,18 +117,22 @@
       <section class="row current-programs-section">
         <h3>Current MITx MicroMasters Programs</h3>
         <ul class="current-programs-list">
-        {% for program in programs %}
+        {% for program, programpage in programs %}
           <li class="col-md-4">
             <div class="program-thumbnail">
-              {% if program.programpage %}
-                {% if program.programpage.external_program_page_url %}
-                  <a href="{{ program.programpage.external_program_page_url }}" class="program-link">
+              {% if programpage %}
+                {% if programpage.external_program_page_url %}
+                  <a href="{{ programpage.external_program_page_url }}" class="program-link">
                 {% else %}
-                  <a href="{{ program.programpage.url }}" class="program-link">
+                  <a href="{{ programpage.url }}" class="program-link">
                 {% endif %}
               {% endif %}
                 <div class="program-info">
-                  <h4 class="program-title" aria-describedby="program-{{ program.id }}-description">{{ program.programpage.title }}</h4>
+                  <h4 class="program-title" aria-describedby="program-{{ program.id }}-description">
+                    {% if programpage %}
+                      {{ programpage.title }}
+                    {% endif %}
+                  </h4>
                   <div class="program-num-courses">
                     {% blocktrans count counter=program.course_set.count %}
                       {{ counter }} course
@@ -137,27 +141,27 @@
                     {% endblocktrans %}
                   </div>
                 </div>
-                {% if program.programpage and program.programpage.thumbnail_image %}
-                  {% image program.programpage.thumbnail_image fill-690x530 as thumbnail_image %}
+                {% if programpage and programpage.thumbnail_image %}
+                  {% image programpage.thumbnail_image fill-690x530 as thumbnail_image %}
                   <img src="{{ thumbnail_image.url }}" alt="course image for {{ program }}"
                        >
                 {% else %}
                   <img src="{% static 'images/course-thumbnail.png' %}"
                        alt="course image for {{ program }}" class="program-default-image">
                 {% endif %}
-              {% if program.programpage %}
+              {% if programpage %}
                 </a>
               {% endif %}
             </div>
             <div class="program-description">
               <p class="program-description-text" id="program-{{ program.id }}-description">{{ program.description|default:"No description available for this program." }}</p>
 
-              {% if program.programpage %}
+              {% if programpage %}
                 <p class="program-description-link">
-                {% if program.programpage.external_program_page_url %}
-                  <a href="{{ program.programpage.external_program_page_url }}" class="program-link">
+                {% if programpage.external_program_page_url %}
+                  <a href="{{ programpage.external_program_page_url }}" class="program-link">
                 {% else %}
-                  <a href="{{ program.programpage.url }}" class="program-link">
+                  <a href="{{ programpage.url }}" class="program-link">
                 {% endif %}
                     More about {{ program }}
                   </a>

--- a/financialaid/views.py
+++ b/financialaid/views.py
@@ -20,7 +20,10 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK
 from rest_framework.views import APIView
-from rolepermissions.verifications import has_object_permission
+from rolepermissions.verifications import (
+    has_object_permission,
+    has_role,
+)
 
 from courses.models import Program
 from dashboard.models import ProgramEnrollment
@@ -46,6 +49,10 @@ from financialaid.serializers import (
     FinancialAidSerializer,
 )
 from mail.serializers import FinancialAidMailSerializer
+from roles.models import (
+    Instructor,
+    Staff,
+)
 from roles.roles import Permissions
 
 
@@ -232,6 +239,7 @@ class ReviewFinancialAidView(UserPassesTestMixin, ListView):
         context["authenticated"] = not self.request.user.is_anonymous()
         context["is_public"] = True
         context["has_zendesk_widget"] = True
+        context["is_staff"] = has_role(self.request.user, [Staff.ROLE_ID, Instructor.ROLE_ID])
         return context
 
     def get_queryset(self):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1713
Fixes #1934 

#### What's this PR do?
- Adds missing `is_staff` context variable for program page and financial aid review page.
- Fixes related object error when accessing missing `ProgramPage` object

This should take care of all template variable warnings except the Django Debug Toolbar ones, though I haven't done an exhaustive search

#### How should this be manually tested?
Make sure you can still view the programs on the home page, and you should be able to click one to go to the program page in the CMS
