### PR TITLE
prevent multiple concurrent image uploads

### DIFF
--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -4,6 +4,7 @@ import Dialog from 'material-ui/Dialog';
 import R from 'ramda';
 import Dropzone from 'react-dropzone';
 import Button from 'react-mdl/lib/Button';
+import Spinner from 'react-mdl/lib/Spinner';
 
 import CropperWrapper from './CropperWrapper';
 import { FETCH_PROCESSING } from '../actions';
@@ -15,7 +16,7 @@ const dropZone = (startPhotoEdit, setPhotoError) => (
   <Dropzone
     onDrop={onDrop(startPhotoEdit)}
     style={{height: uploaderBodyHeight()}}
-    className="photo-active-item photo-dropzone"
+    className="photo-active-item photo-dropzone dashed-border"
     activeClassName="photo-active-item photo-dropzone active"
     accept="image/*"
     onDropRejected={() => setPhotoError('Please select a valid photo')}
@@ -31,6 +32,31 @@ const uploaderBodyHeight = (): number => (
 );
 
 const imageError = err => <div className="img-error">{err}</div>;
+
+const dialogContents = (
+  updatePhotoEdit,
+  photo,
+  startPhotoEdit,
+  setPhotoError,
+  inFlight
+) => {
+  if ( inFlight ) {
+    return <div
+      className="photo-active-item dashed-border spinner"
+      style={{height: uploaderBodyHeight()}}
+    >
+      <Spinner singleColor />
+    </div>;
+  } else if ( photo ) {
+    return <CropperWrapper
+      updatePhotoEdit={updatePhotoEdit}
+      photo={photo}
+      uploaderBodyHeight={uploaderBodyHeight}
+    />;
+  } else {
+    return dropZone(startPhotoEdit, setPhotoError);
+  }
+};
 
 type ImageUploadProps = {
   photoDialogOpen:      boolean,
@@ -53,6 +79,7 @@ const ProfileImageUploader = ({
   updateUserPhoto,
   setPhotoError,
 }: ImageUploadProps) => {
+  const inFlight = patchStatus === FETCH_PROCESSING;
   const disabled = patchStatus === FETCH_PROCESSING || !photo;
 
   return <Dialog
@@ -77,7 +104,7 @@ const ProfileImageUploader = ({
       </Button>,
       <Button
         type='button'
-        className={`save-button ${disabled ? 'secondary-button disabled': 'primary-button'}`}
+        className={`save-button ${disabled ? 'secondary-button disabled' : 'primary-button'}`}
         key="save"
         onClick={disabled ? undefined: updateUserPhoto}>
         Save
@@ -85,9 +112,13 @@ const ProfileImageUploader = ({
     ]}
   >
    { imageError(error) }
-   { photo ? <CropperWrapper
-     {...{updatePhotoEdit, photo, uploaderBodyHeight}} /> : dropZone(startPhotoEdit, setPhotoError)
-   }
+   { dialogContents(
+     updatePhotoEdit,
+     photo,
+     startPhotoEdit,
+     setPhotoError,
+     inFlight
+   )}
   </Dialog>;
 };
 

--- a/static/js/containers/ProfileImage_test.js
+++ b/static/js/containers/ProfileImage_test.js
@@ -133,6 +133,7 @@ describe('ProfileImage', () => {
         let dialog = document.querySelector(".photo-upload-dialog");
         let saveButton = dialog.querySelector('.save-button');
         assert.isFalse(saveButton.className.includes('disabled'));
+        assert.isNull(dialog.querySelector('.mdl-spinner'));
         TestUtils.Simulate.click(saveButton);
         assert.isTrue(updateProfileImageStub.called);
       });
@@ -147,9 +148,21 @@ describe('ProfileImage', () => {
         assert.isTrue(saveButton.className.includes('disabled'));
         TestUtils.Simulate.click(saveButton);
         assert.isFalse(updateProfileImageStub.called);
+        assert.isNull(dialog.querySelector('.mdl-spinner'));
       });
 
-      it('should disable the save button while uploading the image', () => {
+      it('should show a spinner while uploading the image', () => {
+        renderProfileImage(true, {
+          profile: thatProfile
+        });
+        helper.store.dispatch(startPhotoEdit({name: 'a name'}));
+        helper.store.dispatch(setPhotoDialogVisibility(true));
+        helper.store.dispatch(requestPatchUserPhoto(SETTINGS.user.username));
+        let dialog = document.querySelector(".photo-upload-dialog");
+        assert.isNotNull(dialog.querySelector('.mdl-spinner'));
+      });
+
+      it('should disable the save button when uploading an image', () => {
         renderProfileImage(true, {
           profile: thatProfile
         });
@@ -158,7 +171,7 @@ describe('ProfileImage', () => {
         helper.store.dispatch(requestPatchUserPhoto(SETTINGS.user.username));
         let dialog = document.querySelector(".photo-upload-dialog");
         let saveButton = dialog.querySelector('.save-button');
-        assert.isTrue(saveButton.className.includes('disabled'));
+        assert.include(saveButton.className, 'disabled');
         TestUtils.Simulate.click(saveButton);
         assert.isFalse(updateProfileImageStub.called);
       });

--- a/static/js/reducers/image_upload.js
+++ b/static/js/reducers/image_upload.js
@@ -31,14 +31,19 @@ export type ImageUploadState = {
 
 export const imageUpload = (state: ImageUploadState = INITIAL_IMAGE_UPLOAD_STATE, action: Action) => {
   switch (action.type) {
-  case START_PHOTO_EDIT:
-    return { ...state,
-      photo: action.payload,
-      edit: null,
-      error: null,
-    };
+  case START_PHOTO_EDIT: {
+    if ( state.patchStatus === FETCH_PROCESSING ) {
+      return state;
+    } else {
+      return { ...state,
+        photo: action.payload,
+        edit: null,
+        error: null,
+      };
+    }
+  }
   case CLEAR_PHOTO_EDIT:
-    return INITIAL_IMAGE_UPLOAD_STATE;
+    return state.patchStatus === FETCH_PROCESSING ? state : INITIAL_IMAGE_UPLOAD_STATE;
   case UPDATE_PHOTO_EDIT:
     return { ...state, edit: action.payload };
   case SET_PHOTO_ERROR:

--- a/static/js/reducers/image_upload_test.js
+++ b/static/js/reducers/image_upload_test.js
@@ -157,5 +157,26 @@ describe('image upload reducer', () => {
         });
       });
     });
+
+    it('should not clear the edit state if FETCH_PROCESSING', () => {
+      let photo = new Blob;
+      store.dispatch(startPhotoEdit(photo));
+      store.dispatch(requestPatchUserPhoto());
+      let expectation = {
+        edit: null,
+        error: null,
+        photo: photo,
+        patchStatus: FETCH_PROCESSING
+      };
+      let state = store.getState().imageUpload;
+      assert.deepEqual(state, expectation);
+      store.dispatch(clearPhotoEdit());
+      state = store.getState().imageUpload;
+      assert.deepEqual(state, expectation);
+      assert.deepEqual(state, expectation);
+      store.dispatch(startPhotoEdit(photo));
+      state = store.getState().imageUpload;
+      assert.deepEqual(state, expectation);
+    });
   });
 });

--- a/static/scss/profile-image-uploader.scss
+++ b/static/scss/profile-image-uploader.scss
@@ -10,17 +10,26 @@
   }
 
   .photo-dropzone {
+    font-size: 20px;
+    font-weight: 300;
+  }
+
+  .photo-active-item {
+    width: 100%;
+  }
+
+  .dashed-border {
     background-color: $fg-grey;
     border-radius: 7px;
     border: 2px dashed $medgrey;
-    font-size: 20px;
-    font-weight: 300;
     display: flex;
     align-items: center;
     justify-content: space-around;
   }
 
-  .photo-active-item {
-    width: 100%;
+  .spinner {
+    .mdl-spinner__layer {
+      border-color: $mm-brand-bg;
+    }
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2020 

#### What's this PR do?

this persists the photo edit state if the request is currently in-flight, so that the user is prevented from issuing another request (to upload the profile image) if one is already in-flight. I also added an `<Spinner />` to the save button, which we should while the request is processing (should help with longer requests, I think).

#### How should this be manually tested?

this is how, on master, you can currently initiate multiple requests:

1. throttle your upload speed (gives you more wiggle room, 2G is probably sufficient)
2. add a new profile image, and click 'Cancel' after clicking 'Save'
3. Re-open the photo dialog, and add a new profile image.

if you look in the network tab of your browser's dev tools you should see two requests in flight.

If you follow the same steps here there should be only one, and the previous edit state should still be there (so the spinner should still be going and so on) until the request finishes.