### PR TITLE
Removed First and Last Name from the edxorg pipeline

### DIFF
--- a/backends/edxorg.py
+++ b/backends/edxorg.py
@@ -68,15 +68,16 @@ class EdxOrgOAuth2(BaseOAuth2):
                 the following keys:
                 <remote_id>, `username`, `email`, `fullname`, `first_name`, `last_name`
         """
-        full, first, last = self.get_user_names(response['name'])
+        full, _, _ = self.get_user_names(response['name'])
 
         return {
             'edx_id': response['username'],
             'username': response['username'],
             'email': response['email'],
             'fullname': full,
-            'first_name': first,
-            'last_name': last,
+            # the following are not necessary because they are used only inside the User object.
+            'first_name': '',
+            'last_name': '',
         }
 
     def get_user_id(self, details, response):

--- a/backends/edxorg_test.py
+++ b/backends/edxorg_test.py
@@ -25,8 +25,8 @@ class EdxOrgOAuth2Tests(TestCase):
             'username': 'darth',
             'fullname': 'Darth Vader',
             'email': 'darth@deathst.ar',
-            'first_name': 'Darth',
-            'last_name': 'Vader'
+            'first_name': '',
+            'last_name': ''
         } == result
 
     def test_single_name(self):
@@ -46,6 +46,6 @@ class EdxOrgOAuth2Tests(TestCase):
             'username': 'staff',
             'fullname': 'staff',
             'email': 'staff@example.com',
-            'first_name': 'staff',
+            'first_name': '',
             'last_name': ''
         } == result


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #2011

#### What's this PR do?
First and Last name in the EDXORG pipeline are used only to create the Django User object,
but given that we store these informations in the profile, we can remove them from there
and not risk to break the app because they are too long.

#### Where should the reviewer start?

#### How should this be manually tested?
Create a name in edX where the string after the first space is more than 30 characters.
The MM app should not break.

You should also test that an user that previously failed to login, should be able to login after this PR is in place.

You should be able to see that the newly created user has no first and last name in the Django Admin/User.
