### PR TITLE
Disabled photo button during upload

### DIFF
--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -6,6 +6,7 @@ import Dropzone from 'react-dropzone';
 import Button from 'react-mdl/lib/Button';
 
 import CropperWrapper from './CropperWrapper';
+import { FETCH_PROCESSING } from '../actions';
 import type { ImageUploadState } from '../reducers/image_upload';
 
 const onDrop = R.curry((startPhotoEdit, files) => startPhotoEdit(...files));
@@ -48,11 +49,13 @@ const ProfileImageUploader = ({
   startPhotoEdit,
   clearPhotoEdit,
   updatePhotoEdit,
-  imageUpload: { photo, error },
+  imageUpload: { photo, error, patchStatus },
   updateUserPhoto,
   setPhotoError,
-}: ImageUploadProps) => (
-  <Dialog
+}: ImageUploadProps) => {
+  const disabled = patchStatus === FETCH_PROCESSING || !photo;
+
+  return <Dialog
     title="Upload a Profile Photo"
     titleClassName="dialog-title"
     contentClassName="dialog photo-upload-dialog"
@@ -74,9 +77,9 @@ const ProfileImageUploader = ({
       </Button>,
       <Button
         type='button'
-        className={`save-button ${photo ? 'primary-button' : 'secondary-button disabled'}`}
+        className={`save-button ${!disabled ? 'primary-button' : 'secondary-button disabled'}`}
         key="save"
-        onClick={photo ? updateUserPhoto : undefined}>
+        onClick={!disabled ? updateUserPhoto : undefined}>
         Save
       </Button>
     ]}
@@ -86,6 +89,6 @@ const ProfileImageUploader = ({
      {...{updatePhotoEdit, photo, uploaderBodyHeight}} /> : dropZone(startPhotoEdit, setPhotoError)
    }
   </Dialog>
-);
+};
 
 export default ProfileImageUploader;

--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -88,7 +88,7 @@ const ProfileImageUploader = ({
    { photo ? <CropperWrapper
      {...{updatePhotoEdit, photo, uploaderBodyHeight}} /> : dropZone(startPhotoEdit, setPhotoError)
    }
-  </Dialog>
+  </Dialog>;
 };
 
 export default ProfileImageUploader;

--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -77,9 +77,9 @@ const ProfileImageUploader = ({
       </Button>,
       <Button
         type='button'
-        className={`save-button ${!disabled ? 'primary-button' : 'secondary-button disabled'}`}
+        className={`save-button ${disabled ? 'secondary-button disabled': 'primary-button'}`}
         key="save"
-        onClick={!disabled ? updateUserPhoto : undefined}>
+        onClick={disabled ? undefined: updateUserPhoto}>
         Save
       </Button>
     ]}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1990 

#### What's this PR do?
Disables save button during a photo upload

#### How should this be manually tested?
While the image is uploaded the  button should be greyed out. Clicking the disabled button should also not do anything.
