### PR TITLE
Revert "Changed profile validation to not require a photo"

### DIFF
--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -57,7 +57,9 @@ export function programValidation(_: Profile, ui: UIState): ValidationErrors {
   return errors;
 }
 
-export const profileImageValidation = () => ({});
+export const profileImageValidation = (profile: Profile) => (
+  profile.image ? {} : { image: 'Please upload a profile image' }
+);
 
 export function personalValidation(profile: Profile): ValidationErrors {
   let requiredFields = [

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -89,8 +89,10 @@ describe('Profile validation functions', () => {
 
 
   describe('profileImageValidation', () => {
-    it('should return no errors if no image is present', () => {
-      assert.deepEqual(profileImageValidation({}), {});
+    it('should return an error if no image', () => {
+      assert.deepEqual(profileImageValidation({}), {
+        image: 'Please upload a profile image'
+      });
     });
 
     it('should return no errors if image is present', () => {


### PR DESCRIPTION
This should restore the photo requirement. Delete your photo in the django shell, and ensure you can't navigate past the personal stage of the profile flow.