### PR TITLE
Remove React-Sticky

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
     },
     "abbrev": {
       "version": "1.0.9",
-      "from": "abbrev@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
     },
     "accepts": {
@@ -19,7 +19,7 @@
     },
     "acorn": {
       "version": "3.2.0",
-      "from": "acorn@>=3.2.0 <4.0.0",
+      "from": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz"
     },
     "acorn-globals": {
@@ -46,7 +46,7 @@
     },
     "ajaxchimp": {
       "version": "1.3.0",
-      "from": "ajaxchimp@>=1.3.0 <2.0.0",
+      "from": "https://registry.npmjs.org/ajaxchimp/-/ajaxchimp-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/ajaxchimp/-/ajaxchimp-1.3.0.tgz"
     },
     "ajv": {
@@ -113,12 +113,12 @@
     },
     "aproba": {
       "version": "1.0.4",
-      "from": "aproba@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
     },
     "archive-type": {
       "version": "3.2.0",
-      "from": "archive-type@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz"
     },
     "are-we-there-yet": {
@@ -148,7 +148,7 @@
     },
     "array-differ": {
       "version": "1.0.0",
-      "from": "array-differ@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
     },
     "array-equal": {
@@ -158,7 +158,7 @@
     },
     "array-find-index": {
       "version": "1.0.1",
-      "from": "array-find-index@>=1.0.1 <2.0.0",
+      "from": "array-find-index@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
     },
     "array-flatten": {
@@ -173,12 +173,12 @@
     },
     "array-union": {
       "version": "1.0.2",
-      "from": "array-union@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz"
     },
     "array-uniq": {
       "version": "1.0.3",
-      "from": "array-uniq@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
     },
     "array-unique": {
@@ -203,7 +203,7 @@
     },
     "assert": {
       "version": "1.4.1",
-      "from": "assert@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
     },
     "assert-plus": {
@@ -213,7 +213,7 @@
     },
     "assertion-error": {
       "version": "1.0.2",
-      "from": "assertion-error@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
     },
     "ast-types": {
@@ -223,7 +223,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "from": "async@>=1.0.0 <2.0.0",
+      "from": "async@>=1.5.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
     "async-each": {
@@ -280,7 +280,7 @@
     },
     "babel-code-frame": {
       "version": "6.11.0",
-      "from": "babel-code-frame@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz"
     },
     "babel-core": {
@@ -344,7 +344,7 @@
     },
     "babel-eslint": {
       "version": "6.1.0",
-      "from": "babel-eslint@>=6.1.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.0.tgz"
     },
     "babel-generator": {
@@ -685,12 +685,12 @@
     },
     "babel-plugin-syntax-flow": {
       "version": "6.8.0",
-      "from": "babel-plugin-syntax-flow@>=6.8.0 <7.0.0",
+      "from": "babel-plugin-syntax-flow@>=6.3.13 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.8.0.tgz"
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.8.0",
-      "from": "babel-plugin-syntax-jsx@>=6.8.0 <7.0.0",
+      "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.8.0.tgz"
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -851,7 +851,7 @@
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.9.0",
-      "from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-function-name@>=6.3.13 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz"
     },
     "babel-plugin-transform-es2015-literals": {
@@ -1024,7 +1024,7 @@
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.11.0",
-      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz"
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1034,7 +1034,7 @@
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-flow-strip-types@>=6.8.0 <7.0.0",
+      "from": "babel-plugin-transform-flow-strip-types@>=6.3.13 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.8.0.tgz"
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -1054,7 +1054,7 @@
     },
     "babel-plugin-transform-react-jsx-self": {
       "version": "6.11.0",
-      "from": "babel-plugin-transform-react-jsx-self@>=6.11.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz"
     },
     "babel-plugin-transform-react-jsx-source": {
@@ -1088,7 +1088,7 @@
     },
     "babel-polyfill": {
       "version": "6.9.1",
-      "from": "babel-polyfill@>=6.9.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.9.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.9.1.tgz"
     },
     "babel-preset-es2015": {
@@ -1118,32 +1118,32 @@
     },
     "babel-register": {
       "version": "6.9.0",
-      "from": "babel-register@>=6.9.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-register/-/babel-register-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.9.0.tgz"
     },
     "babel-runtime": {
       "version": "6.9.2",
-      "from": "babel-runtime@>=6.9.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz"
     },
     "babel-template": {
       "version": "6.9.0",
-      "from": "babel-template@>=6.9.0 <7.0.0",
+      "from": "babel-template@>=6.8.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.9.0.tgz"
     },
     "babel-traverse": {
       "version": "6.10.4",
-      "from": "babel-traverse@>=6.10.4 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.10.4.tgz",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.10.4.tgz"
     },
     "babel-types": {
       "version": "6.11.1",
-      "from": "babel-types@>=6.9.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.11.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.11.1.tgz"
     },
     "babylon": {
       "version": "6.8.2",
-      "from": "babylon@>=6.7.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babylon/-/babylon-6.8.2.tgz",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.2.tgz"
     },
     "balanced-match": {
@@ -1168,7 +1168,7 @@
     },
     "beeper": {
       "version": "1.1.0",
-      "from": "beeper@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
     },
     "bem-cn": {
@@ -1183,39 +1183,39 @@
     },
     "bin-check": {
       "version": "2.0.0",
-      "from": "bin-check@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz"
     },
     "bin-version": {
       "version": "1.0.4",
-      "from": "bin-version@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz"
     },
     "bin-version-check": {
       "version": "2.1.0",
-      "from": "bin-version-check@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.0.3 <5.0.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "bin-wrapper": {
       "version": "3.0.2",
-      "from": "bin-wrapper@>=3.0.2 <4.0.0",
+      "from": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz"
     },
     "binary-extensions": {
       "version": "1.5.0",
-      "from": "binary-extensions@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.5.0.tgz",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.5.0.tgz"
     },
     "bl": {
       "version": "1.1.2",
-      "from": "bl@>=1.0.0 <2.0.0",
+      "from": "bl@>=1.1.2 <1.2.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz"
     },
     "block-stream": {
@@ -1250,7 +1250,7 @@
     },
     "brace-expansion": {
       "version": "1.1.5",
-      "from": "brace-expansion@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz"
     },
     "braces": {
@@ -1275,12 +1275,12 @@
     },
     "buffer-crc32": {
       "version": "0.2.5",
-      "from": "buffer-crc32@>=0.2.3 <0.3.0",
+      "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
     },
     "buffer-to-vinyl": {
       "version": "1.1.0",
-      "from": "buffer-to-vinyl@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz"
     },
     "builtin-modules": {
@@ -1320,7 +1320,7 @@
     },
     "capture-stack-trace": {
       "version": "1.0.0",
-      "from": "capture-stack-trace@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
     },
     "caseless": {
@@ -1330,12 +1330,12 @@
     },
     "caw": {
       "version": "1.2.0",
-      "from": "caw@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
       "dependencies": {
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
         }
       }
@@ -1347,12 +1347,12 @@
     },
     "chai": {
       "version": "3.5.0",
-      "from": "chai@>=3.5.0 <4.0.0",
+      "from": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz"
     },
     "chai-as-promised": {
       "version": "5.3.0",
-      "from": "chai-as-promised@>=5.3.0 <6.0.0",
+      "from": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz"
     },
     "chalk": {
@@ -1389,7 +1389,7 @@
     },
     "chokidar": {
       "version": "1.6.0",
-      "from": "chokidar@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.0.tgz"
     },
     "circular-json": {
@@ -1424,12 +1424,12 @@
     },
     "cliui": {
       "version": "2.1.0",
-      "from": "cliui@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
+          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
         }
       }
