### PR TITLE
Limited the birth country facet to 15 options

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -165,6 +165,7 @@ export default class LearnerSearch extends SearchkitComponent {
             field="profile.birth_country"
             operator="OR"
             itemComponent={CountryRefinementOption}
+            size={15}
           />
         </FilterVisibilityToggle>
         <FilterVisibilityToggle


### PR DESCRIPTION
this is part of #2038, just taking care of the easier case. we'll come back for the 'current residence' facet later.

![expander](https://cloud.githubusercontent.com/assets/6207644/21148861/9bb64740-c127-11e6-8b19-ff7ce81a74ac.png)

![expanded](https://cloud.githubusercontent.com/assets/6207644/21148881/aa677692-c127-11e6-96f6-2ccd0cf9ee92.png)

copying what I wrote about test data on #2078:


first, save the following as `codes.js`:

```js
var fs = require('fs')
var iso = require('iso-3166-2')

let codes = Object.values(iso.codes)

console.log(codes.join("\n"))
```

then, save the following as `codes.py`:

```py
from django.contrib.auth.models import User

with (open("codes.txt")) as f:
    codes = f.read().splitlines()

for user in User.objects.all():
    user.profile.birth_country = codes[user.id % len(codes)]
    user.profile.save()
```

Then do:

```sh
node codes.js > codes.txt
```

open the django shell and type:

```py
exec(open("codes.py").read())
```
