### PR TITLE
Disable enroll and pay later button during API activity

### DIFF
--- a/static/js/components/SpinnerButton_test.js
+++ b/static/js/components/SpinnerButton_test.js
@@ -1,0 +1,66 @@
+// @flow
+import React from 'react';
+import { shallow } from 'enzyme';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import Button from 'react-mdl/lib/Button';
+
+import SpinnerButton from './SpinnerButton';
+
+describe("SpinnerButton", () => {
+  let sandbox;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('passes through all props when spinning is false', () => {
+    let onClick = sandbox.stub();
+    let props = {
+      disabled: true,
+      "data-x": "y",
+      onClick: onClick,
+      className: "class1 class2"
+    };
+    let wrapper = shallow(<SpinnerButton
+      component="button"
+      spinning={false}
+      {...props}
+    >
+      childText
+    </SpinnerButton>);
+    let button = wrapper.find("button");
+    let buttonProps = button.props();
+    for (let key of Object.keys(props)) {
+      assert.deepEqual(buttonProps[key], props[key]);
+    }
+    assert.equal(button.children().text(), "childText");
+  });
+
+  it('replaces children with a Spinner, disables onClick and updates className when spinning is true', () => {
+    let onClick = sandbox.stub();
+    let props = {
+      disabled: true,
+      "data-x": "y",
+    };
+    let wrapper = shallow(<SpinnerButton
+      component={Button}
+      spinning={true}
+      onClick={onClick}
+      className="class1 class2"
+      {...props}
+    />);
+    let button = wrapper.find("Button");
+    let buttonProps = button.props();
+    for (let key of Object.keys(props)) {
+      assert.deepEqual(buttonProps[key], props[key]);
+    }
+
+    assert.isUndefined(buttonProps.onClick);
+    assert.equal(buttonProps.className, "class1 class2 disabled-with-spinner");
+    assert.equal(button.children().text(), "<Spinner />");
+  });
+});

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -7,6 +7,8 @@ import Spinner from 'react-mdl/lib/Spinner';
 import R from 'ramda';
 import _ from 'lodash';
 
