### PR TITLE
Disable buttons during profile upload for about me and personal info dialogs

### DIFF
--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -4,7 +4,6 @@ import IconButton from 'react-mdl/lib/IconButton';
 import Button from 'react-mdl/lib/Button';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import { Card } from 'react-mdl/lib/Card';
-import Spinner from 'react-mdl/lib/Spinner';
 import _ from 'lodash';
 import R from 'ramda';
 import Dialog from 'material-ui/Dialog';

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -19,6 +19,7 @@ import {
 } from '../util/util';
 import ProfileFormFields from '../util/ProfileFormFields';
 import ConfirmDeletion from './ConfirmDeletion';
+import SpinnerButton from './SpinnerButton';
 import SelectField from './inputs/SelectField';
 import CountrySelectField from './inputs/CountrySelectField';
 import StateSelectField from './inputs/StateSelectField';
@@ -387,13 +388,15 @@ class EducationForm extends ProfileFormFields {
         onClick={this.clearEducationEdit}>
         Cancel
       </Button>,
-      <Button
+      <SpinnerButton
+        component={Button}
+        spinning={inFlight}
         type='button'
         key='save'
-        className={`primary-button save-button ${inFlight ? 'disabled-with-spinner' : ''}`}
-        onClick={inFlight ? undefined : this.saveEducationForm}>
-        {inFlight ? <Spinner singleColor /> : 'Save'}
-      </Button>
+        className="primary-button save-button"
+        onClick={this.saveEducationForm}>
+        Save
+      </SpinnerButton>
     ];
 
     return (

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -23,6 +23,7 @@ import {
   deleteWorkHistoryEntry,
 } from '../util/profile_history_edit';
 import ConfirmDeletion from './ConfirmDeletion';
+import SpinnerButton from './SpinnerButton';
 import SelectField from './inputs/SelectField';
 import CountrySelectField from './inputs/CountrySelectField';
 import StateSelectField from './inputs/StateSelectField';
@@ -331,13 +332,15 @@ class EmploymentForm extends ProfileFormFields {
         onClick={this.closeWorkDialog}>
         Cancel
       </Button>,
-      <Button
+      <SpinnerButton
+        component={Button}
+        spinning={inFlight}
         type='button'
-        className={`primary-button save-button ${inFlight ? 'disabled-with-spinner' : ''}`}
+        className="primary-button save-button"
         key='save'
-        onClick={inFlight ? undefined : this.saveWorkHistoryEntry}>
-        {inFlight ? <Spinner singleColor /> : 'Save'}
-      </Button>
+        onClick={this.saveWorkHistoryEntry}>
+        Save
+      </SpinnerButton>
     ];
 
     return (

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -5,7 +5,6 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Dialog from 'material-ui/Dialog';
 import Card from 'react-mdl/lib/Card/Card';
 import IconButton from 'react-mdl/lib/IconButton';
-import Spinner from 'react-mdl/lib/Spinner';
 import _ from 'lodash';
 import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
 

--- a/static/js/components/ProfileProgressControls.js
+++ b/static/js/components/ProfileProgressControls.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import Spinner from 'react-mdl/lib/Spinner';
 
+import SpinnerButton from './SpinnerButton';
 import { saveProfileStep } from '../util/profile_edit';
 import { FETCH_PROCESSING } from '../actions';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
@@ -57,12 +58,14 @@ export default class ProfileProgressControls extends React.Component {
       </button>;
     }
     if (nextUrl) {
-      nextButton = <button
+      nextButton = <SpinnerButton
+        component="button"
+        spinning={inFlight}
         role="button"
-        className={`mdl-button next ${inFlight ? 'disabled-with-spinner' : ''}`}
-        onClick={inFlight ? undefined : this.saveAndContinue}>
-        {inFlight ? <Spinner singleColor /> : nextBtnLabel}
-      </button>;
+        className="mdl-button next"
+        onClick={this.saveAndContinue}>
+        {nextBtnLabel}
+      </SpinnerButton>;
     }
     return <div className="profile-progress-controls">
       {prevButton}

--- a/static/js/components/ProfileProgressControls.js
+++ b/static/js/components/ProfileProgressControls.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import Spinner from 'react-mdl/lib/Spinner';
 
 import SpinnerButton from './SpinnerButton';
 import { saveProfileStep } from '../util/profile_edit';

--- a/static/js/components/SpinnerButton.js
+++ b/static/js/components/SpinnerButton.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import Spinner from 'react-mdl/lib/Spinner';
+
+export default class SpinnerButton extends React.Component {
+  props: {
+    spinning: bool,
+    component: React.Component<*, *, *>,
+    className?: string,
+    onClick?: Function,
+    children?: any,
+  };
+
+  render() {
+    let {
+      component: ComponentVariable,
+      spinning,
+      className,
+      onClick,
+      children,
+      ...otherProps
+    } = this.props;
+
+    if (spinning) {
+      if (!className) {
+        className = '';
+      }
+      className = `${className} disabled-with-spinner`;
+      onClick = undefined;
+      children = <Spinner singleColor />;
+    }
+
+    return <ComponentVariable
+      className={className}
+      onClick={onClick}
+      {...otherProps}
+    >
+      {children}
+    </ComponentVariable>;
+  }
+}

--- a/static/js/components/UserInfoCard.js
+++ b/static/js/components/UserInfoCard.js
@@ -51,7 +51,11 @@ export default class UserInfoCard extends React.Component {
           {
             userPrivilegeCheck(
               profile,
-              () => <IconButton name="edit about me section" onClick={toggleShowAboutMeDialog}/>
+              () => <IconButton
+                name="edit about me section"
+                className="edit-about-me-button"
+                onClick={toggleShowAboutMeDialog}
+              />
             )
           }
         </div>
@@ -77,7 +81,11 @@ export default class UserInfoCard extends React.Component {
           </div>
           <div className="edit-profile-holder">
             {userPrivilegeCheck(profile, () => (
-              <IconButton name="edit personal information" onClick={toggleShowPersonalDialog}/>
+              <IconButton
+                name="edit personal information"
+                onClick={toggleShowPersonalDialog}
+                className="edit-personal-info-button"
+              />
             ))}
           </div>
         </div>

--- a/static/js/components/UserPageAboutMeDialog.js
+++ b/static/js/components/UserPageAboutMeDialog.js
@@ -2,7 +2,9 @@
 import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import Button from 'react-mdl/lib/Button';
+import Spinner from 'react-mdl/lib/Spinner';
 
+import { FETCH_PROCESSING } from '../actions';
 import ProfileFormFields from '../util/ProfileFormFields';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
@@ -12,6 +14,7 @@ export default class UserPageAboutMeDialog extends ProfileFormFields {
   props: {
     ui:                                   UIState,
     profile:                              Profile,
+    profilePatchStatus:                   ?string,
     saveProfile:                          SaveProfileFunc,
     clearProfileEdit:                     () => void,
     setUserPageAboutMeDialogVisibility:   () => void,
@@ -36,7 +39,8 @@ export default class UserPageAboutMeDialog extends ProfileFormFields {
   };
 
   render () {
-    const { ui: { userPageAboutMeDialogVisibility } } = this.props;
+    const { ui: { userPageAboutMeDialogVisibility }, profilePatchStatus } = this.props;
+    const inFlight = profilePatchStatus === FETCH_PROCESSING;
 
     const actions = [
       <Button
@@ -48,10 +52,10 @@ export default class UserPageAboutMeDialog extends ProfileFormFields {
       </Button>,
       <Button
         type='button'
-        className='primary-button save-button'
+        className={`primary-button save-button ${inFlight ? 'disabled-with-spinner' : ''}`}
         key='save'
-        onClick={this.saveAboutMeInfo}>
-        Save
+        onClick={inFlight ? undefined : this.saveAboutMeInfo}>
+        {inFlight ? <Spinner singleColor /> : 'Save'}
       </Button>
     ];
 

--- a/static/js/components/UserPageAboutMeDialog.js
+++ b/static/js/components/UserPageAboutMeDialog.js
@@ -6,6 +6,7 @@ import Spinner from 'react-mdl/lib/Spinner';
 
 import { FETCH_PROCESSING } from '../actions';
 import ProfileFormFields from '../util/ProfileFormFields';
+import SpinnerButton from './SpinnerButton';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 import type { Validator } from '../lib/validation/profile';
@@ -50,13 +51,15 @@ export default class UserPageAboutMeDialog extends ProfileFormFields {
         onClick={this.closeAboutMeDialog}>
         Cancel
       </Button>,
-      <Button
+      <SpinnerButton
+        component={Button}
+        spinning={inFlight}
         type='button'
-        className={`primary-button save-button ${inFlight ? 'disabled-with-spinner' : ''}`}
+        className="primary-button save-button"
         key='save'
-        onClick={inFlight ? undefined : this.saveAboutMeInfo}>
-        {inFlight ? <Spinner singleColor /> : 'Save'}
-      </Button>
+        onClick={this.saveAboutMeInfo}>
+        Save
+      </SpinnerButton>
     ];
 
     return (

--- a/static/js/components/UserPageAboutMeDialog.js
+++ b/static/js/components/UserPageAboutMeDialog.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import Button from 'react-mdl/lib/Button';
-import Spinner from 'react-mdl/lib/Spinner';
 
 import { FETCH_PROCESSING } from '../actions';
 import ProfileFormFields from '../util/ProfileFormFields';

--- a/static/js/components/UserPageAboutMeDialog_test.js
+++ b/static/js/components/UserPageAboutMeDialog_test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { assert } from 'chai';
 import sinon from 'sinon';
-import _ from 'lodash';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import TestUtils from 'react-addons-test-utils';
@@ -13,7 +12,7 @@ import { USER_PROFILE_RESPONSE } from '../constants';
 
 describe('UserPageAboutMeDialog', () => {
   let sandbox;
-  let defaultRowProps, setUserPageDialogVisibility, clearProfileEdit, saveProfile;
+  let setUserPageDialogVisibility, clearProfileEdit, saveProfile;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();

--- a/static/js/components/UserPageAboutMeDialog_test.js
+++ b/static/js/components/UserPageAboutMeDialog_test.js
@@ -93,6 +93,7 @@ describe('UserPageAboutMeDialog', () => {
     });
     let saveButton = getDialog().querySelector(".save-button");
     assert(saveButton.className.includes("disabled-with-spinner"));
+    assert(saveButton.querySelector(".mdl-spinner"));
     TestUtils.Simulate.click(saveButton);
     assert.equal(saveProfile.callCount, 0);
   });

--- a/static/js/components/UserPageAboutMeDialog_test.js
+++ b/static/js/components/UserPageAboutMeDialog_test.js
@@ -3,11 +3,11 @@ import { mount } from 'enzyme';
 import { assert } from 'chai';
 import sinon from 'sinon';
 import _ from 'lodash';
-
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import TestUtils from 'react-addons-test-utils';
 
+import { FETCH_PROCESSING } from '../actions';
 import UserPageAboutMeDialog from './UserPageAboutMeDialog';
 import { USER_PROFILE_RESPONSE } from '../constants';
 
@@ -20,19 +20,7 @@ describe('UserPageAboutMeDialog', () => {
     setUserPageDialogVisibility = sandbox.stub();
     clearProfileEdit = sandbox.stub();
     saveProfile = sandbox.stub();
-    saveProfile.returns({
-      then: () => {}
-    });
-
-    defaultRowProps = {
-      profile: USER_PROFILE_RESPONSE,
-      setUserPageAboutMeDialogVisibility: setUserPageDialogVisibility,
-      clearProfileEdit: clearProfileEdit,
-      saveProfile: saveProfile,
-      ui: {
-        userPageAboutMeDialogVisibility: true
-      }
-    };
+    saveProfile.returns(Promise.resolve());
   });
 
   afterEach(() => {
@@ -40,10 +28,19 @@ describe('UserPageAboutMeDialog', () => {
   });
 
   const getDialog = () => document.querySelector('.about-me-dialog');
-  const renderDialog = () => (
+  const renderDialog = (props = {}) => (
     mount (
       <MuiThemeProvider muiTheme={getMuiTheme()}>
-        <UserPageAboutMeDialog {...defaultRowProps} />
+        <UserPageAboutMeDialog
+          profile={USER_PROFILE_RESPONSE}
+          setUserPageAboutMeDialogVisibility={setUserPageDialogVisibility}
+          clearProfileEdit={clearProfileEdit}
+          saveProfile={saveProfile}
+          ui={{
+            userPageAboutMeDialogVisibility: true
+          }}
+          {...props}
+        />
       </MuiThemeProvider>,
       {
         context: { router: {}},
@@ -53,10 +50,12 @@ describe('UserPageAboutMeDialog', () => {
   );
 
   it('render dialog with data', () => {
-    defaultRowProps['profile'] = Object.assign(_.cloneDeep(USER_PROFILE_RESPONSE), {
-      about_me: "Hello world"
+    renderDialog({
+      profile: {
+        ...USER_PROFILE_RESPONSE,
+        about_me: "Hello world"
+      }
     });
-    renderDialog();
     assert.equal(document.querySelector('h3.dialog-title').textContent, "About Me");
     assert.equal(document.querySelector("textarea").textContent, "Hello world");
   });
@@ -68,10 +67,11 @@ describe('UserPageAboutMeDialog', () => {
   });
 
   it('render dialog when visibility set to false', () => {
-    defaultRowProps['ui'] = {
-      userPageAboutMeDialogVisibility: false
-    };
-    renderDialog();
+    renderDialog({
+      ui: {
+        userPageAboutMeDialogVisibility: false
+      }
+    });
     assert.isNull(document.querySelector('h3.dialog-title'));
     assert.isNull(document.querySelector("textarea"));
   });
@@ -86,5 +86,15 @@ describe('UserPageAboutMeDialog', () => {
     renderDialog();
     TestUtils.Simulate.click(getDialog().querySelector(".save-button"));
     assert.equal(saveProfile.callCount, 1);
+  });
+
+  it('disables the save button during profile update', () => {
+    renderDialog({
+      profilePatchStatus: FETCH_PROCESSING
+    });
+    let saveButton = getDialog().querySelector(".save-button");
+    assert(saveButton.className.includes("disabled-with-spinner"));
+    TestUtils.Simulate.click(saveButton);
+    assert.equal(saveProfile.callCount, 0);
   });
 });

--- a/static/js/components/UserPagePersonalDialog.js
+++ b/static/js/components/UserPagePersonalDialog.js
@@ -2,11 +2,11 @@
 import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import Button from 'react-mdl/lib/Button';
-import Spinner from 'react-mdl/lib/Spinner';
 
 import { FETCH_PROCESSING } from '../actions';
 import { personalValidation } from '../lib/validation/profile';
 import PersonalForm from './PersonalForm';
+import SpinnerButton from './SpinnerButton';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 
@@ -48,13 +48,15 @@ export default class UserPagePersonalDialog extends React.Component {
         onClick={this.closePersonalDialog}>
         Cancel
       </Button>,
-      <Button
+      <SpinnerButton
+        component={Button}
+        spinning={inFlight}
         type='button'
-        className={`primary-button save-button ${inFlight ? 'disabled-with-spinner' : ''}`}
+        className="primary-button save-button"
         key='save'
-        onClick={inFlight ? undefined : this.savePersonalInfo}>
-        {inFlight ? <Spinner singleColor /> : 'Save'}
-      </Button>
+        onClick={this.savePersonalInfo}>
+        Save
+       </SpinnerButton>
     ];
 
     return (

--- a/static/js/components/UserPagePersonalDialog.js
+++ b/static/js/components/UserPagePersonalDialog.js
@@ -2,7 +2,9 @@
 import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import Button from 'react-mdl/lib/Button';
+import Spinner from 'react-mdl/lib/Spinner';
 
+import { FETCH_PROCESSING } from '../actions';
 import { personalValidation } from '../lib/validation/profile';
 import PersonalForm from './PersonalForm';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
@@ -13,6 +15,7 @@ export default class UserPagePersonalDialog extends React.Component {
     setUserPageDialogVisibility:  () => void,
     ui:                           UIState,
     profile:                      Profile,
+    profilePatchStatus:           ?string,
     saveProfile:                  SaveProfileFunc,
     clearProfileEdit:             () => void,
   };
@@ -35,7 +38,8 @@ export default class UserPagePersonalDialog extends React.Component {
   };
 
   render () {
-    const { ui: { userPageDialogVisibility } } = this.props;
+    const { ui: { userPageDialogVisibility }, profilePatchStatus } = this.props;
+    const inFlight = profilePatchStatus === FETCH_PROCESSING;
     const actions = [
       <Button
         type='button'
@@ -46,10 +50,10 @@ export default class UserPagePersonalDialog extends React.Component {
       </Button>,
       <Button
         type='button'
-        className='primary-button save-button'
+        className={`primary-button save-button ${inFlight ? 'disabled-with-spinner' : ''}`}
         key='save'
-        onClick={this.savePersonalInfo}>
-        Save
+        onClick={inFlight ? undefined : this.savePersonalInfo}>
+        {inFlight ? <Spinner singleColor /> : 'Save'}
       </Button>
     ];
 

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -848,7 +848,7 @@ describe("UserPage", function() {
           returns(Promise.resolve(expectedProfile));
 
         return renderComponent(`/learner/${username}`, userActions).then(([wrapper]) => {
-          let personalButton = wrapper.find('.edit-profile-holder').find('.mdl-button');
+          let personalButton = wrapper.find('.edit-personal-info-button');
 
           return listenForActions([
             SET_USER_PAGE_DIALOG_VISIBILITY,
@@ -892,8 +892,7 @@ describe("UserPage", function() {
           returns(Promise.resolve(expectedProfile));
 
         return renderComponent(`/learner/${username}`, userActions).then(([, div]) => {
-          let aboutMEBtn = div.querySelector('.edit-about-me-holder').
-            getElementsByClassName('mdl-button')[0];
+          let aboutMEBtn = div.querySelector('.edit-about-me-button');
 
           return listenForActions([
             SET_USER_PAGE_ABOUT_ME_DIALOG_VISIBILITY,
@@ -922,6 +921,29 @@ describe("UserPage", function() {
                 assert.deepEqual(state.profiles[username].profile, expectedProfile);
               });
             });
+          });
+        });
+      });
+
+      it('should disable the save button while a PATCH is in progress', () => {
+        const username = SETTINGS.user.username;
+        return renderComponent(`/learner/${username}`, userActions).then(([, div]) => {
+          let addButton = div.querySelector(".edit-personal-info-button");
+
+          TestUtils.Simulate.click(addButton);
+
+          let dialog = document.querySelector('.personal-dialog');
+
+          return listenForActions([
+            REQUEST_PATCH_USER_PROFILE,
+          ], () => {
+            helper.store.dispatch(requestPatchUserProfile(username));
+          }).then(() => {
+            let button = dialog.querySelector(".save-button");
+            assert(button.className.includes("disabled-with-spinner"));
+
+            TestUtils.Simulate.click(button);
+            assert.isFalse(patchUserProfileStub.called);
           });
         });
       });

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -941,6 +941,7 @@ describe("UserPage", function() {
           }).then(() => {
             let button = dialog.querySelector(".save-button");
             assert(button.className.includes("disabled-with-spinner"));
+            assert(button.querySelector(".mdl-spinner"));
 
             TestUtils.Simulate.click(button);
             assert.isFalse(patchUserProfileStub.called);


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1752

#### What's this PR do?
Disable buttons during profile upload for about me and personal info dialogs.

#### How should this be manually tested?
AFAIK these dialogs are only accessible on the user page. Edit the about me and click save, and edit the personal info and click save. A blue spinner should appear in place of the save button and more clicks should not cause the button to get clicked anymore.