@@ -1441,12 +1441,12 @@
     },
     "clone-stats": {
       "version": "0.0.1",
-      "from": "clone-stats@>=0.0.1 <0.0.2",
+      "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
     },
     "co": {
       "version": "3.1.0",
-      "from": "co@3.1.0",
+      "from": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
     },
     "coa": {
@@ -1466,12 +1466,12 @@
     },
     "color": {
       "version": "0.11.3",
-      "from": "color@>=0.11.0 <0.12.0",
+      "from": "https://registry.npmjs.org/color/-/color-0.11.3.tgz",
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.3.tgz"
     },
     "color-convert": {
       "version": "1.3.1",
-      "from": "color-convert@>=1.3.0 <2.0.0",
+      "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.3.1.tgz"
     },
     "color-name": {
@@ -1501,7 +1501,7 @@
     },
     "commander": {
       "version": "2.8.1",
-      "from": "commander@>=2.8.1 <2.9.0",
+      "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
     },
     "commoner": {
@@ -1543,12 +1543,12 @@
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "from": "console-control-strings@>=1.1.0 <1.2.0",
+      "from": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
     },
     "console-stream": {
       "version": "0.1.1",
-      "from": "console-stream@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz"
     },
     "constants-browserify": {
@@ -1563,7 +1563,7 @@
     },
     "content-type": {
       "version": "1.0.2",
-      "from": "content-type@>=1.0.2 <1.1.0",
+      "from": "content-type@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
     },
     "convert-source-map": {
@@ -1573,7 +1573,7 @@
     },
     "cookie": {
       "version": "0.3.1",
-      "from": "cookie@0.3.1",
+      "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
     },
     "cookie-signature": {
@@ -1598,7 +1598,7 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "from": "create-error-class@>=3.0.1 <4.0.0",
+      "from": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz"
     },
     "cropperjs": {
@@ -1665,7 +1665,7 @@
     },
     "cssnano": {
       "version": "3.7.1",
-      "from": "cssnano@>=2.6.1 <4.0.0",
+      "from": "https://registry.npmjs.org/cssnano/-/cssnano-3.7.1.tgz",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.7.1.tgz"
     },
     "csso": {
@@ -1680,7 +1680,7 @@
     },
     "cssstyle": {
       "version": "0.2.36",
-      "from": "cssstyle@>=0.2.34 <0.3.0",
+      "from": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.36.tgz",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.36.tgz"
     },
     "currency-codes": {
@@ -1690,7 +1690,7 @@
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "from": "currently-unhandled@>=0.4.1 <0.5.0",
+      "from": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
     },
     "d": {
@@ -1700,12 +1700,12 @@
     },
     "dashdash": {
       "version": "1.14.0",
-      "from": "dashdash@>=1.12.0 <2.0.0",
+      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
@@ -1717,7 +1717,7 @@
     },
     "dateformat": {
       "version": "1.0.12",
-      "from": "dateformat@>=1.0.11 <2.0.0",
+      "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz"
     },
     "debug": {
@@ -1732,95 +1732,95 @@
     },
     "decompress": {
       "version": "3.0.0",
-      "from": "decompress@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz"
     },
     "decompress-tar": {
       "version": "3.1.0",
-      "from": "decompress-tar@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
       "dependencies": {
         "clone": {
           "version": "0.2.0",
-          "from": "clone@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.3 <0.5.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
         }
       }
     },
     "decompress-tarbz2": {
       "version": "3.1.0",
-      "from": "decompress-tarbz2@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
       "dependencies": {
         "clone": {
           "version": "0.2.0",
-          "from": "clone@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.3 <0.5.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
         }
       }
     },
     "decompress-targz": {
       "version": "3.1.0",
-      "from": "decompress-targz@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
       "dependencies": {
         "clone": {
           "version": "0.2.0",
-          "from": "clone@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.3 <0.5.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
         }
       }
     },
     "decompress-unzip": {
       "version": "3.4.0",
-      "from": "decompress-unzip@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
       "dependencies": {
         "through2": {
           "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
     },
     "deep-eql": {
       "version": "0.1.3",
-      "from": "deep-eql@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
-          "from": "type-detect@0.1.1",
+          "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
         }
       }
@@ -1832,7 +1832,7 @@
     },
     "deep-extend": {
       "version": "0.4.1",
-      "from": "deep-extend@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
     },
     "deep-freeze": {
@@ -1904,7 +1904,7 @@
     },
     "doctrine": {
       "version": "1.2.2",
-      "from": "doctrine@>=1.2.2 <2.0.0",
+      "from": "doctrine@>=1.2.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.2.tgz",
       "dependencies": {
         "esutils": {
@@ -1963,12 +1963,12 @@
     },
     "download": {
       "version": "4.4.3",
-      "from": "download@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
       "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz"
     },
     "duplexer2": {
       "version": "0.1.4",
-      "from": "duplexer2@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
     },
     "duplexify": {
@@ -1978,14 +1978,14 @@
       "dependencies": {
         "end-of-stream": {
           "version": "1.0.0",
-          "from": "end-of-stream@1.0.0",
+          "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz"
         }
       }
     },
     "each-async": {
       "version": "1.1.1",
-      "from": "each-async@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz"
     },
     "ecc-jsbn": {
@@ -2005,7 +2005,7 @@
     },
     "encodeurl": {
       "version": "1.0.1",
-      "from": "encodeurl@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
     },
     "encoding": {
@@ -2015,7 +2015,7 @@
     },
     "end-of-stream": {
       "version": "1.1.0",
-      "from": "end-of-stream@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
     },
     "enhanced-resolve": {
@@ -2074,17 +2074,17 @@
     },
     "es-abstract": {
       "version": "1.5.1",
-      "from": "es-abstract@>=1.3.2 <2.0.0",
+      "from": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.1.tgz"
     },
     "es-to-primitive": {
       "version": "1.1.1",
-      "from": "es-to-primitive@>=1.1.1 <2.0.0",
+      "from": "es-to-primitive@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz"
     },
     "es5-ext": {
       "version": "0.10.12",
-      "from": "es5-ext@>=0.10.11 <0.11.0",
+      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
     },
     "es6-iterator": {
@@ -2094,7 +2094,7 @@
     },
     "es6-map": {
       "version": "0.1.4",
-      "from": "es6-map@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz"
     },
     "es6-promise": {
@@ -2109,7 +2109,7 @@
     },
     "es6-symbol": {
       "version": "3.1.0",
-      "from": "es6-symbol@>=3.1.0 <3.2.0",
+      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
     },
     "es6-weak-map": {
@@ -2181,7 +2181,7 @@
         },
         "user-home": {
           "version": "2.0.0",
-          "from": "user-home@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
         }
       }
@@ -2193,7 +2193,7 @@
     },
     "eslint-plugin-babel": {
       "version": "3.3.0",
-      "from": "eslint-plugin-babel@>=3.3.0 <4.0.0",
+      "from": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.3.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.3.0.tgz"
     },
     "eslint-plugin-flow-vars": {
@@ -2269,7 +2269,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "from": "events@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz"
     },
     "execSync": {
@@ -2279,7 +2279,7 @@
     },
     "executable": {
       "version": "1.1.0",
-      "from": "executable@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz"
     },
     "exit-hook": {
@@ -2299,24 +2299,24 @@
     },
     "express": {
       "version": "4.14.0",
-      "from": "express@>=4.13.3 <5.0.0",
+      "from": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "dependencies": {
         "qs": {
           "version": "6.2.0",
-          "from": "qs@6.2.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
         }
       }
     },
     "extend": {
       "version": "3.0.0",
-      "from": "extend@>=3.0.0 <4.0.0",
+      "from": "extend@>=3.0.0 <3.1.0",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
     },
     "extend-shallow": {
       "version": "2.0.1",
-      "from": "extend-shallow@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
     },
     "extglob": {
@@ -2331,7 +2331,7 @@
     },
     "fancy-log": {
       "version": "1.2.0",
-      "from": "fancy-log@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz"
     },
     "fast-levenshtein": {
@@ -2358,7 +2358,7 @@
     },
     "fd-slicer": {
       "version": "1.0.1",
-      "from": "fd-slicer@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
     },
     "fetch-mock": {
@@ -2378,12 +2378,12 @@
     },
     "file-loader": {
       "version": "0.8.5",
-      "from": "file-loader@0.8.5",
+      "from": "file-loader@*",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz"
     },
     "file-type": {
       "version": "3.8.0",
-      "from": "file-type@>=3.1.0 <4.0.0",
+      "from": "https://registry.npmjs.org/file-type/-/file-type-3.8.0.tgz",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.8.0.tgz"
     },
     "filename-regex": {
@@ -2393,12 +2393,12 @@
     },
     "filename-reserved-regex": {
       "version": "1.0.0",
-      "from": "filename-reserved-regex@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz"
     },
     "filenamify": {
       "version": "1.2.1",
-      "from": "filenamify@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz"
     },
     "fileset": {
@@ -2425,7 +2425,7 @@
     },
     "finalhandler": {
       "version": "0.5.0",
-      "from": "finalhandler@0.5.0",
+      "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz"
     },
     "find-up": {
@@ -2442,12 +2442,12 @@
     },
     "find-versions": {
       "version": "1.2.1",
-      "from": "find-versions@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz"
     },
     "first-chunk-stream": {
       "version": "1.0.0",
-      "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
     },
     "first-match": {
@@ -2527,7 +2527,7 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "from": "fs.realpath@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
     },
     "fsevents": {
@@ -3139,7 +3139,7 @@
     },
     "fstream": {
       "version": "1.0.10",
-      "from": "fstream@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
     },
     "function-bind": {
@@ -3149,12 +3149,12 @@
     },
     "gauge": {
       "version": "2.6.0",
-      "from": "gauge@>=2.6.0 <2.7.0",
+      "from": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz"
     },
     "gaze": {
       "version": "1.1.0",
-      "from": "gaze@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/gaze/-/gaze-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.0.tgz"
     },
     "generate-function": {
@@ -3169,7 +3169,7 @@
     },
     "get-proxy": {
       "version": "1.1.0",
-      "from": "get-proxy@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz"
     },
     "get-stdin": {
@@ -3191,7 +3191,7 @@
     },
     "glob": {
       "version": "7.0.5",
-      "from": "glob@>=7.0.3 <8.0.0",
+      "from": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
     },
     "glob-base": {
@@ -3206,12 +3206,12 @@
     },
     "glob-stream": {
       "version": "5.3.2",
-      "from": "glob-stream@>=5.3.2 <6.0.0",
+      "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.2.tgz",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.2.tgz",
       "dependencies": {
         "glob": {
           "version": "5.0.15",
-          "from": "glob@>=5.0.3 <6.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         }
       }
@@ -3235,24 +3235,24 @@
     },
     "globby": {
       "version": "5.0.0",
-      "from": "globby@>=5.0.0 <6.0.0",
+      "from": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz"
     },
     "globule": {
       "version": "1.0.0",
-      "from": "globule@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/globule/-/globule-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.0.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.9.0",
-          "from": "lodash@>=4.9.0 <4.10.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.9.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.9.0.tgz"
         }
       }
     },
     "glogg": {
       "version": "1.0.0",
-      "from": "glogg@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
     },
     "gonzales-pe": {
@@ -3269,7 +3269,7 @@
     },
     "got": {
       "version": "5.6.0",
-      "from": "got@>=5.0.0 <6.0.0",
+      "from": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
       "resolved": "https://registry.npmjs.org/got/-/got-5.6.0.tgz"
     },
     "graceful-fs": {
@@ -3289,51 +3289,51 @@
     },
     "gulp-decompress": {
       "version": "1.2.0",
-      "from": "gulp-decompress@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz"
     },
     "gulp-rename": {
       "version": "1.2.2",
-      "from": "gulp-rename@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz"
     },
     "gulp-sourcemaps": {
       "version": "1.6.0",
-      "from": "gulp-sourcemaps@>=1.5.2 <2.0.0",
+      "from": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "dependencies": {
         "through2": {
           "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
     },
     "gulp-util": {
       "version": "3.0.7",
-      "from": "gulp-util@>=3.0.1 <4.0.0",
+      "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "dependencies": {
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
         },
         "through2": {
           "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         },
         "vinyl": {
           "version": "0.5.3",
-          "from": "vinyl@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
         }
       }
     },
     "gulplog": {
       "version": "1.0.0",
-      "from": "gulplog@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
     },
     "handlebars": {
@@ -3372,7 +3372,7 @@
     },
     "has-color": {
       "version": "0.1.7",
-      "from": "has-color@>=0.1.7 <0.2.0",
+      "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
     },
     "has-flag": {
@@ -3382,7 +3382,7 @@
     },
     "has-gulplog": {
       "version": "0.1.0",
-      "from": "has-gulplog@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
     },
     "has-own": {
@@ -3392,7 +3392,7 @@
     },
     "has-unicode": {
       "version": "2.0.1",
-      "from": "has-unicode@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
     },
     "hawk": {
@@ -3419,12 +3419,12 @@
     },
     "hoist-non-react-statics": {
       "version": "1.2.0",
-      "from": "hoist-non-react-statics@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz"
     },
     "home-or-tmp": {
       "version": "1.0.0",
-      "from": "home-or-tmp@>=1.0.0 <2.0.0",
+      "from": "home-or-tmp@^1.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
     },
     "hosted-git-info": {
@@ -3471,7 +3471,7 @@
     },
     "http-errors": {
       "version": "1.5.0",
-      "from": "http-errors@>=1.5.0 <1.6.0",
+      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz"
     },
     "http-signature": {
@@ -3506,12 +3506,12 @@
     },
     "iflow-lodash": {
       "version": "1.1.16",
-      "from": "iflow-lodash@>=1.1.16 <2.0.0",
+      "from": "https://registry.npmjs.org/iflow-lodash/-/iflow-lodash-1.1.16.tgz",
       "resolved": "https://registry.npmjs.org/iflow-lodash/-/iflow-lodash-1.1.16.tgz"
     },
     "iflow-react-router": {
       "version": "1.1.16",
-      "from": "iflow-react-router@>=1.1.16 <2.0.0",
+      "from": "https://registry.npmjs.org/iflow-react-router/-/iflow-react-router-1.1.16.tgz",
       "resolved": "https://registry.npmjs.org/iflow-react-router/-/iflow-react-router-1.1.16.tgz"
     },
     "ignore": {
@@ -3521,12 +3521,12 @@
     },
     "imports-loader": {
       "version": "0.6.5",
-      "from": "imports-loader@>=0.6.5 <0.7.0",
+      "from": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
       "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.1.43",
-          "from": "source-map@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
         }
       }
