### PR TITLE
Added add_past_passed_run command in alter_data

### DIFF
--- a/seed_data/management/commands/alter_data.py
+++ b/seed_data/management/commands/alter_data.py
@@ -35,49 +35,49 @@ USAGE_DETAILS = (
     """
     Example commands:
 
-    # Turn financial aid off/on for a program with a title that contains 'Digital'
-    alter_data --action=turn_financial_aid_off --program-title="Digital"
-    alter_data --action=turn_financial_aid_on --program-title="Digital"
+    # Turn financial aid off/on for a program with a title that contains 'Analog'
+    alter_data --action=turn_financial_aid_off --program-title="Analog"
+    alter_data --action=turn_financial_aid_on --program-title="Analog"
 
-    # For a user with a username 'staff', set the 'Digital Learning' 100-level course to enrolled
-    alter_data --action=set_course_to_enrolled --username=staff --program-title='Digital' --course-title='100'
+    # For a user with a username 'staff', set the 'Analog Learning' 100-level course to enrolled
+    alter_data --action=set_course_to_enrolled --username=staff --program-title='Analog' --course-title='100'
 
-    # Set the 'Digital Learning' 200-level course to failed with a specific grade
-    alter_data --action=set_course_to_failed --username=staff --program-title='Digital' --course-title='200' --grade=45
+    # Set the 'Analog Learning' 200-level course to failed with a specific grade
+    alter_data --action=set_course_to_failed --username=staff --program-title='Analog' --course-title='200' --grade=45
 
-    # Set the 'Digital Learning' 300-level course to enrolled
-    alter_data --action=set_course_to_enrolled --username=staff --program-title='Digital' --course-title='300'
+    # Set the 'Analog Learning' 300-level course to enrolled
+    alter_data --action=set_course_to_enrolled --username=staff --program-title='Analog' --course-title='300'
 
-    # Set the 'Digital Learning' 300-level course to enrolled, and set it to start in the future
+    # Set the 'Analog Learning' 300-level course to enrolled, and set it to start in the future
     """
-    "alter_data --action=set_course_to_enrolled --username=staff --program-title='Digital' --course-title='300' "
+    "alter_data --action=set_course_to_enrolled --username=staff --program-title='Analog' --course-title='300' "
     "--in-future"
     """
 
-    # Set the 'Digital Learning' 300-level course to enrolled, but in need of upgrade (aka 'audit')
-    alter_data --action=set_course_to_needs_upgrade --username=staff --program-title='Digital' --course-title='300'
+    # Set the 'Analog Learning' 300-level course to enrolled, but in need of upgrade (aka 'audit')
+    alter_data --action=set_course_to_needs_upgrade --username=staff --program-title='Analog' --course-title='300'
 
     # (Another way to achieve the result of the above command...)
-    alter_data --action=set_course_to_enrolled --username=staff --program-title='Digital' --course-title='100' --audit
+    alter_data --action=set_course_to_enrolled --username=staff --program-title='Analog' --course-title='100' --audit
 
-    # Set the 'Digital Learning' 300-level course to enrolled and in need of upgrade, but past the deadline
+    # Set the 'Analog Learning' 300-level course to enrolled and in need of upgrade, but past the deadline
     """
-    "alter_data --action=set_course_to_needs_upgrade --username=staff --program-title='Digital' "
+    "alter_data --action=set_course_to_needs_upgrade --username=staff --program-title='Analog' "
     "--course-title='300' --missed-deadline"
     """
 
-    # Set the 'Digital Learning' 100-level course to have an offered course run (and no enrollments)
-    alter_data --action=set_course_to_offered --username=staff --program-title='Digital' --course-title='100'
+    # Set the 'Analog Learning' 100-level course to have an offered course run (and no enrollments)
+    alter_data --action=set_course_to_offered --username=staff --program-title='Analog' --course-title='100'
 
-    # Set the 'Digital Learning' 100-level course to have an offered course run with a fuzzy start date
-    alter_data --action=set_course_to_offered --username=staff --program-title='Digital' --course-title='100' --fuzzy
+    # Set the 'Analog Learning' 100-level course to have an offered course run with a fuzzy start date
+    alter_data --action=set_course_to_offered --username=staff --program-title='Analog' --course-title='100' --fuzzy
 
     # Add a past failed course run with a specific grade
-    alter_data --action=add_past_failed_run --username=staff --program-title='Digital' --course-title='100' --grade=30
+    alter_data --action=add_past_failed_run --username=staff --program-title='Analog' --course-title='100' --grade=30
 
     # Add a past failed course run, even if a previous failed run already exists
     """
-    "alter_data --action=add_past_failed_run --username=staff --program-title='Digital' --course-title='100' "
+    "alter_data --action=add_past_failed_run --username=staff --program-title='Analog' --course-title='100' "
     "--add-if-exists"
     """
 

--- a/seed_data/management/commands/alter_data.py
+++ b/seed_data/management/commands/alter_data.py
@@ -190,10 +190,9 @@ def get_past_course_run(user=None, course=None, now=None, add_if_exists=False):
         end_date__lt=now,
     ).exclude(end_date=None).order_by('-end_date').all()
     for past_run in past_runs:
-        if not (CachedCurrentGradeHandler(user).exists(past_run)
-                or CachedCertificateHandler(user).exists(past_run)):
+        if not (CachedCurrentGradeHandler(user).exists(past_run) or
+                CachedCertificateHandler(user).exists(past_run)):
             chosen_past_run = past_run
-            continue
         elif not add_if_exists:
             raise Exception("Past failed/passed course run already exists (id: {}, title: {})".format(
                 past_run.id,


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #2044
#### What's this PR do?
Added a management command that allows the user to make a past passed course run for a user (in a non FA program)


#### How should this be manually tested?
Enroll in the Analog Learning program.
Run this command and check if you can see the passed course in the dashboard:

`alter_data --action=add_past_passed_run --username=staff --program-title='Analog' --course-title='100' --add-if-exists`
