### PR TITLE
Fixed "View on edx" links to wrong URLs

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -329,7 +329,8 @@ def format_courserun_for_dashboard(course_run, status_for_user, mmtrack, positio
         'position': position,
         'course_start_date': course_run.start_date,
         'course_end_date': course_run.end_date,
-        'fuzzy_start_date': course_run.fuzzy_start_date
+        'fuzzy_start_date': course_run.fuzzy_start_date,
+        'enrollment_url': course_run.enrollment_url,
     }
 
     # check if there are extra fields to pull in

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -161,6 +161,7 @@ class FormatRunTest(CourseTests):
             'course_end_date': crun.end_date,
             'fuzzy_start_date': crun.fuzzy_start_date,
             'final_grade': 99.99,
+            'enrollment_url': crun.enrollment_url,
         }
 
         self.assertEqual(
@@ -217,7 +218,8 @@ class FormatRunTest(CourseTests):
                 'position': 1,
                 'course_start_date': crun.start_date,
                 'course_end_date': crun.end_date,
-                'fuzzy_start_date': crun.fuzzy_start_date
+                'fuzzy_start_date': crun.fuzzy_start_date,
+                'enrollment_url': crun.enrollment_url,
             }
         )
 

--- a/static/js/components/dashboard/CourseDescription.js
+++ b/static/js/components/dashboard/CourseDescription.js
@@ -87,7 +87,7 @@ export default class CourseDescription extends React.Component {
     }
     let url = null;
 