@@ -3570,12 +3570,12 @@
     },
     "inherits": {
       "version": "2.0.1",
-      "from": "inherits@>=2.0.1 <2.1.0",
+      "from": "inherits@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "ini": {
       "version": "1.3.4",
-      "from": "ini@>=1.3.0 <1.4.0",
+      "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "inline-style-prefixer": {
@@ -3605,12 +3605,12 @@
     },
     "ipaddr.js": {
       "version": "1.1.1",
-      "from": "ipaddr.js@1.1.1",
+      "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
     },
     "is-absolute": {
       "version": "0.1.7",
-      "from": "is-absolute@>=0.1.5 <0.2.0",
+      "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz"
     },
     "is-absolute-url": {
@@ -3640,12 +3640,12 @@
     },
     "is-bzip2": {
       "version": "1.0.0",
-      "from": "is-bzip2@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
     },
     "is-callable": {
       "version": "1.1.3",
-      "from": "is-callable@>=1.1.3 <2.0.0",
+      "from": "is-callable@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
     },
     "is-date-object": {
@@ -3690,17 +3690,17 @@
     },
     "is-gzip": {
       "version": "1.0.0",
-      "from": "is-gzip@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
     },
     "is-my-json-valid": {
       "version": "2.13.1",
-      "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
     },
     "is-natural-number": {
       "version": "2.1.1",
-      "from": "is-natural-number@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz"
     },
     "is-number": {
@@ -3710,7 +3710,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "from": "is-obj@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
     },
     "is-path-cwd": {
@@ -3750,7 +3750,7 @@
     },
     "is-redirect": {
       "version": "1.0.0",
-      "from": "is-redirect@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
     },
     "is-regex": {
@@ -3760,7 +3760,7 @@
     },
     "is-relative": {
       "version": "0.1.3",
-      "from": "is-relative@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
     },
     "is-resolvable": {
@@ -3795,7 +3795,7 @@
     },
     "is-tar": {
       "version": "1.0.0",
-      "from": "is-tar@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
     },
     "is-typedarray": {
@@ -3815,12 +3815,12 @@
     },
     "is-valid-glob": {
       "version": "0.3.0",
-      "from": "is-valid-glob@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz"
     },
     "is-zip": {
       "version": "1.0.0",
-      "from": "is-zip@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
     },
     "isarray": {
@@ -3860,7 +3860,7 @@
     },
     "istanbul-api": {
       "version": "1.0.0-aplha.10",
-      "from": "istanbul-api@>=1.0.0-alpha <2.0.0",
+      "from": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.0.0-aplha.10.tgz",
       "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.0.0-aplha.10.tgz"
     },
     "istanbul-lib-coverage": {
@@ -3897,7 +3897,7 @@
     },
     "istanbul-reports": {
       "version": "1.0.0-alpha.6",
-      "from": "istanbul-reports@>=1.0.0-alpha <2.0.0",
+      "from": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.0-alpha.6.tgz",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.0-alpha.6.tgz"
     },
     "jade": {
@@ -3934,7 +3934,7 @@
     },
     "js-tokens": {
       "version": "2.0.0",
-      "from": "js-tokens@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
     },
     "js-yaml": {
@@ -4018,7 +4018,7 @@
     },
     "jsprim": {
       "version": "1.3.0",
-      "from": "jsprim@>=1.2.2 <2.0.0",
+      "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz"
     },
     "jstransform": {
@@ -4077,12 +4077,12 @@
     },
     "lazy-req": {
       "version": "1.1.0",
-      "from": "lazy-req@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz"
     },
     "lazystream": {
       "version": "1.0.0",
-      "from": "lazystream@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
     },
     "lcid": {
@@ -4124,7 +4124,7 @@
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
     },
     "lodash._baseiteratee": {
@@ -4139,7 +4139,7 @@
     },
     "lodash._basevalues": {
       "version": "3.0.0",
-      "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
     },
     "lodash._createcompounder": {
@@ -4149,27 +4149,27 @@
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
     },
     "lodash._reescape": {
       "version": "3.0.0",
-      "from": "lodash._reescape@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
     },
     "lodash._reevaluate": {
       "version": "3.0.0",
-      "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
     },
     "lodash._root": {
@@ -4204,17 +4204,17 @@
     },
     "lodash.escape": {
       "version": "3.2.0",
-      "from": "lodash.escape@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
     },
     "lodash.isarguments": {
       "version": "3.0.8",
-      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
     },
     "lodash.isequal": {
@@ -4254,29 +4254,29 @@
     },
     "lodash.restparam": {
       "version": "3.6.1",
-      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
     },
     "lodash.template": {
       "version": "3.6.2",
-      "from": "lodash.template@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "dependencies": {
         "lodash._basetostring": {
           "version": "3.0.1",
-          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
         },
         "lodash.keys": {
           "version": "3.1.2",
-          "from": "lodash.keys@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
         }
       }
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
-      "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
     },
     "lodash.throttle": {
@@ -4291,7 +4291,7 @@
     },
     "logalot": {
       "version": "2.1.0",
-      "from": "logalot@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz"
     },
     "lolex": {
@@ -4301,7 +4301,7 @@
     },
     "longest": {
       "version": "1.0.1",
-      "from": "longest@>=1.0.0 <2.0.0",
+      "from": "longest@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "loose-envify": {
@@ -4318,22 +4318,22 @@
     },
     "loud-rejection": {
       "version": "1.5.0",
-      "from": "loud-rejection@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.5.0.tgz",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.5.0.tgz"
     },
     "lowercase-keys": {
       "version": "1.0.0",
-      "from": "lowercase-keys@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
     },
     "lpad": {
       "version": "2.0.1",
-      "from": "lpad@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/lpad/-/lpad-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lpad/-/lpad-2.0.1.tgz"
     },
     "lpad-align": {
       "version": "1.1.0",
-      "from": "lpad-align@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.0.tgz"
     },
     "map-obj": {
@@ -4370,7 +4370,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "from": "meow@>=3.1.0 <4.0.0",
+      "from": "meow@>=3.7.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
     },
     "merge": {
@@ -4385,7 +4385,7 @@
     },
     "merge-stream": {
       "version": "1.0.0",
-      "from": "merge-stream@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz"
     },
     "methods": {
@@ -4395,7 +4395,7 @@
     },
     "micromatch": {
       "version": "2.3.10",
-      "from": "micromatch@>=2.3.7 <3.0.0",
+      "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.10.tgz",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.10.tgz"
     },
     "mime": {
@@ -4420,7 +4420,7 @@
     },
     "minimatch": {
       "version": "3.0.2",
-      "from": "minimatch@>=3.0.2 <4.0.0",
+      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
     },
     "minimist": {
@@ -4496,22 +4496,22 @@
     },
     "multipipe": {
       "version": "0.1.2",
-      "from": "multipipe@>=0.1.2 <0.2.0",
+      "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "dependencies": {
         "duplexer2": {
           "version": "0.0.2",
-          "from": "duplexer2@0.0.2",
+          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@>=1.1.9 <1.2.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         }
       }
