### PR TITLE
Disable buttons on employment and education dialogs during profile update

### DIFF
--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -4,6 +4,7 @@ import IconButton from 'react-mdl/lib/IconButton';
 import Button from 'react-mdl/lib/Button';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import { Card } from 'react-mdl/lib/Card';
+import Spinner from 'react-mdl/lib/Spinner';
 import _ from 'lodash';
 import R from 'ramda';
 import Dialog from 'material-ui/Dialog';
@@ -377,7 +378,7 @@ class EducationForm extends ProfileFormFields {
       profilePatchStatus,
     } = this.props;
 
-    const disabled = profilePatchStatus === FETCH_PROCESSING;
+    const inFlight = profilePatchStatus === FETCH_PROCESSING;
     const actions = [
       <Button
         type='cancel'
@@ -389,9 +390,9 @@ class EducationForm extends ProfileFormFields {
       <Button
         type='button'
         key='save'
-        className={`primary-button save-button ${disabled ? 'disabled-with-spinner' : ''}`}
-        onClick={disabled ? undefined : this.saveEducationForm}>
-        Save
+        className={`primary-button save-button ${inFlight ? 'disabled-with-spinner' : ''}`}
+        onClick={inFlight ? undefined : this.saveEducationForm}>
+        {inFlight ? <Spinner singleColor /> : 'Save'}
       </Button>
     ];
 

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -9,6 +9,7 @@ import R from 'ramda';
 import Dialog from 'material-ui/Dialog';
 import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
 
+import { FETCH_PROCESSING } from '../actions';
 import { educationValidation } from '../lib/validation/profile';
 import {
   userPrivilegeCheck,
@@ -161,7 +162,7 @@ class EducationForm extends ProfileFormFields {
       userPrivilegeCheck(profile, () =>
         <Cell col={12} className="profile-form-row add" key="add-row">
           <button
-            className="mm-minor-action"
+            className="mm-minor-action add-education-button"
             onClick={() => this.openNewEducationForm(levelValue, null)}
           >
             Add degree
@@ -371,9 +372,11 @@ class EducationForm extends ProfileFormFields {
       ui: {
         showEducationDeleteDialog,
         educationDialogVisibility,
-      }
+      },
+      profilePatchStatus,
     } = this.props;
 
+    const disabled = profilePatchStatus === FETCH_PROCESSING;
     const actions = [
       <Button
         type='cancel'
@@ -385,8 +388,8 @@ class EducationForm extends ProfileFormFields {
       <Button
         type='button'
         key='save'
-        className="primary-button save-button"
-        onClick={this.saveEducationForm}>
+        className={`primary-button save-button ${disabled ? 'disabled-with-spinner' : ''}`}
+        onClick={disabled ? undefined : this.saveEducationForm}>
         Save
       </Button>
     ];

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -61,6 +61,7 @@ EDUCATION_LEVEL_OPTIONS.forEach(level => {
 class EducationForm extends ProfileFormFields {
   props: {
     profile:                          Profile,
+    profilePatchStatus:               ?string,
     ui:                               UIState,
     updateProfile:                    UpdateProfileFunc,
     saveProfile:                      SaveProfileFunc,

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -5,9 +5,11 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Dialog from 'material-ui/Dialog';
 import Card from 'react-mdl/lib/Card/Card';
 import IconButton from 'react-mdl/lib/IconButton';
+import Spinner from 'react-mdl/lib/Spinner';
 import _ from 'lodash';
 import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
 
+import { FETCH_PROCESSING } from '../actions';
 import {
   userPrivilegeCheck,
   isProfileOfLoggedinUser
@@ -175,7 +177,7 @@ class EmploymentForm extends ProfileFormFields {
         workHistoryRows.push(
         <Cell col={12} className="profile-form-row add" key="I'm unique!">
           <button
-            className="mm-minor-action"
+            className="mm-minor-action add-employment-button"
             onClick={this.openNewWorkHistoryForm}
           >
             Add employment
@@ -316,7 +318,14 @@ class EmploymentForm extends ProfileFormFields {
         workDialogVisibility,
         showWorkDeleteDialog,
       },
+      profilePatchStatus,
     } = this.props;
+
+    const disabled = profilePatchStatus === FETCH_PROCESSING;
+    let saveLabel = 'Save';
+    if (disabled) {
+      saveLabel = <Spinner singleColor />;
+    }
     const actions = [
       <Button
         type='button'
@@ -327,10 +336,10 @@ class EmploymentForm extends ProfileFormFields {
       </Button>,
       <Button
         type='button'
-        className="primary-button save-button"
+        className={`primary-button save-button ${disabled ? 'disabled-with-spinner' : ''}`}
         key='save'
-        onClick={this.saveWorkHistoryEntry}>
-        Save
+        onClick={disabled ? undefined : this.saveWorkHistoryEntry}>
+        {saveLabel}
       </Button>
     ];
 

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -322,11 +322,7 @@ class EmploymentForm extends ProfileFormFields {
       profilePatchStatus,
     } = this.props;
 
-    const disabled = profilePatchStatus === FETCH_PROCESSING;
-    let saveLabel = 'Save';
-    if (disabled) {
-      saveLabel = <Spinner singleColor />;
-    }
+    const inFlight = profilePatchStatus === FETCH_PROCESSING;
     const actions = [
       <Button
         type='button'
@@ -337,10 +333,10 @@ class EmploymentForm extends ProfileFormFields {
       </Button>,
       <Button
         type='button'
-        className={`primary-button save-button ${disabled ? 'disabled-with-spinner' : ''}`}
+        className={`primary-button save-button ${inFlight ? 'disabled-with-spinner' : ''}`}
         key='save'
-        onClick={disabled ? undefined : this.saveWorkHistoryEntry}>
-        {saveLabel}
+        onClick={inFlight ? undefined : this.saveWorkHistoryEntry}>
+        {inFlight ? <Spinner singleColor /> : 'Save'}
       </Button>
     ];
 

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -48,6 +48,7 @@ class EmploymentForm extends ProfileFormFields {
 
   props: {
     profile:                          Profile,
+    profilePatchStatus:               ?string,
     ui:                               UIState,
     updateProfile:                    UpdateProfileFunc,
     saveProfile:                      SaveProfileFunc,

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -217,6 +217,7 @@ describe("ProfilePage", function() {
       assert(next.props().className.includes("disabled-with-spinner"));
       next.simulate("click");
       assert.isFalse(patchUserProfileStub.called);
+      assert.lengthOf(next.find(".mdl-spinner"), 1);
     });
   });
 

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -569,6 +569,7 @@ describe("UserPage", function() {
           }).then(() => {
             let button = dialog.querySelector(".save-button");
             assert(button.className.includes("disabled-with-spinner"));
+            assert(button.querySelector(".mdl-spinner"));
 
             TestUtils.Simulate.click(button);
             assert.isFalse(patchUserProfileStub.called);
@@ -795,6 +796,7 @@ describe("UserPage", function() {
           }).then(() => {
             let button = dialog.querySelector(".save-button");
             assert(button.className.includes("disabled-with-spinner"));
+            assert(button.querySelector(".mdl-spinner"));
 
             TestUtils.Simulate.click(button);
             assert.isFalse(patchUserProfileStub.called);

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -16,6 +16,7 @@ import {
   UPDATE_VALIDATION_VISIBILITY,
   CLEAR_PROFILE_EDIT,
 
+  requestPatchUserProfile,
   startProfileEdit,
   updateProfile,
 } from '../actions/profile';
@@ -474,8 +475,7 @@ describe("UserPage", function() {
       it('should let you add an education entry', () => {
         const username = SETTINGS.user.username;
         return renderComponent(`/learner/${username}`, userActions).then(([, div]) => {
-          let addButton = div.getElementsByClassName('profile-form')[1].
-            querySelector('.mm-minor-action');
+          let addButton = div.querySelector('.add-education-button');
 
           let expectedProfile = _.cloneDeep(userProfile);
           let entry = Object.assign({}, generateNewEducation(HIGH_SCHOOL), {
@@ -549,6 +549,29 @@ describe("UserPage", function() {
             modifyTextField(inputs[6], "FoobarVille");
             let save = dialog.querySelector('.save-button');
             TestUtils.Simulate.click(save);
+          });
+        });
+      });
+
+      it('should disable the save button while a PATCH is in progress', () => {
+        const username = SETTINGS.user.username;
+        return renderComponent(`/learner/${username}`, userActions).then(([, div]) => {
+          let addButton = div.querySelector(".add-education-button");
+
+          TestUtils.Simulate.click(addButton);
+
+          let dialog = document.querySelector('.education-dialog');
+
+          return listenForActions([
+            REQUEST_PATCH_USER_PROFILE,
+          ], () => {
+            helper.store.dispatch(requestPatchUserProfile(username));
+          }).then(() => {
+            let button = dialog.querySelector(".save-button");
+            assert(button.className.includes("disabled-with-spinner"));
+
+            TestUtils.Simulate.click(button);
+            assert.isFalse(patchUserProfileStub.called);
           });
         });
       });
@@ -752,6 +775,29 @@ describe("UserPage", function() {
 
             let button = dialog.querySelector(".save-button");
             TestUtils.Simulate.click(button);
+          });
+        });
+      });
+
+      it('should disable the save button while a PATCH is in progress', () => {
+        const username = SETTINGS.user.username;
+        return renderComponent(`/learner/${username}`, userActions).then(([, div]) => {
+          let addButton = div.querySelector(".add-employment-button");
+
+          TestUtils.Simulate.click(addButton);
+
+          let dialog = document.querySelector('.employment-dialog');
+
+          return listenForActions([
+            REQUEST_PATCH_USER_PROFILE,
+          ], () => {
+            helper.store.dispatch(requestPatchUserProfile(username));
+          }).then(() => {
+            let button = dialog.querySelector(".save-button");
+            assert(button.className.includes("disabled-with-spinner"));
+
+            TestUtils.Simulate.click(button);
+            assert.isFalse(patchUserProfileStub.called);
           });
         });
       });

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -207,3 +207,13 @@ a.btn {
     border-color: white !important;
   }
 }
+
+.dialog {
+  .disabled-with-spinner {
+    display: inline-block !important;
+
+    .mdl-spinner__layer {
+      border-color: blue !important;
+    }
+  }
+}

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -213,7 +213,7 @@ a.btn {
     display: inline-block !important;
 
     .mdl-spinner__layer {
-      border-color: blue !important;
+      border-color: $button-color !important;
     }
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1752

#### What's this PR do?
Disables buttons for saving during profile upload for Education and Employment dialogs

#### How should this be manually tested?
Verify that the save buttons are disabled and that a blue spinner is shown in the buttons place. This should happen for employment and education, for both add and edit, and for both the signup page and the user page.
