### PR TITLE
Check for cross-domain security for Zendesk widget

### DIFF
--- a/static/js/entry/zendesk_widget.js
+++ b/static/js/entry/zendesk_widget.js
@@ -188,10 +188,22 @@ const zendeskPollForExistence = (name) => {
 
 const zendeskPollForLoaded = (name) => {
   let tries = 0;
+  let iframeDocument = null;
   const intervalID = setInterval(() => {
     tries += 1;
     const iframe = document.querySelector(`iframe.zEWidget-${name}`);
-    const div = iframe.contentDocument.querySelector("div");
+    try {
+      iframeDocument = iframe.contentDocument;
+    } catch (err) {
+      // cross-domain exception: can't continue
+    }
+    if (!iframeDocument) {
+      console.error(`Can't access content of Zendesk iframe: ${name}`);  // eslint-disable-line no-console
+      clearInterval(intervalID);
+      return;
+    }
+
+    const div = iframeDocument.querySelector("div");
     if (div) {
       clearInterval(intervalID);
       const callback = zendeskCallbacks[`${name}Loaded`];


### PR DESCRIPTION
Fixes #2074. It appears that sometimes, the Zendesk web widget loads with HTTP headers that instruct the browser to increase cross-domain security. When that happens, our Javascript is unable to modify the Zendesk web widget at all, and the browser raises an exception every time it tries. These exceptions go to Sentry, and clog up the exception logs.

This pull request mades the code more defensive, check to see if it can modify the iframe before doing so. If it can't, it doesn't even try. This should prevent these errors from going to Sentry, but it does _not_ solve the underlying problem of being unable to modify the Zendesk web widget.