@@ -4523,7 +4523,7 @@
     },
     "nan": {
       "version": "2.3.5",
-      "from": "nan@>=2.3.2 <3.0.0",
+      "from": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz"
     },
     "natural-compare": {
@@ -4538,12 +4538,12 @@
     },
     "node-fetch": {
       "version": "1.5.3",
-      "from": "node-fetch@>=1.3.3 <2.0.0",
+      "from": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.5.3.tgz",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.5.3.tgz"
     },
     "node-gyp": {
       "version": "3.4.0",
-      "from": "node-gyp@>=3.3.1 <4.0.0",
+      "from": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz"
     },
     "node-libs-browser": {
@@ -4570,7 +4570,7 @@
     },
     "node-status-codes": {
       "version": "1.0.0",
-      "from": "node-status-codes@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
     },
     "node-uuid": {
@@ -4580,7 +4580,7 @@
     },
     "nopt": {
       "version": "3.0.6",
-      "from": "nopt@>=3.0.0 <4.0.0",
+      "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
     },
     "normalize-package-data": {
@@ -4600,12 +4600,12 @@
     },
     "normalize-url": {
       "version": "1.5.3",
-      "from": "normalize-url@>=1.4.0 <2.0.0",
+      "from": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.5.3.tgz",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.5.3.tgz"
     },
     "npmlog": {
       "version": "3.1.2",
-      "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz"
     },
     "nth-check": {
@@ -4630,7 +4630,7 @@
     },
     "nwmatcher": {
       "version": "1.3.8",
-      "from": "nwmatcher@>=1.3.7 <2.0.0",
+      "from": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.8.tgz",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.8.tgz"
     },
     "oauth-sign": {
@@ -4697,7 +4697,7 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "from": "optimist@>=0.6.1 <0.7.0",
+      "from": "optimist@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "dependencies": {
         "minimist": {
@@ -4719,7 +4719,7 @@
     },
     "ordered-read-streams": {
       "version": "0.3.0",
-      "from": "ordered-read-streams@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz"
     },
     "os-browserify": {
@@ -4729,7 +4729,7 @@
     },
     "os-filter-obj": {
       "version": "1.0.3",
-      "from": "os-filter-obj@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz"
     },
     "os-homedir": {
@@ -4824,7 +4824,7 @@
     },
     "pend": {
       "version": "1.2.0",
-      "from": "pend@>=1.2.0 <1.3.0",
+      "from": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
     },
     "pify": {
@@ -4844,7 +4844,7 @@
     },
     "pkg-conf": {
       "version": "1.1.3",
-      "from": "pkg-conf@>=1.1.2 <2.0.0",
+      "from": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz"
     },
     "pluralize": {
@@ -4876,7 +4876,7 @@
     },
     "postcss-convert-values": {
       "version": "2.4.0",
-      "from": "postcss-convert-values@>=2.3.4 <3.0.0",
+      "from": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.4.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.4.0.tgz"
     },
     "postcss-discard-comments": {
@@ -4978,7 +4978,7 @@
     },
     "postcss-minify-gradients": {
       "version": "1.0.3",
-      "from": "postcss-minify-gradients@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.3.tgz"
     },
     "postcss-minify-params": {
@@ -4998,7 +4998,7 @@
     },
     "postcss-modules-local-by-default": {
       "version": "1.1.0",
-      "from": "postcss-modules-local-by-default@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.1.0.tgz"
     },
     "postcss-modules-scope": {
@@ -5033,7 +5033,7 @@
     },
     "postcss-reduce-initial": {
       "version": "1.0.0",
-      "from": "postcss-reduce-initial@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.0.tgz"
     },
     "postcss-reduce-transforms": {
@@ -5043,7 +5043,7 @@
     },
     "postcss-selector-parser": {
       "version": "2.1.0",
-      "from": "postcss-selector-parser@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.1.0.tgz"
     },
     "postcss-svgo": {
@@ -5088,7 +5088,7 @@
     },
     "process": {
       "version": "0.11.5",
-      "from": "process@>=0.11.0 <0.12.0",
+      "from": "https://registry.npmjs.org/process/-/process-0.11.5.tgz",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.5.tgz"
     },
     "process-nextick-args": {
@@ -5108,7 +5108,7 @@
     },
     "proxy-addr": {
       "version": "1.1.2",
-      "from": "proxy-addr@>=1.1.2 <1.2.0",
+      "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz"
     },
     "prr": {
@@ -5138,7 +5138,7 @@
     },
     "query-string": {
       "version": "4.2.2",
-      "from": "query-string@>=4.1.0 <5.0.0",
+      "from": "https://registry.npmjs.org/query-string/-/query-string-4.2.2.tgz",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.2.2.tgz"
     },
     "querystring": {
@@ -5163,7 +5163,7 @@
     },
     "range-parser": {
       "version": "1.2.0",
-      "from": "range-parser@>=1.2.0 <1.3.0",
+      "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
     },
     "raven-js": {
@@ -5173,7 +5173,7 @@
     },
     "rc": {
       "version": "1.1.6",
-      "from": "rc@>=1.1.2 <2.0.0",
+      "from": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz"
     },
     "rc-align": {
@@ -5405,11 +5405,6 @@
       "from": "react-slick@>=0.14.4 <0.15.0",
       "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.14.4.tgz"
     },
-    "react-sticky": {
-      "version": "5.0.5",
-      "from": "react-sticky@latest",
-      "resolved": "https://registry.npmjs.org/react-sticky/-/react-sticky-5.0.5.tgz"
-    },
     "react-swipeable": {
       "version": "3.6.0",
       "from": "react-swipeable@latest",
@@ -5451,7 +5446,7 @@
     },
     "read-all-stream": {
       "version": "3.1.0",
-      "from": "read-all-stream@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz"
     },
     "read-pkg": {
@@ -5466,12 +5461,12 @@
     },
     "readable-stream": {
       "version": "2.0.6",
-      "from": "readable-stream@>=2.0.0 <2.1.0",
+      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
     },
     "readdirp": {
       "version": "2.1.0",
-      "from": "readdirp@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
     },
     "readline2": {
@@ -5513,12 +5508,12 @@
     },
     "reduce-css-calc": {
       "version": "1.2.4",
-      "from": "reduce-css-calc@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.4.tgz",
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.4.tgz",
       "dependencies": {
         "balanced-match": {
           "version": "0.1.0",
-          "from": "balanced-match@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
         }
       }
@@ -5542,7 +5537,7 @@
     },
     "redux": {
       "version": "3.5.2",
-      "from": "redux@3.5.2",
+      "from": "redux@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.5.2.tgz"
     },
     "redux-actions": {
@@ -5589,7 +5584,7 @@
     },
     "regenerator-runtime": {
       "version": "0.9.5",
-      "from": "regenerator-runtime@>=0.9.5 <0.10.0",
+      "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
     },
     "regex-cache": {
@@ -5599,7 +5594,7 @@
     },
     "regexpu-core": {
       "version": "2.0.0",
-      "from": "regexpu-core@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
     },
     "regjsgen": {
@@ -5629,12 +5624,12 @@
     },
     "replace-ext": {
       "version": "0.0.1",
-      "from": "replace-ext@0.0.1",
+      "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
     },
     "request": {
       "version": "2.72.0",
-      "from": "request@>=2.55.0 <3.0.0",
+      "from": "request@>=2.61.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz"
     },
     "require-from-string": {
@@ -5644,7 +5639,7 @@
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "from": "require-main-filename@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
     },
     "require-uncached": {
@@ -5679,7 +5674,7 @@
     },
     "rimraf": {
       "version": "2.5.2",
-      "from": "rimraf@>=2.2.8 <3.0.0",
+      "from": "rimraf@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
     },
     "ripemd160": {
@@ -5726,32 +5721,32 @@
     },
     "sass-graph": {
       "version": "2.1.2",
-      "from": "sass-graph@>=2.1.1 <3.0.0",
+      "from": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.2.tgz",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.2.tgz",
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
-          "from": "camelcase@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
         },
         "cliui": {
           "version": "3.2.0",
-          "from": "cliui@>=3.2.0 <4.0.0",
+          "from": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
         },
         "set-blocking": {
           "version": "1.0.0",
-          "from": "set-blocking@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/set-blocking/-/set-blocking-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-1.0.0.tgz"
         },
         "window-size": {
           "version": "0.2.0",
-          "from": "window-size@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
         },
         "yargs": {
           "version": "4.7.1",
-          "from": "yargs@>=4.7.1 <5.0.0",
+          "from": "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz"
         }
       }
