### PR TITLE
ensure that query is reset when changing programs

### DIFF
--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -29,6 +29,7 @@ export default class ProgramFilter extends SearchkitComponent {
   componentDidUpdate(prevProps: Object): void {
     if (!_.isEqual(prevProps.currentProgramEnrollment, this.props.currentProgramEnrollment)) {
       // (╯°□°)╯︵ ┻━┻
+      this.context.searchkit.resetState();
       this.context.searchkit.reloadSearch();
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2090

#### What's this PR do?

This ensures that we call the `resetState` method before the `reloadSearch` method in `<ProgramFilter />`. `resetState` clears the current UI state (things selected and so on) and `reloadSearch` causes searchkit to perform a new search.

#### How should this be manually tested?

Go to the search page and select a value for, say, country. You should then be able to switch countries, and the search UI will reset to it's normal state.