### PR TITLE
only use https in npm-shrinkwrap (security vulnerability fix)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5174,7 +5174,7 @@
     "raven-js": {
       "version": "3.8.1",
       "from": "raven-js@3.8.1",
-      "resolved": "http://registry.npmjs.org/raven-js/-/raven-js-3.8.1.tgz"
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.8.1.tgz"
     },
     "rc": {
       "version": "1.1.6",


### PR DESCRIPTION
fixes this problem: 

https://hackernoon.com/npm-shrinkwrap-allows-remote-code-execution-63e6e0a566a7#.h0me122hf