### PR TITLE
don't require a profile photo

### DIFF
--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -57,9 +57,7 @@ export function programValidation(_: Profile, ui: UIState): ValidationErrors {
   return errors;
 }
 
-export const profileImageValidation = (profile: Profile) => (
-  profile.image ? {} : { image: 'Please upload a profile image' }
-);
+export const profileImageValidation = () => ({});
 
 export function personalValidation(profile: Profile): ValidationErrors {
   let requiredFields = [

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -89,10 +89,8 @@ describe('Profile validation functions', () => {
 
 
   describe('profileImageValidation', () => {
-    it('should return an error if no image', () => {
-      assert.deepEqual(profileImageValidation({}), {
-        image: 'Please upload a profile image'
-      });
+    it('should return no errors if no image is present', () => {
+      assert.deepEqual(profileImageValidation({}), {});
     });
 
     it('should return no errors if image is present', () => {


### PR DESCRIPTION
1. use the django shell to delete your user's profile image
2. go to `/profile/personal`
3. confirm you can navigate forward without being prompted to add a profile image.