### PR TITLE
Removed 'Clear all filters' link when user switch pages of unfiltered search

### DIFF
--- a/static/js/components/search/CustomResetFiltersDisplay.js
+++ b/static/js/components/search/CustomResetFiltersDisplay.js
@@ -1,11 +1,11 @@
 // @flow
 import React from 'react';
 import {
-  ResetFiltersDisplay,
+  SearchkitComponent,
   FastClick
 } from 'searchkit';
 
-export default class CustomResetFiltersDisplay extends ResetFiltersDisplay {
+export default class CustomResetFiltersDisplay extends SearchkitComponent {
   props: {
     bemBlock:      any,
     hasFilters:    boolean,
@@ -21,7 +21,14 @@ export default class CustomResetFiltersDisplay extends ResetFiltersDisplay {
       clearAllLabel
     } = this.props;
 
-    if (hasFilters) {
+    let hasFiltersOtherThanSelectedProgram = (
+      this.getQuery() &&
+      this.getQuery().index &&
+      this.getQuery().index.filters &&
+      this.getQuery().index.filters.length > 1
+    );
+
+    if (hasFilters && hasFiltersOtherThanSelectedProgram) {
       return (
         <div>
           <FastClick handler={resetFilters}>

--- a/static/js/components/search/CustomResetFiltersDisplay_test.js
+++ b/static/js/components/search/CustomResetFiltersDisplay_test.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import _ from 'lodash';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 import { assert } from 'chai';
@@ -11,16 +10,6 @@ import CustomResetFiltersDisplay from './CustomResetFiltersDisplay';
 describe('CustomResetFiltersDisplay', () => {
   let sandbox;
   let searchKit;
-  let props = {
-    clearAllLabel: "Clear all filters",
-    hasFilters: true,
-    resetFilters: () => {},
-    bemBlock: (): Object => {
-      return {
-        state: (): void => {}
-      };
-    }
-  };
 
   beforeEach(() => {
     searchKit = new SearchkitManager();
@@ -31,6 +20,20 @@ describe('CustomResetFiltersDisplay', () => {
     sandbox.restore();
   });
 
+  let renderFilters = (props = {}) => (
+    mount(
+      <SearchkitProvider searchkit={searchKit}>
+        <CustomResetFiltersDisplay
+          clearAllLabel="Clear all filters"
+          hasFilters={true}
+          resetFilters={() => {}}
+          bemBlock={() => ({ state: () => {} })}
+          {...props}
+        />
+      </SearchkitProvider>
+    )
+  );
+
   it('renders reset filters link', () => {
     sandbox.stub(CustomResetFiltersDisplay.prototype, 'getQuery').returns({
       'index': {
@@ -40,12 +43,7 @@ describe('CustomResetFiltersDisplay', () => {
         ]
       }
     });
-    const wrapper = mount(
-      <SearchkitProvider searchkit={searchKit}>
-        <CustomResetFiltersDisplay {...props}/>
-      </SearchkitProvider>
-    );
-
+    const wrapper = renderFilters();
     assert.equal(wrapper.children().children().text(), 'Clear all filters');
   });
 
@@ -58,13 +56,9 @@ describe('CustomResetFiltersDisplay', () => {
         ]
       }
     });
-    let noFilterProps = _.clone(props);
-    noFilterProps.hasFilters = false;
-    const wrapper = mount(
-      <SearchkitProvider searchkit={searchKit}>
-        <CustomResetFiltersDisplay {...noFilterProps}/>
-      </SearchkitProvider>
-    );
+    const wrapper = renderFilters({
+      hasFilters: false
+    });
 
     assert.lengthOf(wrapper.children(), 0);
   });
@@ -77,11 +71,7 @@ describe('CustomResetFiltersDisplay', () => {
         ]
       }
     });
-    const wrapper = mount(
-      <SearchkitProvider searchkit={searchKit}>
-        <CustomResetFiltersDisplay {...props}/>
-      </SearchkitProvider>
-    );
+    const wrapper = renderFilters();
     assert.lengthOf(wrapper.children(), 0);
   });
 });

--- a/static/js/components/search/CustomResetFiltersDisplay_test.js
+++ b/static/js/components/search/CustomResetFiltersDisplay_test.js
@@ -2,11 +2,13 @@
 import React from 'react';
 import _ from 'lodash';
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 import { assert } from 'chai';
 
 import CustomResetFiltersDisplay from './CustomResetFiltersDisplay';
 
 describe('CustomResetFiltersDisplay', () => {
+  let sandbox;
   let props = {
     clearAllLabel: "Clear all filters",
     hasFilters: true,
@@ -18,17 +20,53 @@ describe('CustomResetFiltersDisplay', () => {
     }
   };
 
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   it('renders reset filters link', () => {
+    sandbox.stub(CustomResetFiltersDisplay.prototype, 'getQuery').returns({
+      'index': {
+        'filters': [
+          "program filter",
+          "any other filter"
+        ]
+      }
+    });
     const wrapper = shallow(<CustomResetFiltersDisplay {...props}/>);
 
     assert.equal(wrapper.children().children().text(), 'Clear all filters');
   });
 
   it('reset filter link does not render when hasFilters is false', () => {
+    sandbox.stub(CustomResetFiltersDisplay.prototype, 'getQuery').returns({
+      'index': {
+        'filters': [
+          "program filter",
+          "any other filter"
+        ]
+      }
+    });
     let noFilterProps = _.clone(props);
     noFilterProps.hasFilters = false;
     const wrapper = shallow(<CustomResetFiltersDisplay {...noFilterProps}/>);
 
+    assert.lengthOf(wrapper.children(), 0);
+  });
+
+  it('do not render when there is only program filter selected', () => {
+    sandbox.stub(CustomResetFiltersDisplay.prototype, 'getQuery').returns({
+      'index': {
+        'filters': [
+          "program filter"
+        ]
+      }
+    });
+    const wrapper = shallow(<CustomResetFiltersDisplay {...props}/>);
     assert.lengthOf(wrapper.children(), 0);
   });
 });

--- a/static/js/components/search/CustomResetFiltersDisplay_test.js
+++ b/static/js/components/search/CustomResetFiltersDisplay_test.js
@@ -1,14 +1,16 @@
 // @flow
 import React from 'react';
 import _ from 'lodash';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import sinon from 'sinon';
 import { assert } from 'chai';
+import { SearchkitManager, SearchkitProvider } from 'searchkit';
 
 import CustomResetFiltersDisplay from './CustomResetFiltersDisplay';
 
 describe('CustomResetFiltersDisplay', () => {
   let sandbox;
+  let searchKit;
   let props = {
     clearAllLabel: "Clear all filters",
     hasFilters: true,
@@ -21,6 +23,7 @@ describe('CustomResetFiltersDisplay', () => {
   };
 
   beforeEach(() => {
+    searchKit = new SearchkitManager();
     sandbox = sinon.sandbox.create();
   });
 
@@ -37,7 +40,11 @@ describe('CustomResetFiltersDisplay', () => {
         ]
       }
     });
-    const wrapper = shallow(<CustomResetFiltersDisplay {...props}/>);
+    const wrapper = mount(
+      <SearchkitProvider searchkit={searchKit}>
+        <CustomResetFiltersDisplay {...props}/>
+      </SearchkitProvider>
+    );
 
     assert.equal(wrapper.children().children().text(), 'Clear all filters');
   });
@@ -53,7 +60,11 @@ describe('CustomResetFiltersDisplay', () => {
     });
     let noFilterProps = _.clone(props);
     noFilterProps.hasFilters = false;
-    const wrapper = shallow(<CustomResetFiltersDisplay {...noFilterProps}/>);
+    const wrapper = mount(
+      <SearchkitProvider searchkit={searchKit}>
+        <CustomResetFiltersDisplay {...noFilterProps}/>
+      </SearchkitProvider>
+    );
 
     assert.lengthOf(wrapper.children(), 0);
   });
