### PR TITLE
Disable document sent button during API activity

### DIFF
--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -93,7 +93,7 @@ export default class CourseAction extends React.Component {
 
     return (
       <SpinnerButton
-        className="dashboard-button"
+        className="dashboard-button pay-button"
         key="1"
         component={Button}
         spinning={run.status === STATUS_PENDING_ENROLLMENT || checkoutStatus === FETCH_PROCESSING}

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -44,7 +44,7 @@ describe('CourseAction', () => {
   });
 
   let getElements = (renderedComponent) => {
-    let button = renderedComponent.find(".dashboard-button");
+    let button = renderedComponent.find(".pay-button");
     let buttonText;
     if (button.length > 0 && button.children().length > 0) {
       buttonText = button.children().text();
@@ -447,8 +447,8 @@ describe('CourseAction', () => {
         courseRun: firstRun,
         checkoutStatus: FETCH_PROCESSING
       });
-      let link = wrapper.find(".dashboard-button");
-      assert.isTrue(link.props().spinning);
+      let button = wrapper.find(".pay-button");
+      assert.isTrue(button.props().spinning);
     });
   });
 });

--- a/static/js/components/dashboard/CourseSubRow_test.js
+++ b/static/js/components/dashboard/CourseSubRow_test.js
@@ -74,7 +74,7 @@ describe('CourseSubRow', () => {
     assert.include(wrapper.find(".course-description").html(), "Enrollment open");
     assert.equal(wrapper.find(".course-grade").text().trim(), "");
     let actionCell = wrapper.find(".course-action");
-    assert.equal(actionCell.find("button.dashboard-button").text(), "Calculate Cost");
+    assert.equal(actionCell.find("button.pay-button").text(), "Calculate Cost");
     assert.equal(actionCell.find("button.enroll-pay-later").text(), "Enroll and pay later");
   });
 

--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -7,6 +7,8 @@ import Icon from 'react-mdl/lib/Icon';
 import DatePicker from 'react-datepicker';
 import moment from 'moment';
 
