### PR TITLE
Use enrollment_url if provided for URL

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -88,6 +88,8 @@ class Course(models.Model):
         course_run = self.first_unexpired_run()
         if not course_run:
             return ""
+        if course_run.enrollment_url:
+            return course_run.enrollment_url
         if not course_run.edx_course_key:
             return ""
         return urllib.parse.urljoin(

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -3,9 +3,11 @@ Model tests
 """
 # pylint: disable=no-self-use
 from datetime import datetime, timedelta
+from urllib.parse import urljoin
 
 import pytz
 from ddt import ddt, data, unpack
+from django.test import override_settings
 
 from courses.factories import (
     ProgramFactory,
@@ -14,6 +16,9 @@ from courses.factories import (
 )
 from courses.models import CourseRun
 from search.base import ESTestCase
+
+
+BASE_URL = "http://base.url/"
 
 
 class ProgramTests(ESTestCase):
@@ -228,6 +233,55 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
             enrollment_end=None,
         )
         assert self.course.enrollment_text == 'Coming Fall 2017'
+
+    def test_url_with_no_run(self):
+        """Test course url with no course runs"""
+        course = CourseFactory.create()
+        assert course.url == ""
+
+    def test_url_with_empty_course_key(self):
+        """Course with no course key or enrollment_url should have empty url"""
+        course_run = CourseRunFactory.create(
+            course=self.course,
+            start_date=self.from_weeks(-1),
+            end_date=None,
+            enrollment_start=self.from_weeks(-1),
+            enrollment_end=None,
+            enrollment_url=None,
+            edx_course_key=None,
+        )
+        assert course_run.course.url == ""
+
+    def test_enrollment_url(self):
+        """If enrollment_url is available we should use it over edx_course_key"""
+        course_run = CourseRunFactory.create(
+            course=self.course,
+            start_date=self.from_weeks(-1),
+            end_date=None,
+            enrollment_start=self.from_weeks(-1),
+            enrollment_end=None,
+            enrollment_url="http://enrollment.url/",
+            edx_course_key="course_key"
+        )
+        assert course_run.course.url == "http://enrollment.url/"
+
+    @override_settings(EDXORG_BASE_URL=BASE_URL)
+    def test_url_with_course_key(self):
+        """Test course url with no course key"""
+        course_run = CourseRunFactory.create(
+            course=self.course,
+            start_date=self.from_weeks(-1),
+            end_date=None,
+            enrollment_start=self.from_weeks(-1),
+            enrollment_end=None,
+            enrollment_url=None,
+            edx_course_key="course_key"
+        )
+        expected = urljoin(
+            BASE_URL,
+            'courses/{key}/about'.format(key=course_run.edx_course_key)
+        )
+        assert course_run.course.url == expected
 
 
 @ddt

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -253,7 +253,7 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
         assert course_run.course.url == ""
 
     def test_enrollment_url(self):
-        """If enrollment_url is available we should use it over edx_course_key"""
+        """If both enrollment_url and edx_course_key are available, use enrollment_url"""
         course_run = CourseRunFactory.create(
             course=self.course,
             start_date=self.from_weeks(-1),
@@ -267,7 +267,7 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
 
     @override_settings(EDXORG_BASE_URL=BASE_URL)
     def test_url_with_course_key(self):
-        """Test course url with no course key"""
+        """Test course url with a course key and no enrollment_url"""
         course_run = CourseRunFactory.create(
             course=self.course,
             start_date=self.from_weeks(-1),

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -4,8 +4,6 @@ Tests for serializers
 
 from unittest.mock import Mock
 
-from django.test import override_settings
-
 from cms.factories import ProgramPageFactory
 from cms.models import HomePage
 from courses.factories import (

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -43,15 +43,14 @@ class CourseSerializerTests(ESTestCase):
         }
         assert data == expected
 
-    @override_settings(EDXORG_BASE_URL="http://192.168.33.10:8000")
     def test_course_with_run(self):
         """
         Make sure the course URL serializes properly
         """
-        course_run = CourseRunFactory.create(edx_course_key='my-course-key')
+        course_run = CourseRunFactory.create()
         course = course_run.course
         data = CourseSerializer(course).data
-        assert data['url'] == 'http://192.168.33.10:8000/courses/my-course-key/about'
+        assert data['url'] == course_run.enrollment_url
         assert data['enrollment_text'] == course.enrollment_text
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1961

#### What's this PR do?
Uses `CourseRun.enrollment_url` for the `View on edX` link if it's available. Else, construct a URL using the course key as before

#### How should this be manually tested?
Set `CourseRun.enrollment_url` for some course run and look at its program page. The View on edX link should go to the URL you provided.
