### PR TITLE
Notified user when enrollment status doesn't match paid status

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -286,6 +286,8 @@ def get_status_for_courserun(course_run, mmtrack):
         CourseRunUserStatus: an object representing the run status for the user
     """
     if not mmtrack.is_enrolled(course_run.edx_course_key):
+        if mmtrack.has_paid(course_run.edx_course_key):
+            return CourseRunUserStatus(CourseRunStatus.PAID_BUT_NOT_ENROLLED, course_run)
         return CourseRunUserStatus(CourseRunStatus.NOT_ENROLLED, course_run)
     status = None
     if mmtrack.is_enrolled_mmtrack(course_run.edx_course_key):
@@ -297,9 +299,7 @@ def get_status_for_courserun(course_run, mmtrack):
             status = CourseRunStatus.WILL_ATTEND
         # If a course run has no start or end date, is_past, is_current, and is_future all return False
     else:
-        if mmtrack.has_paid(course_run.edx_course_key):
-            return CourseRunUserStatus(CourseRunStatus.PAID_BUT_NOT_ENROLLED, course_run)
-        elif course_run.is_past:
+        if course_run.is_past:
             status = CourseRunStatus.NOT_PASSED
         else:
             if course_run.is_upgradable:

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -28,11 +28,12 @@ class CourseStatus:
     CAN_UPGRADE = 'can-upgrade'
     MISSED_DEADLINE = 'missed-deadline'
     OFFERED = 'offered'
+    PAID_BUT_NOT_ENROLLED = 'paid-but-not-enrolled'
 
     @classmethod
     def all_statuses(cls):
         """Helper to get all the statuses"""
-        return [cls.PASSED, cls.NOT_PASSED, cls.CURRENTLY_ENROLLED,
+        return [cls.PASSED, cls.NOT_PASSED, cls.CURRENTLY_ENROLLED, cls.PAID_BUT_NOT_ENROLLED,
                 cls.CAN_UPGRADE, cls.OFFERED, cls.WILL_ATTEND, cls.MISSED_DEADLINE]
 
 
@@ -47,6 +48,7 @@ class CourseRunStatus:
     CAN_UPGRADE = 'can-upgrade'
     MISSED_DEADLINE = 'missed-deadline'
     NOT_PASSED = 'not-passed'
+    PAID_BUT_NOT_ENROLLED = 'paid-but-not-enrolled'
 
 
 class CourseFormatConditionalFields:
@@ -255,6 +257,8 @@ def get_info_for_course(course, mmtrack):
         _add_run(run_status.course_run, mmtrack, CourseStatus.WILL_ATTEND)
     elif run_status.status == CourseRunStatus.CAN_UPGRADE:
         _add_run(run_status.course_run, mmtrack, CourseStatus.CAN_UPGRADE)
+    elif run_status.status == CourseRunStatus.PAID_BUT_NOT_ENROLLED:
+        _add_run(run_status.course_run, mmtrack, CourseRunStatus.PAID_BUT_NOT_ENROLLED)
 
     # add all the other runs with status != NOT_ENROLLED
     # the first one (or two in some cases) has been added with the logic before
@@ -281,6 +285,8 @@ def get_status_for_courserun(course_run, mmtrack):
     Returns:
         CourseRunUserStatus: an object representing the run status for the user
     """
