### PR TITLE
Created course payment status facet

### DIFF
--- a/dashboard/factories_test.py
+++ b/dashboard/factories_test.py
@@ -1,0 +1,40 @@
+"""
+Tests for dashboard factories
+"""
+from django.db.models.signals import post_save
+from django.test import TestCase
+from factory.django import mute_signals
+
+from ecommerce.models import Line, Order
+from micromasters.factories import UserFactory
+from courses.factories import ProgramFactory
+from dashboard.factories import CachedEnrollmentVerifiedFactory
+
+
+class DashboardFactoryTests(TestCase):
+    """
+    Tests for dashboard factories
+    """
+    def test_verified_enroll_factory_fa_create(self):  # pylint: disable=no-self-use
+        """
+        Tests that CachedEnrollmentVerifiedFactory creates additional data for a FA-enabled course run
+        """
+        assert Line.objects.count() == 0
+        with mute_signals(post_save):
+            user = UserFactory.create()
+        fa_program = ProgramFactory.create(financial_aid_availability=True)
+        CachedEnrollmentVerifiedFactory.create(user=user, course_run__course__program=fa_program)
+        lines = Line.objects.all()
+        assert len(lines) == 1
+        assert lines[0].order.status == Order.FULFILLED
+
+    def test_verified_enrollment_factory_fa_build(self):  # pylint: disable=no-self-use
+        """
+        Tests that CachedEnrollmentVerifiedFactory does not run post-generation on .build()
+        """
+        assert Line.objects.count() == 0
+        with mute_signals(post_save):
+            user = UserFactory.create()
+        fa_program = ProgramFactory.create(financial_aid_availability=True)
+        CachedEnrollmentVerifiedFactory.build(user=user, course_run__course__program=fa_program)
+        assert Line.objects.count() == 0

--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -12,17 +12,30 @@ class UserProgramSearchSerializer:
     Provides functions for serializing a ProgramEnrollment for the ES index
     """
     @classmethod
-    def serialize_enrollments(cls, enrollments):
+    def serialize_enrollments(cls, mmtrack, enrollments):
         """
         Serializes a user's enrollment data for search results
 
         Args:
+            mmtrack (MMTrack): An MMTrack object
             enrollments (iterable): An iterable of CachedEnrollments
         Returns:
             list: Serialized courses
         """
-        enrolled_courses = set(enrollment.course_run.course for enrollment in enrollments)
-        return [{'title': course.title} for course in enrolled_courses]
+        enrollment_status_map = {}
+        for enrollment in enrollments:
+            course_title = enrollment.course_run.course.title
+            is_verified = mmtrack.is_enrolled_mmtrack(enrollment.course_run.edx_course_key)
+            # If any course run for this course was verified/paid, maintain the verified status
+            enrollment_status_map[course_title] = enrollment_status_map.get(course_title) or is_verified
+        serialized_enrollments = []
+        for course_title, is_verified in enrollment_status_map.items():
+            enrollment_status = 'Paid' if is_verified else 'Auditing'
+            serialized_enrollments.extend([
+                {'level': 1, 'value': course_title, 'ancestors': []},
+                {'level': 2, 'value': enrollment_status, 'ancestors': [course_title]}
+            ])
+        return serialized_enrollments
 
     @classmethod
     def serialize(cls, program_enrollment):
@@ -38,9 +51,10 @@ class UserProgramSearchSerializer:
             program,
             edx_user_data
         )
+        enrollments_qset = CachedEnrollment.user_course_qset(user, program=program)
         return {
             'id': program.id,
-            'enrollments': cls.serialize_enrollments(CachedEnrollment.user_course_qset(user, program=program)),
+            'enrollments': cls.serialize_enrollments(mmtrack, enrollments_qset),
             'grade_average': mmtrack.calculate_final_grade_average(),
             'is_learner': is_learner(user, program),
             'email_optin': user.profile.email_optin,

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -250,16 +250,11 @@ def program_enrolled_user_mapping():
         'grade_average': LONG_TYPE,
         'is_learner': BOOL_TYPE,
         'enrollments': {'type': 'nested', 'properties': {
-            'course_details': {
-                'type': 'object',
-                'properties': {
-                    'course_modes': {
-                        'type': 'nested',
-                    }
-                }
-            }
-        }},
-        'certificates': {'type': 'nested'}
+            'level': LONG_TYPE,
+            'ancestors': NOT_ANALYZED_STRING_TYPE,
+            'value': NOT_ANALYZED_STRING_TYPE,
+            'order': LONG_TYPE
+        }}
     })
     # Make strings not_analyzed by default
     mapping.meta('dynamic_templates', [{

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -4,10 +4,10 @@ import React from 'react';
 import {
   SearchkitComponent,
   HierarchicalMenuFilter,
+  HierarchicalRefinementFilter,
   Hits,
   SelectedFilters,
   RefinementListFilter,
-  MenuFilter,
   HitsStats,
   Pagination,
   ResetFilters,
@@ -148,9 +148,8 @@ export default class LearnerSearch extends SearchkitComponent {
           {...this.props}
           filterName="courses"
         >
-          <MenuFilter
-            field="program.enrollments.title"
-            fieldOptions={{type: 'nested', options: { path: 'program.enrollments' } }}
+          <HierarchicalRefinementFilter
+            field={"program.enrollments"}
             title="Course"
             id="courses"
           />

--- a/static/js/components/search/FilterVisibilityToggle.js
+++ b/static/js/components/search/FilterVisibilityToggle.js
@@ -6,7 +6,6 @@ import Icon from 'react-mdl/lib/Icon';
 
 const FILTER_ID_ADJUST = {
   "birth_location": "profile.birth_country4",
-  "courses": "program.enrollments.title3"
 };
 
 export default class FilterVisibilityToggle extends SearchkitComponent {

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -77,7 +77,9 @@
     .sk-panel__content .sk-item-list-option__text,
     .sk-panel__content .sk-item-list-option__count,
     .sk-hierarchical-menu-list__root .sk-hierarchical-menu-option__text,
-    .sk-hierarchical-menu-list__root .sk-hierarchical-menu-option__count {
+    .sk-hierarchical-menu-list__root .sk-hierarchical-menu-option__count,
+    .sk-hierarchical-refinement-list__root .sk-hierarchical-refinement-option__text,
+    .sk-hierarchical-refinement-list__root .sk-hierarchical-refinement-option__count {
       color: $font-gray;
     }
 
@@ -116,7 +118,9 @@
         transform: rotate(0.75turn);
       }
 
-      .sk-panel__content, .sk-hierarchical-menu-list__root {
+      .sk-panel__content,
+      .sk-hierarchical-menu-list__root,
+      .sk-hierarchical-refinement-list__root {
         display: none;
       }
     }


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #1730 

#### What's this PR do?

Adds additional Paid/Audit filters to the course facet

#### Where should the reviewer start?

dashboard/serializers.py

#### How should this be manually tested?

1. Seed your data and make yourself a staff user
1. Run the code block that I will include in a comment (it's somewhat long, so I didn't want to overwhelm the PR description)
1. Check the course facets for both the Analog and Digital Learning programs for the 100-level course. They should have some Paid and some Auditing users, and applying those filters should work

#### Any background context you want to provide?

The change in format for the enrollments nested index was made to support a specific searchkit component. 

#### Screenshots (if appropriate)

![ss 2016-12-13 at 10 57 50](https://cloud.githubusercontent.com/assets/14932219/21186741/91fa4dca-c1e3-11e6-82fd-3690e744cdff.png)
