### PR TITLE
only run the getCroppedCanvas method if this.refs.cropper is defined

### DIFF
--- a/static/js/components/CropperWrapper.js
+++ b/static/js/components/CropperWrapper.js
@@ -13,22 +13,24 @@ export default class CropperWrapper extends React.Component {
   cropperHelper = () => {
     const { updatePhotoEdit } = this.props;
     let canvas;
-    if ( browser.name === 'safari' || browser.name === 'ios' ) {
-      canvas = this.refs.cropper.getCroppedCanvas();
-    } else {
-      canvas = this.refs.cropper.getCroppedCanvas({
-        width: 512,
-        height: 512,
-      });
+    if ( this.cropper ) {
+      if ( browser.name === 'safari' || browser.name === 'ios' ) {
+        canvas = this.cropper.getCroppedCanvas();
+      } else {
+        canvas = this.cropper.getCroppedCanvas({
+          width: 512,
+          height: 512,
+        });
+      }
+      canvas.toBlob(blob => updatePhotoEdit(blob), 'image/jpeg');
     }
-    canvas.toBlob(blob => updatePhotoEdit(blob), 'image/jpeg');
   };
 
   render () {
     const { photo, uploaderBodyHeight } = this.props;
 
     return <Cropper
-      ref='cropper'
+      ref={cropper => this.cropper = cropper}
       style={{'height': uploaderBodyHeight()}}
       className="photo-active-item cropper"
       src={photo.preview}


### PR DESCRIPTION
closes #2096

This fixes an error that I think is related to a subtle race condition with how we take down the photo upload dialog. We pass a callback (`ready`) to the `<Cropper />` component, which is something that fires when the image finishes loading. We do this so that as soon as the user's picture is loaded they can click 'save' in order to save it (without that the user would need to make at least one edit to the picture in order to save it). I think what is happening is that after the upload request is successfully completed, we dispatch the `CLEAR_PHOTO_EDIT` action, which forces a redraw of the `<Cropper />` element (because the `photo` prop passed in to it changes). Then the `ready` callback will be called, but I think what's happening is that the dialog closes at the same time, so that, in the function, `this.refs.cropper` is no longer present.

All this PR does to fix this is just check if `this.refs.cropper` is present before we try to call any methods on it.

To test this just ensure that you can upload a photo, and that there are no exceptions after the photo upload has finished. The bug this fixes should repro on master right now, where basically after the upload is finished you'll see three errors like this:

![errors_canvas](https://cloud.githubusercontent.com/assets/6207644/21148664/f62924d2-c126-11e6-8d5a-45ccc5828aca.png)
