### PR TITLE
Fixes a small layout issue on the FAQ tab

### DIFF
--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -265,8 +265,11 @@
 
       .question {
         font-weight: 500;
-        font-size: 18px;
+        font-size: 16px;
         margin: 0 0 25px 0;
+        line-height: 1.4em;
+        position: relative;
+        padding-left: 32px;
       }
     }
   }
@@ -440,7 +443,9 @@
 
   .accordion-icon {
     font-size: 30px;
-    vertical-align: top;
+    position: absolute;
+    left: -10px;
+    top: -6px;
   }
 }
 


### PR DESCRIPTION
#### What's this PR do?

This fixes an issue where the FAQ "question" was wrapping underneath the toggle-arrow, which looked weird. It also slightly reduces the font size of the question. Closes #1993 

Before:
![image](https://cloud.githubusercontent.com/assets/20047260/20942633/3c3f8ebe-bbca-11e6-863a-4fa0cb8b8351.png)

After:
![image](https://cloud.githubusercontent.com/assets/20047260/20942620/29d250e0-bbca-11e6-9473-42ef2e2ac287.png)
