### PR TITLE
Added redirect when visitors are using the herokuapp domain

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -33,3 +33,4 @@ endif =
 if-not-env = DEV_ENV
 memory-report = true
 endif =
+route-host = ^micromasters.herokuapp.com redirect-permanent:https://micromasters.mit.edu${REQUEST_URI}


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2001 

#### What's this PR do?
Adds a 301 redirect from micromasters.herokuapp.com to micromasters.mit.edu

#### Where should the reviewer start?
uwsgi.ini

#### How should this be manually tested?
Edit your /etc/hosts to make micromasters.herokuapp.com resolve to your localhost and try visiting that URL. It should redirect you to micromasters.mit.edu (including the path portion of the request).

#### Any background context you want to provide?
Some of our links are pointing to herokuapp.com so we want to make sure that everyone is using the mit.edu domain.

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

If users are visiting the site at the micromasters.herokuapp.com
domain this will issue a 301 redirect to micromasters.mit.edu