-    if (courseRun.course_id && this.isCurrentOrPastEnrolled(courseRun)) {
+    if (this.isCurrentOrPastEnrolled(courseRun)) {
       url = `${EDX_LINK_BASE}${courseRun.course_id}`;
     } else {
       url = courseRun.enrollment_url;

--- a/static/js/components/dashboard/CourseDescription.js
+++ b/static/js/components/dashboard/CourseDescription.js
@@ -68,24 +68,30 @@ export default class CourseDescription extends React.Component {
     return _.compact([dateMessage, additionalDetail]);
   }
 
+  isCurrentOrPastEnrolled = (courseRun: CourseRun): boolean => {
+    if([STATUS_CURRENTLY_ENROLLED, STATUS_PASSED, STATUS_NOT_PASSED].includes(courseRun.status)) {
+      return true;
+    } else {
+      if ([STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE].includes(courseRun.status)) {
+        let now = moment();
+        let courseStart = moment(courseRun.course_start_date);
+        return courseStart.isBefore(now);
+      } else {
+        return false;
+      }
+    }
+  };
+
   renderViewCourseLink = (courseRun: CourseRun): React$Element<*>|null => {
     if (!courseRun || !courseRun.course_id) {
       return null;
     }
-
     let url = null;
-    switch (courseRun.status) {
-    case STATUS_WILL_ATTEND:
-    case STATUS_OFFERED:
-    case STATUS_PENDING_ENROLLMENT:
-      url = courseRun.enrollment_url;
-      break;
-    case STATUS_CAN_UPGRADE:
-    case STATUS_MISSED_DEADLINE:
-      url = courseRun.enrollment_url;
-      break;
-    default:
+
+    if (this.isCurrentOrPastEnrolled(courseRun)) {
       url = `${EDX_LINK_BASE}${courseRun.course_id}`;
+    } else {
+      url = courseRun.enrollment_url;
     }
 
     return url ? <a href={url} target="_blank">View on edX</a> : null;

--- a/static/js/components/dashboard/CourseDescription.js
+++ b/static/js/components/dashboard/CourseDescription.js
@@ -68,13 +68,28 @@ export default class CourseDescription extends React.Component {
     return _.compact([dateMessage, additionalDetail]);
   }
 
-  renderViewCourseLink = (courseRun: CourseRun): React$Element<*>|null => (
-    (courseRun && courseRun.course_id) ?
-      <a href={`${EDX_LINK_BASE}${courseRun.course_id}`} target="_blank">
-        View on edX
-      </a> :
-      null
-  );
+  renderViewCourseLink = (courseRun: CourseRun): React$Element<*>|null => {
+    if (!courseRun || !courseRun.course_id) {
+      return null;
+    }
+
+    let url = null;
+    switch (courseRun.status) {
+    case STATUS_WILL_ATTEND:
+    case STATUS_OFFERED:
+    case STATUS_PENDING_ENROLLMENT:
+      url = courseRun.enrollment_url;
+      break;
+    case STATUS_CAN_UPGRADE:
+    case STATUS_MISSED_DEADLINE:
+      url = courseRun.enrollment_url;
+      break;
+    default:
+      url = `${EDX_LINK_BASE}${courseRun.course_id}`;
+    }
+
+    return url ? <a href={url} target="_blank">View on edX</a> : null;
+  }
 
   render() {
     const { courseRun, courseTitle } = this.props;

--- a/static/js/components/dashboard/CourseDescription.js
+++ b/static/js/components/dashboard/CourseDescription.js
@@ -74,8 +74,7 @@ export default class CourseDescription extends React.Component {
     } else {
       if ([STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE].includes(courseRun.status)) {
         let now = moment();
-        let courseStart = moment(courseRun.course_start_date);
-        return courseStart.isBefore(now);
+        return courseRun.course_start_date && moment(courseRun.course_start_date).isBefore(now);
       } else {
         return false;
       }
@@ -88,7 +87,7 @@ export default class CourseDescription extends React.Component {
     }
     let url = null;
 
-    if (this.isCurrentOrPastEnrolled(courseRun)) {
+    if (courseRun.course_id && this.isCurrentOrPastEnrolled(courseRun)) {
       url = `${EDX_LINK_BASE}${courseRun.course_id}`;
     } else {
       url = courseRun.enrollment_url;

--- a/static/js/components/dashboard/CourseDescription_test.js
+++ b/static/js/components/dashboard/CourseDescription_test.js
@@ -55,7 +55,7 @@ describe('CourseDescription', () => {
 
   it('does not show view the course on edX link if enrollment_url is no define', () => {
     const NOT_ENROLLED_STATUSES =[
-      STATUS_WILL_ATTEND, STATUS_OFFERED, STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE, STATUS_PENDING_ENROLLMENT
+      STATUS_WILL_ATTEND, STATUS_OFFERED, STATUS_PENDING_ENROLLMENT
     ];
 
     for (let status of NOT_ENROLLED_STATUSES) {
@@ -67,6 +67,66 @@ describe('CourseDescription', () => {
       const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
       let elements = getElements(wrapper);
 
+      assert.lengthOf(elements.titleLink, 0);
+    }
+  });
+
+  it('view the course on edX link when course start date is past chages', () => {
+    const EXPECTED_STATUSES = [
+      STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
+    ];
+
+    for (let status of EXPECTED_STATUSES) {
+      let course = findAndCloneCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
+      let firstRun = course.runs[0];
+      firstRun.course_start_date = moment().subtract(2, 'days').format();
+      firstRun.enrollment_url = null;
+      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+      let elements = getElements(wrapper);
+
+      assert.equal(elements.titleLink.text(), 'View on edX');
+      assert.isAbove(elements.titleLink.props().href.length, 0);
+    }
+  });
+
+  it('view the course on edX link when course is not start', () => {
+    const EXPECTED_STATUSES = [
+      STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
+    ];
+
+    for (let status of EXPECTED_STATUSES) {
+      let course = findAndCloneCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
+      let firstRun = course.runs[0];
+      firstRun.course_start_date = moment().add(2, 'days').format();
+      firstRun.enrollment_url = 'http://example.com';
+      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+      let elements = getElements(wrapper);
+      assert.equal(elements.titleLink.text(), 'View on edX');
+      assert.isAbove(elements.titleLink.props().href.length, 0);
+    }
+  });
+
+  it('view the course on edX link when course is not start and enrollment_url not set', () => {
+    const EXPECTED_STATUSES = [
+      STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
+    ];
+
+    for (let status of EXPECTED_STATUSES) {
+      let course = findAndCloneCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
+      let firstRun = course.runs[0];
+      firstRun.course_start_date = moment().add(2, 'days').format();
+      firstRun.enrollment_url = null;
+      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+      let elements = getElements(wrapper);
       assert.lengthOf(elements.titleLink, 0);
     }
   });

--- a/static/js/components/dashboard/CourseDescription_test.js
+++ b/static/js/components/dashboard/CourseDescription_test.js
@@ -53,25 +53,7 @@ describe('CourseDescription', () => {
     }
   });
 
-  it('does not show view the course on edX link if enrollment_url is no define', () => {
-    const NOT_ENROLLED_STATUSES =[
-      STATUS_WILL_ATTEND, STATUS_OFFERED, STATUS_PENDING_ENROLLMENT
-    ];
-
-    for (let status of NOT_ENROLLED_STATUSES) {
-      let course = findAndCloneCourse(course => (
-        course.runs.length > 0 &&
-        course.runs[0].status === status
-      ));
-      let firstRun = course.runs[0];
-      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
-      let elements = getElements(wrapper);
-
-      assert.lengthOf(elements.titleLink, 0);
-    }
-  });
-
-  it('view the course on edX link when course start date is past chages', () => {
+  it('shows a course link for an audited course run that has already started', () => {
     const EXPECTED_STATUSES = [
       STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
     ];
@@ -83,117 +65,42 @@ describe('CourseDescription', () => {
       ));
       let firstRun = course.runs[0];
       firstRun.course_start_date = moment().subtract(2, 'days').format();
+      firstRun.course_id = "example+run";
       firstRun.enrollment_url = null;
       const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
       let elements = getElements(wrapper);
 
-      assert.equal(elements.titleLink.text(), 'View on edX');
-      assert.isAbove(elements.titleLink.props().href.length, 0);
-    }
-  });
-
-  it('show view on edX link when course is not start', () => {
-    const EXPECTED_STATUSES = [
-      STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
-    ];
-
-    for (let status of EXPECTED_STATUSES) {
-      let course = findAndCloneCourse(course => (
-        course.runs.length > 0 &&
-        course.runs[0].status === status
-      ));
-      let firstRun = course.runs[0];
-      firstRun.course_start_date = moment().add(2, 'days').format();
-      firstRun.enrollment_url = 'http://example.com';
-      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
-      let elements = getElements(wrapper);
-      assert.equal(elements.titleLink.text(), 'View on edX');
-      assert.isAbove(elements.titleLink.props().href.length, 0);
-      assert.include(elements.titleLink.props().href, firstRun.enrollment_url);
-    }
-  });
-
-  it('view the course on edX link when course is not start and enrollment_url not set', () => {
-    const EXPECTED_STATUSES = [
-      STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
-    ];
-
-    for (let status of EXPECTED_STATUSES) {
-      let course = findAndCloneCourse(course => (
-        course.runs.length > 0 &&
-        course.runs[0].status === status
-      ));
-      let firstRun = course.runs[0];
-      firstRun.course_start_date = moment().add(2, 'days').format();
-      firstRun.enrollment_url = null;
-      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
-      let elements = getElements(wrapper);
-      assert.lengthOf(elements.titleLink, 0);
-    }
-  });
-
-  it('view the course on edX link when course has no start and enrollment_url is set', () => {
-    const EXPECTED_STATUSES = [
-      STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
-    ];
-
-    for (let status of EXPECTED_STATUSES) {
-      let course = findAndCloneCourse(course => (
-        course.runs.length > 0 &&
-        course.runs[0].status === status
-      ));
-      let firstRun = course.runs[0];
-      firstRun.course_start_date = null;
-      firstRun.enrollment_url = 'http://example.com';
-      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
-      let elements = getElements(wrapper);
-      assert.equal(elements.titleLink.text(), 'View on edX');
-      assert.isAbove(elements.titleLink.props().href.length, 0);
-      assert.include(elements.titleLink.props().href, firstRun.enrollment_url);
-    }
-  });
-
-  it('view the course on edX link when course has no start and enrollment_url is not set', () => {
-    const EXPECTED_STATUSES = [
-      STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
-    ];
-
-    for (let status of EXPECTED_STATUSES) {
-      let course = findAndCloneCourse(course => (
-        course.runs.length > 0 &&
-        course.runs[0].status === status
-      ));
-      let firstRun = course.runs[0];
-      firstRun.course_start_date = null;
-      firstRun.enrollment_url = null;
-      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
-      let elements = getElements(wrapper);
-      assert.lengthOf(elements.titleLink, 0);
-    }
-  });
-
-  it('view the course on edX link when course is already start and enrollment_url is set', () => {
-    const EXPECTED_STATUSES = [
-      STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
-    ];
-
-    for (let status of EXPECTED_STATUSES) {
-      let course = findAndCloneCourse(course => (
-        course.runs.length > 0 &&
-        course.runs[0].status === status
-      ));
-      let firstRun = course.runs[0];
-      firstRun.course_start_date = moment().subtract(2, 'days').format();
-      firstRun.enrollment_url = 'http://example.com';
-      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
-      let elements = getElements(wrapper);
       assert.equal(elements.titleLink.text(), 'View on edX');
       assert.isAbove(elements.titleLink.props().href.length, 0);
       assert.include(elements.titleLink.props().href, firstRun.course_id);
     }
   });
 
-  it('does not show view on edX link when course has current/past statuses and enrollment_url is not set ', () => {
+  it('shows an enrollment link for an audited course run that starts in the future', () => {
+    const EXPECTED_STATUSES = [
+      STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
+    ];
+
+    for (let status of EXPECTED_STATUSES) {
+      let course = findAndCloneCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
+      let firstRun = course.runs[0];
+      const START_DATES_TO_TEST = [moment().add(2, 'days').format(), null];
+      for (let courseStartDate of START_DATES_TO_TEST) {
+        firstRun.course_start_date = courseStartDate;
+        firstRun.enrollment_url = 'http://example.com';
+        const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+        let elements = getElements(wrapper);
+        assert.equal(elements.titleLink.text(), 'View on edX');
+        assert.isAbove(elements.titleLink.props().href.length, 0);
+        assert.include(elements.titleLink.props().href, firstRun.enrollment_url);
+      }
+    }
+  });
+
+  it('shows a course link for an enrolled course run with a course id', () => {
     const EXPECTED_STATUSES = [
       STATUS_CURRENTLY_ENROLLED, STATUS_PASSED, STATUS_NOT_PASSED
     ];
@@ -205,7 +112,7 @@ describe('CourseDescription', () => {
       ));
       let firstRun = course.runs[0];
       firstRun.course_start_date = moment().add(2, 'days').format();
-      firstRun.enrollment_url = null;
+      firstRun.course_id = "example+run";
       const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
       let elements = getElements(wrapper);
       assert.equal(elements.titleLink.text(), 'View on edX');
@@ -227,7 +134,7 @@ describe('CourseDescription', () => {
     assert.lengthOf(elements.titleLink, 0);
   });
 
-  it('show view course on edX link when non-enroll statues and enrollment_url is set', () => {
+  it('shows an enrollment link for an unenrolled course run with an enrollment url', () => {
     const EXPECTED_STATUSES = [
       STATUS_OFFERED, STATUS_PENDING_ENROLLMENT, STATUS_WILL_ATTEND
     ];
@@ -247,7 +154,7 @@ describe('CourseDescription', () => {
     }
   });
 
-  it('does not show view course on edX link when non-enroll statues and enrollment_url is not set', () => {
+  it('does not show an edX link for an unenrolled course run with no enrollment url', () => {
     const EXPECTED_STATUSES = [
       STATUS_OFFERED, STATUS_PENDING_ENROLLMENT, STATUS_WILL_ATTEND
     ];

--- a/static/js/components/dashboard/CourseDescription_test.js
+++ b/static/js/components/dashboard/CourseDescription_test.js
@@ -18,6 +18,8 @@ import {
   STATUS_MISSED_DEADLINE,
   STATUS_CURRENTLY_ENROLLED,
   STATUS_OFFERED,
+  STATUS_WILL_ATTEND,
+  STATUS_PENDING_ENROLLMENT,
   ALL_COURSE_STATUSES,
 } from '../../constants';
 
@@ -35,11 +37,12 @@ describe('CourseDescription', () => {
 
   it('shows the course title and a link to view the course on edX', () => {
     for (let status of ALL_COURSE_STATUSES) {
-      let course = findCourse(course => (
+      let course = findAndCloneCourse(course => (
         course.runs.length > 0 &&
         course.runs[0].status === status
       ));
       let firstRun = course.runs[0];
+      firstRun.enrollment_url = 'http://test.com';
       const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
       let elements = getElements(wrapper);
 
@@ -47,6 +50,24 @@ describe('CourseDescription', () => {
       assert.isAbove(elements.titleLink.length, 0);
       assert.equal(elements.titleLink.text(), 'View on edX');
       assert.isAbove(elements.titleLink.props().href.length, 0);
+    }
+  });
+
+  it('does not show view the course on edX link if enrollment_url is no define', () => {
+    const NOT_ENROLLED_STATUSES =[
+      STATUS_WILL_ATTEND, STATUS_OFFERED, STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE, STATUS_PENDING_ENROLLMENT
+    ];
+
+    for (let status of NOT_ENROLLED_STATUSES) {
+      let course = findAndCloneCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
+      let firstRun = course.runs[0];
+      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+      let elements = getElements(wrapper);
+
+      assert.lengthOf(elements.titleLink, 0);
     }
   });
 

--- a/static/js/components/dashboard/CourseDescription_test.js
+++ b/static/js/components/dashboard/CourseDescription_test.js
@@ -92,7 +92,7 @@ describe('CourseDescription', () => {
     }
   });
 
-  it('view the course on edX link when course is not start', () => {
+  it('show view on edX link when course is not start', () => {
     const EXPECTED_STATUSES = [
       STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
     ];
@@ -109,6 +109,7 @@ describe('CourseDescription', () => {
       let elements = getElements(wrapper);
       assert.equal(elements.titleLink.text(), 'View on edX');
       assert.isAbove(elements.titleLink.props().href.length, 0);
+      assert.include(elements.titleLink.props().href, firstRun.enrollment_url);
     }
   });
 
@@ -131,10 +132,92 @@ describe('CourseDescription', () => {
     }
   });
 
+  it('view the course on edX link when course has no start and enrollment_url is set', () => {
+    const EXPECTED_STATUSES = [
+      STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
+    ];
+
+    for (let status of EXPECTED_STATUSES) {
+      let course = findAndCloneCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
+      let firstRun = course.runs[0];
+      firstRun.course_start_date = null;
+      firstRun.enrollment_url = 'http://example.com';
+      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+      let elements = getElements(wrapper);
+      assert.equal(elements.titleLink.text(), 'View on edX');
+      assert.isAbove(elements.titleLink.props().href.length, 0);
+      assert.include(elements.titleLink.props().href, firstRun.enrollment_url);
+    }
+  });
+
+  it('view the course on edX link when course has no start and enrollment_url is not set', () => {
+    const EXPECTED_STATUSES = [
+      STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
+    ];
+
+    for (let status of EXPECTED_STATUSES) {
+      let course = findAndCloneCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
+      let firstRun = course.runs[0];
+      firstRun.course_start_date = null;
+      firstRun.enrollment_url = null;
+      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+      let elements = getElements(wrapper);
+      assert.lengthOf(elements.titleLink, 0);
+    }
+  });
+
+  it('view the course on edX link when course is already start and enrollment_url is set', () => {
+    const EXPECTED_STATUSES = [
+      STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE
+    ];
+
+    for (let status of EXPECTED_STATUSES) {
+      let course = findAndCloneCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
+      let firstRun = course.runs[0];
+      firstRun.course_start_date = moment().subtract(2, 'days').format();
+      firstRun.enrollment_url = 'http://example.com';
+      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+      let elements = getElements(wrapper);
+      assert.equal(elements.titleLink.text(), 'View on edX');
+      assert.isAbove(elements.titleLink.props().href.length, 0);
+      assert.include(elements.titleLink.props().href, firstRun.course_id);
+    }
+  });
+
+  it('does not show view on edX link when course has current/past statuses and enrollment_url is not set ', () => {
+    const EXPECTED_STATUSES = [
+      STATUS_CURRENTLY_ENROLLED, STATUS_PASSED, STATUS_NOT_PASSED
+    ];
+
+    for (let status of EXPECTED_STATUSES) {
+      let course = findAndCloneCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
+      let firstRun = course.runs[0];
+      firstRun.course_start_date = moment().add(2, 'days').format();
+      firstRun.enrollment_url = null;
+      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+      let elements = getElements(wrapper);
+      assert.equal(elements.titleLink.text(), 'View on edX');
+      assert.isAbove(elements.titleLink.props().href.length, 0);
+      assert.include(elements.titleLink.props().href, firstRun.course_id);
+    }
+  });
+
   it('does not show a link to view the course on edX if the course run lacks an id', () => {
     let course = findAndCloneCourse(course => (
       course.runs.length > 0 &&
-      course.runs[0].status === STATUS_OFFERED
+      course.runs[0].status === STATUS_PASSED
     ));
     let firstRun = course.runs[0];
     firstRun.course_id = null;
@@ -142,6 +225,44 @@ describe('CourseDescription', () => {
     let elements = getElements(wrapper);
 
     assert.lengthOf(elements.titleLink, 0);
+  });
+
+  it('show view course on edX link when non-enroll statues and enrollment_url is set', () => {
+    const EXPECTED_STATUSES = [
+      STATUS_OFFERED, STATUS_PENDING_ENROLLMENT, STATUS_WILL_ATTEND
+    ];
+
+    for (let status of EXPECTED_STATUSES) {
+      let course = findAndCloneCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
+      let firstRun = course.runs[0];
+      firstRun.enrollment_url = 'http://example.com';
+      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+      let elements = getElements(wrapper);
+      assert.equal(elements.titleLink.text(), 'View on edX');
+      assert.isAbove(elements.titleLink.props().href.length, 0);
+      assert.include(elements.titleLink.props().href, firstRun.enrollment_url);
+    }
+  });
+
+  it('does not show view course on edX link when non-enroll statues and enrollment_url is not set', () => {
+    const EXPECTED_STATUSES = [
+      STATUS_OFFERED, STATUS_PENDING_ENROLLMENT, STATUS_WILL_ATTEND
+    ];
+
+    for (let status of EXPECTED_STATUSES) {
+      let course = findAndCloneCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === status
+      ));
+      let firstRun = course.runs[0];
+      firstRun.enrollment_url = null;
+      const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
+      let elements = getElements(wrapper);
+      assert.lengthOf(elements.titleLink, 0);
+    }
   });
 
   it('does show date with status passed', () => {

--- a/static/js/components/dashboard/CourseDescription_test.js
+++ b/static/js/components/dashboard/CourseDescription_test.js
@@ -42,7 +42,7 @@ describe('CourseDescription', () => {
         course.runs[0].status === status
       ));
       let firstRun = course.runs[0];
-      firstRun.enrollment_url = 'http://test.com';
+      firstRun.enrollment_url = 'http://example.com';
       const wrapper = shallow(<CourseDescription courseRun={firstRun} courseTitle={course.title} />);
       let elements = getElements(wrapper);
 


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2064

#### How should this be manually tested?
- from admin panel, go to course run and set ``enrollment_url``
- then see course where you are not enrolled. open link it will take you to your entered url.
- then see course where you are enrolled, it will take you to course.
- remove ``enrollment_url`` from same course run on admin panel
- see link will not visible.

