### PR TITLE
Fix handling of currently selected unenrolled program

### DIFF
--- a/static/js/reducers/programs.js
+++ b/static/js/reducers/programs.js
@@ -58,21 +58,23 @@ export const currentProgramEnrollment = (state: any = null, action: Action) => {
   switch (action.type) {
   case SET_CURRENT_PROGRAM_ENROLLMENT:
     return action.payload;
-  case RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS:
+  case RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS: {
+    let enrollments = action.payload.filter(enrollment => enrollment.enrolled);
     if (!_.isNil(state)) {
-      let enrollment = action.payload.find(enrollment => (
-        enrollment.id === state.id && enrollment.enrolled
+      let enrollment = enrollments.find(enrollment => (
+        enrollment.id === state.id
       ));
       if (enrollment === undefined) {
         // current enrollment not found in list
         state = null;
       }
     }
-    if (_.isNil(state) && action.payload.length > 0) {
+    if (_.isNil(state) && enrollments.length > 0) {
       // no current enrollment selected, pick first from list if there are any
-      state = action.payload[0];
+      state = enrollments[0];
     }
     return state;
+  }
   case RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS:
     return action.payload;
   default:

--- a/static/js/reducers/programs_test.js
+++ b/static/js/reducers/programs_test.js
@@ -190,7 +190,7 @@ describe('enrollments', () => {
     it("should replace the current enrollment if it can't be found in the list of enrollments", () => {
       let enrollment = {"id": 999, "title": "not an enrollment anymore"};
       store.dispatch(setCurrentProgramEnrollment(enrollment));
-      store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAMS));
+      store.dispatch(receiveGetProgramEnrollmentsSuccess([enrollment].concat(PROGRAMS)));
       assert.deepEqual(store.getState().currentProgramEnrollment, PROGRAMS[0]);
     });
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1942 

#### What's this PR do?
Fixes a bug for selection of the currently enrolled program. It previously chose the first one in the enrollment list, but this programs list now has unenrolled programs too. It's been changed to pick the first program the user is enrolled in, if it exists.

#### How should this be manually tested?
- Enroll in the first program that's live (the lowest id number). Make sure some other program is also enrolled.
- Select that program in the UI
- Delete the `ProgramEnrollment` for that program and user
- Refresh the browser. You should see the next program chosen in the program selector.

