### PR TITLE
Created course facet to filter learners by course enrollment

### DIFF
--- a/dashboard/api_edx_cache.py
+++ b/dashboard/api_edx_cache.py
@@ -3,9 +3,8 @@ APIs that deal with the edx cached data
 """
 import datetime
 import logging
-
-from django.db import transaction
 import pytz
+from django.db import transaction
 
 from courses.models import CourseRun
 from dashboard import models
@@ -16,42 +15,22 @@ log = logging.getLogger(__name__)
 
 
 class CachedEdxUserData:
-    """Represents all edx data related to a User"""
+    """Represents all edX data related to a User"""
     # pylint: disable=too-many-instance-attributes
 
-    enrollments = None
-    certificates = None
-    current_grades = None
-    raw_enrollments = None
-    raw_certificates = None
-    raw_current_grades = None
-
-    def __init__(self, user, program=None, include_raw_data=False):
+    def __init__(self, user, program=None):
         """
         Fetches the given User's edx data and sets object properties
 
         Args:
             user (User): a User object
             program (Program): an optional Program to filter on
-            include_raw_data (bool): Set to True if raw edx data is needed (in addition to actual edX objects)
         """
         self.user = user
         self.program = program
-        self.fetch_and_set_edx_data()
-        if include_raw_data:
-            self.fetch_and_set_raw_data()
-
-    def fetch_and_set_edx_data(self):
-        """Fetches edx data and sets object properties"""
         self.enrollments = models.CachedEnrollment.get_edx_data(self.user, program=self.program)
         self.certificates = models.CachedCertificate.get_edx_data(self.user, program=self.program)
         self.current_grades = models.CachedCurrentGrade.get_edx_data(self.user, program=self.program)
-
-    def fetch_and_set_raw_data(self):
-        """Fetches raw cached data and sets object properties"""
-        self.raw_enrollments = list(models.CachedEnrollment.data_qset(self.user, program=self.program))
-        self.raw_certificates = list(models.CachedCertificate.data_qset(self.user, program=self.program))
-        self.raw_current_grades = list(models.CachedCurrentGrade.data_qset(self.user, program=self.program))
 
 
 class CachedEdxDataApi:

--- a/dashboard/api_edx_cache_test.py
+++ b/dashboard/api_edx_cache_test.py
@@ -12,7 +12,10 @@ from edx_api.grades.models import CurrentGrade, CurrentGrades
 
 from courses.factories import ProgramFactory, CourseFactory, CourseRunFactory
 from dashboard import models
-from dashboard.api_edx_cache import CachedEdxUserData, CachedEdxDataApi
+from dashboard.api_edx_cache import (
+    CachedEdxUserData,
+    CachedEdxDataApi
+)
 from dashboard.factories import (
     CachedEnrollmentFactory,
     CachedCertificateFactory,
@@ -62,9 +65,9 @@ class CachedEdxUserDataTests(ESTestCase):
 
     def assert_edx_data_has_given_ids(self, edx_user_data, ids):
         """Asserts that all edX object course id sets match the given list of ids"""
-        assert sorted(edx_user_data.enrollments.get_enrolled_course_ids()) == ids
-        assert sorted(edx_user_data.certificates.all_courses_verified_certs) == ids
-        assert sorted(edx_user_data.current_grades.all_course_ids) == ids
+        assert sorted(edx_user_data.enrollments.get_enrolled_course_ids()) == sorted(ids)
+        assert sorted(edx_user_data.certificates.all_courses_verified_certs) == sorted(ids)
+        assert sorted(edx_user_data.current_grades.all_course_ids) == sorted(ids)
 
     def test_edx_data_fetch_and_set(self):
         """Test that a user's edX data is properly fetched and set onto object properties"""
@@ -82,13 +85,6 @@ class CachedEdxUserDataTests(ESTestCase):
         p2_course_run_program = self.p2_course_run_1.course.program
         edx_user_data = CachedEdxUserData(self.user, program=p2_course_run_program)
         self.assert_edx_data_has_given_ids(edx_user_data, self.p2_course_run_keys)
