### PR TITLE
Disable the Pay now button during API activity

### DIFF
--- a/static/js/components/SpinnerButton.js
+++ b/static/js/components/SpinnerButton.js
@@ -8,6 +8,7 @@ export default class SpinnerButton extends React.Component {
     className?: string,
     onClick?: Function,
     children?: any,
+    disabled?: ?bool,
   };
 
   render() {
@@ -17,6 +18,7 @@ export default class SpinnerButton extends React.Component {
       className,
       onClick,
       children,
+      disabled,
       ...otherProps
     } = this.props;
 
@@ -27,11 +29,13 @@ export default class SpinnerButton extends React.Component {
       className = `${className} disabled-with-spinner`;
       onClick = undefined;
       children = <Spinner singleColor />;
+      disabled = true;
     }
 
     return <ComponentVariable
       className={className}
       onClick={onClick}
+      disabled={disabled}
       {...otherProps}
     >
       {children}

--- a/static/js/components/SpinnerButton_test.js
+++ b/static/js/components/SpinnerButton_test.js
@@ -20,7 +20,6 @@ describe("SpinnerButton", () => {
   it('passes through all props when spinning is false', () => {
     let onClick = sandbox.stub();
     let props = {
-      disabled: true,
       "data-x": "y",
       onClick: onClick,
       className: "class1 class2"
@@ -38,6 +37,7 @@ describe("SpinnerButton", () => {
       assert.deepEqual(buttonProps[key], props[key]);
     }
     assert.equal(button.children().text(), "childText");
+    assert.isUndefined(buttonProps.disabled);
   });
 
   it('replaces children with a Spinner, disables onClick and updates className when spinning is true', () => {
@@ -61,6 +61,7 @@ describe("SpinnerButton", () => {
 
     assert.isUndefined(buttonProps.onClick);
     assert.equal(buttonProps.className, "class1 class2 disabled-with-spinner");
+    assert.isTrue(buttonProps.disabled);
     assert.equal(button.children().text(), "<Spinner />");
   });
 });

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import moment from 'moment';
 import Button from 'react-mdl/lib/Button';
-import Spinner from 'react-mdl/lib/Spinner';
 import R from 'ramda';
 import _ from 'lodash';
 
@@ -31,6 +30,7 @@ import { ifValidDate } from '../../util/date';
 export default class CourseAction extends React.Component {
   props: {
     checkout: Function,
+    checkoutStatus?: string,
     courseRun: CourseRun,
     coursePrice: CoursePrice,
     courseEnrollAddStatus?: string,
@@ -66,6 +66,7 @@ export default class CourseAction extends React.Component {
   renderEnrollButton(run: CourseRun): React$Element<*> {
     const {
       checkout,
+      checkoutStatus,
       openFinancialAidCalculator
     } = this.props;
     let text = '';
@@ -90,18 +91,16 @@ export default class CourseAction extends React.Component {
       }
     }
 
-    if (run.status === STATUS_PENDING_ENROLLMENT) {
-      buttonProps.disabled = true;
-
-      text = <div className="spinner-container">
-        <Spinner singleColor />
-      </div>;
-    }
-
     return (
-      <Button className="dashboard-button" key="1" {...buttonProps}>
+      <SpinnerButton
+        className="dashboard-button"
+        key="1"
+        component={Button}
+        spinning={run.status === STATUS_PENDING_ENROLLMENT || checkoutStatus === FETCH_PROCESSING}
+        {...buttonProps}
+      >
         {text}
-      </Button>
+      </SpinnerButton>
     );
   }
 

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -329,9 +329,9 @@ describe('CourseAction', () => {
       courseRun: firstRun
     });
 
-    assert.equal(wrapper.text(), "<Button />Processing...");
-    assert.isTrue(wrapper.find("Button").props()['disabled']);
-    assert.equal(wrapper.find("Spinner").length, 1);
+    assert.equal(wrapper.find(".description").text(), "Processing...");
+    let buttonProps = wrapper.find("SpinnerButton").props();
+    assert.isTrue(buttonProps.spinning);
   });
 
   it('hides an invalid date if the user is enrolled and the course has yet to start', () => {
@@ -416,6 +416,8 @@ describe('CourseAction', () => {
         let elements = getElements(wrapper);
 
         assert.isTrue(elements.button.props().disabled);
+        // we don't show a spinner in this case, only for API loads or when waiting for Cybersource callback
+        assert.isFalse(elements.button.props().spinning);
         assert.include(elements.buttonText, 'Pay Now');
         assert.equal(elements.linkText, 'Enroll and pay later');
       });
@@ -432,6 +434,20 @@ describe('CourseAction', () => {
         courseEnrollAddStatus: FETCH_PROCESSING
       });
       let link = wrapper.find("SpinnerButton.enroll-pay-later");
+      assert.isTrue(link.props().spinning);
+    });
+
+    it('shows a spinner in place of the pay button while API call is in progress', () => {
+      let course = findCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === STATUS_CAN_UPGRADE
+      ));
+      let firstRun = course.runs[0];
+      const wrapper = renderCourseAction({
+        courseRun: firstRun,
+        checkoutStatus: FETCH_PROCESSING
+      });
+      let link = wrapper.find(".dashboard-button");
       assert.isTrue(link.props().spinning);
     });
   });

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -12,6 +12,7 @@ import FinancialAidCalculator from '../../containers/FinancialAidCalculator';
 export default class CourseListCard extends React.Component {
   props: {
     checkout:                     Function,
+    checkoutStatus?:              string,
     program:                      Program,
     courseEnrollAddStatus?:       string,
     coursePrice:                  CoursePrice,
@@ -26,6 +27,7 @@ export default class CourseListCard extends React.Component {
       coursePrice,
       now,
       checkout,
+      checkoutStatus,
       openFinancialAidCalculator,
       addCourseEnrollment,
       courseEnrollAddStatus,
@@ -44,6 +46,7 @@ export default class CourseListCard extends React.Component {
         coursePrice={coursePrice}
         key={course.id}
         checkout={checkout}
+        checkoutStatus={checkoutStatus}
         openFinancialAidCalculator={openFinancialAidCalculator}
         now={now}
         addCourseEnrollment={addCourseEnrollment}

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -19,6 +19,7 @@ export default class CourseRow extends React.Component {
   props: {
     course: Course,
     checkout: Function,
+    checkoutStatus?: string,
     courseEnrollAddStatus?: string,
     coursePrice: CoursePrice,
     now: moment$Moment,
@@ -60,6 +61,7 @@ export default class CourseRow extends React.Component {
       course,
       coursePrice,
       checkout,
+      checkoutStatus,
       courseEnrollAddStatus,
       now,
       financialAid,
@@ -93,6 +95,7 @@ export default class CourseRow extends React.Component {
           courseRun={run}
           coursePrice={coursePrice}
           checkout={checkout}
+          checkoutStatus={checkoutStatus}
           courseEnrollAddStatus={courseEnrollAddStatus}
           now={now}
           hasFinancialAid={hasFinancialAid}

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -57,6 +57,7 @@ import type { CoursePricesState, DashboardState } from '../flow/dashboardTypes';
 import type { AvailableProgram, CourseEnrollmentsState } from '../flow/enrollmentTypes';
 import type { ProfileGetResult } from '../flow/profileTypes';
 import type { Course, CourseRun } from '../flow/programTypes';
+import type { CheckoutState } from '../reducers';
 import { skipFinancialAid } from '../actions/financial_aid';
 import { currencyForCountry } from '../lib/currency';
 import DocsInstructionsDialog from '../components/DocsInstructionsDialog';
@@ -78,6 +79,7 @@ class DashboardPage extends React.Component {
     fetchDashboard:           () => void,
     orderReceipt:             OrderReceiptState,
     courseEnrollments:        CourseEnrollmentsState,
+    checkout:                 CheckoutState,
   };
 
   componentDidMount() {
@@ -259,6 +261,7 @@ class DashboardPage extends React.Component {
       currentProgramEnrollment,
       ui,
       courseEnrollments,
+      checkout,
     } = this.props;
     const loaded = dashboard.fetchStatus !== FETCH_PROCESSING && prices.fetchStatus !== FETCH_PROCESSING;
     let errorMessage;
@@ -307,6 +310,7 @@ class DashboardPage extends React.Component {
               coursePrice={coursePrice}
               key={program.id}
               checkout={this.dispatchCheckout}
+              checkoutStatus={checkout.fetchStatus}
               openFinancialAidCalculator={this.openFinancialAidCalculator}
               addCourseEnrollment={this.addCourseEnrollment}
             />
@@ -345,6 +349,7 @@ const mapStateToProps = (state) => {
     documents: state.documents,
     orderReceipt: state.orderReceipt,
     courseEnrollments: state.courseEnrollments,
+    checkout: state.checkout,
   };
 };
 

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -225,10 +225,11 @@
           color: #ffffff;
         }
 
-        .spinner-container {
+        .disabled-with-spinner {
           width: 130px;
-          height: 20px !important;
-          line-height: 20px !important;
+          // mdl-button height is 36px, spinner below is 20px so this should
+          // hackishly vertically center it
+          padding-top: 8px;
 
           .mdl-spinner {
             height: 20px !important;


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1752 
#### What's this PR do?
Disable the 'Pay now' button during API activity

#### How should this be manually tested?
It's probably easiest to mock the methods in `api.js` (see [here](https://gist.github.com/noisecapella/6de5541d42f0334dbae1fa4b45f10b81)) . Once you see the 'Pay now' button, click it. It should show a spinner while it POSTs to the checkout API.

Also verify that the pending enrollment status hasn't changed despite CSS updates. If you're using the mocked data this is the second row from the bottom on Master program