+import SpinnerButton from '../SpinnerButton';
+import { FETCH_PROCESSING } from '../../actions';
 import type { CourseRun, FinancialAidUserInfo } from '../../flow/programTypes';
 import type { CoursePrice } from '../../flow/dashboardTypes';
 import {
@@ -31,6 +33,7 @@ export default class CourseAction extends React.Component {
     checkout: Function,
     courseRun: CourseRun,
     coursePrice: CoursePrice,
+    courseEnrollAddStatus?: string,
     now: moment$Moment,
     financialAid: FinancialAidUserInfo,
     hasFinancialAid: boolean,
@@ -118,26 +121,29 @@ export default class CourseAction extends React.Component {
 
   renderStatusDescription = this.renderDescription('boxed description');
 
-  handleAddCourseEnrollment = (event: Event, run: CourseRun): void => {
+  handleAddCourseEnrollment = (run: CourseRun): void => {
     const { addCourseEnrollment } = this.props;
-    event.preventDefault();
     addCourseEnrollment(run.course_id);
   };
 
-  renderPayLaterLink(run: CourseRun): React$Element<*> {
+  renderPayLaterLink(run: CourseRun, inFlight: bool): React$Element<*> {
     return (
-      <button
+      <SpinnerButton
+        component="button"
+        spinning={inFlight}
         className="mm-minor-action enroll-pay-later"
-        onClick={e => this.handleAddCourseEnrollment(e, run)} key="2"
+        onClick={() => this.handleAddCourseEnrollment(run)}
+        key="2"
       >
         Enroll and pay later
-      </button>
+      </SpinnerButton>
     );
   }
 
   renderContents(run: CourseRun) {
-    const { now } = this.props;
+    const { now, courseEnrollAddStatus } = this.props;
 
+    const inFlight = courseEnrollAddStatus === FETCH_PROCESSING;
     let action, description;
 
     switch (run.status) {
@@ -169,7 +175,7 @@ export default class CourseAction extends React.Component {
       let enrollmentStartDate = run.enrollment_start_date ? moment(run.enrollment_start_date) : null;
       if (isCurrentlyEnrollable(enrollmentStartDate, now)) {
         action = this.renderEnrollButton(run);
-        description = this.renderPayLaterLink(run);
+        description = this.renderPayLaterLink(run, inFlight);
       } else {
         let text;
         if (enrollmentStartDate) {

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -6,6 +6,7 @@ import moment from 'moment';
 import { assert } from 'chai';
 import sinon from 'sinon';
 
+import { FETCH_PROCESSING } from '../../actions';
 import CourseAction from './CourseAction';
 import {
   DASHBOARD_FORMAT,
@@ -137,9 +138,7 @@ describe('CourseAction', () => {
     assert.equal(elements.linkText, 'Enroll and pay later');
     assertCheckoutButton(elements.button, firstRun.course_id);
 
-    wrapper.find(".enroll-pay-later").simulate('click', {
-      preventDefault: sandbox.stub()
-    });
+    wrapper.find(".enroll-pay-later").simulate('click');
     assert(addCourseEnrollmentStub.calledWith(firstRun.course_id));
   });
 
@@ -420,6 +419,23 @@ describe('CourseAction', () => {
         assert.include(elements.buttonText, 'Pay Now');
         assert.equal(elements.linkText, 'Enroll and pay later');
       });
+    });
+
+    it('shows a spinner in place of the enroll button while API call is in progress', () => {
+      let course = findCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === STATUS_OFFERED
+      ));
+      let firstRun = course.runs[0];
+      const wrapper = renderCourseAction({
+        courseRun: firstRun,
+        courseEnrollAddStatus: FETCH_PROCESSING
+      });
+      let link = wrapper.find(".enroll-pay-later");
+      assert(link.props().className.includes("disabled-with-spinner"));
+      assert(link.find("Spinner"));
+      link.simulate("click");
+      assert.isFalse(addCourseEnrollmentStub.called);
     });
   });
 });

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -51,8 +51,8 @@ describe('CourseAction', () => {
     }
     let description = renderedComponent.find(".description");
     let descriptionText = description.length === 1 ? description.text() : undefined;
-    let link = renderedComponent.find("button.enroll-pay-later");
-    let linkText = link.length === 1 ? link.text() : undefined;
+    let link = renderedComponent.find("SpinnerButton.enroll-pay-later");
+    let linkText = link.length === 1 ? link.children().text() : undefined;
     return {
       button: button,
       buttonText: buttonText,
@@ -431,11 +431,8 @@ describe('CourseAction', () => {
         courseRun: firstRun,
         courseEnrollAddStatus: FETCH_PROCESSING
       });
-      let link = wrapper.find(".enroll-pay-later");
-      assert(link.props().className.includes("disabled-with-spinner"));
-      assert(link.find("Spinner"));
-      link.simulate("click");
-      assert.isFalse(addCourseEnrollmentStub.called);
+      let link = wrapper.find("SpinnerButton.enroll-pay-later");
+      assert.isTrue(link.props().spinning);
     });
   });
 });

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -13,6 +13,7 @@ export default class CourseListCard extends React.Component {
   props: {
     checkout:                     Function,
     program:                      Program,
+    courseEnrollAddStatus?:       string,
     coursePrice:                  CoursePrice,
     openFinancialAidCalculator?:  () => void,
     now?:                         Object,
@@ -27,6 +28,7 @@ export default class CourseListCard extends React.Component {
       checkout,
       openFinancialAidCalculator,
       addCourseEnrollment,
+      courseEnrollAddStatus,
     } = this.props;
     if (now === undefined) {
       now = moment();
@@ -38,6 +40,7 @@ export default class CourseListCard extends React.Component {
         hasFinancialAid={program.financial_aid_availability}
         financialAid={program.financial_aid_user_info}
         course={course}
+        courseEnrollAddStatus={courseEnrollAddStatus}
         coursePrice={coursePrice}
         key={course.id}
         checkout={checkout}

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -4,46 +4,58 @@ import { shallow } from 'enzyme';
 import moment from 'moment';
 import { assert } from 'chai';
 import _ from 'lodash';
+import sinon from 'sinon';
 
 import CourseListCard from './CourseListCard';
 import CourseRow from './CourseRow';
 import { DASHBOARD_RESPONSE, COURSE_PRICES_RESPONSE } from '../../constants';
 
 describe('CourseListCard', () => {
-  let program, defaultCardParams;
+  let program, checkout, sandbox;
   beforeEach(() => {
     program = _.cloneDeep(DASHBOARD_RESPONSE[1]);
     assert(program.courses.length > 0);
+    sandbox = sinon.sandbox.create();
+    checkout = sandbox.stub();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  let renderCourseListCard = (props = {}) => {
     let coursePrice = COURSE_PRICES_RESPONSE.find(
       coursePrice => coursePrice.program_id === program.id
     );
 
-    defaultCardParams = {
-      coursePrice: coursePrice,
-      checkout: () => null,
-      addCourseEnrollment: () => undefined,
-    };
-  });
+    return shallow(
+      <CourseListCard
+        program={program}
+        coursePrice={coursePrice}
+        checkout={checkout}
+        addCourseEnrollment={() => undefined}
+        {...props}
+      />
+    );
+  };
 
   it('creates a CourseRow for each course', () => {
     let now = moment();
-    const wrapper = shallow(
-      <CourseListCard program={program} now={now} {...defaultCardParams} />
-    );
+    const wrapper = renderCourseListCard({
+      now: now
+    });
     assert.equal(wrapper.find(CourseRow).length, program.courses.length);
     let courses = _.sortBy(program.courses, 'position_in_program');
     wrapper.find(CourseRow).forEach((courseRow, i) => {
       const props = courseRow.props();
       assert.equal(props.now, now);
       assert.deepEqual(props.course, courses[i]);
-      assert.equal(props.checkout, defaultCardParams.checkout);
+      assert.equal(props.checkout, checkout);
     });
   });
 
   it("fills in now if it's missing in the props", () => {
-    const wrapper = shallow(
-      <CourseListCard program={program} {...defaultCardParams} />
-    );
+    const wrapper = renderCourseListCard();
     let nows = wrapper.find(CourseRow).map(courseRow => courseRow.props().now);
     assert.isAbove(nows.length, 0);
     for (let now of nows) {
@@ -54,9 +66,7 @@ describe('CourseListCard', () => {
 
   it("doesn't show the personalized pricing box for programs without it", () => {
     program.financial_aid_availability = false;
-    const wrapper = shallow(
-      <CourseListCard program={program} {...defaultCardParams} />
-    );
+    const wrapper = renderCourseListCard();
     assert.equal(wrapper.find('.personalized-pricing').length, 0);
   });
 });

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -19,6 +19,7 @@ export default class CourseRow extends React.Component {
   props: {
     course: Course,
     checkout: Function,
+    courseEnrollAddStatus?: string,
     coursePrice: CoursePrice,
     now: moment$Moment,
     financialAid: FinancialAidUserInfo,
@@ -59,6 +60,7 @@ export default class CourseRow extends React.Component {
       course,
       coursePrice,
       checkout,
+      courseEnrollAddStatus,
       now,
       financialAid,
       hasFinancialAid,
@@ -91,6 +93,7 @@ export default class CourseRow extends React.Component {
           courseRun={run}
           coursePrice={coursePrice}
           checkout={checkout}
+          courseEnrollAddStatus={courseEnrollAddStatus}
           now={now}
           hasFinancialAid={hasFinancialAid}
           financialAid={financialAid}

--- a/static/js/components/dashboard/CourseSubRow.js
+++ b/static/js/components/dashboard/CourseSubRow.js
@@ -17,6 +17,7 @@ import {
 export default class CourseSubRow extends React.Component {
   props: {
     courseRun: CourseRun,
+    courseEnrollAddStatus?: string,
     checkout: Function,
     coursePrice: CoursePrice,
     now: moment$Moment,

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -54,7 +54,7 @@ import type {
   DocumentsState,
 } from '../reducers/documents';
 import type { CoursePricesState, DashboardState } from '../flow/dashboardTypes';
-import type { AvailableProgram } from '../flow/enrollmentTypes';
+import type { AvailableProgram, CourseEnrollmentsState } from '../flow/enrollmentTypes';
 import type { ProfileGetResult } from '../flow/profileTypes';
 import type { Course, CourseRun } from '../flow/programTypes';
 import { skipFinancialAid } from '../actions/financial_aid';
@@ -77,6 +77,7 @@ class DashboardPage extends React.Component {
     documents:                DocumentsState,
     fetchDashboard:           () => void,
     orderReceipt:             OrderReceiptState,
+    courseEnrollments:        CourseEnrollmentsState,
   };
 
   componentDidMount() {
@@ -257,6 +258,7 @@ class DashboardPage extends React.Component {
       documents,
       currentProgramEnrollment,
       ui,
+      courseEnrollments,
     } = this.props;
     const loaded = dashboard.fetchStatus !== FETCH_PROCESSING && prices.fetchStatus !== FETCH_PROCESSING;
     let errorMessage;
@@ -301,6 +303,7 @@ class DashboardPage extends React.Component {
             {financialAidCard}
             <CourseListCard
               program={program}
+              courseEnrollAddStatus={courseEnrollments.courseEnrollAddStatus}
               coursePrice={coursePrice}
               key={program.id}
               checkout={this.dispatchCheckout}
@@ -341,6 +344,7 @@ const mapStateToProps = (state) => {
     ui: state.ui,
     documents: state.documents,
     orderReceipt: state.orderReceipt,
+    courseEnrollments: state.courseEnrollments,
   };
 };
 

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -208,11 +208,18 @@ a.btn {
   }
 }
 
-.dialog {
+.dialog, .course-action {
   .disabled-with-spinner {
     display: inline-block !important;
 
+    .mdl-spinner {
+      height: 20px !important;
+      line-height: 20px !important;
+      width: 20px !important;
+    }
+
     .mdl-spinner__layer {
+      // these are against a white background
       border-color: $button-color !important;
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1752 

#### What's this PR do?
Disable enroll and pay later button during API activity

#### How should this be manually tested?
Unenroll yourself in a course run via edX, then click the link. It should temporarily turn into a spinner and then disappear after successful enroll.