+    if mmtrack.paid_but_not_enrolled_mmtrack(course_run.edx_course_key):
+        return CourseRunUserStatus(CourseRunStatus.PAID_BUT_NOT_ENROLLED, course_run)
     if not mmtrack.is_enrolled(course_run.edx_course_key):
         return CourseRunUserStatus(CourseRunStatus.NOT_ENROLLED, course_run)
     status = None

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -285,8 +285,6 @@ def get_status_for_courserun(course_run, mmtrack):
     Returns:
         CourseRunUserStatus: an object representing the run status for the user
     """
-    if mmtrack.paid_but_not_enrolled_mmtrack(course_run.edx_course_key):
-        return CourseRunUserStatus(CourseRunStatus.PAID_BUT_NOT_ENROLLED, course_run)
     if not mmtrack.is_enrolled(course_run.edx_course_key):
         return CourseRunUserStatus(CourseRunStatus.NOT_ENROLLED, course_run)
     status = None
@@ -299,7 +297,9 @@ def get_status_for_courserun(course_run, mmtrack):
             status = CourseRunStatus.WILL_ATTEND
         # If a course run has no start or end date, is_past, is_current, and is_future all return False
     else:
-        if course_run.is_past:
+        if mmtrack.has_paid(course_run.edx_course_key):
+            return CourseRunUserStatus(CourseRunStatus.PAID_BUT_NOT_ENROLLED, course_run)
+        elif course_run.is_past:
             status = CourseRunStatus.NOT_PASSED
         else:
             if course_run.is_upgradable:

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -240,7 +240,7 @@ class CourseRunTest(CourseTests):
         """test for get_status_for_courserun for course without enrollment"""
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': False,
-            'paid_but_not_enrolled_mmtrack.return_value': False
+            'has_paid.return_value': False
         })
         crun = self.create_run(
             start=self.now+timedelta(weeks=52),
@@ -259,7 +259,7 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': True,
-            'paid_but_not_enrolled_mmtrack.return_value': False
+            'has_paid.return_value': True
         })
         # create a run that is current
         crun = self.create_run(
@@ -278,7 +278,7 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': True,
-            'paid_but_not_enrolled_mmtrack.return_value': False
+            'has_paid.return_value': True
         })
         # create a run that is past
         crun = self.create_run(
@@ -297,7 +297,7 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': True,
-            'paid_but_not_enrolled_mmtrack.return_value': False
+            'has_paid.return_value': True
         })
         # create a run that is future
         crun = self.create_run(
@@ -316,7 +316,7 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': False,
-            'paid_but_not_enrolled_mmtrack.return_value': False
+            'has_paid.return_value': False
         })
         # create a run that is future
         future_run = self.create_run(
@@ -346,7 +346,7 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': False,
-            'paid_but_not_enrolled_mmtrack.return_value': False
+            'has_paid.return_value': False
         })
         # create a run that is current with upgrade deadline None
         current_run = self.create_run(
@@ -377,7 +377,7 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': False,
-            'paid_but_not_enrolled_mmtrack.return_value': False
+            'has_paid.return_value': False
         })
         # create a run that is past
         crun = self.create_run(
@@ -395,7 +395,8 @@ class CourseRunTest(CourseTests):
         """test for get_status_for_courserun for course without enrollment and it is paid"""
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': False,
-            'paid_but_not_enrolled_mmtrack.return_value': True
+            'is_enrolled_mmtrack.return_value': False,
+            'has_paid.return_value': True
         })
         crun = self.create_run(
             start=self.now+timedelta(weeks=52),

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -521,6 +521,28 @@ class InfoCourseTest(CourseTests):
         mock_format.assert_called_once_with(self.course_run, api.CourseStatus.OFFERED, None, position=1)
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
+    def test_info_not_enrolled_but_paid(self, mock_format):
+        """test for get_info_for_course for course with with a paid but not enrolled run"""
+        with patch(
+            'dashboard.api.get_status_for_courserun',
+            autospec=True,
+            return_value=api.CourseRunUserStatus(
+                status=api.CourseRunStatus.PAID_BUT_NOT_ENROLLED,
+                course_run=self.course_run
+            )
+        ):
+            self.assert_course_equal(
+                self.course,
+                api.get_info_for_course(self.course, None)
+            )
+        mock_format.assert_called_once_with(
+            self.course_run,
+            api.CourseStatus.PAID_BUT_NOT_ENROLLED,
+            None,
+            position=1
+        )
+
+    @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     def test_info_not_passed_offered(self, mock_format):
         """test for get_info_for_course for course with a run not passed and another offered"""
         with patch(

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -148,7 +148,7 @@ class MMTrack:
 
     def paid_but_not_enrolled_mmtrack(self, course_id):
         """