@@ -5847,54 +5842,54 @@
     },
     "seek-bzip": {
       "version": "1.0.5",
-      "from": "seek-bzip@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz"
     },
     "semver": {
       "version": "5.2.0",
-      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+      "from": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz"
     },
     "semver-regex": {
       "version": "1.0.0",
-      "from": "semver-regex@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
     },
     "semver-truncate": {
       "version": "1.1.0",
-      "from": "semver-truncate@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.0.tgz"
     },
     "send": {
       "version": "0.14.1",
-      "from": "send@0.14.1",
+      "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
       "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
       "dependencies": {
         "mime": {
           "version": "1.3.4",
-          "from": "mime@1.3.4",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         }
       }
     },
     "serve-static": {
       "version": "1.11.1",
-      "from": "serve-static@>=1.11.1 <1.12.0",
+      "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
     },
     "set-blocking": {
       "version": "2.0.0",
-      "from": "set-blocking@>=2.0.0 <2.1.0",
+      "from": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
     },
     "setprototypeof": {
       "version": "1.0.1",
-      "from": "setprototypeof@1.0.1",
+      "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
     },
     "sha.js": {
@@ -5933,7 +5928,7 @@
     },
     "signal-exit": {
       "version": "3.0.0",
-      "from": "signal-exit@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
     },
     "simple-assign": {
@@ -5983,7 +5978,7 @@
     },
     "source-map-support": {
       "version": "0.2.10",
-      "from": "source-map-support@>=0.2.10 <0.3.0",
+      "from": "source-map-support@^0.2.10",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
       "dependencies": {
         "source-map": {
@@ -5995,7 +5990,7 @@
     },
     "sparkles": {
       "version": "1.0.0",
-      "from": "sparkles@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
     },
     "spdx-correct": {
@@ -6025,7 +6020,7 @@
     },
     "squeak": {
       "version": "1.3.0",
-      "from": "squeak@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz"
     },
     "sshpk": {
@@ -6047,12 +6042,12 @@
     },
     "stat-mode": {
       "version": "0.2.1",
-      "from": "stat-mode@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz"
     },
     "statuses": {
       "version": "1.3.0",
-      "from": "statuses@>=1.3.0 <1.4.0",
+      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
     },
     "stream-browserify": {
@@ -6074,7 +6069,7 @@
     },
     "stream-combiner2": {
       "version": "1.1.1",
-      "from": "stream-combiner2@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
     },
     "stream-consume": {
@@ -6124,12 +6119,12 @@
     },
     "strip-bom-stream": {
       "version": "1.0.0",
-      "from": "strip-bom-stream@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz"
     },
     "strip-dirs": {
       "version": "1.1.1",
-      "from": "strip-dirs@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz"
     },
     "strip-indent": {
@@ -6144,7 +6139,7 @@
     },
     "strip-outer": {
       "version": "1.0.0",
-      "from": "strip-outer@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz"
     },
     "striptags": {
@@ -6159,7 +6154,7 @@
     },
     "sum-up": {
       "version": "1.0.3",
-      "from": "sum-up@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz"
     },
     "supports-color": {
@@ -6174,7 +6169,7 @@
     },
     "symbol": {
       "version": "0.2.3",
-      "from": "symbol@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz"
     },
     "symbol-observable": {
@@ -6216,7 +6211,7 @@
     },
     "tar-stream": {
       "version": "1.5.2",
-      "from": "tar-stream@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz"
     },
     "temp": {
@@ -6253,41 +6248,41 @@
     },
     "through2": {
       "version": "0.6.5",
-      "from": "through2@>=0.6.1 <0.7.0",
+      "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "readable-stream": {
           "version": "1.0.34",
-          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         }
       }
     },
     "through2-filter": {
       "version": "2.0.0",
-      "from": "through2-filter@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "dependencies": {
         "through2": {
           "version": "2.0.1",
-          "from": "through2@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
     },
     "time-stamp": {
       "version": "1.0.1",
-      "from": "time-stamp@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz"
     },
     "timed-out": {
       "version": "2.0.0",
-      "from": "timed-out@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
     },
     "timers-browserify": {
@@ -6297,7 +6292,7 @@
     },
     "to-absolute-glob": {
       "version": "0.1.1",
-      "from": "to-absolute-glob@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz"
     },
     "to-fast-properties": {
@@ -6307,7 +6302,7 @@
     },
     "tough-cookie": {
       "version": "2.2.2",
-      "from": "tough-cookie@>=2.2.0 <3.0.0",
+      "from": "tough-cookie@>=2.2.0 <2.3.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
     },
     "tr46": {
@@ -6322,7 +6317,7 @@
     },
     "trim-repeated": {
       "version": "1.0.0",
-      "from": "trim-repeated@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz"
     },
     "tryit": {
@@ -6337,7 +6332,7 @@
     },
     "tunnel-agent": {
       "version": "0.4.3",
-      "from": "tunnel-agent@>=0.4.0 <0.5.0",
+      "from": "tunnel-agent@>=0.4.1 <0.5.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
     },
     "tweetnacl": {
@@ -6352,12 +6347,12 @@
     },
     "type-detect": {
       "version": "1.0.0",
-      "from": "type-detect@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
     },
     "type-is": {
       "version": "1.6.13",
-      "from": "type-is@>=1.6.13 <1.7.0",
+      "from": "type-is@>=1.6.6 <1.7.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz"
     },
     "typedarray": {
@@ -6372,12 +6367,12 @@
     },
     "uglify-js": {
       "version": "2.6.4",
-      "from": "uglify-js@>=2.6.0 <3.0.0",
+      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.6 <0.3.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         }
       }
