### PR TITLE
Fixed faulty hiding for facets that use nested fields

### DIFF
--- a/static/js/components/search/FilterVisibilityToggle.js
+++ b/static/js/components/search/FilterVisibilityToggle.js
@@ -22,11 +22,20 @@ export default class FilterVisibilityToggle extends SearchkitComponent {
     return checkFilterVisibility(filterName) ? "" : "closed";
   };
 
-  isInResults: Function = (id: string): boolean => {
-    if (this.getResults()) {
-      const elmId = FILTER_ID_ADJUST[id] || id;
-      const docCount = _.get(this.getResults(), ['aggregations', elmId, 'doc_count'], 0);
+  getChildFacetDocCount: Function = (results: Object, resultId: string): number => {
+    const elementResult = _.get(results, ['aggregations', resultId]);
+    if (elementResult['inner']) {
+      return elementResult['inner']['doc_count'];
+    } else {
+      return elementResult['doc_count'];
+    }
+  };
 
+  isInResults: Function = (id: string): boolean => {
+    let results = this.getResults();
+    if (results) {
+      const resultId = FILTER_ID_ADJUST[id] || id;
+      const docCount = this.getChildFacetDocCount(results, resultId);
       if (docCount > 0) {
         return true;
       }


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #2062 

#### What's this PR do?

The course facet queries against a nested field ("enrollments"). Nested field results contain a `doc_count` that equals the total number of docs returned, and an `inner` element that indicates the number of docs that matched the nested query. We didn't have logic for hiding search facets on empty 'inner' results for nested fields. This PR fixes that

#### How should this be manually tested?

1. Seed the db and give yourself staff permissions on the fake programs (`./manage.py seed_db --staff-user=YOUR_USER`)
1. Go into a Django shell and run the following:
    ```python
    from dashboard.models import CachedEnrollment
    from courses.models import Program
    analog_program = Program.objects.get(title__startswith='Analog')
    CachedEnrollment.objects.filter(user__profile__birth_country='ES', course_run__course__program=analog_program).delete()
    ```
1. Recreate the index
1. Load 'Analog Program' in the learner's search page and select "Spain" in the "Country of Birth" facet
1. Confirm that the "Course" facet is hidden due to no matching users with enrollments

#### Any background context you want to provide?

This was a quick fix with a low burden for code review, hence the fast-tracking

#### Screenshots (if appropriate)

![ss 2016-12-12 at 12 39 51](https://cloud.githubusercontent.com/assets/14932219/21109685/1d2899f6-c068-11e6-8fe0-191dded5df66.png)



