### PR TITLE
Fix about me width issue

### DIFF
--- a/static/scss/profile.scss
+++ b/static/scss/profile.scss
@@ -91,6 +91,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    justify-content: space-between;
 
     &.row-with-border {
       border-bottom: 1px #e2e2e2 solid;
@@ -248,6 +249,7 @@
   flex-direction: column;
   align-items: flex-start;
   margin-left: 15px;
+  width: 80%;
 
   h3 {
     padding: 14px 0;
@@ -255,8 +257,11 @@
   }
 
   .bio {
-    width: 170%;
+    width: 100%;
     white-space: pre-wrap;
+    font-weight: 400;
+    color: rbga(0,0,0,.75);
+    line-height: 1.4em;
 
     &.placeholder {
       color: #939393;

--- a/static/scss/user-page.scss
+++ b/static/scss/user-page.scss
@@ -1,4 +1,5 @@
 .user-page {
+
   .profile-title {
     margin-top: 19px;
     font-size: 23px;
@@ -17,7 +18,7 @@
   }
 
   .edit-profile-holder, .edit-about-me-holder {
-    width: 100%;
     text-align: right;
   }
+
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1937

#### What's this PR do?

This fixes a layout bug with the About Me copy on the user page. There are still some weird layout bugs with the user avatar and the user name in the same box, but I think that should be fixed in a separate PR. The problem was an incorrect implementation of flexbox, and widths.

#### Where should the reviewer start?

Test this on a few browsers.

Before and after screenshots:
![image](https://cloud.githubusercontent.com/assets/20047260/20903043/dcd80ebe-bb07-11e6-94d3-35941c418687.png)

![image](https://cloud.githubusercontent.com/assets/20047260/20903051/e4e6cfaa-bb07-11e6-892f-6491199ac997.png)