@@ -6409,7 +6404,7 @@
     },
     "unique-stream": {
       "version": "2.2.1",
-      "from": "unique-stream@>=2.0.2 <3.0.0",
+      "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
     },
     "unpipe": {
@@ -6419,7 +6414,7 @@
     },
     "unzip-response": {
       "version": "1.0.0",
-      "from": "unzip-response@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz"
     },
     "url": {
@@ -6446,7 +6441,7 @@
     },
     "url-parse-lax": {
       "version": "1.0.0",
-      "from": "url-parse-lax@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz"
     },
     "urlgrey": {
@@ -6456,12 +6451,12 @@
     },
     "user-home": {
       "version": "1.1.1",
-      "from": "user-home@>=1.1.1 <2.0.0",
+      "from": "user-home@^1.1.1",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
     },
     "util": {
       "version": "0.10.3",
-      "from": "util@>=0.10.3 <1.0.0",
+      "from": "util@>=0.10.3 <0.11.0",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
     },
     "util-deprecate": {
@@ -6476,12 +6471,12 @@
     },
     "uuid": {
       "version": "2.0.2",
-      "from": "uuid@>=2.0.1 <3.0.0",
+      "from": "uuid@>=2.0.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
     },
     "vali-date": {
       "version": "1.0.0",
-      "from": "vali-date@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz"
     },
     "validate-npm-package-license": {
@@ -6511,17 +6506,17 @@
     },
     "vinyl-assign": {
       "version": "1.2.1",
-      "from": "vinyl-assign@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz"
     },
     "vinyl-fs": {
       "version": "2.4.3",
-      "from": "vinyl-fs@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
       "dependencies": {
         "through2": {
           "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
@@ -6533,7 +6528,7 @@
     },
     "ware": {
       "version": "1.3.0",
-      "from": "ware@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz"
     },
     "warning": {
@@ -6638,22 +6633,22 @@
     },
     "which": {
       "version": "1.2.10",
-      "from": "which@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
     },
     "wide-align": {
       "version": "1.1.0",
-      "from": "wide-align@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
     },
     "window-size": {
       "version": "0.1.0",
-      "from": "window-size@0.1.0",
+      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
     },
     "wordwrap": {
       "version": "1.0.0",
-      "from": "wordwrap@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
     },
     "wrap-ansi": {
@@ -6663,7 +6658,7 @@
     },
     "wrap-fn": {
       "version": "0.1.5",
-      "from": "wrap-fn@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz"
     },
     "wrappy": {
@@ -6688,7 +6683,7 @@
     },
     "y18n": {
       "version": "3.2.1",
-      "from": "y18n@>=3.2.1 <4.0.0",
+      "from": "y18n@>=3.2.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
     },
     "yallist": {
@@ -6698,24 +6693,24 @@
     },
     "yargs": {
       "version": "3.10.0",
-      "from": "yargs@>=3.10.0 <3.11.0",
+      "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
-          "from": "camelcase@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
         }
       }
     },
     "yargs-parser": {
       "version": "2.4.0",
-      "from": "yargs-parser@>=2.4.0 <3.0.0",
+      "from": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.0.tgz",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.0.tgz"
     },
     "yauzl": {
       "version": "2.6.0",
-      "from": "yauzl@>=2.2.1 <3.0.0",
+      "from": "https://registry.npmjs.org/yauzl/-/yauzl-2.6.0.tgz",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.6.0.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "react-router-bootstrap": "0.23.0",
     "react-select": "^1.0.0-rc.1",
     "react-slick": "^0.14.4",
-    "react-sticky": "^5.0.5",
     "react-swipeable": "^3.6.0",
     "react-tap-event-plugin": "^2.0.1",
     "react-tooltip": "^3.1.6",

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -17,7 +17,6 @@ import {
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Card from 'react-mdl/lib/Card/Card';
 import iso3166 from 'iso-3166-2';
-import { StickyContainer, Sticky } from 'react-sticky';
 import _ from 'lodash';
 
 import ProgramFilter from './ProgramFilter';
@@ -144,57 +143,55 @@ export default class LearnerSearch extends SearchkitComponent {
     }
 
     return (
-      <Sticky>
-        <Card className="fullwidth" shadow={1}>
-          <FilterVisibilityToggle
-            {...this.props}
-            filterName="courses"
-          >
-            <MenuFilter
-              field="program.enrollments.title"
-              fieldOptions={{type: 'nested', options: { path: 'program.enrollments' } }}
-              title="Course"
-              id="courses"
-            />
-          </FilterVisibilityToggle>
-          <FilterVisibilityToggle
-            {...this.props}
-            filterName="birth-location"
-          >
-            <RefinementListFilter
-              id="birth_location"
-              title="Country of Birth"
-              field="profile.birth_country"
-              operator="OR"
-              itemComponent={CountryRefinementOption}
-            />
-          </FilterVisibilityToggle>
-          <FilterVisibilityToggle
-            {...this.props}
-            filterName="residence-country"
-          >
-            <HierarchicalMenuFilter
-              fields={["profile.country", "profile.state_or_territory"]}
-              title="Current Residence"
-              id="country"
-              translations={this.searchkitTranslations}
-            />
-          </FilterVisibilityToggle>
-          <FilterVisibilityToggle
-            {...this.props}
-            filterName="grade-average"
-          >
-            <RangeFilter
-              field="program.grade_average"
-              id="grade-average"
-              min={0}
-              max={100}
-              showHistogram={true}
-              title="Average Grade in Program"
-            />
-          </FilterVisibilityToggle>
-        </Card>
-      </Sticky>
+      <Card className="fullwidth" shadow={1}>
+        <FilterVisibilityToggle
+          {...this.props}
+          filterName="courses"
+        >
+          <MenuFilter
+            field="program.enrollments.title"
+            fieldOptions={{type: 'nested', options: { path: 'program.enrollments' } }}
+            title="Course"
+            id="courses"
+          />
+        </FilterVisibilityToggle>
+        <FilterVisibilityToggle
+          {...this.props}
+          filterName="birth-location"
+        >
+          <RefinementListFilter
+            id="birth_location"
+            title="Country of Birth"
+            field="profile.birth_country"
+            operator="OR"
+            itemComponent={CountryRefinementOption}
+          />
+        </FilterVisibilityToggle>
+        <FilterVisibilityToggle
+          {...this.props}
+          filterName="residence-country"
+        >
+          <HierarchicalMenuFilter
+            fields={["profile.country", "profile.state_or_territory"]}
+            title="Current Residence"
+            id="country"
+            translations={this.searchkitTranslations}
+          />
+        </FilterVisibilityToggle>
+        <FilterVisibilityToggle
+          {...this.props}
+          filterName="grade-average"
+        >
+          <RangeFilter
+            field="program.grade_average"
+            id="grade-average"
+            min={0}
+            max={100}
+            showHistogram={true}
+            title="Average Grade in Program"
+          />
+        </FilterVisibilityToggle>
+      </Card>
     );
   };
 
@@ -222,23 +219,21 @@ export default class LearnerSearch extends SearchkitComponent {
           sendEmail={sendEmail}
           searchkit={this.searchkit}
         />
-        <StickyContainer>
-          <Grid className="search-grid">
-            <Cell col={3} className="search-sidebar">
-              { this.renderFacets(currentProgramEnrollment) }
-            </Cell>
-            <Cell col={9}>
-              <Card className="fullwidth results-padding" shadow={1}>
-                { this.renderSearchHeader(openEmailComposer) }
-                <Hits
-                  className="learner-results"
-                  hitsPerPage={SETTINGS.es_page_size}
-                  itemComponent={LearnerResult} />
-                <CustomNoHits />
-              </Card>
-            </Cell>
-          </Grid>
-        </StickyContainer>
+        <Grid className="search-grid">
+          <Cell col={3} className="search-sidebar">
+            { this.renderFacets(currentProgramEnrollment) }
+          </Cell>
+          <Cell col={9}>
+            <Card className="fullwidth results-padding" shadow={1}>
+              { this.renderSearchHeader(openEmailComposer) }
+              <Hits
+                className="learner-results"
+                hitsPerPage={SETTINGS.es_page_size}
+                itemComponent={LearnerResult} />
+              <CustomNoHits />
+            </Card>
+          </Cell>
+        </Grid>
       </div>
     );
   }


### PR DESCRIPTION
Fixes #1948 by removing [`react-sticky`](https://github.com/captivationsoftware/react-sticky). The library doesn't have a way to keep a sticky element bounded within a container in the way that we need. Note that this change causes the facets sidebar to scroll with the rest of the page, so that scrolling down through the results causes the facets to hide from view.