### PR TITLE
Tests: make factories default to populating dependent objects

### DIFF
--- a/cms/serializers_test.py
+++ b/cms/serializers_test.py
@@ -52,8 +52,8 @@ class WagtailSerializerTests(ESTestCase):
         """
         Test program page serializer
         """
-        program = ProgramFactory.create(title="Supply Chain Management")
-        course = CourseFactory.create(program=program, title="Learning How to Supply")
+        program = ProgramFactory.create(title="Supply Chain Management", course=None)
+        course = CourseFactory.create(program=program, title="Learning How to Supply", course_run=None)
         page = ProgramPageFactory.create(program=program, title=program.title)
         faculty = FacultyFactory.create(
             program_page=page, name="Charles Fluffles", image=None,

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -45,7 +45,7 @@ class CourseModelTests(ESTestCase):
     @classmethod
     def setUpTestData(cls):
         super(CourseModelTests, cls).setUpTestData()
-        cls.course = CourseFactory.create(title="Title")
+        cls.course = CourseFactory.create(title="Title", course_run=None)
 
     def setUp(self):
         super(CourseModelTests, self).setUp()
@@ -236,7 +236,7 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
 
     def test_url_with_no_run(self):
         """Test course url with no course runs"""
-        course = CourseFactory.create()
+        course = CourseFactory.create(course_run=None)
         assert course.url == ""
 
     def test_url_with_empty_course_key(self):

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -26,11 +26,11 @@ class CourseSerializerTests(ESTestCase):
     Tests for CourseSerializer
     """
 
-    def test_course(self):
+    def test_course_without_run(self):
         """
         Make sure course serializes correctly
         """
-        course = CourseFactory.create()
+        course = CourseFactory.create(course_run=None)
         data = CourseSerializer(course).data
         expected = {
             "id": course.id,

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -55,9 +55,9 @@ class ProgramEnrollmentTests(ESTestCase, APITestCase):
 
         cls.user1 = UserFactory.create()
         cls.user2 = UserFactory.create()
-        cls.program1 = ProgramFactory.create(live=True)
-        cls.program2 = ProgramFactory.create(live=True)
-        cls.program3 = ProgramFactory.create(live=True)
+        cls.program1 = ProgramFactory.create()
+        cls.program2 = ProgramFactory.create()
+        cls.program3 = ProgramFactory.create()
 
         cls.url = reverse('user_program_enrollments')
 

--- a/dashboard/api_edx_cache_test.py
+++ b/dashboard/api_edx_cache_test.py
@@ -43,7 +43,7 @@ class CachedEdxUserDataTests(ESTestCase):
         cls.p1_course_run_keys = ['p1_course_run']
         cls.p2_course_run_keys = ['p2_course_run_1', 'p2_course_run_2']
         cls.p1_course_run = CourseRunFactory.create(edx_course_key=cls.p1_course_run_keys[0])
-        p2 = ProgramFactory.create(full=True)
+        p2 = ProgramFactory.create()
         first_course = p2.course_set.first()
         extra_course = CourseFactory.create(program=p2)
         cls.p2_course_run_1 = CourseRunFactory.create(course=first_course, edx_course_key=cls.p2_course_run_keys[0])

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -43,18 +43,22 @@ class MMTrackTest(TestCase):
         )
 
         # create the programs
-        cls.program = ProgramFactory.create(live=True, financial_aid_availability=False)
-        cls.program_financial_aid = ProgramFactory.create(live=True, financial_aid_availability=True)
+        cls.program = ProgramFactory.create(course=None)
+        cls.program_financial_aid = ProgramFactory.create(
+            financial_aid_availability=True, course=None, tiers=None,
+        )
 
         # create course runs for the normal program
-        course = CourseFactory.create(program=cls.program)
+        course = CourseFactory.create(program=cls.program, course_run=False)
         for course_key in ["course-v1:edX+DemoX+Demo_Course", "course-v1:MITx+8.MechCX+2014_T1", '', None]:
             CourseRunFactory.create(
                 course=course,
                 edx_course_key=course_key
             )
         # and the program with financial aid
-        finaid_course = CourseFactory.create(program=cls.program_financial_aid)
+        finaid_course = CourseFactory.create(
+            program=cls.program_financial_aid, course=None,
+        )
         cls.now = datetime.now(pytz.utc)
         cls.end_date = cls.now - timedelta(weeks=45)
         cls.crun_fa = CourseRunFactory.create(
@@ -63,19 +67,14 @@ class MMTrackTest(TestCase):
             end_date=cls.end_date,
             enrollment_start=cls.now-timedelta(weeks=62),
             enrollment_end=cls.now-timedelta(weeks=53),
-            edx_course_key="course-v1:odl+FOO101+CR-FALL15"
+            edx_course_key="course-v1:odl+FOO101+CR-FALL15",
+            course_price__price=1000,
         )
         CourseRunFactory.create(
             course=finaid_course,
             edx_course_key=None
         )
 
-        # create price for the financial aid course
-        CoursePriceFactory.create(
-            course_run=cls.crun_fa,
-            is_valid=True,
-            price=1000
-        )
         cls.min_tier_program = TierProgramFactory.create(
             program=cls.program_financial_aid,
             discount_amount=750,
@@ -249,7 +248,7 @@ class MMTrackTest(TestCase):
         """
         Test that if financial aid is available for the program, at least one course price should be available.
         """
-        program = ProgramFactory.create(live=True, financial_aid_availability=True)
+        program = ProgramFactory.create(financial_aid_availability=True)
         TierProgramFactory.create(
             program=program,
             discount_amount=750,
@@ -266,7 +265,7 @@ class MMTrackTest(TestCase):
         """
         Test that if financial aid is available for the program, at least one tier should be available.
         """
-        program = ProgramFactory.create(live=True, financial_aid_availability=True)
+        program = ProgramFactory.create(financial_aid_availability=True)
         course = CourseFactory.create(program=program)
         crun_fa = CourseRunFactory.create(course=course)
         CoursePriceFactory.create(

--- a/financialaid/api_test.py
+++ b/financialaid/api_test.py
@@ -43,16 +43,9 @@ def create_program(create_tiers=True):
     """
     program = ProgramFactory.create(
         financial_aid_availability=True,
-        live=True
-    )
-    course = CourseFactory.create(program=program)
-    course_run = CourseRunFactory.create(
-        enrollment_end=datetime.utcnow() + timedelta(hours=1),
-        course=course
-    )
-    CoursePriceFactory.create(
-        course_run=course_run,
-        is_valid=True
+        live=True,
+        course__course_run__enrollment_end=datetime.utcnow() + timedelta(hours=1),
+        tiers=False,
     )
     tier_programs = None
     if create_tiers:
@@ -189,7 +182,7 @@ class FinancialAidAPITests(FinancialAidBaseTestCase):
         Tests that determine_tier_program() raises ImproperlyConfigured if no $0-discount TierProgram
         has been created and income supplied is too low.
         """
-        program = ProgramFactory.create()
+        program = ProgramFactory.create(tiers=False)
         with self.assertRaises(ImproperlyConfigured):
             determine_tier_program(program, 0)
 

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -39,7 +39,7 @@ class MailViewsTests(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.search_result_mail_url = reverse('search_result_mail_api')
-        cls.program = ProgramFactory.create(live=True)
+        cls.program = ProgramFactory.create()
         # create a user with a role for one program
         with mute_signals(post_save):
             staff_profile = ProfileFactory.create()

--- a/roles/api_test.py
+++ b/roles/api_test.py
@@ -19,8 +19,8 @@ class APITests(ESTestCase):
         # create an user
         cls.user = UserFactory.create()
         # create the programs
-        cls.program1 = ProgramFactory.create(live=True)
-        cls.program2 = ProgramFactory.create(live=True)
+        cls.program1 = ProgramFactory.create()
+        cls.program2 = ProgramFactory.create()
 
     def test_get_advance_searchable_programs(self):
         """

--- a/search/permissions_test.py
+++ b/search/permissions_test.py
@@ -21,7 +21,7 @@ class PermissionsTests(ESTestCase):
         # create an user
         cls.user = UserFactory.create()
         # create the program
-        cls.program = ProgramFactory.create(live=True)
+        cls.program = ProgramFactory.create()
 
     def setUp(self):
         super(PermissionsTests, self).setUp()

--- a/search/views_test.py
+++ b/search/views_test.py
@@ -34,9 +34,9 @@ class SearchTests(ESTestCase, APITestCase):
         with mute_signals(post_save):
             cls.students = [(ProfileFactory.create()).user for _ in range(30)]
         # create the programs
-        cls.program1 = ProgramFactory.create(live=True)
-        cls.program2 = ProgramFactory.create(live=True)
-        cls.program3 = ProgramFactory.create(live=True)
+        cls.program1 = ProgramFactory.create()
+        cls.program2 = ProgramFactory.create()
+        cls.program3 = ProgramFactory.create()
 
         # enroll the users in the programs
         for num, student in enumerate(cls.students):


### PR DESCRIPTION
The [Factory Boy](http://factoryboy.readthedocs.io/en/latest/) library, which we're using for making test data, has some nice utilities for automatically populating dependent objects in a data model. In particular, we can use [`SubFactory`](http://factoryboy.readthedocs.io/en/latest/reference.html#factory.SubFactory) to create a dependent object *before* the target object is finished being created, and we can use [`RelatedFactory`](http://factoryboy.readthedocs.io/en/latest/reference.html#factory.RelatedFactory) to create a dependent object *after* the target object is finished being created. In both cases, it's easy to indicate that the dependent object shouldn't be created at all, simply by passing `<dependent>=None` as keyword arguments when creating the target object.

For example, when creating a Program object, you'll probably also want to create a Course object for it, and a CourseRun object for the Course, and perhaps even a CoursePrice object for the CourseRun. Previously, this was handled by passing a `full=True` parameter to the `ProgramFactory` class, which was detected by overriding the `_create()` method. Now, creating these dependent objects is the default usage. If you _don't_ want to create a Course object, you can call `ProgramFactory.create(course=None)`, and you'll just get a Program object. If you want a Program and a Course but not a CourseRun, you can call `ProgramFactory.create(course__course_run=None)`. You'll still get a Program object, and a Course object will be created for you, but a CourseRun object will not be created.

This pull request is still in progress, because there are a few tests in the codebase that need to be changed to accommodate this new assumption. However, it's mostly working already.