-        Returns whether
+        Returns true if user paid for a course but he is not enrolled.
 
         Args:
             course_id (str): an edX course run id

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -146,6 +146,27 @@ class MMTrack:
         else:
             return course_id in self.paid_course_ids
 
+    def paid_but_not_enrolled_mmtrack(self, course_id):
+        """
+        Returns whether
+
+        Args:
+            course_id (str): an edX course run id
+
+        Returns:
+            bool: whether the user is paid but no enrolled mmtrack in the course
+        """
+        if self.is_enrolled(course_id):
+            return False
+
+        # financial aid programs need to have an audit enrollment and a paid entry for the course
+        if self.financial_aid_available:
+            return course_id in self.paid_course_ids
+
+        # need to find a way to check if user paid for course
+        # for normal programs and he is not entolled
+        return False
+
     def has_passed_course(self, course_id):
         """
         Returns whether the user has passed a course run.

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -154,7 +154,7 @@ class MMTrack:
 
         # normal programs need to have a verified enrollment
         enrollment = self.enrollments.get_enrollment_for_course(course_id)
-        return enrollment.is_verified
+        return enrollment and enrollment.is_verified
 
     def has_passed_course(self, course_id):
         """

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -136,36 +136,25 @@ class MMTrack:
         Returns:
             bool: whether the user is enrolled mmtrack in the course
         """
-        if not self.is_enrolled(course_id):
-            return False
-        # normal programs need to have a verified enrollment
-        if not self.financial_aid_available:
-            enrollment = self.enrollments.get_enrollment_for_course(course_id)
-            return enrollment.is_verified
-        # financial aid programs need to have an audit enrollment and a paid entry for the course
-        else:
-            return course_id in self.paid_course_ids
+        return self.is_enrolled(course_id) and self.has_paid(course_id)
 
-    def paid_but_not_enrolled_mmtrack(self, course_id):
+    def has_paid(self, course_id):
         """
-        Returns true if user paid for a course but he is not enrolled.
+        Returns true if user paid for a course.
 
         Args:
             course_id (str): an edX course run id
 
         Returns:
-            bool: whether the user is paid but no enrolled mmtrack in the course
+            bool: whether the user is paid
         """
-        if self.is_enrolled(course_id):
-            return False
-
         # financial aid programs need to have an audit enrollment and a paid entry for the course
         if self.financial_aid_available:
             return course_id in self.paid_course_ids
 
-        # need to find a way to check if user paid for course
-        # for normal programs and he is not entolled
-        return False
+        # normal programs need to have a verified enrollment
+        enrollment = self.enrollments.get_enrollment_for_course(course_id)
+        return enrollment.is_verified
 
     def has_passed_course(self, course_id):
         """

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -19,9 +19,10 @@ import {
   STATUS_WILL_ATTEND,
   STATUS_OFFERED,
   STATUS_PENDING_ENROLLMENT,
+  STATUS_PAID_BUT_NOT_ENROLLED,
   DASHBOARD_FORMAT,
   FA_PENDING_STATUSES,
-  FA_STATUS_SKIPPED
+  FA_STATUS_SKIPPED,
 } from '../../constants';
 import { isCurrentlyEnrollable } from './util';
 import { formatPrice } from '../../util/util';
@@ -114,6 +115,19 @@ export default class CourseAction extends React.Component {
     }
   );
 
+  renderDescriptionForError = R.curry(
+    (className: string, text: ?string, contact: ?string): React$Element<*>|null => {
+      let classDefinition = className;
+      let contactLink = null;
+
+      if (contact) {
+        contactLink = <a href={contact}>Contact us for help.</a>;
+      }
+      return (text && text.length > 0 || contactLink) ?
+        <div className={classDefinition} key="2">{text}{contactLink}</div> : null;
+    }
+  );
+
   renderTextDescription = this.renderDescription('description', null);
 
   renderBoxedDescription = this.renderDescription('boxed description', null);
