### PR TITLE
Limit user photo uploads to 1024x1024 pixels

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1880,6 +1880,11 @@
       "from": "destroy@>=1.0.4 <1.1.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
     },
+    "detect-browser": {
+      "version": "1.5.0",
+      "from": "detect-browser@latest",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-1.5.0.tgz"
+    },
     "detect-indent": {
       "version": "4.0.0",
       "from": "detect-indent@>=4.0.0 <5.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "css-loader": "0.23.1",
     "currency-codes": "^1.1.2",
     "deep-freeze": "0.0.1",
+    "detect-browser": "^1.5.0",
     "enzyme": "^2.4.1",
     "eslint": "^3.11.1",
     "eslint-config-defaults": "9.0.0",

--- a/static/js/components/CropperWrapper.js
+++ b/static/js/components/CropperWrapper.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import Cropper from 'react-cropper';
+import browser from 'detect-browser';
 
 export default class CropperWrapper extends React.Component {
   props: {
@@ -11,10 +12,16 @@ export default class CropperWrapper extends React.Component {
 
   cropperHelper = () => {
     const { updatePhotoEdit } = this.props;
-    let canvas = this.refs.cropper.getCroppedCanvas();
-    if (canvas.toBlob !== undefined) {
-      canvas.toBlob(blob => updatePhotoEdit(blob), 'image/jpeg');
+    let canvas;
+    if ( browser.name === 'safari' || browser.name === 'ios' ) {
+      canvas = this.refs.cropper.getCroppedCanvas();
+    } else {
+      canvas = this.refs.cropper.getCroppedCanvas({
+        width: 512,
+        height: 512,
+      });
     }
+    canvas.toBlob(blob => updatePhotoEdit(blob), 'image/jpeg');
   };
 
   render () {


### PR DESCRIPTION
#### What are the relevant tickets?

#### What's this PR do?

This implements a function that uses `<canvas>` to limit the maximum dimensions of user photos to 1024x1024 (right now, we can use whatever number we want).

#### Where should the reviewer start?

#### How should this be manually tested?

Probably just ensure that even if you throttle your connection it is possible to upload an image? hopefully...

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
