### PR TITLE
Replace utcnow() with now(tz=pytz.UTC)

### DIFF
--- a/backends/edxorg.py
+++ b/backends/edxorg.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from urllib.parse import urljoin
 
 from django.conf import settings
+import pytz
 from social.backends.oauth import BaseOAuth2
 
 
@@ -105,5 +106,5 @@ class EdxOrgOAuth2(BaseOAuth2):
             dict of information about the user
         """
         response = super(EdxOrgOAuth2, self).refresh_token(token, *args, **kwargs)
-        response['updated_at'] = datetime.utcnow().timestamp()
+        response['updated_at'] = datetime.now(tz=pytz.UTC).timestamp()
         return response

--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from urllib.parse import urljoin
 
+import pytz
 from rolepermissions.verifications import has_role
 
 from backends.edxorg import EdxOrgOAuth2
@@ -140,5 +141,5 @@ def set_last_update(details, *args, **kwargs):  # pylint: disable=unused-argumen
     Returns:
         dict: updated details dictionary
     """
-    details['updated_at'] = datetime.utcnow().timestamp()
+    details['updated_at'] = datetime.now(tz=pytz.UTC).timestamp()
     return details

--- a/backends/utils.py
+++ b/backends/utils.py
@@ -2,6 +2,7 @@
 Utility functions for the backends
 """
 from datetime import datetime, timedelta
+import pytz
 
 from requests.exceptions import HTTPError
 from social.apps.django_app.utils import load_strategy
@@ -39,12 +40,12 @@ def refresh_user_token(user_social):
         user_social (UserSocialAuth): a user social auth instance
     """
     try:
-        last_update = datetime.fromtimestamp(user_social.extra_data.get('updated_at'))
+        last_update = datetime.fromtimestamp(user_social.extra_data.get('updated_at'), tz=pytz.UTC)
         expires_in = timedelta(seconds=user_social.extra_data.get('expires_in'))
     except TypeError:
         _send_refresh_request(user_social)
         return
     # small error margin of 5 minutes to be safe
     error_margin = timedelta(minutes=5)
-    if datetime.utcnow() - last_update >= expires_in - error_margin:
+    if datetime.now(tz=pytz.UTC) - last_update >= expires_in - error_margin:
         _send_refresh_request(user_social)

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -15,6 +15,7 @@ from django.db import transaction
 from django.http.response import Http404
 from django.shortcuts import get_object_or_404
 from edx_api.client import EdxApi
+import pytz
 from rest_framework.exceptions import ValidationError
 
 from backends.edxorg import EdxOrgOAuth2
@@ -205,7 +206,7 @@ def generate_cybersource_sa_payload(order, dashboard_url):
         ),
         'reference_number': make_reference_id(order),
         'profile_id': settings.CYBERSOURCE_PROFILE_ID,
-        'signed_date_time': datetime.utcnow().strftime(ISO_8601_FORMAT),
+        'signed_date_time': datetime.now(tz=pytz.UTC).strftime(ISO_8601_FORMAT),
         'transaction_type': 'sale',
         'transaction_uuid': uuid.uuid4().hex,
         'unsigned_field_names': '',

--- a/financialaid/api_test.py
+++ b/financialaid/api_test.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.models.signals import post_save
 from django.test import TestCase
 from factory.django import mute_signals
+import pytz
 
 from courses.factories import ProgramFactory, CourseFactory, CourseRunFactory
 from dashboard.models import ProgramEnrollment
@@ -47,7 +48,7 @@ def create_program(create_tiers=True):
     )
     course = CourseFactory.create(program=program)
     course_run = CourseRunFactory.create(
-        enrollment_end=datetime.utcnow() + timedelta(hours=1),
+        enrollment_end=datetime.now(tz=pytz.UTC) + timedelta(hours=1),
         course=course
     )
     CoursePriceFactory.create(

--- a/micromasters/models.py
+++ b/micromasters/models.py
@@ -14,6 +14,7 @@ from django.db.models import (
     SET_NULL,
 )
 from django.db.models.query import QuerySet
+import pytz
 
 
 class TimestampedModelQuerySet(QuerySet):
@@ -27,7 +28,7 @@ class TimestampedModelQuerySet(QuerySet):
         database level without loading objects into memory.
         """
         if "updated_on" not in kwargs:
-            kwargs["updated_on"] = datetime.datetime.utcnow()
+            kwargs["updated_on"] = datetime.datetime.now(tz=pytz.UTC)
         return super().update(**kwargs)
 
 

--- a/seed_data/lib.py
+++ b/seed_data/lib.py
@@ -4,6 +4,7 @@ Library functions for interacting with test data
 import re
 from datetime import datetime, timedelta
 from functools import wraps
+import pytz
 
 from django.contrib.auth.models import User
 from courses.models import Program, Course
@@ -165,7 +166,7 @@ class CachedHandler(object):
         if not created:
             obj.data = data
             obj.save()
-        CachedEdxDataApi.update_cache_last_access(self.user, self.cache_type, timestamp=datetime.utcnow())
+        CachedEdxDataApi.update_cache_last_access(self.user, self.cache_type, timestamp=datetime.now(tz=pytz.UTC))
         return obj
 
     def find(self, course_run):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1960

#### What's this PR do?
Fixes datetime handling to use a specific timezone. It doesn't look like this was causing problems for us since `timestamp()` returns the same value for a naive datetime and one set to `UTC`, but it may prevent problems in the future if we're explicit.

#### How should this be manually tested?
There shouldn't be any change of behavior