@@ -196,6 +210,12 @@ export default class CourseAction extends React.Component {
     case STATUS_PENDING_ENROLLMENT:
       action = this.renderEnrollButton(run);
       description = this.renderTextDescription('Processing...');
+      break;
+    case STATUS_PAID_BUT_NOT_ENROLLED:
+      description = this.renderContactUsDescription(
+        'Something went wrong.\n You paid for this course but \nare not enrolled.',
+        `mailto:${SETTINGS.support_email}`
+      );
       break;
     }
 

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -115,19 +115,6 @@ export default class CourseAction extends React.Component {
     }
   );
 
-  renderDescriptionForError = R.curry(
-    (className: string, text: ?string, contact: ?string): React$Element<*>|null => {
-      let classDefinition = className;
-      let contactLink = null;
-
-      if (contact) {
-        contactLink = <a href={contact}>Contact us for help.</a>;
-      }
-      return (text && text.length > 0 || contactLink) ?
-        <div className={classDefinition} key="2">{text}{contactLink}</div> : null;
-    }
-  );
-
   renderTextDescription = this.renderDescription('description', null);
 
   renderBoxedDescription = this.renderDescription('boxed description', null);
@@ -211,13 +198,17 @@ export default class CourseAction extends React.Component {
       action = this.renderEnrollButton(run);
       description = this.renderTextDescription('Processing...');
       break;
-    case STATUS_PAID_BUT_NOT_ENROLLED:
-      description = this.renderContactUsDescription(
-        'Something went wrong.\n You paid for this course but \nare not enrolled.',
-        `mailto:${SETTINGS.support_email}`
+    case STATUS_PAID_BUT_NOT_ENROLLED: {
+      const contactText = 'Contact us for help.';
+      const contactHref = `mailto:${SETTINGS.support_email}`;
+      const descriptionText = 'Something went wrong. You paid for this course but are not enrolled.';
+      description = (
+        <div className='description' key='2'>
+          {descriptionText} <a href={contactHref}>{contactText}</a>
+        </div>
       );
       break;
-    }
+    }}
 
     return _.compact([action, description]);
   }

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -132,12 +132,15 @@ describe('CourseAction', () => {
     const wrapper = renderCourseAction({
       courseRun: firstRun
     });
-    let elements = getElements(wrapper);
+    let description = wrapper.find(".description");
+    let contactLink = description.find('a');
 
     assert.equal(
-      elements.descriptionText,
-      'Something went wrong.\n You paid for this course but \nare not enrolled.Contact us for help.'
+      description.text(),
+      'Something went wrong. You paid for this course but are not enrolled. Contact us for help.'
     );
+    assert.isAbove(contactLink.props().href.length, 0);
+    assert.include(contactLink.props().href, SETTINGS.support_email);
   });
 
   it('shows a button to enroll and pay, and a link to enroll and pay later', () => {

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -21,7 +21,8 @@ import {
   STATUS_MISSED_DEADLINE,
   STATUS_PENDING_ENROLLMENT,
   FA_PENDING_STATUSES,
-  FA_STATUS_SKIPPED
+  FA_STATUS_SKIPPED,
+  STATUS_PAID_BUT_NOT_ENROLLED,
 } from '../../constants';
 import {
   findCourse,
@@ -120,6 +121,23 @@ describe('CourseAction', () => {
     let elements = getElements(wrapper);
 
     assert.equal(elements.descriptionText, 'In Progress');
+  });
+
+  it('shows a message for course user paid but not enrolled', () => {
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_PAID_BUT_NOT_ENROLLED
+    ));
+    let firstRun = course.runs[0];
+    const wrapper = renderCourseAction({
+      courseRun: firstRun
+    });
+    let elements = getElements(wrapper);
+
+    assert.equal(
+      elements.descriptionText,
+      'Something went wrong.\n You paid for this course but \nare not enrolled.Contact us for help.'
+    );
   });
 
   it('shows a button to enroll and pay, and a link to enroll and pay later', () => {

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -53,6 +53,7 @@ export const STATUS_WILL_ATTEND = 'will-attend';
 export const STATUS_CAN_UPGRADE = 'can-upgrade';
 export const STATUS_MISSED_DEADLINE = 'missed-deadline';
 export const STATUS_OFFERED = 'offered';
+export const STATUS_PAID_BUT_NOT_ENROLLED = 'paid-but-not-enrolled';
 
 // note: this status is not sent from the server
 export const STATUS_PENDING_ENROLLMENT = 'pending-enrollment';
@@ -66,6 +67,7 @@ export const ALL_COURSE_STATUSES = [
   STATUS_WILL_ATTEND,
   STATUS_PENDING_ENROLLMENT,
   STATUS_MISSED_DEADLINE,
+  STATUS_PAID_BUT_NOT_ENROLLED,
 ];
 
 // financial aid statuses

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -614,7 +614,7 @@ export const DASHBOARD_RESPONSE = deepFreeze([
       "prerequisites": "",
       "runs": [{
         "course_id": "course-v1:edX+missed+deadline",
-        "id": 6,
+        "id": 12,
         "status": STATUS_MISSED_DEADLINE,
         "title": "Course run for the missed deadline program",
         "position": 0,
@@ -623,6 +623,28 @@ export const DASHBOARD_RESPONSE = deepFreeze([
       }]
     }],
     "id": 5
+  },
+  {
+    "title": "Paid but not enrolled",
+    "description": "Paid but not enrolled",
+    "courses": [{
+      "id": 14,
+      "position_in_program": 0,
+      "title": "Course for paid but not enrolled program",
+      "description": "Course for paid but not enrolled program",
+      "prerequisites": "",
+      "runs": [{
+        "course_id": "course-v1:edX+paid+not+enrolled",
+        "id": 6,
+        "status": STATUS_PAID_BUT_NOT_ENROLLED,
+        "title": "Course run for paid but not enrolled program",
+        "position": 0,
+        "course_start_date": "2016-01-01",
+        "course_end_date": "2018-09-09T10:20:10Z",
+      }]
+    }],
+    "financial_aid_availability": true,
+    "id": 7
   },
   {
     "title": "Empty program",

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -625,28 +625,6 @@ export const DASHBOARD_RESPONSE = deepFreeze([
     "id": 5
   },
   {
-    "title": "Paid but not enrolled",
-    "description": "Paid but not enrolled",
-    "courses": [{
-      "id": 14,
-      "position_in_program": 0,
-      "title": "Course for paid but not enrolled program",
-      "description": "Course for paid but not enrolled program",
-      "prerequisites": "",
-      "runs": [{
-        "course_id": "course-v1:edX+paid+not+enrolled",
-        "id": 6,
-        "status": STATUS_PAID_BUT_NOT_ENROLLED,
-        "title": "Course run for paid but not enrolled program",
-        "position": 0,
-        "course_start_date": "2016-01-01",
-        "course_end_date": "2018-09-09T10:20:10Z",
-      }]
-    }],
-    "financial_aid_availability": true,
-    "id": 7
-  },
-  {
     "title": "Empty program",
     "description": "The empty program",
     "courses": [
@@ -679,6 +657,31 @@ export const DASHBOARD_RESPONSE = deepFreeze([
     ],
     "financial_aid_availability": false,
     "id": 6
+  },
+  {
+    "title": "Paid but not enrolled",
+    "description": "Paid but not enrolled",
+    "courses": [{
+      "id": 24,
+      "position_in_program": 1,
+      "title": "Course for paid but not enrolled program",
+      "description": "Course for paid but not enrolled program",
+      "prerequisites": "",
+      "runs": [{
+        "position": 1,
+        "course_id": "course-v1:MITx+paid+not+enrolled+100+Jan_2015",
+        "id": 66,
+        "course_start_date": "2016-12-20T00:00:00Z",
+        "course_end_date": "2018-05-15T00:00:00Z",
+        "enrollment_url": "",
+        "fuzzy_start_date": "",
+        "current_grade": null,
+        "title": "Digital Learning 100 - January 2015",
+        "status": STATUS_PAID_BUT_NOT_ENROLLED
+      }]
+    }],
+    "financial_aid_availability": true,
+    "id": 7
   },
 ]);
 

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -25,6 +25,7 @@ import {
   STATUS_NOT_PASSED,
   STATUS_PASSED,
   STATUS_CURRENTLY_ENROLLED,
+  STATUS_PAID_BUT_NOT_ENROLLED,
 } from '../constants';
 import { addCourseEnrollment } from '../actions/course_enrollments';
 import {
@@ -100,11 +101,21 @@ class DashboardPage extends React.Component {
 
   handleOrderSuccess = (course: Course): void => {
     const { dispatch } = this.props;
-    dispatch(setToastMessage({
-      title: 'Order Complete!',
-      message: `You are now enrolled in ${course.title}`,
-      icon: TOAST_SUCCESS,
-    }));
+    let firstRun: CourseRun = course.runs.length > 0 ? course.runs[0] : null;
+
+    if (firstRun && firstRun.status === STATUS_PAID_BUT_NOT_ENROLLED) {
+      dispatch(setToastMessage({
+        title: 'Course Enrollment',
+        message: `Something went wrong. You paid for this course '${course.title}' but are not enrolled.`,
+        icon: TOAST_FAILURE,
+      }));
+    } else {
+      dispatch(setToastMessage({
+        title: 'Order Complete!',
+        message: `You are now enrolled in ${course.title}`,
+        icon: TOAST_SUCCESS,
+      }));
+    }
     this.context.router.push('/dashboard/');
   };
 
@@ -180,6 +191,7 @@ class DashboardPage extends React.Component {
       case STATUS_NOT_PASSED:
       case STATUS_PASSED:
       case STATUS_CURRENTLY_ENROLLED:
+      case STATUS_PAID_BUT_NOT_ENROLLED:
         this.handleOrderSuccess(course);
         break;
       default:

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -39,6 +39,7 @@ import {
   STATUS_CURRENTLY_ENROLLED,
   STATUS_PENDING_ENROLLMENT,
   STATUS_OFFERED,
+  STATUS_PAID_BUT_NOT_ENROLLED,
 } from '../constants';
 import { findCourse } from '../util/test_utils';
 import { DASHBOARD_SUCCESS_ACTIONS } from './test_util';
@@ -158,6 +159,25 @@ describe('DashboardPage', () => {
           title: "Order Complete!",
           message: `You are now enrolled in ${course.title}`,
           icon: TOAST_SUCCESS
+        });
+      });
+    });
+
+    it('shows the toast when the query param is set for a success but user is not enrolled', () => {
+      let course = findCourse(course =>
+        course.runs.length > 0 &&
+        course.runs[0].status === STATUS_PAID_BUT_NOT_ENROLLED
+      );
+      let run = course.runs[0];
+      let encodedKey = encodeURIComponent(run.course_id);
+      return renderComponent(
+        `/dashboard?status=receipt&course_key=${encodedKey}`,
+        SUCCESS_WITH_TOAST_ACTIONS
+      ).then(() => {
+        assert.deepEqual(helper.store.getState().ui.toastMessage, {
+          title: "Course Enrollment",
+          message: `Something went wrong. You paid for this course '${course.title}' but are not enrolled.`,
+          icon: TOAST_FAILURE
         });
       });
     });


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/1568

#### What's this PR do?
- show error message when user paid for course but not enroll.

#### How should this be manually tested?

#### Screenshots (if appropriate)
<img width="768" alt="screen shot 2016-12-09 at 5 50 02 pm" src="https://cloud.githubusercontent.com/assets/10431250/21049763/8a2b776c-be38-11e6-9e06-1dce7c102b76.png">
