### PR TITLE
don't use png, it is too big

### DIFF
--- a/static/js/components/CropperWrapper.js
+++ b/static/js/components/CropperWrapper.js
@@ -13,7 +13,7 @@ export default class CropperWrapper extends React.Component {
     const { updatePhotoEdit } = this.props;
     let canvas = this.refs.cropper.getCroppedCanvas();
     if (canvas.toBlob !== undefined) {
-      canvas.toBlob(blob => updatePhotoEdit(blob));
+      canvas.toBlob(blob => updatePhotoEdit(blob), 'image/jpeg');
     }
   };
 

--- a/static/js/containers/ProfileImage.js
+++ b/static/js/containers/ProfileImage.js
@@ -25,7 +25,7 @@ import {
 import { fetchUserProfile } from '../actions/profile';
 
 const formatPhotoName = photo => (
-  `${photo.name.replace(/\.\w*$/, '')}-${moment().format()}.png`
+  `${photo.name.replace(/\.\w*$/, '')}-${moment().format()}.jpg`
 );
 
 class ProfileImage extends React.Component {


### PR DESCRIPTION
#### What are the relevant tickets?

part of #1971 

#### What's this PR do?

This changes the encoding when we call `.toBlob` in order to save a `jpg` instead of a `png`. In testing this results in a pretty big decrease in image size. 

Saving a `png` through our image thing actually seems to usually result in bigger images by default. Changing the encoding to `image/jpeg` seems to do a pretty good job of cutting this down.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