-
-    def test_raw_data_fetch_and_set(self):
-        """Test that a user's raw edX data is properly fetched and set onto object properties"""
-        edx_user_data = CachedEdxUserData(self.user, include_raw_data=True)
-        assert edx_user_data.raw_enrollments == [obj.data for obj in self.enrollments]
-        assert edx_user_data.raw_certificates == [obj.data for obj in self.certificates]
-        assert edx_user_data.raw_current_grades == [obj.data for obj in self.current_grades]
 
 
 class CachedEdxDataApiTests(ESTestCase):

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -38,19 +38,33 @@ class CachedEdxInfoModel(Model):
     @classmethod
     def user_qset(cls, user, program=None):
         """
-        Returns a queryset for the active records associated with a User
+        Returns a queryset for the records associated with a User
 
         Args:
             user (User): an User object
             program (Program): optional Program to filter on
 
         Returns:
-            QuerySet: a queryset of all the elements for the provided user
+            QuerySet: a queryset of all records for the provided user
         """
         query_params = dict(user=user)
         if program is not None:
             query_params.update(dict(course_run__course__program=program))
         return cls.objects.filter(**query_params)
+
+    @classmethod
+    def user_course_qset(cls, user, program=None):
+        """
+        Returns a queryset for the records associated with a User and prefetched Course data
+
+        Args:
+            user (User): an User object
+            program (Program): optional Program to filter on
+
+        Returns:
+            QuerySet: a queryset of all records for the provided user with prefetched Course data
+        """
+        return cls.user_qset(user, program=program).select_related('course_run__course')
 
     @classmethod
     def data_qset(cls, user, program=None):

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -18,12 +18,7 @@ from dashboard.factories import (
     CachedCurrentGradeFactory,
     CachedEnrollmentFactory,
 )