+import { FETCH_PROCESSING } from '../../actions';
+import SpinnerButton from '../SpinnerButton';
 import type { CoursePrice } from '../../flow/dashboardTypes';
 import type { Program } from '../../flow/programTypes';
 import type {
@@ -56,7 +58,10 @@ export default class FinancialAidCard extends React.Component {
   renderDocumentStatus() {
     const {
       setDocumentSentDate,
-      documents,
+      documents: {
+        documentSentDate,
+        fetchStatus,
+      },
       program: {
         financial_aid_user_info: {
           application_status: applicationStatus,
@@ -83,12 +88,17 @@ export default class FinancialAidCard extends React.Component {
         <Grid className="document-row">
           <Cell col={12}>
             <DatePicker
-              selected={moment(documents.documentSentDate)}
+              selected={moment(documentSentDate)}
               onChange={(obj) => setDocumentSentDate(obj.format(ISO_8601_FORMAT))}
             />
-            <Button className="dashboard-button" onClick={this.submitDocuments}>
+            <SpinnerButton
+              className="dashboard-button document-sent-button"
+              component={Button}
+              onClick={this.submitDocuments}
+              spinning={fetchStatus === FETCH_PROCESSING}
+            >
               Submit
-            </Button>
+            </SpinnerButton>
           </Cell>
         </Grid>
       </div>;
@@ -122,7 +132,7 @@ export default class FinancialAidCard extends React.Component {
       </div>
       <div className="pricing-actions">
         <button
-          className="mdl-button dashboard-button"
+          className="mdl-button dashboard-button calculate-cost-button"
           onClick={openFinancialAidCalculator}
         >
           Calculate your cost

--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -81,12 +81,12 @@ export default class FinancialAidCard extends React.Component {
     case FA_STATUS_PENDING_DOCS:
       return <div>
         <Grid>
-          <Cell col={12}>
+          <Cell col={12} >
             Please tell us the date you sent the documents
           </Cell>
         </Grid>
         <Grid className="document-row">
-          <Cell col={12}>
+          <Cell col={12} className="document-sent-button-container">
             <DatePicker
               selected={moment(documentSentDate)}
               onChange={(obj) => setDocumentSentDate(obj.format(ISO_8601_FORMAT))}

--- a/static/js/components/dashboard/FinancialAidCard_test.js
+++ b/static/js/components/dashboard/FinancialAidCard_test.js
@@ -8,6 +8,7 @@ import moment from 'moment';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
+import { FETCH_PROCESSING } from '../../actions';
 import FinancialAidCard from './FinancialAidCard';
 import {
   DASHBOARD_RESPONSE,
@@ -91,7 +92,7 @@ describe("FinancialAidCard", () => {
       const program = programWithStatus();
       program.financial_aid_user_info.has_user_applied = false;
       let wrapper = renderCard({ program });
-      let button = wrapper.find(".dashboard-button");
+      let button = wrapper.find(".calculate-cost-button");
       assert.equal(button.text(), "Calculate your cost");
       button.simulate('click');
       assert.ok(openFinancialAidCalculatorStub.calledWith());
@@ -190,9 +191,27 @@ describe("FinancialAidCard", () => {
         updateDocumentSentDate.returns(Promise.resolve());
         let wrapper = renderCard({ program, updateDocumentSentDate });
 
-        wrapper.find(".dashboard-button").simulate('click');
+        wrapper.find(".document-sent-button").simulate('click');
         assert(updateDocumentSentDate.calledWith(123, '2011-11-11'));
       });
+
+      for (let activity of [true, false]) {
+        it(`has a document sent button with API activity = ${activity.toString()}`, () => {
+          let program = programWithStatus(FA_STATUS_PENDING_DOCS);
+
+          let wrapper = renderCard({
+            program,
+            documents: {
+              documentSentDate: '2011-11-11',
+              fetchStatus: activity ? FETCH_PROCESSING : undefined,
+            },
+          });
+
+          let button = wrapper.find("SpinnerButton");
+          assert(button.props().className.includes("document-sent-button"));
+          assert.equal(button.props().spinning, activity);
+        });
+      }
 
       for (let status of [FA_STATUS_DOCS_SENT, FA_STATUS_PENDING_MANUAL_APPROVAL]) {
         it(`shows the document sent date for status ${status}`, () => {

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -65,7 +65,7 @@ describe('FinancialAidCalculator', () => {
 
   it('should let you open and close the financial aid calculator', () => {
     return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
-      wrapper.find('.pricing-actions').find('.dashboard-button').simulate('click');
+      wrapper.find('.pricing-actions').find('.calculate-cost-button').simulate('click');
       assert.equal(helper.store.getState().ui.calculatorDialogVisibility, true);
       let calculator = document.querySelector('.financial-aid-calculator');
 
@@ -92,7 +92,7 @@ describe('FinancialAidCalculator', () => {
         RECEIVE_DASHBOARD_SUCCESS,
         SET_CONFIRM_SKIP_DIALOG_VISIBILITY,
       ], () => {
-        wrapper.find('.pricing-actions').find('.dashboard-button').simulate('click');
+        wrapper.find('.pricing-actions').find('.calculate-cost-button').simulate('click');
         assert.equal(helper.store.getState().ui.calculatorDialogVisibility, true);
         let calculator = document.querySelector('.financial-aid-calculator-wrapper');
         TestUtils.Simulate.click(calculator.querySelector('.full-price'));
@@ -116,7 +116,7 @@ describe('FinancialAidCalculator', () => {
         UPDATE_CALCULATOR_VALIDATION,
         UPDATE_CALCULATOR_EDIT
       ], () => {
-        wrapper.find('.pricing-actions').find('.dashboard-button').simulate('click');
+        wrapper.find('.pricing-actions').find('.calculate-cost-button').simulate('click');
         modifyTextField(document.querySelector('#user-salary-input'), '1000');
       }).then(() => {
         assert.deepEqual(helper.store.getState().financialAid, {
@@ -150,7 +150,7 @@ describe('FinancialAidCalculator', () => {
         UPDATE_CALCULATOR_VALIDATION,
         UPDATE_CALCULATOR_EDIT,
       ], () => {
-        wrapper.find('.pricing-actions').find('.dashboard-button').simulate('click');
+        wrapper.find('.pricing-actions').find('.calculate-cost-button').simulate('click');
         clearSelectField(document.querySelector('.currency'));
         TestUtils.Simulate.click(document.querySelector('.financial-aid-calculator .save-button'));
       }).then(() => {
@@ -176,7 +176,7 @@ describe('FinancialAidCalculator', () => {
         UPDATE_CALCULATOR_VALIDATION,
         UPDATE_CALCULATOR_EDIT,
       ], () => {
-        wrapper.find('.pricing-actions').find('.dashboard-button').simulate('click');
+        wrapper.find('.pricing-actions').find('.calculate-cost-button').simulate('click');
         let select = document.querySelector('.currency');
         modifySelectField(select, 'GBP');
       }).then(() => {
@@ -215,7 +215,7 @@ describe('FinancialAidCalculator', () => {
         RECEIVE_DASHBOARD_SUCCESS,
         CLEAR_CALCULATOR_EDIT,
       ], () => {
-        wrapper.find('.pricing-actions').find('.dashboard-button').simulate('click');
+        wrapper.find('.pricing-actions').find('.calculate-cost-button').simulate('click');
         let calculator = document.querySelector('.financial-aid-calculator');
         TestUtils.Simulate.change(calculator.querySelector('.mdl-checkbox__input'));
         modifyTextField(document.querySelector('#user-salary-input'), '1000');
@@ -246,7 +246,7 @@ describe('FinancialAidCalculator', () => {
         REQUEST_ADD_FINANCIAL_AID,
         RECEIVE_ADD_FINANCIAL_AID_FAILURE,
       ], () => {
-        wrapper.find('.pricing-actions').find('.dashboard-button').simulate('click');
+        wrapper.find('.pricing-actions').find('.calculate-cost-button').simulate('click');
         let calculator = document.querySelector('.financial-aid-calculator');
         TestUtils.Simulate.change(calculator.querySelector('.mdl-checkbox__input'));
         modifyTextField(document.querySelector('#user-salary-input'), '1000');

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -208,9 +208,10 @@ a.btn {
   }
 }
 
-.dialog, .course-action {
+.dialog, .course-action, .document-sent-button-container {
   .disabled-with-spinner {
     display: inline-block !important;
+    box-shadow: none;
 
     .mdl-spinner {
       height: 20px !important;


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1752

#### What's this PR do?
Disables the document sent button during API activity

#### How should this be manually tested?
Apply for financial aid, then click the button which submits the document sent date. It should show a spinner and be unclickable during that time.