### PR TITLE
limit the number of options displayed for country of birth

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -165,6 +165,7 @@ export default class LearnerSearch extends SearchkitComponent {
             field="profile.birth_country"
             operator="OR"
             itemComponent={CountryRefinementOption}
+            size={15}
           />
         </FilterVisibilityToggle>
         <FilterVisibilityToggle


### PR DESCRIPTION
## testing

here's a quick way to set a separate birth country for each user.

first, save the following as `codes.js`:

```js
var fs = require('fs')
var iso = require('iso-3166-2')

let codes = Object.values(iso.codes)

console.log(codes.join("\n"))
```

then, save the following as `codes.py`:

```py
from django.contrib.auth.models import User

with (open("codes.txt")) as f:
    codes = f.read().splitlines()

for user in User.objects.all():
    user.profile.birth_country = codes[user.id % len(codes)]
    user.profile.save()
```

Then do:

```sh
node codes.js > codes.txt
```

open the django shell and type:

```py
exec(open("codes.py").read())
```

that should do it!