-from dashboard.models import (
-    CachedCertificate,
-    CachedCurrentGrade,
-    CachedEnrollment,
-    ProgramEnrollment,
-)
+from dashboard.models import ProgramEnrollment
 from dashboard.serializers import UserProgramSearchSerializer
 from ecommerce.factories import (
     OrderFactory,
@@ -55,14 +50,14 @@ class UserProgramSearchSerializerTests(TestCase):
         """
         fake = faker.Factory.create()
         course = CourseFactory.create(program=program)
-        cours_run_params = dict(before_now=True, after_now=False, tzinfo=pytz.utc)
+        course_run_params = dict(before_now=True, after_now=False, tzinfo=pytz.utc)
         course_runs = [
             CourseRunFactory.create(
                 course=course,
-                enrollment_start=fake.date_time_this_month(**cours_run_params),
-                start_date=fake.date_time_this_month(**cours_run_params),
-                enrollment_end=fake.date_time_this_month(**cours_run_params),
-                end_date=fake.date_time_this_year(**cours_run_params),
+                enrollment_start=fake.date_time_this_month(**course_run_params),
+                start_date=fake.date_time_this_month(**course_run_params),
+                enrollment_end=fake.date_time_this_month(**course_run_params),
+                end_date=fake.date_time_this_year(**course_run_params),
             ) for _ in range(num_course_runs)
         ]
         factory_kwargs = dict(user=user)
@@ -80,6 +75,7 @@ class UserProgramSearchSerializerTests(TestCase):
         # create a normal program
         program = ProgramFactory.create()
         cls.enrollments = cls._generate_cached_enrollments(cls.user, program, num_course_runs=2)
+        cls.serialized_enrollments = UserProgramSearchSerializer.serialize_enrollments(cls.enrollments)
         certificate_grades_vals = [0.7, 0.8]
         cls.current_grades_vals = [0.9, 1.0]
         cls.certificates = []
@@ -112,6 +108,7 @@ class UserProgramSearchSerializerTests(TestCase):
         cls.fa_program, _ = create_program()
         cls.fa_program_enrollment = ProgramEnrollment.objects.create(user=cls.user, program=cls.fa_program)
         cls.fa_enrollments = cls._generate_cached_enrollments(cls.user, cls.fa_program, num_course_runs=2)
+        cls.fa_serialized_enrollments = UserProgramSearchSerializer.serialize_enrollments(cls.fa_enrollments)
         cls.current_grades = []
         for i, enrollment in enumerate(cls.fa_enrollments):
             order = OrderFactory.create(user=cls.user, status='fulfilled')
@@ -137,9 +134,7 @@ class UserProgramSearchSerializerTests(TestCase):
         program = self.program_enrollment.program
         assert UserProgramSearchSerializer.serialize(self.program_enrollment) == {
             'id': program.id,
-            'enrollments': list(CachedEnrollment.data_qset(self.user, program=program)),
-            'certificates': list(CachedCertificate.data_qset(self.user, program=program)),
-            'current_grades': list(CachedCurrentGrade.data_qset(self.user, program=program)),
+            'enrollments': self.serialized_enrollments,
             'grade_average': 75,
             'is_learner': True,
             'email_optin': True
@@ -155,9 +150,7 @@ class UserProgramSearchSerializerTests(TestCase):
         program = self.program_enrollment.program
         assert UserProgramSearchSerializer.serialize(self.program_enrollment) == {
             'id': program.id,
-            'enrollments': list(CachedEnrollment.data_qset(self.user, program=program)),
-            'certificates': list(CachedCertificate.data_qset(self.user, program=program)),
-            'current_grades': list(CachedCurrentGrade.data_qset(self.user, program=program)),
+            'enrollments': self.serialized_enrollments,
             'grade_average': 75,
             'is_learner': True,
             'email_optin': email_optin_flag
@@ -174,9 +167,7 @@ class UserProgramSearchSerializerTests(TestCase):
         self.profile.refresh_from_db()
         expected_result = {
             'id': self.fa_program.id,
-            'enrollments': list(CachedEnrollment.data_qset(self.user, program=self.fa_program)),
-            'certificates': [],
-            'current_grades': list(CachedCurrentGrade.data_qset(self.user, program=self.fa_program)),
+            'enrollments': self.fa_serialized_enrollments,
             'grade_average': 95,
             'is_learner': True,
             'email_optin': True
@@ -198,38 +189,111 @@ class UserProgramSearchSerializerTests(TestCase):
 
         assert UserProgramSearchSerializer.serialize(self.program_enrollment) == {
             'id': program.id,
-            'enrollments': list(CachedEnrollment.data_qset(self.user, program=program)),
-            'certificates': list(CachedCertificate.data_qset(self.user, program=program)),
-            'current_grades': list(CachedCurrentGrade.data_qset(self.user, program=program)),
+            'enrollments': self.serialized_enrollments,
             'grade_average': 75,
             'is_learner': False,
             'email_optin': True
         }
 
-    def test_cached_edx_model_serialization(self):
+
+class UserProgramSearchSerializerEdxTests(TestCase):
+    """
+    Test cases for the serialization of a user's course enrollments for search results
+    """
+
+    @staticmethod
+    def generate_course_with_run(program, course_params=None, course_run_params=None):
         """
-        Tests the serialization of cached edX model objects (CachedEnrollment, CachedCertificate)
+        Helper method to generate a Course and CourseRun for a Program
         """
-        expected_serialized = {
-            'enrollments': [enrollment.data for enrollment in self.enrollments],
-            'certificates': [certificate.data for certificate in self.certificates]
-        }
-        serialized_user_program = UserProgramSearchSerializer.serialize(self.program_enrollment)
-        for key in ['enrollments', 'certificates']:
-            assert len(serialized_user_program[key]) == len(expected_serialized[key])
-            assert all([data in serialized_user_program[key] for data in expected_serialized[key]])
+        course_params = course_params or {}
+        course_run_params = course_run_params or {}
+        course = CourseFactory.create(program=program, **course_params)
+        course_run = CourseRunFactory.create(course=course, **course_run_params)
+        return course, course_run
+
+    @staticmethod
+    def is_course_serialized(serialized_enrollments, course):
+        """
+        Helper method to test if a course appears in serialized enrollments
+
+        Args:
+            serialized_enrollments (list): A list of serialized enrollments
+            courses (dashboard.models.Course): A Course Object
+        """
+        return {'title': course.title} in serialized_enrollments
+
+    @staticmethod
+    def all_courses_serialized(serialized_enrollments, courses):
+        """
+        Helper method to test that serialized enrollments match a list of courses and have the correct format
+
+        Args:
+            serialized_enrollments (list): A list of serialized enrollments
+            courses (iterable): An iterable of Course objects
+        """
+        return serialized_enrollments == [{'title': course.title} for course in courses]
+
+    @classmethod
+    def enroll(cls, user, course_run):
+        """Helper method to enroll the test user in a course run"""
+        return CachedEnrollmentFactory.create(user=user, course_run=course_run)
+
+    @classmethod
+    def setUpTestData(cls):
+        with mute_signals(post_save):
+            cls.profile = profile = ProfileFactory.create()
+        cls.user = profile.user
+        # Create non-FA program data
+        cls.non_fa_program = ProgramFactory.create()
+        _, course_run = cls.generate_course_with_run(
+            cls.non_fa_program,
+            course_params=dict(title='Non FA Course 1')
+        )
+        cls.non_fa_enrollments = [cls.enroll(cls.user, course_run)]
+        cls.non_fa_program_enrollment = ProgramEnrollment.objects.create(user=cls.user, program=cls.non_fa_program)
+        # Create FA program data
+        cls.fa_program = ProgramFactory.create(financial_aid_availability=False)
+        _, course_run = cls.generate_course_with_run(
+            cls.fa_program,
+            course_params=dict(title='FA Course 1')
+        )
+        cls.fa_enrollments = [cls.enroll(cls.user, course_run)]
+        cls.fa_program_enrollment = ProgramEnrollment.objects.create(user=cls.user, program=cls.fa_program)
+
+    def test_enrollment_serialization(self):
+        """
+        Tests that a user's course enrollments are properly serialized
+        """
+        for program_enrollment in (self.non_fa_program_enrollment, self.fa_program_enrollment):
+            serialized_program_user = UserProgramSearchSerializer.serialize(program_enrollment)
+            serialized_enrollments = serialized_program_user['enrollments']
+            assert self.all_courses_serialized(serialized_enrollments, program_enrollment.program.course_set.all())
 
     def test_other_programs_not_serialized(self):
         """
         Tests that the serialization for a ProgramEnrollment doesn't yield enrollment data for a different program
         """
-        # Create an enrollment in a different program and make sure it is not part of the serialized version
-        enrolled_program = self.program_enrollment.program
-        other_program = ProgramFactory.create()
-        self._generate_cached_enrollments(self.user, other_program, num_course_runs=1, data={'enroll': '1'})
-        serialized_program_user = UserProgramSearchSerializer.serialize(self.program_enrollment)
-        assert len([e for e in serialized_program_user['enrollments'] if e == {'enroll': '1'}]) == 0
-        # Create an enrollment in the same program and make sure it is part of the serialized version
-        self._generate_cached_enrollments(self.user, enrolled_program, num_course_runs=1, data={'enroll': '2'})
-        serialized_program_user = UserProgramSearchSerializer.serialize(self.program_enrollment)
-        assert len([e for e in serialized_program_user['enrollments'] if e == {'enroll': '2'}]) == 1
+        program_enrollment_to_test = self.non_fa_program_enrollment
+        # We want to test serialization for a new course in the enrolled program and a different program
+        programs_to_test = [program_enrollment_to_test.program, ProgramFactory.create()]
+        for program in programs_to_test:
+            course, course_run = self.generate_course_with_run(program)
+            self.enroll(self.user, course_run)
+            serialized_program_user = UserProgramSearchSerializer.serialize(program_enrollment_to_test)
+            # If the new course's program is the same one we just serialized, we expect the course to be serialized.
+            course_is_expected_serialized = program == program_enrollment_to_test.program
+            course_is_serialized = self.is_course_serialized(serialized_program_user['enrollments'], course)
+            assert course_is_serialized == course_is_expected_serialized
+
+    def test_course_enrollments_serialized_unique(self):
+        """
+        Tests that enrollments in multiple runs of the same course won't result in multiple serializations
+        """
+        # Create an enrollment for a different course run of an already-enrolled course
+        first_enrollment = self.non_fa_enrollments[0]
+        new_course_run = CourseRunFactory.create(course=first_enrollment.course_run.course)
+        self.enroll(self.user, new_course_run)
+        serialized_program_user = UserProgramSearchSerializer.serialize(self.non_fa_program_enrollment)
+        # Number of serialized enrollments should be unaffected
+        assert len(serialized_program_user['enrollments']) == len(self.non_fa_enrollments)

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -2,7 +2,7 @@
 Utility functions and classes for the dashboard
 """
 import logging
-
+from decimal import Decimal
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 from django.db.models import Max, Min, Q
@@ -212,6 +212,14 @@ class MMTrack:
             if final_grade is not None:
                 final_grades[course_id] = final_grade
         return final_grades
+
+    def calculate_final_grade_average(self):
+        """
+        Calculates an average grade (integer) from the program final grades
+        """
+        final_grades = self.get_all_final_grades()
+        if final_grades:
+            return round(sum(Decimal(final_grade) for final_grade in final_grades.values()) / len(final_grades))
 
     def get_current_grade(self, course_id):
         """

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -3,7 +3,6 @@ Tests for the utils module
 """
 from datetime import datetime, timedelta
 from unittest.mock import patch, MagicMock
-
 import pytz
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
@@ -34,7 +33,6 @@ class MMTrackTest(TestCase):
         super().setUpTestData()
         # create an user
         cls.user = UserFactory.create()
-
         cls.cached_edx_user_data = MagicMock(
             spec=CachedEdxUserData,
             enrollments=CachedEnrollment.deserialize_edx_data(cls.enrollments_json),

--- a/roles/api.py
+++ b/roles/api.py
@@ -3,7 +3,10 @@ API for roles
 """
 from rolepermissions.verifications import has_object_permission
 
-from roles.models import Role
+from roles.models import (
+    Role,
+    NON_LEARNERS
+)
 
 
 def get_advance_searchable_programs(user):
@@ -21,3 +24,16 @@ def get_advance_searchable_programs(user):
         if has_object_permission('can_advance_search', user, role.program)
     ]
     return programs
+
+
+def is_learner(user, program):
+    """
+    Returns true if user is a learner
+
+    Args:
+        user (django.contrib.auth.models.User): A user
+        program (courses.models.Program): Program object
+    """
+    return (
+        not Role.objects.filter(user=user, role__in=NON_LEARNERS, program=program).exists()
+    )

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -7,6 +7,7 @@ import {
   Hits,
   SelectedFilters,
   RefinementListFilter,
+  MenuFilter,
   HitsStats,
   Pagination,
   ResetFilters,
@@ -33,7 +34,7 @@ import type { Option } from '../flow/generalTypes';
 import type { Email } from '../flow/emailTypes';
 import type { AvailableProgram } from '../flow/enrollmentTypes';
 
-let makeSearchkitTranslations: () => Object = () => {
+const makeSearchkitTranslations: () => Object = () => {
   let translations = {};
   for (let code of Object.keys(iso3166.data)) {
     translations[code] = iso3166.data[code].name;
@@ -129,7 +130,7 @@ export default class LearnerSearch extends SearchkitComponent {
         </Cell>
       </Grid>
     );
-  }
+  };
 
   renderFacets: Function = (currentProgram: AvailableProgram): React$Element<*> => {
     if (_.isNull(this.getResults())) {
@@ -145,6 +146,17 @@ export default class LearnerSearch extends SearchkitComponent {
     return (
       <Sticky>
         <Card className="fullwidth" shadow={1}>
+          <FilterVisibilityToggle
+            {...this.props}
+            filterName="courses"
+          >
+            <MenuFilter
+              field="program.enrollments.title"
+              fieldOptions={{type: 'nested', options: { path: 'program.enrollments' } }}
+              title="Course"
+              id="courses"
+            />
+          </FilterVisibilityToggle>
           <FilterVisibilityToggle
             {...this.props}
             filterName="birth-location"
@@ -184,7 +196,7 @@ export default class LearnerSearch extends SearchkitComponent {
         </Card>
       </Sticky>
     );
-  }
+  };
 
   render () {
     const {

--- a/static/js/components/search/FilterVisibilityToggle.js
+++ b/static/js/components/search/FilterVisibilityToggle.js
@@ -4,6 +4,11 @@ import _ from 'lodash';
 import { SearchkitComponent } from 'searchkit';
 import Icon from 'react-mdl/lib/Icon';
 
+const FILTER_ID_ADJUST = {
+  "birth_location": "profile.birth_country4",
+  "courses": "program.enrollments.title3"
+};
+
 export default class FilterVisibilityToggle extends SearchkitComponent {
   props: {
     filterName:             string,
@@ -19,7 +24,7 @@ export default class FilterVisibilityToggle extends SearchkitComponent {
 
   isInResults: Function = (id: string): boolean => {
     if (this.getResults()) {
-      const elmId = (id === "birth_location") ? "profile.birth_country3" : id;
+      const elmId = FILTER_ID_ADJUST[id] || id;
       const docCount = _.get(this.getResults(), ['aggregations', elmId, 'doc_count'], 0);
 
       if (docCount > 0) {
@@ -27,7 +32,7 @@ export default class FilterVisibilityToggle extends SearchkitComponent {
       }
     }
     return false;
-  }
+  };
 
   openStateIcon: Function = (children: React$Element<*>): React$Element<*>|null => {
     if (!this.isInResults(children.props.id)) {
@@ -39,7 +44,7 @@ export default class FilterVisibilityToggle extends SearchkitComponent {
       onClick={this.toggleFilterVisibility}
       className={this.openClass()}
     />;
-  }
+  };
 
   toggleFilterVisibility: Function = (): void => {
     const {


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #933 

#### What's this PR do?

Adds the course facet to the learner search page

#### Where should the reviewer start?

Probably dashboard/api_edx_cache.py and dashboard/serializers.py

#### How should this be manually tested?

With seed data loaded and your user given staff permissions, run the `recreate_index` command and check the learners search page. The course facet should be at the top.

#### Any background context you want to provide?

Mockup: https://projects.invisionapp.com/share/E49IZSEWM#/screens/202316455_Learner_Search

There's a design quirk with this implementation: the facet shows an "All" option, and that option potentially shows a higher count than there are students in the search results. Basically it's a count of all of the unique course enrollments, so if User A is enrolled in 3 courses, it adds 3 to the "All" count. The "All" option is not part of the mockup, but it is added by searchkit and I haven't yet found a clear way to get rid of it and make it click-on-click-off like the "Current Residence" facet. We could just hide that row via CSS, but that's more than a little hacky. @aliceriot maybe you and I can talk about this.

#### Screenshots (if appropriate)

<img width="623" alt="ss 2016-12-06 at 22 04 46" src="https://cloud.githubusercontent.com/assets/14932219/20953256/0f565cb2-bc00-11e6-93e1-514dc219f787.png">