### PR TITLE
Fixes minor layout issue with the userchip

### DIFF
--- a/static/scss/user-chip.scss
+++ b/static/scss/user-chip.scss
@@ -1,10 +1,10 @@
 .mdl-card.user-chip {
   min-height: 0;
-  width: 345px;
+  width: 385px;
   position: absolute;
   display: none;
   top: 10%;
-  left: 170px;
+  left: 250px;
   padding: 12px 24px 16px;
   box-shadow: 2px 3px 15px 0px rgba(0, 0, 0, 0.27);
   border-radius: 0;
@@ -27,11 +27,7 @@
     .employer {
       font-weight: 400;
       color: $font-gray;
-      margin: 0 0 10px 2px;
-    }
-
-    a {
-      margin-left: 2px;
+      margin: 0 0 10px 0;
     }
 
     a:hover {
@@ -52,16 +48,20 @@
     }
   }
 
-  .avatar {
-    width: 93px;
+  .profile-image {
     float: right;
 
-    img {
-      border-radius: 50px;
-      width: 100%;
-      height: auto !important;
-      border: 1px solid rgba(0, 0, 0, 0.15);
+    .avatar {
+      width: 93px;
+      float: right;
+
+      img {
+        border-radius: 50px;
+        width: 100%;
+        height: auto !important;
+        border: 1px solid rgba(0, 0, 0, 0.15);
       }
+    }
   }
 
 }


### PR DESCRIPTION

#### What's this PR do?

This fixes a couple small layout issues with the user chip. First, it moves it slightly to the right so it does not cover up the user name as much in the results table. Then it floats the user image to the right side of the user chip. A couple other minor changes to margins etc.

Before:
![image](https://cloud.githubusercontent.com/assets/20047260/21064874/61cc391c-be2b-11e6-8692-db27019c303a.png)

After:

![image](https://cloud.githubusercontent.com/assets/20047260/21064880/697f13d2-be2b-11e6-91bd-705b7344baf8.png)
