### PR TITLE
Remove closest, use parentNode.parentNode if available

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1998,11 +1998,6 @@
       "from": "ee-first@1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
     },
-    "element-closest": {
-      "version": "2.0.2",
-      "from": "element-closest@latest",
-      "resolved": "http://registry.npmjs.org/element-closest/-/element-closest-2.0.2.tgz"
-    },
     "emojis-list": {
       "version": "2.0.1",
       "from": "emojis-list@>=2.0.0 <3.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "css-loader": "0.23.1",
     "currency-codes": "^1.1.2",
     "deep-freeze": "0.0.1",
-    "element-closest": "^2.0.2",
     "enzyme": "^2.4.1",
     "eslint": "^3.11.1",
     "eslint-config-defaults": "9.0.0",

--- a/static/js/entry/zendesk_widget.js
+++ b/static/js/entry/zendesk_widget.js
@@ -1,6 +1,5 @@
 /* global SETTINGS:false zE:false _:false */
 __webpack_public_path__ = `http://${SETTINGS.host}:8078/`;  // eslint-disable-line no-undef, camelcase
-import "element-closest";
 import R from 'ramda';
 
 // Start of odl Zendesk Widget script
@@ -142,8 +141,8 @@ const zendeskCallbacks = {
       if ( !fieldVisibility[name] ) {
         const element = fieldElement(name);
         if (element) {
-          const label = element.closest('label');
-          if (label) {
+          const label = element.parentNode.parentNode;
+          if (label.tagName.toLowerCase() === "label") {
             label.style.setProperty("display", "none", "important");
           }
         }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1962 

#### What's this PR do?
Removes closest polyfill, uses `parentNode.parentNode` which works for now

#### How should this be manually tested?
Go to a programpage and verify that you see a zendesk widget