@@ -66,7 +77,11 @@ describe('CustomResetFiltersDisplay', () => {
         ]
       }
     });
-    const wrapper = shallow(<CustomResetFiltersDisplay {...props}/>);
+    const wrapper = mount(
+      <SearchkitProvider searchkit={searchKit}>
+        <CustomResetFiltersDisplay {...props}/>
+      </SearchkitProvider>
+    );
     assert.lengthOf(wrapper.children(), 0);
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
- fixes https://github.com/mitodl/micromasters/issues/1803

#### How should this be manually tested?
- Enable pagination on ```/learners```. You can set ```ELASTICSEARCH_DEFAULT_PAGE_SIZE=10``` to any smaller value on ```.env``` file.
- Navigate between pages, you will not see 'Clear all filters' link.
- Apply filter and navigate, now you will see 'Clear all filters' link.

@pdpinch @noisecapella @aliceriot 
#### Screenshots (if appropriate)
<img width="1272" alt="screen shot 2016-12-06 at 3 37 22 pm" src="https://cloud.githubusercontent.com/assets/10431250/20922422/eac75882-bbc9-11e6-9ab6-af8d7b087525.png">

<img width="1239" alt="screen shot 2016-12-06 at 3 37 54 pm" src="https://cloud.githubusercontent.com/assets/10431250/20922445/ffeb6f46-bbc9-11e6-8f35-74b265407d78.png">
