### PR TITLE
Disabled buttons on signup and settings pages during profile update

### DIFF
--- a/static/js/actions/profile.js
+++ b/static/js/actions/profile.js
@@ -8,7 +8,7 @@ import type { Dispatcher } from '../flow/reduxTypes';
 
 // actions for user profile
 export const REQUEST_GET_USER_PROFILE = 'REQUEST_GET_USER_PROFILE';
-const requestGetUserProfile = createAction(REQUEST_GET_USER_PROFILE, username => ({ username }));
+export const requestGetUserProfile = createAction(REQUEST_GET_USER_PROFILE, username => ({ username }));
 
 export const RECEIVE_GET_USER_PROFILE_SUCCESS = 'RECEIVE_GET_USER_PROFILE_SUCCESS';
 export const receiveGetUserProfileSuccess = createAction(RECEIVE_GET_USER_PROFILE_SUCCESS, 
@@ -35,7 +35,7 @@ export const CLEAR_PROFILE_EDIT = 'CLEAR_PROFILE_EDIT';
 export const clearProfileEdit = createAction(CLEAR_PROFILE_EDIT, username => ({ username }));
 
 export const REQUEST_PATCH_USER_PROFILE = 'REQUEST_PATCH_USER_PROFILE';
-const requestPatchUserProfile = createAction(REQUEST_PATCH_USER_PROFILE, username => ({ username }));
+export const requestPatchUserProfile = createAction(REQUEST_PATCH_USER_PROFILE, username => ({ username }));
 
 export const RECEIVE_PATCH_USER_PROFILE_SUCCESS = 'RECEIVE_PATCH_USER_PROFILE_SUCCESS';
 const receivePatchUserProfileSuccess = createAction(RECEIVE_PATCH_USER_PROFILE_SUCCESS,

--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -11,12 +11,12 @@ import { EDUCATION_STEP } from '../constants';
 
 class EducationTab extends React.Component {
   props: {
-    profile:      Profile,
-    profilePatchStatus: ?string,
-    ui:           UIState,
-    saveProfile:  SaveProfileFunc,
-    addProgramEnrollment: Function,
-    dispatch:     Function,
+    profile:               Profile,
+    profilePatchStatus:    ?string,
+    ui:                    UIState,
+    saveProfile:           SaveProfileFunc,
+    addProgramEnrollment:  Function,
+    dispatch:              Function,
   };
 
   componentWillMount() {

--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -12,6 +12,7 @@ import { EDUCATION_STEP } from '../constants';
 class EducationTab extends React.Component {
   props: {
     profile:      Profile,
+    profilePatchStatus: ?string,
     ui:           UIState,
     saveProfile:  SaveProfileFunc,
     addProgramEnrollment: Function,

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -16,12 +16,12 @@ import { EMPLOYMENT_STEP } from '../constants';
 
 class EmploymentTab extends React.Component {
   props: {
-    saveProfile:  SaveProfileFunc,
-    profile:      Profile,
-    profilePatchStatus: ?string,
-    ui:           UIState,
-    addProgramEnrollment: Function,
-    dispatch:     Function,
+    saveProfile:           SaveProfileFunc,
+    profile:               Profile,
+    profilePatchStatus:    ?string,
+    ui:                    UIState,
+    addProgramEnrollment:  Function,
+    dispatch:              Function,
   };
 
   componentWillMount() {

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -18,6 +18,7 @@ class EmploymentTab extends React.Component {
   props: {
     saveProfile:  SaveProfileFunc,
     profile:      Profile,
+    profilePatchStatus: ?string,
     ui:           UIState,
     addProgramEnrollment: Function,
     dispatch:     Function,

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -47,6 +47,7 @@ export default class PersonalTab extends React.Component {
     nextStep:                 () => void,
     prevStep:                 () => void,
     profile:                  Profile,
+    profilePatchStatus:       ?string,
     uneditedProfile:          Profile,
     programs:                 AvailablePrograms,
     saveProfile:              SaveProfileFunc,

--- a/static/js/components/ProfileProgressControls.js
+++ b/static/js/components/ProfileProgressControls.js
@@ -1,7 +1,9 @@
 // @flow
 import React from 'react';
+import Spinner from 'react-mdl/lib/Spinner';
 
 import { saveProfileStep } from '../util/profile_edit';
+import { FETCH_PROCESSING } from '../actions';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
@@ -13,6 +15,7 @@ export default class ProfileProgressControls extends React.Component {
     isLastTab:    boolean,
     validator:    Function,
     profile:      Profile,
+    profilePatchStatus: ?string,
     ui:           UIState,
     saveProfile:  SaveProfileFunc,
     programIdForEnrollment: ?number,
@@ -42,7 +45,12 @@ export default class ProfileProgressControls extends React.Component {
   };
 
   render() {
-    const { nextUrl, prevUrl, nextBtnLabel } = this.props;
+    let { nextUrl, prevUrl, nextBtnLabel, profilePatchStatus } = this.props;
+
+    let disabled = profilePatchStatus === FETCH_PROCESSING;
+    if (disabled) {
+      nextBtnLabel = <Spinner singleColor />;
+    }
 
     let prevButton, nextButton;
     if (prevUrl) {
@@ -55,9 +63,9 @@ export default class ProfileProgressControls extends React.Component {
     if (nextUrl) {
       nextButton = <button
         role="button"
-        className="mdl-button next"
-        onClick={this.saveAndContinue}>
-        <span>{nextBtnLabel}</span>
+        className={`mdl-button next ${disabled ? 'disabled-with-spinner' : ''}`}
+        onClick={disabled ? undefined : this.saveAndContinue}>
+        {nextBtnLabel}
       </button>;
     }
     return <div className="profile-progress-controls">

--- a/static/js/components/ProfileProgressControls.js
+++ b/static/js/components/ProfileProgressControls.js
@@ -45,13 +45,9 @@ export default class ProfileProgressControls extends React.Component {
   };
 
   render() {
-    let { nextUrl, prevUrl, nextBtnLabel, profilePatchStatus } = this.props;
+    const { nextUrl, prevUrl, nextBtnLabel, profilePatchStatus } = this.props;
 
-    let disabled = profilePatchStatus === FETCH_PROCESSING;
-    if (disabled) {
-      nextBtnLabel = <Spinner singleColor />;
-    }
-
+    const inFlight = profilePatchStatus === FETCH_PROCESSING;
     let prevButton, nextButton;
     if (prevUrl) {
       prevButton = <button
@@ -63,9 +59,9 @@ export default class ProfileProgressControls extends React.Component {
     if (nextUrl) {
       nextButton = <button
         role="button"
-        className={`mdl-button next ${disabled ? 'disabled-with-spinner' : ''}`}
-        onClick={disabled ? undefined : this.saveAndContinue}>
-        {nextBtnLabel}
+        className={`mdl-button next ${inFlight ? 'disabled-with-spinner' : ''}`}
+        onClick={inFlight ? undefined : this.saveAndContinue}>
+        {inFlight ? <Spinner singleColor /> : nextBtnLabel}
       </button>;
     }
     return <div className="profile-progress-controls">

--- a/static/js/components/User.js
+++ b/static/js/components/User.js
@@ -17,6 +17,7 @@ import type { UIState } from '../reducers/ui';
 export default class User extends React.Component {
   props: {
     profile:                      Profile,
+    profilePatchStatus:           ?string,
     setUserPageDialogVisibility:  () => void,
     ui:                           UIState,
     clearProfileEdit:             () => void,

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -185,7 +185,7 @@ class ProfileFormContainer extends React.Component {
       dispatch,
       currentProgramEnrollment
     } = this.props;
-    let errors, isEdit, profile, uneditedProfile;
+    let errors, isEdit, profile, uneditedProfile, patchStatus;
 
     if ( profileFromStore === undefined ) {
       profile = {};
@@ -193,6 +193,7 @@ class ProfileFormContainer extends React.Component {
       errors = {};
       isEdit = false;
     } else {
+      patchStatus = profileFromStore.patchStatus;
       if (profileFromStore.edit !== undefined) {
         errors = profileFromStore.edit.errors;
         profile = profileFromStore.edit.profile;
@@ -212,6 +213,7 @@ class ProfileFormContainer extends React.Component {
       errors: errors,
       fetchProfile: this.fetchProfile,
       profile: profile,
+      profilePatchStatus: patchStatus,
       uneditedProfile: uneditedProfile,
       programs: programs.availablePrograms,
       saveProfile: this.saveProfile.bind(this, isEdit),

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -11,8 +11,10 @@ import {
   RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
 } from '../actions/programs';
 import {
+  requestGetUserProfile,
   REQUEST_GET_USER_PROFILE,
   RECEIVE_GET_USER_PROFILE_SUCCESS,
+  requestPatchUserProfile,
   REQUEST_PATCH_USER_PROFILE,
   RECEIVE_PATCH_USER_PROFILE_SUCCESS,
   START_PROFILE_EDIT,
@@ -199,16 +201,22 @@ describe("ProfilePage", function() {
   }
 
   it('shows a spinner when profile get is processing', () => {
-    return renderComponent('/profile/personal', SUCCESS_ACTIONS).then(([, div]) => {
-      assert.notOk(div.querySelector(".loader"), "Found spinner but no fetch in progress");
-      helper.store.dispatch({
-        type: REQUEST_GET_USER_PROFILE,
-        payload: {
-          username: SETTINGS.user.username
-        }
-      });
+    return renderComponent('/profile/personal', SUCCESS_ACTIONS).then(([wrapper]) => {
+      assert.equal(wrapper.find(".loader").length, 0);
+      helper.store.dispatch(requestGetUserProfile(SETTINGS.user.username));
 
-      assert(div.querySelector(".loader"), "Unable to find spinner");
+      assert.equal(wrapper.find(".loader").length, 1);
+    });
+  });
+
+  it('disables the button and shows a spinner when profile patch is processing', () => {
+    return renderComponent('/profile/personal', SUCCESS_ACTIONS).then(([wrapper]) => {
+      helper.store.dispatch(requestPatchUserProfile(SETTINGS.user.username));
+
+      let next = wrapper.find(".next");
+      assert(next.props().className.includes("disabled-with-spinner"));
+      next.simulate("click");
+      assert.isFalse(patchUserProfileStub.called);
     });
   });
 

--- a/static/js/containers/SettingsPage_test.js
+++ b/static/js/containers/SettingsPage_test.js
@@ -5,6 +5,7 @@ import { assert } from 'chai';
 import _ from 'lodash';
 
 import {
+  requestPatchUserProfile,
   REQUEST_GET_USER_PROFILE,
   RECEIVE_GET_USER_PROFILE_SUCCESS,
 } from '../actions/profile';
@@ -110,6 +111,17 @@ describe("SettingsPage", function() {
           filled_out: true
         });
         return confirmSaveButtonBehavior(updatedProfile, {button: button});
+      });
+    });
+
+    it('disables the button and shows a spinner when profile patch is processing', () => {
+      return renderComponent('/settings', userActions).then(([wrapper]) => {
+        helper.store.dispatch(requestPatchUserProfile(SETTINGS.user.username));
+
+        let next = wrapper.find(".next");
+        assert(next.props().className.includes("disabled-with-spinner"));
+        next.simulate("click");
+        assert.isFalse(patchUserProfileStub.called);
       });
     });
   });

--- a/static/js/flow/profileTypes.js
+++ b/static/js/flow/profileTypes.js
@@ -69,7 +69,8 @@ type ValidationVisibility = Array<string[]>;
 export type ProfileGetResult = {
   profile: Profile,
   errorInfo?: APIErrorInfo,
-  getStatus: string,
+  getStatus?: string,
+  patchStatus?: string,
   edit?: {
     errors: ValidationErrors,
     profile: Profile,

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -197,3 +197,13 @@
 a.btn {
   text-decoration: none;
 }
+
+.disabled-with-spinner {
+  display: flex;
+  align-items: center;
+  cursor: default;
+
+  .mdl-spinner__layer {
+    border-color: white !important;
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1752 

#### What's this PR do?
Disables buttons when updating the profile on the signup page, settings page and user page

This does not handle the user page at all or employment or education dialogs. Those will be a separate PR

#### How should this be manually tested?
Click next or save on the signup and settings page. The button should replace its text with a white spinner for the duration of the API activity.