### PR TITLE
Release 0.31.0

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,2 @@
+instrumentation:
+  excludes: ['**/*_test.js']

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,24 @@
 Release Notes
 =============
 
+Version 0.31.0
+--------------
+
+- Made twitter description tag shorter (#2083)
+- Disable enroll and pay later button during API activity (#2056)
+- Added cropper to object types (#2114)
+- Fixed race condition with getCroppedCanvas
+- Replace utcnow() with now(tz=pytz.UTC) (#2107)
+- Fixed &quot;View on edx&quot; links to wrong URLs (#2073)
+- Ensured that search query is reset when changing programs
+- Added do not set income tax statement by email instruction message (#2091)
+- Limited the birth country facet to 15 options
+- Display tagline on mobile (#2085)
+- Filter out *_test.js files from test coverage (#1968)
+- Replace Object.assign with spread syntax (#2069)
+- Changed to https-only in npm-shrinkwrap
+- Fixed faulty hiding for facets that use nested fields
+
 Version 0.30.1
 --------------
 

--- a/backends/edxorg.py
+++ b/backends/edxorg.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from urllib.parse import urljoin
 
 from django.conf import settings
+import pytz
 from social.backends.oauth import BaseOAuth2
 
 
@@ -105,5 +106,5 @@ class EdxOrgOAuth2(BaseOAuth2):
             dict of information about the user
         """
         response = super(EdxOrgOAuth2, self).refresh_token(token, *args, **kwargs)
-        response['updated_at'] = datetime.utcnow().timestamp()
+        response['updated_at'] = datetime.now(tz=pytz.UTC).timestamp()
         return response

--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from urllib.parse import urljoin
 
+import pytz
 from rolepermissions.verifications import has_role
 
 from backends.edxorg import EdxOrgOAuth2
@@ -140,5 +141,5 @@ def set_last_update(details, *args, **kwargs):  # pylint: disable=unused-argumen
     Returns:
         dict: updated details dictionary
     """
-    details['updated_at'] = datetime.utcnow().timestamp()
+    details['updated_at'] = datetime.now(tz=pytz.UTC).timestamp()
     return details

--- a/backends/utils.py
+++ b/backends/utils.py
@@ -2,6 +2,7 @@
 Utility functions for the backends
 """
 from datetime import datetime, timedelta
+import pytz
 
 from requests.exceptions import HTTPError
 from social.apps.django_app.utils import load_strategy
@@ -39,12 +40,12 @@ def refresh_user_token(user_social):
         user_social (UserSocialAuth): a user social auth instance
     """
     try:
-        last_update = datetime.fromtimestamp(user_social.extra_data.get('updated_at'))
+        last_update = datetime.fromtimestamp(user_social.extra_data.get('updated_at'), tz=pytz.UTC)
         expires_in = timedelta(seconds=user_social.extra_data.get('expires_in'))
     except TypeError:
         _send_refresh_request(user_social)
         return
     # small error margin of 5 minutes to be safe
     error_margin = timedelta(minutes=5)
-    if datetime.utcnow() - last_update >= expires_in - error_margin:
+    if datetime.now(tz=pytz.UTC) - last_update >= expires_in - error_margin:
         _send_refresh_request(user_social)

--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -37,6 +37,8 @@
     credentials, learners can apply for an accelerated master's degree
     program on campus, at MIT or other top universities.">
   <meta itemprop="image" content="{{ request.build_absolute_uri }}static/images/lp_hero.jpg">
+  <meta name="twitter:description" content="MITx MicroMasters Programs: a new academic credential
+    and a new path to a master’s degree from MIT. Learn more ">
 {% endblock %}
 
 {% block content %}

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -329,7 +329,8 @@ def format_courserun_for_dashboard(course_run, status_for_user, mmtrack, positio
         'position': position,
         'course_start_date': course_run.start_date,
         'course_end_date': course_run.end_date,
-        'fuzzy_start_date': course_run.fuzzy_start_date
+        'fuzzy_start_date': course_run.fuzzy_start_date,
+        'enrollment_url': course_run.enrollment_url,
     }
 
     # check if there are extra fields to pull in

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -161,6 +161,7 @@ class FormatRunTest(CourseTests):
             'course_end_date': crun.end_date,
             'fuzzy_start_date': crun.fuzzy_start_date,
             'final_grade': 99.99,
+            'enrollment_url': crun.enrollment_url,
         }
 
         self.assertEqual(
@@ -217,7 +218,8 @@ class FormatRunTest(CourseTests):
                 'position': 1,
                 'course_start_date': crun.start_date,
                 'course_end_date': crun.end_date,
-                'fuzzy_start_date': crun.fuzzy_start_date
+                'fuzzy_start_date': crun.fuzzy_start_date,
+                'enrollment_url': crun.enrollment_url,
             }
         )
 

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -15,6 +15,7 @@ from django.db import transaction
 from django.http.response import Http404
 from django.shortcuts import get_object_or_404
 from edx_api.client import EdxApi
+import pytz
 from rest_framework.exceptions import ValidationError
 
 from backends.edxorg import EdxOrgOAuth2
@@ -205,7 +206,7 @@ def generate_cybersource_sa_payload(order, dashboard_url):
         ),
         'reference_number': make_reference_id(order),
         'profile_id': settings.CYBERSOURCE_PROFILE_ID,
-        'signed_date_time': datetime.utcnow().strftime(ISO_8601_FORMAT),
+        'signed_date_time': datetime.now(tz=pytz.UTC).strftime(ISO_8601_FORMAT),
         'transaction_type': 'sale',
         'transaction_uuid': uuid.uuid4().hex,
         'unsigned_field_names': '',

--- a/financialaid/api_test.py
+++ b/financialaid/api_test.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.models.signals import post_save
 from django.test import TestCase
 from factory.django import mute_signals
+import pytz
 
 from courses.factories import ProgramFactory, CourseFactory, CourseRunFactory
 from dashboard.models import ProgramEnrollment
@@ -47,7 +48,7 @@ def create_program(create_tiers=True):
     )
     course = CourseFactory.create(program=program)
     course_run = CourseRunFactory.create(
-        enrollment_end=datetime.utcnow() + timedelta(hours=1),
+        enrollment_end=datetime.now(tz=pytz.UTC) + timedelta(hours=1),
         course=course
     )
     CoursePriceFactory.create(

--- a/micromasters/models.py
+++ b/micromasters/models.py
@@ -14,6 +14,7 @@ from django.db.models import (
     SET_NULL,
 )
 from django.db.models.query import QuerySet
+import pytz
 
 
 class TimestampedModelQuerySet(QuerySet):
@@ -27,7 +28,7 @@ class TimestampedModelQuerySet(QuerySet):
         database level without loading objects into memory.
         """
         if "updated_on" not in kwargs:
-            kwargs["updated_on"] = datetime.datetime.utcnow()
+            kwargs["updated_on"] = datetime.datetime.now(tz=pytz.UTC)
         return super().update(**kwargs)
 
 

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -22,7 +22,7 @@ from celery.schedules import crontab
 from django.core.exceptions import ImproperlyConfigured
 
 
-VERSION = "0.30.1"
+VERSION = "0.31.0"
 
 CONFIG_PATHS = [
     os.environ.get('MICROMASTERS_CONFIG', ''),

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5174,7 +5174,7 @@
     "raven-js": {
       "version": "3.8.1",
       "from": "raven-js@3.8.1",
-      "resolved": "http://registry.npmjs.org/raven-js/-/raven-js-3.8.1.tgz"
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.8.1.tgz"
     },
     "rc": {
       "version": "1.1.6",

--- a/seed_data/lib.py
+++ b/seed_data/lib.py
@@ -4,6 +4,7 @@ Library functions for interacting with test data
 import re
 from datetime import datetime, timedelta
 from functools import wraps
+import pytz
 
 from django.contrib.auth.models import User
 from courses.models import Program, Course
@@ -165,7 +166,7 @@ class CachedHandler(object):
         if not created:
             obj.data = data
             obj.save()
-        CachedEdxDataApi.update_cache_last_access(self.user, self.cache_type, timestamp=datetime.utcnow())
+        CachedEdxDataApi.update_cache_last_access(self.user, self.cache_type, timestamp=datetime.now(tz=pytz.UTC))
         return obj
 
     def find(self, course_run):

--- a/static/js/components/CropperWrapper.js
+++ b/static/js/components/CropperWrapper.js
@@ -13,22 +13,24 @@ export default class CropperWrapper extends React.Component {
   cropperHelper = () => {
     const { updatePhotoEdit } = this.props;
     let canvas;
-    if ( browser.name === 'safari' || browser.name === 'ios' ) {
-      canvas = this.refs.cropper.getCroppedCanvas();
-    } else {
-      canvas = this.refs.cropper.getCroppedCanvas({
-        width: 512,
-        height: 512,
-      });
+    if ( this.cropper ) {
+      if ( browser.name === 'safari' || browser.name === 'ios' ) {
+        canvas = this.cropper.getCroppedCanvas();
+      } else {
+        canvas = this.cropper.getCroppedCanvas({
+          width: 512,
+          height: 512,
+        });
+      }
+      canvas.toBlob(blob => updatePhotoEdit(blob), 'image/jpeg');
     }
-    canvas.toBlob(blob => updatePhotoEdit(blob), 'image/jpeg');
   };
 
   render () {
     const { photo, uploaderBodyHeight } = this.props;
 
     return <Cropper
-      ref='cropper'
+      ref={cropper => this.cropper = cropper}
       style={{'height': uploaderBodyHeight()}}
       className="photo-active-item cropper"
       src={photo.preview}

--- a/static/js/components/CropperWrapper.js
+++ b/static/js/components/CropperWrapper.js
@@ -4,6 +4,7 @@ import Cropper from 'react-cropper';
 import browser from 'detect-browser';
 
 export default class CropperWrapper extends React.Component {
+  cropper: Cropper;
   props: {
     updatePhotoEdit:    (b: Blob) => void,
     photo:              Object,

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -122,7 +122,10 @@ class EducationForm extends ProfileFormFields {
       }
       this.openNewEducationForm(level, null);
     } else {
-      setEducationLevelAnswers(Object.assign({}, educationLevelAnswers, {[level]: "No"}));
+      setEducationLevelAnswers({
+        ...educationLevelAnswers,
+        [level]: "No"
+      });
     }
   }
 

--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -94,9 +94,10 @@ describe("ErrorMessage", () => {
       helper.profileGetStub.
         withArgs(SETTINGS.user.username).
         returns(
-          Promise.resolve(Object.assign({}, USER_PROFILE_RESPONSE, {
-            username: SETTINGS.user.username
-          }))
+          Promise.resolve({
+            ...USER_PROFILE_RESPONSE,
+            username: SETTINGS.user.username,
+          })
         );
     });
 

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -165,6 +165,7 @@ export default class LearnerSearch extends SearchkitComponent {
             field="profile.birth_country"
             operator="OR"
             itemComponent={CountryRefinementOption}
+            size={15}
           />
         </FilterVisibilityToggle>
         <FilterVisibilityToggle

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -104,7 +104,7 @@ export default class PersonalTab extends React.Component {
     const { profile, updateProfile } = this.props;
     let editState = _.cloneDeep(profile);
     let { payload: { profile: { image } }} = fetchResponse;
-    let newEditState = Object.assign({}, editState, { image });
+    let newEditState = { ...editState, image };
     updateProfile(newEditState, personalTabValidator);
   };
 

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -29,6 +29,7 @@ export default class ProgramFilter extends SearchkitComponent {
   componentDidUpdate(prevProps: Object): void {
     if (!_.isEqual(prevProps.currentProgramEnrollment, this.props.currentProgramEnrollment)) {
       // (╯°□°)╯︵ ┻━┻
+      this.context.searchkit.resetState();
       this.context.searchkit.reloadSearch();
     }
   }

--- a/static/js/components/ProgramSelector_test.js
+++ b/static/js/components/ProgramSelector_test.js
@@ -74,8 +74,8 @@ describe('ProgramSelector', () => {
   });
 
   it("does not render the 'Enroll in a new program' option if there is not at least one available program", () => {
-    let allEnrollments = programs.map(program => Object.assign({}, program, {
-      enrolled: true
+    let allEnrollments = programs.map(program => ({
+      ...program, enrolled: true
     }));
     let wrapper = renderProgramSelector({
       programs: allEnrollments

--- a/static/js/components/SpinnerButton_test.js
+++ b/static/js/components/SpinnerButton_test.js
@@ -1,0 +1,66 @@
+// @flow
+import React from 'react';
+import { shallow } from 'enzyme';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import Button from 'react-mdl/lib/Button';
+
+import SpinnerButton from './SpinnerButton';
+
+describe("SpinnerButton", () => {
+  let sandbox;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('passes through all props when spinning is false', () => {
+    let onClick = sandbox.stub();
+    let props = {
+      disabled: true,
+      "data-x": "y",
+      onClick: onClick,
+      className: "class1 class2"
+    };
+    let wrapper = shallow(<SpinnerButton
+      component="button"
+      spinning={false}
+      {...props}
+    >
+      childText
+    </SpinnerButton>);
+    let button = wrapper.find("button");
+    let buttonProps = button.props();
+    for (let key of Object.keys(props)) {
+      assert.deepEqual(buttonProps[key], props[key]);
+    }
+    assert.equal(button.children().text(), "childText");
+  });
+
+  it('replaces children with a Spinner, disables onClick and updates className when spinning is true', () => {
+    let onClick = sandbox.stub();
+    let props = {
+      disabled: true,
+      "data-x": "y",
+    };
+    let wrapper = shallow(<SpinnerButton
+      component={Button}
+      spinning={true}
+      onClick={onClick}
+      className="class1 class2"
+      {...props}
+    />);
+    let button = wrapper.find("Button");
+    let buttonProps = button.props();
+    for (let key of Object.keys(props)) {
+      assert.deepEqual(buttonProps[key], props[key]);
+    }
+
+    assert.isUndefined(buttonProps.onClick);
+    assert.equal(buttonProps.className, "class1 class2 disabled-with-spinner");
+    assert.equal(button.children().text(), "<Spinner />");
+  });
+});

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -7,6 +7,8 @@ import Spinner from 'react-mdl/lib/Spinner';
 import R from 'ramda';
 import _ from 'lodash';
 
+import SpinnerButton from '../SpinnerButton';
+import { FETCH_PROCESSING } from '../../actions';
 import type { CourseRun, FinancialAidUserInfo } from '../../flow/programTypes';
 import type { CoursePrice } from '../../flow/dashboardTypes';
 import {
@@ -31,6 +33,7 @@ export default class CourseAction extends React.Component {
     checkout: Function,
     courseRun: CourseRun,
     coursePrice: CoursePrice,
+    courseEnrollAddStatus?: string,
     now: moment$Moment,
     financialAid: FinancialAidUserInfo,
     hasFinancialAid: boolean,
@@ -118,26 +121,29 @@ export default class CourseAction extends React.Component {
 
   renderStatusDescription = this.renderDescription('boxed description');
 
-  handleAddCourseEnrollment = (event: Event, run: CourseRun): void => {
+  handleAddCourseEnrollment = (run: CourseRun): void => {
     const { addCourseEnrollment } = this.props;
-    event.preventDefault();
     addCourseEnrollment(run.course_id);
   };
 
-  renderPayLaterLink(run: CourseRun): React$Element<*> {
+  renderPayLaterLink(run: CourseRun, inFlight: bool): React$Element<*> {
     return (
-      <button
+      <SpinnerButton
+        component="button"
+        spinning={inFlight}
         className="mm-minor-action enroll-pay-later"
-        onClick={e => this.handleAddCourseEnrollment(e, run)} key="2"
+        onClick={() => this.handleAddCourseEnrollment(run)}
+        key="2"
       >
         Enroll and pay later
-      </button>
+      </SpinnerButton>
     );
   }
 
   renderContents(run: CourseRun) {
-    const { now } = this.props;
+    const { now, courseEnrollAddStatus } = this.props;
 
+    const inFlight = courseEnrollAddStatus === FETCH_PROCESSING;
     let action, description;
 
     switch (run.status) {
@@ -169,7 +175,7 @@ export default class CourseAction extends React.Component {
       let enrollmentStartDate = run.enrollment_start_date ? moment(run.enrollment_start_date) : null;
       if (isCurrentlyEnrollable(enrollmentStartDate, now)) {
         action = this.renderEnrollButton(run);
-        description = this.renderPayLaterLink(run);
+        description = this.renderPayLaterLink(run, inFlight);
       } else {
         let text;
         if (enrollmentStartDate) {

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -6,6 +6,7 @@ import moment from 'moment';
 import { assert } from 'chai';
 import sinon from 'sinon';
 
+import { FETCH_PROCESSING } from '../../actions';
 import CourseAction from './CourseAction';
 import {
   DASHBOARD_FORMAT,
@@ -50,8 +51,8 @@ describe('CourseAction', () => {
     }
     let description = renderedComponent.find(".description");
     let descriptionText = description.length === 1 ? description.text() : undefined;
-    let link = renderedComponent.find("button.enroll-pay-later");
-    let linkText = link.length === 1 ? link.text() : undefined;
+    let link = renderedComponent.find("SpinnerButton.enroll-pay-later");
+    let linkText = link.length === 1 ? link.children().text() : undefined;
     return {
       button: button,
       buttonText: buttonText,
@@ -137,9 +138,7 @@ describe('CourseAction', () => {
     assert.equal(elements.linkText, 'Enroll and pay later');
     assertCheckoutButton(elements.button, firstRun.course_id);
 
-    wrapper.find(".enroll-pay-later").simulate('click', {
-      preventDefault: sandbox.stub()
-    });
+    wrapper.find(".enroll-pay-later").simulate('click');
     assert(addCourseEnrollmentStub.calledWith(firstRun.course_id));
   });
 
@@ -420,6 +419,20 @@ describe('CourseAction', () => {
         assert.include(elements.buttonText, 'Pay Now');
         assert.equal(elements.linkText, 'Enroll and pay later');
       });
+    });
+
+    it('shows a spinner in place of the enroll button while API call is in progress', () => {
+      let course = findCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === STATUS_OFFERED
+      ));
+      let firstRun = course.runs[0];
+      const wrapper = renderCourseAction({
+        courseRun: firstRun,
+        courseEnrollAddStatus: FETCH_PROCESSING
+      });
+      let link = wrapper.find("SpinnerButton.enroll-pay-later");
+      assert.isTrue(link.props().spinning);
     });
   });
 });

--- a/static/js/components/dashboard/CourseDescription.js
+++ b/static/js/components/dashboard/CourseDescription.js
@@ -68,13 +68,33 @@ export default class CourseDescription extends React.Component {
     return _.compact([dateMessage, additionalDetail]);
   }
 
-  renderViewCourseLink = (courseRun: CourseRun): React$Element<*>|null => (
-    (courseRun && courseRun.course_id) ?
-      <a href={`${EDX_LINK_BASE}${courseRun.course_id}`} target="_blank">
-        View on edX
-      </a> :
-      null
-  );
+  isCurrentOrPastEnrolled = (courseRun: CourseRun): boolean => {
+    if([STATUS_CURRENTLY_ENROLLED, STATUS_PASSED, STATUS_NOT_PASSED].includes(courseRun.status)) {
+      return true;
+    } else {
+      if ([STATUS_CAN_UPGRADE, STATUS_MISSED_DEADLINE].includes(courseRun.status)) {
+        let now = moment();
+        return courseRun.course_start_date && moment(courseRun.course_start_date).isBefore(now);
+      } else {
+        return false;
+      }
+    }
+  };
+
+  renderViewCourseLink = (courseRun: CourseRun): React$Element<*>|null => {
+    if (!courseRun || !courseRun.course_id) {
+      return null;
+    }
+    let url = null;
+
+    if (this.isCurrentOrPastEnrolled(courseRun)) {
+      url = `${EDX_LINK_BASE}${courseRun.course_id}`;
+    } else {
+      url = courseRun.enrollment_url;
+    }
+
+    return url ? <a href={url} target="_blank">View on edX</a> : null;
+  }
 
   render() {
     const { courseRun, courseTitle } = this.props;

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -13,6 +13,7 @@ export default class CourseListCard extends React.Component {
   props: {
     checkout:                     Function,
     program:                      Program,
+    courseEnrollAddStatus?:       string,
     coursePrice:                  CoursePrice,
     openFinancialAidCalculator?:  () => void,
     now?:                         Object,
@@ -27,6 +28,7 @@ export default class CourseListCard extends React.Component {
       checkout,
       openFinancialAidCalculator,
       addCourseEnrollment,
+      courseEnrollAddStatus,
     } = this.props;
     if (now === undefined) {
       now = moment();
@@ -38,6 +40,7 @@ export default class CourseListCard extends React.Component {
         hasFinancialAid={program.financial_aid_availability}
         financialAid={program.financial_aid_user_info}
         course={course}
+        courseEnrollAddStatus={courseEnrollAddStatus}
         coursePrice={coursePrice}
         key={course.id}
         checkout={checkout}

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -4,46 +4,58 @@ import { shallow } from 'enzyme';
 import moment from 'moment';
 import { assert } from 'chai';
 import _ from 'lodash';
+import sinon from 'sinon';
 
 import CourseListCard from './CourseListCard';
 import CourseRow from './CourseRow';
 import { DASHBOARD_RESPONSE, COURSE_PRICES_RESPONSE } from '../../constants';
 
 describe('CourseListCard', () => {
-  let program, defaultCardParams;
+  let program, checkout, sandbox;
   beforeEach(() => {
     program = _.cloneDeep(DASHBOARD_RESPONSE[1]);
     assert(program.courses.length > 0);
+    sandbox = sinon.sandbox.create();
+    checkout = sandbox.stub();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  let renderCourseListCard = (props = {}) => {
     let coursePrice = COURSE_PRICES_RESPONSE.find(
       coursePrice => coursePrice.program_id === program.id
     );
 
-    defaultCardParams = {
-      coursePrice: coursePrice,
-      checkout: () => null,
-      addCourseEnrollment: () => undefined,
-    };
-  });
+    return shallow(
+      <CourseListCard
+        program={program}
+        coursePrice={coursePrice}
+        checkout={checkout}
+        addCourseEnrollment={() => undefined}
+        {...props}
+      />
+    );
+  };
 
   it('creates a CourseRow for each course', () => {
     let now = moment();
-    const wrapper = shallow(
-      <CourseListCard program={program} now={now} {...defaultCardParams} />
-    );
+    const wrapper = renderCourseListCard({
+      now: now
+    });
     assert.equal(wrapper.find(CourseRow).length, program.courses.length);
     let courses = _.sortBy(program.courses, 'position_in_program');
     wrapper.find(CourseRow).forEach((courseRow, i) => {
       const props = courseRow.props();
       assert.equal(props.now, now);
       assert.deepEqual(props.course, courses[i]);
-      assert.equal(props.checkout, defaultCardParams.checkout);
+      assert.equal(props.checkout, checkout);
     });
   });
 
   it("fills in now if it's missing in the props", () => {
-    const wrapper = shallow(
-      <CourseListCard program={program} {...defaultCardParams} />
-    );
+    const wrapper = renderCourseListCard();
     let nows = wrapper.find(CourseRow).map(courseRow => courseRow.props().now);
     assert.isAbove(nows.length, 0);
     for (let now of nows) {
@@ -54,9 +66,7 @@ describe('CourseListCard', () => {
 
   it("doesn't show the personalized pricing box for programs without it", () => {
     program.financial_aid_availability = false;
-    const wrapper = shallow(
-      <CourseListCard program={program} {...defaultCardParams} />
-    );
+    const wrapper = renderCourseListCard();
     assert.equal(wrapper.find('.personalized-pricing').length, 0);
   });
 });

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -19,6 +19,7 @@ export default class CourseRow extends React.Component {
   props: {
     course: Course,
     checkout: Function,
+    courseEnrollAddStatus?: string,
     coursePrice: CoursePrice,
     now: moment$Moment,
     financialAid: FinancialAidUserInfo,
@@ -59,6 +60,7 @@ export default class CourseRow extends React.Component {
       course,
       coursePrice,
       checkout,
+      courseEnrollAddStatus,
       now,
       financialAid,
       hasFinancialAid,
@@ -91,6 +93,7 @@ export default class CourseRow extends React.Component {
           courseRun={run}
           coursePrice={coursePrice}
           checkout={checkout}
+          courseEnrollAddStatus={courseEnrollAddStatus}
           now={now}
           hasFinancialAid={hasFinancialAid}
           financialAid={financialAid}

--- a/static/js/components/dashboard/CourseSubRow.js
+++ b/static/js/components/dashboard/CourseSubRow.js
@@ -17,6 +17,7 @@ import {
 export default class CourseSubRow extends React.Component {
   props: {
     courseRun: CourseRun,
+    courseEnrollAddStatus?: string,
     checkout: Function,
     coursePrice: CoursePrice,
     now: moment$Moment,

--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -170,6 +170,7 @@ export default class FinancialAidCard extends React.Component {
           <Cell col={12}>
             Before you can pay, you need to verify your income. Please mail or fax an
             English-translated and notarized income tax or income statement document.
+            DO NOT SEND BY EMAIL.
           </Cell>
           <Cell col={12}>
             <a onClick={() => setDocsInstructionsVisibility(true)}>

--- a/static/js/components/dashboard/FinancialAidCard_test.js
+++ b/static/js/components/dashboard/FinancialAidCard_test.js
@@ -170,6 +170,19 @@ describe("FinancialAidCard", () => {
         assert.ok(setDocsInstructionsVisibility.called, 'should have called onClick handler');
       });
 
+      it(`instruction for status ${FA_STATUS_PENDING_DOCS}`, () => {
+        let program = programWithStatus(FA_STATUS_PENDING_DOCS);
+        let wrapper = renderCard({ program, setDocsInstructionsVisibility });
+        let instruction = wrapper.find('.financial-aid-box').find('div').first();
+        assert.equal(
+          instruction.text(),
+          'Before you can pay, you need to verify your income. ' +
+          'Please mail or fax an English-translated and notarized income tax or ' +
+          'income statement document. DO NOT SEND BY EMAIL.' +
+          'Read Complete Instructions'
+        );
+      });
+
       it('sends the document date', () => {
         let program = programWithStatus(FA_STATUS_PENDING_DOCS);
 

--- a/static/js/components/inputs/DateField.js
+++ b/static/js/components/inputs/DateField.js
@@ -86,11 +86,12 @@ export default class DateField extends React.Component {
       // Update tuple with the typed text. Typically only one of the arguments
       // will have text at a time since the user can't edit more than one field at once
       // so we need to look in the state to see
-      let newEdit = Object.assign({}, edit, {
+      let newEdit = {
+        ...edit,
         year: year !== undefined ? year : edit.year,
         month: month !== undefined ? month : edit.month,
         day: day !== undefined ? day : edit.day
-      });
+      };
 
       const firstIfNumEqual = R.curry((x, y) => Number(x) === y ? x : y);
       let validatedDay = Maybe.of(1);

--- a/static/js/components/inputs/inputs_test.js
+++ b/static/js/components/inputs/inputs_test.js
@@ -41,14 +41,14 @@ describe('Profile inputs', () => {
     ];
 
     let renderGenderSelectField = (props = {}) => {
-      return renderTestSelectField(
-        Object.assign({}, inputProps, {
-          keySet: ['gender'],
-          label: "Gender",
-          options: genderOptions,
-          updateProfile: updateProfileStub,
-        }, props)
-      );
+      return renderTestSelectField({
+        ...inputProps,
+        keySet: ['gender'],
+        label: "Gender",
+        options: genderOptions,
+        updateProfile: updateProfileStub,
+        ...props,
+      });
     };
 
     beforeEach(() => {
@@ -148,7 +148,7 @@ describe('Profile inputs', () => {
       };
       selectField = renderGenderSelectField(props);
       modifyWrapperSelectField(selectField.find(VirtualizedSelect), 'genderqueer');
-      selectField.setProps(Object.assign({}, inputProps, props));
+      selectField.setProps({...inputProps, ...props});
       assert.deepEqual(selectField.state(), {
         customOptions: [
           { value: 'genderqueer', label: 'genderqueer' }
@@ -180,7 +180,7 @@ describe('Profile inputs', () => {
         stateKeySet: ['state_key'],
         countryKeySet: ['country_key'],
         label: 'State',
-        profile: Object.assign({}, USER_PROFILE_RESPONSE),
+        profile: {...USER_PROFILE_RESPONSE},
         errors: {},
         updateProfile: change
       };
@@ -219,7 +219,7 @@ describe('Profile inputs', () => {
         stateKeySet: ['state_key'],
         countryKeySet: ['country_key'],
         label: 'Country',
-        profile: Object.assign({}, USER_PROFILE_RESPONSE),
+        profile: {...USER_PROFILE_RESPONSE},
         errors: {},
         updateProfile: change
       };

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -82,9 +82,10 @@ describe('App', function() {
     let checkStep = () => helper.store.getState().ui.profileStep;
 
     it('redirects to /profile/personal if profile is not complete', () => {
-      let response = Object.assign(_.cloneDeep(USER_PROFILE_RESPONSE), {
-        first_name: undefined
-      });
+      let response = {
+        ...USER_PROFILE_RESPONSE,
+        first_name: undefined,
+      };
       helper.profileGetStub.withArgs(SETTINGS.user.username).returns(Promise.resolve(response));
 
       return renderComponent("/", EDIT_PROFILE_ACTIONS).then(() => {
@@ -94,9 +95,10 @@ describe('App', function() {
     });
 
     it('redirects to /profile/professional if profile is not filled out', () => {
-      let response = Object.assign(_.cloneDeep(USER_PROFILE_RESPONSE), {
-        filled_out: false
-      });
+      let response = {
+        ...USER_PROFILE_RESPONSE,
+        filled_out: false,
+      };
       helper.profileGetStub.withArgs(SETTINGS.user.username).returns(Promise.resolve(response));
 
       return renderComponent("/", REDIRECT_ACTIONS).then(() => {

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -54,7 +54,7 @@ import type {
   DocumentsState,
 } from '../reducers/documents';
 import type { CoursePricesState, DashboardState } from '../flow/dashboardTypes';
-import type { AvailableProgram } from '../flow/enrollmentTypes';
+import type { AvailableProgram, CourseEnrollmentsState } from '../flow/enrollmentTypes';
 import type { ProfileGetResult } from '../flow/profileTypes';
 import type { Course, CourseRun } from '../flow/programTypes';
 import { skipFinancialAid } from '../actions/financial_aid';
@@ -77,6 +77,7 @@ class DashboardPage extends React.Component {
     documents:                DocumentsState,
     fetchDashboard:           () => void,
     orderReceipt:             OrderReceiptState,
+    courseEnrollments:        CourseEnrollmentsState,
   };
 
   componentDidMount() {
@@ -257,6 +258,7 @@ class DashboardPage extends React.Component {
       documents,
       currentProgramEnrollment,
       ui,
+      courseEnrollments,
     } = this.props;
     const loaded = dashboard.fetchStatus !== FETCH_PROCESSING && prices.fetchStatus !== FETCH_PROCESSING;
     let errorMessage;
@@ -301,6 +303,7 @@ class DashboardPage extends React.Component {
             {financialAidCard}
             <CourseListCard
               program={program}
+              courseEnrollAddStatus={courseEnrollments.courseEnrollAddStatus}
               coursePrice={coursePrice}
               key={program.id}
               checkout={this.dispatchCheckout}
@@ -341,6 +344,7 @@ const mapStateToProps = (state) => {
     ui: state.ui,
     documents: state.documents,
     orderReceipt: state.orderReceipt,
+    courseEnrollments: state.courseEnrollments,
   };
 };
 

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -114,17 +114,14 @@ describe("ProfilePage", function() {
 
   describe('switch toggling behavior', () => {
     beforeEach(() => {
-      let userProfile = Object.assign({}, _.cloneDeep(USER_PROFILE_RESPONSE), {
+      let userProfile = {
+        ...USER_PROFILE_RESPONSE,
         education: [],
         work_history: []
-      });
+      };
       helper.profileGetStub.
         withArgs(SETTINGS.user.username).
-        returns(
-          Promise.resolve(Object.assign({}, userProfile, {
-            username: SETTINGS.user.username
-          }))
-        );
+        returns(Promise.resolve(userProfile));
     });
 
     it('should launch a dialog to add an entry when an education switch is set to Yes', () => {
@@ -148,9 +145,10 @@ describe("ProfilePage", function() {
 
   describe('profile completeness', () => {
     it('redirects to /profile/personal if profile is not complete', () => {
-      let response = Object.assign(_.cloneDeep(USER_PROFILE_RESPONSE), {
-        first_name: undefined
-      });
+      let response = {
+        ...USER_PROFILE_RESPONSE,
+        first_name: undefined,
+      };
       helper.profileGetStub.withArgs(SETTINGS.user.username).returns(Promise.resolve(response));
 
       return renderComponent("/profile/education", REDIRECT_ACTIONS).then(() => {
@@ -183,11 +181,12 @@ describe("ProfilePage", function() {
   for (let step of profileSteps.slice(0,2)) {
     for (let filledOutValue of [true, false]) {
       it(`respects the current value (${filledOutValue}) when saving on ${step}`, () => {
-        let updatedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+        let updatedProfile = {
+          ...USER_PROFILE_RESPONSE,
           filled_out: filledOutValue,
           education: [],
           work_history: [],
-        });
+        };
         helper.profileGetStub.withArgs(SETTINGS.user.username).returns(Promise.resolve(updatedProfile));
         return renderComponent(`/profile/${step}`, SUCCESS_ACTIONS).then(([, div]) => {
           // close all switches

--- a/static/js/containers/SettingsPage.js
+++ b/static/js/containers/SettingsPage.js
@@ -23,7 +23,7 @@ class SettingsPage extends ProfileFormContainer {
 
   render() {
     const { profiles } = this.props;
-    let props = Object.assign({}, this.profileProps(profiles[SETTINGS.user.username]));
+    let props = this.profileProps(profiles[SETTINGS.user.username]);
     let loaded = false;
     const username = SETTINGS.user.username;
 

--- a/static/js/containers/SettingsPage_test.js
+++ b/static/js/containers/SettingsPage_test.js
@@ -99,17 +99,19 @@ describe("SettingsPage", function() {
     it('save privacy changes', () => {
       return renderComponent("/settings", userActions).then(([, div]) => {
         let button = div.querySelector(nextButtonSelector);
-        let receivedProfile = Object.assign(_.cloneDeep(USER_PROFILE_RESPONSE), {
+        let receivedProfile = {
+          ...USER_PROFILE_RESPONSE,
           account_privacy: 'public',
-          email_optin: true
-        });
+          email_optin: true,
+        };
         helper.store.dispatch(receiveGetUserProfileSuccess(SETTINGS.user.username, receivedProfile));
 
         assert(button.innerHTML.includes("Save"));
-        let updatedProfile = Object.assign(_.cloneDeep(receivedProfile), {
+        let updatedProfile = {
+          ...receivedProfile,
           email_optin: true,
           filled_out: true
-        });
+        };
         return confirmSaveButtonBehavior(updatedProfile, {button: button});
       });
     });

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -113,11 +113,7 @@ describe("UserPage", function() {
 
       helper.profileGetStub.
         withArgs(SETTINGS.user.username).
-        returns(
-        Promise.resolve(Object.assign({}, USER_PROFILE_RESPONSE, {
-          username: SETTINGS.user.username
-        }))
-      );
+        returns(Promise.resolve(USER_PROFILE_RESPONSE));
     });
 
     afterEach(() => {
@@ -350,9 +346,7 @@ describe("UserPage", function() {
       };
 
       beforeEach(() => {
-        userProfile = Object.assign(_.cloneDeep(USER_PROFILE_RESPONSE), {
-          username: SETTINGS.user.username
-        });
+        userProfile = _.cloneDeep(USER_PROFILE_RESPONSE);
         userProfile.education.push({
           "id": 3,
           "degree_name": DOCTORATE,
@@ -478,7 +472,8 @@ describe("UserPage", function() {
           let addButton = div.querySelector('.add-education-button');
 
           let expectedProfile = _.cloneDeep(userProfile);
-          let entry = Object.assign({}, generateNewEducation(HIGH_SCHOOL), {
+          let entry = {
+            ...generateNewEducation(HIGH_SCHOOL),
             graduation_date: "1999-12-01",
             graduation_date_edit: {
               year: '1999',
@@ -489,7 +484,7 @@ describe("UserPage", function() {
             school_country: "AF",
             school_state_or_territory: "AF-BAL",
             school_city: "FoobarVille"
-          });
+          };
           expectedProfile.education.push(entry);
 
           patchUserProfileStub.throws("Invalid arguments");
@@ -695,7 +690,8 @@ describe("UserPage", function() {
 
           let updatedProfile = _.cloneDeep(USER_PROFILE_RESPONSE);
           updatedProfile.username = SETTINGS.user.username;
-          let entry = Object.assign({}, generateNewWorkHistory(), {
+          let entry = {
+            ...generateNewWorkHistory(),
             position: "Assistant Foobar",
             industry: "Accounting",
             company_name: "FoobarCorp",
@@ -714,7 +710,7 @@ describe("UserPage", function() {
             city: "FoobarVille",
             country: "AF",
             state_or_territory: "AF-BAL",
-          });
+          };
           updatedProfile.work_history.push(entry);
 
           patchUserProfileStub.throws("Invalid arguments");
@@ -825,10 +821,10 @@ describe("UserPage", function() {
         helper.profileGetStub.
           withArgs(SETTINGS.user.username).
           returns(
-            Promise.resolve(Object.assign({}, USER_PROFILE_RESPONSE, {
-              username: SETTINGS.user.username,
+            Promise.resolve({
+              ...USER_PROFILE_RESPONSE,
               email: null,
-            }))
+            })
           );
 
         const username = SETTINGS.user.username;
@@ -840,9 +836,10 @@ describe("UserPage", function() {
       it('should let you edit personal info', () => {
         const username = SETTINGS.user.username;
         const newFirstName = "New name";
-        let expectedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+        let expectedProfile = {
+          ...USER_PROFILE_RESPONSE,
           first_name: newFirstName
-        });
+        };
         patchUserProfileStub.
           withArgs(username, expectedProfile).
           returns(Promise.resolve(expectedProfile));
@@ -884,9 +881,10 @@ describe("UserPage", function() {
       it('should let you edit about me', () => {
         const username = SETTINGS.user.username;
         const aboutMe = "🐱";
-        const expectedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+        const expectedProfile = {
+          ...USER_PROFILE_RESPONSE,
           about_me: aboutMe
-        });
+        };
         patchUserProfileStub.
           withArgs(username, expectedProfile).
           returns(Promise.resolve(expectedProfile));
@@ -962,9 +960,10 @@ describe("UserPage", function() {
     });
 
     it("should not show any edit, delete icons for other user pages" , () => {
-      let otherProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
+      let otherProfile = {
+        ...USER_PROFILE_RESPONSE,
         username: 'other'
-      });
+      };
       helper.profileGetStub.withArgs('other').returns(Promise.resolve(otherProfile));
       return renderComponent(`/learner/other`, userActions).then(([, div]) => {
         let count = div.getElementsByClassName('mdl-button--icon').length;

--- a/static/js/entry/public.js
+++ b/static/js/entry/public.js
@@ -154,6 +154,8 @@ jQuery(document).ready(function ($) {
     'integrated set of graduate-level online courses. With the MicroMasters ' +
     "credentials, learners can apply for an accelerated master's degree " +
     "program on campus, at MIT or other top universities.";
+  const twitterDescription = 'MITx MicroMasters Programs: a new academic credential ' +
+    'and a new path to a master’s degree from MIT. Learn more ';
 
   $('.rrssb-buttons').rrssb({
     // required:
@@ -164,6 +166,8 @@ jQuery(document).ready(function ($) {
     description: description,
     emailBody: description + CURRENT_PAGE_URL
   });
+  const tweetUrl = `https://twitter.com/intent/tweet?text=${twitterDescription}%20${CURRENT_PAGE_URL}`;
+  document.querySelector('.rrssb-buttons .rrssb-twitter a').href = tweetUrl;
 });
 
 /**

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -140,8 +140,10 @@ export function getUserProfile(username: string): Promise<ProfileGetResult> {
 }
 
 export function patchUserProfile(username: string, profile: Profile): Promise<ProfilePatchResult> {
-  profile = Object.assign({}, profile);
-  delete profile['image'];
+  profile = {
+    ...profile,
+    image: undefined,
+  };
   return mockableFetchJSONWithCSRF(`/api/v0/profiles/${username}/`, {
     method: 'PATCH',
     body: JSON.stringify(profile)

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -91,7 +91,7 @@ describe('api', function() {
     it('fails to patch a user profile', () => {
       fetchJSONStub.returns(Promise.reject());
       return assert.isRejected(patchUserProfile('jane', USER_PROFILE_RESPONSE)).then(() => {
-        let profileWithoutImage = Object.assign({}, USER_PROFILE_RESPONSE);
+        let profileWithoutImage = {...USER_PROFILE_RESPONSE};
         delete profileWithoutImage['image'];
         assert.ok(fetchJSONStub.calledWith('/api/v0/profiles/jane/', {
           method: 'PATCH',

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -77,9 +77,10 @@ describe('Profile validation functions', () => {
     });
 
     it('should error if date of birth is in the future', () => {
-      let profile = Object.assign(_.cloneDeep(USER_PROFILE_RESPONSE), {
+      let profile = {
+        ...USER_PROFILE_RESPONSE,
         date_of_birth: "2077-01-01"
-      });
+      };
       let errors = {
         date_of_birth: "Please enter a valid date of birth"
       };
@@ -330,7 +331,10 @@ describe('Privacy validation', () => {
   });
 
   it('should return an appropriate error if a field is missing', () => {
-    let clone = Object.assign(_.cloneDeep(USER_PROFILE_RESPONSE), {account_privacy: ''});
+    let clone = {
+      ...USER_PROFILE_RESPONSE,
+      account_privacy: '',
+    };
     let expectation = {account_privacy: 'Privacy level is required'};
     assert.deepEqual(expectation, privacyValidation(clone));
   });

--- a/static/js/reducers/financial_aid_test.js
+++ b/static/js/reducers/financial_aid_test.js
@@ -58,9 +58,10 @@ describe('financial aid reducers', () => {
 
   it('should let you start editing', () => {
     return dispatchThen(startCalculatorEdit(1), [START_CALCULATOR_EDIT]).then(state => {
-      let expectation = Object.assign({}, FINANCIAL_AID_EDIT, {
-        programId: 1
-      });
+      let expectation = {
+        ...FINANCIAL_AID_EDIT,
+        programId: 1,
+      };
       assert.deepEqual(state, expectation);
     });
   });
@@ -111,10 +112,11 @@ describe('financial aid reducers', () => {
       REQUEST_ADD_FINANCIAL_AID,
       RECEIVE_ADD_FINANCIAL_AID_SUCCESS,
     ]).then(state => {
-      let expectation = Object.assign({}, FINANCIAL_AID_EDIT, {
+      let expectation = {
+        ...FINANCIAL_AID_EDIT,
         programId: programId,
         fetchStatus: FETCH_SUCCESS
-      });
+      };
       assert.deepEqual(state, expectation);
       assert.ok(fetchCoursePricesStub.calledWith());
       assert.ok(fetchDashboardStub.calledWith());
@@ -132,14 +134,15 @@ describe('financial aid reducers', () => {
       REQUEST_ADD_FINANCIAL_AID,
       RECEIVE_ADD_FINANCIAL_AID_FAILURE,
     ]).then(state => {
-      let expectation = Object.assign({}, FINANCIAL_AID_EDIT, {
+      let expectation = {
+        ...FINANCIAL_AID_EDIT,
         programId: programId,
         fetchStatus: FETCH_FAILURE,
         fetchError: {
           message: 'an error message',
           code: 500
         }
-      });
+      };
       assert.deepEqual(state, expectation);
       assert.ok(addFinancialAidStub.calledWith(income, currency, programId));
       assert.notOk(fetchCoursePricesStub.calledWith());

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -61,14 +61,15 @@ import { ALL_ERRORS_VISIBLE } from '../constants';
 export const INITIAL_PROFILES_STATE = {};
 export const profiles = (state: Profiles = INITIAL_PROFILES_STATE, action: Action) => {
   let patchProfile = newProfile => {
-    let clone = Object.assign({}, state);
     let username = action.payload.username;
-    clone[username] = Object.assign(
-      { profile: {} },
-      clone[username],
-      newProfile
-    );
-    return clone;
+    return {
+      ...state,
+      [username]: {
+        ...{ profile: {} },
+        ...state[username],
+        ...newProfile,
+      },
+    };
   };
 
   let getProfile = (): ProfileGetResult|void => {
@@ -94,7 +95,7 @@ export const profiles = (state: Profiles = INITIAL_PROFILES_STATE, action: Actio
       errorInfo: action.payload.errorInfo
     });
   case CLEAR_PROFILE: {
-    let clone = Object.assign({}, state);
+    let clone = {...state};
     delete clone[action.payload.username];
     return clone;
   }
@@ -105,9 +106,10 @@ export const profiles = (state: Profiles = INITIAL_PROFILES_STATE, action: Actio
       return state;
     }
     return patchProfile({
-      edit: Object.assign({}, profile.edit, {
-        profile: action.payload.profile
-      })
+      edit: {
+        ...profile.edit,
+        profile: action.payload.profile,
+      }
     });
   case START_PROFILE_EDIT:
     profile = getProfile();
@@ -156,7 +158,10 @@ export const profiles = (state: Profiles = INITIAL_PROFILES_STATE, action: Actio
         });
       }
       return patchProfile({
-        edit: Object.assign({}, profile.edit, { errors })
+        edit: {
+          ...profile.edit,
+          errors,
+        }
       });
     }
   case UPDATE_VALIDATION_VISIBILITY:
@@ -166,9 +171,10 @@ export const profiles = (state: Profiles = INITIAL_PROFILES_STATE, action: Actio
     } else {
       let visibility = profile.edit.visibility;
       return patchProfile({
-        edit: Object.assign({}, profile.edit, {
-          visibility: R.append(action.payload.keySet, visibility)
-        })
+        edit: {
+          ...profile.edit,
+          visibility: R.append(action.payload.keySet, visibility),
+        }
       });
     }
   default:
@@ -186,20 +192,23 @@ export const dashboard = (state: DashboardState = INITIAL_DASHBOARD_STATE, actio
     if (action.payload.noSpinner) {
       return state;
     } else {
-      return Object.assign({}, state, {
+      return {
+        ...state,
         fetchStatus: FETCH_PROCESSING
-      });
+      };
     }
   case RECEIVE_DASHBOARD_SUCCESS:
-    return Object.assign({}, state, {
+    return {
+      ...state,
       fetchStatus: FETCH_SUCCESS,
       programs: action.payload.programs
-    });
+    };
   case RECEIVE_DASHBOARD_FAILURE:
-    return Object.assign({}, state, {
+    return {
+      ...state,
       fetchStatus: FETCH_FAILURE,
-      errorInfo: action.payload.errorInfo
-    });
+      errorInfo: action.payload.errorInfo,
+    };
   case UPDATE_COURSE_STATUS: {
     const { courseId, status } = action.payload;
     let programs = _.cloneDeep(state.programs);
@@ -212,7 +221,10 @@ export const dashboard = (state: DashboardState = INITIAL_DASHBOARD_STATE, actio
         }
       }
     }
-    return Object.assign({}, state, { programs });
+    return {
+      ...state,
+      programs,
+    };
   }
   case CLEAR_DASHBOARD:
     return INITIAL_DASHBOARD_STATE;
@@ -228,17 +240,20 @@ const INITIAL_CHECKOUT_STATE = {};
 export const checkout = (state: CheckoutState = INITIAL_CHECKOUT_STATE, action: Action) => {
   switch (action.type) {
   case REQUEST_CHECKOUT:
-    return Object.assign({}, state, {
-      fetchStatus: FETCH_PROCESSING
-    });
+    return {
+      ...state,
+      fetchStatus: FETCH_PROCESSING,
+    };
   case RECEIVE_CHECKOUT_SUCCESS:
-    return Object.assign({}, state, {
-      fetchStatus: FETCH_SUCCESS
-    });
+    return {
+      ...state,
+      fetchStatus: FETCH_SUCCESS,
+    };
   case RECEIVE_CHECKOUT_FAILURE:
-    return Object.assign({}, state, {
-      fetchStatus: FETCH_FAILURE
-    });
+    return {
+      ...state,
+      fetchStatus: FETCH_FAILURE,
+    };
   default:
     return state;
   }
@@ -250,19 +265,22 @@ const INITIAL_COURSE_PRICES_STATE: CoursePricesState = {
 export const prices = (state: CoursePricesState = INITIAL_COURSE_PRICES_STATE, action: Action) => {
   switch (action.type) {
   case REQUEST_COURSE_PRICES:
-    return Object.assign({}, state, {
+    return {
+      ...state,
       fetchStatus: FETCH_PROCESSING
-    });
+    };
   case RECEIVE_COURSE_PRICES_SUCCESS:
-    return Object.assign({}, state, {
+    return {
+      ...state,
       fetchStatus: FETCH_SUCCESS,
       coursePrices: action.payload
-    });
+    };
   case RECEIVE_COURSE_PRICES_FAILURE:
-    return Object.assign({}, state, {
+    return {
+      ...state,
       fetchStatus: FETCH_FAILURE,
       errorInfo: action.payload
-    });
+    };
   case CLEAR_COURSE_PRICES:
     return INITIAL_COURSE_PRICES_STATE;
   default:

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -122,9 +122,10 @@ describe('reducers', () => {
     });
 
     it("should patch the profile successfully", () => {
-      let updatedProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
-        change: true
-      });
+      let updatedProfile = {
+        ...USER_PROFILE_RESPONSE,
+        change: true,
+      };
       patchUserProfileStub.withArgs(SETTINGS.user.username).returns(Promise.resolve(updatedProfile));
 
       return dispatchThen(
@@ -162,9 +163,10 @@ describe('reducers', () => {
           visibility: [],
         });
 
-        let newProfile = Object.assign({}, USER_PROFILE_RESPONSE, {
-          newField: true
-        });
+        let newProfile = {
+          ...USER_PROFILE_RESPONSE,
+          newField: true,
+        };
 
         return dispatchThen(updateProfile('jane', newProfile), [UPDATE_PROFILE]).then(profileState => {
           assert.deepEqual(profileState['jane'].edit, {

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -120,131 +120,153 @@ export const INITIAL_UI_STATE: UIState = {
 export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
   switch (action.type) {
   case UPDATE_DIALOG_TEXT:
-    return Object.assign({}, state, {
-      dialog: Object.assign(
-        {},
-        state.dialog,
-        { text: action.payload }
-      )
-    });
+    return {
+      ...state,
+      dialog: {
+        ...state.dialog,
+        text: action.payload,
+      },
+    };
   case UPDATE_DIALOG_TITLE:
-    return Object.assign({}, state, {
-      dialog: Object.assign(
-        {},
-        state.dialog,
-        { title: action.payload }
-      )
-    });
+    return {
+      ...state,
+      dialog: {
+        ...state.dialog,
+        title: action.payload,
+      },
+    };
   case SET_DIALOG_VISIBILITY:
-    return Object.assign({}, state, {
-      dialog: Object.assign(
-        {},
-        state.dialog,
-        { visible: action.payload }
-      )
-    });
+    return {
+      ...state,
+      dialog: {
+        ...state.dialog,
+        visible: action.payload,
+      },
+    };
   case SET_PROGRAM:
-    return Object.assign({}, state, {
-      selectedProgram: action.payload
-    });
+    return {
+      ...state,
+      selectedProgram: action.payload,
+    };
   case SET_WORK_HISTORY_EDIT:
-    return Object.assign({}, state, {
-      workHistoryEdit: action.payload
-    });
+    return {
+      ...state,
+      workHistoryEdit: action.payload,
+    };
   case SET_WORK_DIALOG_VISIBILITY:
-    return Object.assign({}, state, {
-      workDialogVisibility: action.payload
-    });
+    return {
+      ...state,
+      workDialogVisibility: action.payload,
+    };
   case SET_WORK_DIALOG_INDEX:
-    return Object.assign({}, state, {
-      workDialogIndex: action.payload
-    });
+    return {
+      ...state,
+      workDialogIndex: action.payload,
+    };
   case SET_WORK_HISTORY_ANSWER:
-    return Object.assign({}, state, {
-      workHistoryAnswer: action.payload
-    });
+    return {
+      ...state,
+      workHistoryAnswer: action.payload,
+    };
   case SET_EDUCATION_DIALOG_VISIBILITY:
-    return Object.assign({}, state, {
-      educationDialogVisibility: action.payload
-    });
+    return {
+      ...state,
+      educationDialogVisibility: action.payload,
+    };
   case SET_EDUCATION_DIALOG_INDEX:
-    return Object.assign({}, state, {
-      educationDialogIndex: action.payload
-    });
+    return {
+      ...state,
+      educationDialogIndex: action.payload,
+    };
   case SET_EDUCATION_DEGREE_LEVEL:
-    return Object.assign({}, state, {
-      educationDegreeLevel: action.payload
-    });
+    return {
+      ...state,
+      educationDegreeLevel: action.payload,
+    };
   case SET_EDUCATION_LEVEL_ANSWERS:
-    return Object.assign({}, state, {
-      educationLevelAnswers: action.payload
-    });
+    return {
+      ...state,
+      educationLevelAnswers: action.payload,
+    };
   case CLEAR_UI:
     return INITIAL_UI_STATE;
   case SET_USER_PAGE_DIALOG_VISIBILITY: {
-    return Object.assign({}, state, {
-      userPageDialogVisibility: action.payload
-    });
+    return {
+      ...state,
+      userPageDialogVisibility: action.payload,
+    };
   }
   case SET_USER_PAGE_ABOUT_ME_DIALOG_VISIBILITY: {
-    return Object.assign({}, state, {
-      userPageAboutMeDialogVisibility: action.payload
-    });
+    return {
+      ...state,
+      userPageAboutMeDialogVisibility: action.payload,
+    };
   }
   case SET_SHOW_EDUCATION_DELETE_DIALOG: {
-    return Object.assign({}, state, {
-      showEducationDeleteDialog: action.payload
-    });
+    return {
+      ...state,
+      showEducationDeleteDialog: action.payload,
+    };
   }
   case SET_SHOW_WORK_DELETE_DIALOG: {
-    return Object.assign({}, state, {
-      showWorkDeleteDialog: action.payload
-    });
+    return {
+      ...state,
+      showWorkDeleteDialog: action.payload,
+    };
   }
   case SET_DELETION_INDEX: {
-    return Object.assign({}, state, {
-      deletionIndex: action.payload
-    });
+    return {
+      ...state,
+      deletionIndex: action.payload,
+    };
   }
   case SET_PROFILE_STEP: {
-    return Object.assign({}, state, {
-      profileStep: action.payload
-    });
+    return {
+      ...state,
+      profileStep: action.payload,
+    };
   }
   case SET_USER_MENU_OPEN: {
-    return Object.assign({}, state, {
-      userMenuOpen: action.payload
-    });
+    return {
+      ...state,
+      userMenuOpen: action.payload,
+    };
   }
   case SET_SEARCH_FILTER_VISIBILITY: {
-    return Object.assign({}, state, {
-      searchFilterVisibility: action.payload
-    });
+    return {
+      ...state,
+      searchFilterVisibility: action.payload,
+    };
   }
   case SET_EMAIL_DIALOG_VISIBILITY: {
-    return Object.assign({}, state, {
-      emailDialogVisibility: action.payload
-    });
+    return {
+      ...state,
+      emailDialogVisibility: action.payload,
+    };
   }
   case SET_ENROLL_DIALOG_ERROR: {
-    return Object.assign({}, state, {
-      enrollDialogError: action.payload
-    });
+    return {
+      ...state,
+      enrollDialogError: action.payload,
+    };
   }
   case SET_TOAST_MESSAGE: {
-    return Object.assign({}, state, {
-      toastMessage: action.payload
-    });
+    return {
+      ...state,
+      toastMessage: action.payload,
+    };
   }
   case SET_ENROLL_SELECTED_PROGRAM: {
-    return Object.assign({}, state, {
-      enrollSelectedProgram: action.payload
-    });
+    return {
+      ...state,
+      enrollSelectedProgram: action.payload,
+    };
   }
   case SET_ENROLL_DIALOG_VISIBILITY: {
-    return Object.assign({}, state, {
+    return {
+      ...state,
       enrollDialogVisibility: action.payload
-    });
+    };
   }
   case SET_PHOTO_DIALOG_VISIBILITY:
     return { ...state, photoDialogVisibility: action.payload };

--- a/static/js/util/popover_animation.js
+++ b/static/js/util/popover_animation.js
@@ -67,7 +67,7 @@ export default class PopoverNullAnimation extends Component {
 
     return (
       <Paper
-        style={Object.assign(styles.root, style)}
+        style={{...styles.root, style}}
         zDepth={zDepth}
         className={className}
       >

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -221,9 +221,10 @@ export function boundCheckbox(keySet: string[], label: string|React$Element<*>):
  */
 export function saveProfileStep(validator: Validator|UIValidator, isLastStep: boolean = false): Promise<Profile> {
   const { saveProfile, profile, ui } = this.props;
-  let clone = Object.assign({}, profile, {
+  let clone = {
+    ...profile,
     filled_out: profile.filled_out || isLastStep
-  });
+  };
 
   if (isLastStep && !profile.filled_out) {
     clone.email_optin = true;

--- a/static/js/util/profile_edit_test.js
+++ b/static/js/util/profile_edit_test.js
@@ -537,10 +537,11 @@ describe('Profile Editing utility functions', () => {
       let func = () => null;
       let ret = saveProfileStep.call(that, func, true);
 
-      let clone = Object.assign({}, that.props.profile, {
+      let clone = {
+        ...that.props.profile,
         filled_out: true,
-        email_optin: true
-      });
+        email_optin: true,
+      };
 
       assert.ok(that.props.saveProfile.calledWith(
         func,

--- a/static/js/util/profile_history_edit.js
+++ b/static/js/util/profile_history_edit.js
@@ -32,8 +32,10 @@ export function openNewEducationForm(level: string, index: number) {
     newIndex = profile['education'].length;
   }
   /* add empty education */
-  let clone = Object.assign({}, profile);
-  clone['education'] = clone['education'].concat(generateNewEducation(level));
+  let clone = {
+    ...profile,
+    education: [...profile.education, generateNewEducation(level)]
+  };
   updateProfile(clone, validator, true);
   setEducationDialogIndex(newIndex);
   setEducationDegreeLevel(level);
@@ -55,8 +57,10 @@ export function openNewWorkHistoryForm () {
     setWorkDialogVisibility,
     validator,
   } = this.props;
-  let clone = Object.assign({}, profile);
-  clone['work_history'] = clone['work_history'].concat(generateNewWorkHistory());
+  let clone = {
+    ...profile,
+    work_history: [...profile.work_history, generateNewWorkHistory()]
+  };
   updateProfile(clone, validator, true);
   setWorkDialogIndex(clone.work_history.length - 1);
   setWorkDialogVisibility(true);

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -26,7 +26,10 @@ export function findCourse(courseSelector: (course: Course, program: Program) =>
 }
 
 export const alterFirstRun = (course: Course, overrideObject: Object): CourseRun => {
-  course.runs[0] = Object.assign({}, course.runs[0], overrideObject);
+  course.runs[0] = {
+    ...course.runs[0],
+    ...overrideObject
+  };
   return course.runs[0];
 };
 

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -320,10 +320,11 @@ describe('utility functions', () => {
           }
         }
 
-        let clone = Object.assign({}, USER_PROFILE_RESPONSE, {
+        let clone = {
+          ...USER_PROFILE_RESPONSE,
           edx_level_of_education: outerValue,
-          education: []
-        });
+          education: [],
+        };
         assert.deepEqual(copy, calculateDegreeInclusions(clone));
       });
     }
@@ -334,22 +335,24 @@ describe('utility functions', () => {
         defaults[value] = true;
       }
 
-      let clone = Object.assign({}, USER_PROFILE_RESPONSE, {
+      let clone = {
+        ...USER_PROFILE_RESPONSE,
         edx_level_of_education: null,
-        education: []
-      });
+        education: [],
+      };
       assert.deepEqual(defaults, calculateDegreeInclusions(clone));
     });
 
     it('turns on the switch if there is at least one education of that level', () => {
-      let clone = Object.assign({}, USER_PROFILE_RESPONSE, {
+      let clone = {
+        ...USER_PROFILE_RESPONSE,
         edx_level_of_education: HIGH_SCHOOL,
         education: [{
           degree_name: HIGH_SCHOOL
         }, {
           degree_name: DOCTORATE
-        }]
-      });
+        }],
+      };
       assert.deepEqual(calculateDegreeInclusions(clone), {
         [HIGH_SCHOOL]: true,
         [DOCTORATE]: true,

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -208,11 +208,18 @@ a.btn {
   }
 }
 
-.dialog {
+.dialog, .course-action {
   .disabled-with-spinner {
     display: inline-block !important;
 
+    .mdl-spinner {
+      height: 20px !important;
+      line-height: 20px !important;
+      width: 20px !important;
+    }
+
     .mdl-spinner__layer {
+      // these are against a white background
       border-color: $button-color !important;
     }
   }

--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -205,7 +205,7 @@ body.app-media {
       @include breakpoint(phone) {
         font-size: 25px;
         line-height: 1.15;
-        margin-bottom: 0;
+        margin-bottom: 10px;
       }
     }
 
@@ -221,7 +221,9 @@ body.app-media {
       }
 
       @include breakpoint(phone) {
-        display: none;
+        font-size: 20px;
+        line-height: 1.15;
+        margin-bottom: 0;
       }
     }
 


### PR DESCRIPTION
## Anna Gavrilman
  - [ ] Made twitter description tag shorter (#2083) ([13f73765](../commit/13f7376570c3c57b6b6ad0c657b1fcdb400e5a7a))

## George Schneeloch
  - [ ] Disable enroll and pay later button during API activity (#2056) ([cb27c91b](../commit/cb27c91b6ef3363a39bbe101b1a7bd6d5614b4cc))
  - [ ] Added cropper to object types (#2114) ([7f6e4f40](../commit/7f6e4f4019a9c31489cb3c356be44c49da63151d))
  - [ ] Replace utcnow() with now(tz=pytz.UTC) (#2107) ([6843eeba](../commit/6843eebaa972a5b64510fa6bdab5e58a17758fc1))
  - [ ] Filter out *_test.js files from test coverage (#1968) ([d254701f](../commit/d254701f0618df813949120b38fff193375e21cf))
  - [ ] Replace Object.assign with spread syntax (#2069) ([2d26906c](../commit/2d26906c552ea79d026721f1d347205d425de505))

## Alice Pote
  - [ ] Fixed race condition with getCroppedCanvas ([6911636c](../commit/6911636cb46ccf6df68603a63054f31f4541b19f))
  - [ ] Ensured that search query is reset when changing programs ([025b18a6](../commit/025b18a6c1b3e818eff2292fc6c47d8eec02aeeb))
  - [ ] Limited the birth country facet to 15 options ([ecce6d53](../commit/ecce6d536f94eb4269f9811813621c0bab3ca5ca))
  - [ ] Changed to https-only in npm-shrinkwrap ([a29af513](../commit/a29af513dff69895d5b5b91db82a58812c7b42fc))

## Amir Qayyum Khan
  - [ ] Fixed &quot;View on edx&quot; links to wrong URLs (#2073) ([fc2cf8ff](../commit/fc2cf8ff0d9f81e84886962aca63645039018cf0))
  - [ ] Added do not set income tax statement by email instruction message (#2091) ([93d790d4](../commit/93d790d4ee2c18f24e21a13864adfa24c7902386))

## David Baumgold
  - [ ] Display tagline on mobile (#2085) ([a4cc23a6](../commit/a4cc23a6097c4d9043b6d5c43ab08068ceac2b40))

## Gavin Sidebottom
  - [ ] Fixed faulty hiding for facets that use nested fields ([fb663df6](../commit/fb663df65074c4f73e340a484a2b66879c315300))