### PR TITLE
Show grade for prior passed course runs

### DIFF
--- a/static/js/components/dashboard/CourseSubRow_test.js
+++ b/static/js/components/dashboard/CourseSubRow_test.js
@@ -12,6 +12,7 @@ import {
   COURSE_PRICES_RESPONSE,
   FINANCIAL_AID_PARTIAL_RESPONSE,
   STATUS_NOT_PASSED,
+  STATUS_PASSED,
   STATUS_OFFERED,
 } from '../../constants';
 
@@ -88,7 +89,6 @@ describe('CourseSubRow', () => {
       courseRun: courseRun,
     });
     assert.include(wrapper.find(".course-description").html(), "Enrollment starts:");
-    assert.equal(wrapper.find(".course-action").text(), "");
   });
 
   it('shows fuzzy start date for offered course run if start date is missing', () => {
@@ -130,6 +130,20 @@ describe('CourseSubRow', () => {
     assert.equal(wrapper.find(".course-grade").text(), "50%");
     assert.equal(wrapper.find(".course-action").text(), "Failed");
   });
+
+  it('should course information if a course was passed', () => {
+    let courseRun = {
+      ...courseRun,
+      status: STATUS_PASSED,
+      final_grade: 100
+    };
+    const wrapper = renderSubRow({
+      courseRun: courseRun,
+    });
+    assert.equal(wrapper.find(".course-grade").text(), "100%");
+    assert.equal(wrapper.find(".course-action").text(), "Passed");
+  });
+
 
   it('shows a course date range for a failed course run', () => {
     Object.assign(courseRun, {

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -491,7 +491,49 @@ export const DASHBOARD_RESPONSE = deepFreeze([
         "prerequisites": null
       },
       {
-        "id": 12,
+        "id": 1278,
+        "title": "Passed course, most recent run non-passed, older passed",
+        "position_in_program": 7,
+        "runs": [
+          {
+            "certificate_url": "www.google.com",
+            "title": "Passed run missing grade",
+            "status": STATUS_PASSED,
+            "position": 2,
+            "course_id": "course_id_one",
+            "id": 100,
+            "course_start_date": "2015-08-22T11:48:27Z",
+            "fuzzy_start_date": "Fall 2015",
+            "course_end_date": "2015-09-09T10:20:10Z",
+          },
+          {
+            "certificate_url": "www.google.com",
+            "title": "Passed run missing grade",
+            "status": STATUS_PASSED,
+            "position": 1,
+            "course_id": "course_id_two",
+            "final_grade": "88",
+            "id": 102,
+            "course_start_date": "2015-08-22T11:48:27Z",
+            "fuzzy_start_date": "Fall 2015",
+            "course_end_date": "2015-09-09T10:20:10Z",
+          },
+          {
+            "certificate_url": "www.google.com",
+            "title": "Passed run missing grade",
+            "status": STATUS_NOT_PASSED,
+            "position": 0,
+            "course_id": "course_id_three",
+            "final_grade": "43",
+            "id": 101,
+            "course_start_date": "2016-08-22T11:48:27Z",
+            "fuzzy_start_date": "Fall 2017",
+            "course_end_date": "2016-09-09T10:20:10Z",
+          }
+        ]
+      },
+      {
+        "id": 17,
         "title": "Passed course missing grade - check mark, no grade",
         "position_in_program": 6,
         "runs": [

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -281,7 +281,7 @@
         font-size: 10pt;
       }
 
-      &.course-not-passed {
+      &.course-completed {
         font-style: italic;
       }
     }


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #1887 

#### What's this PR do?

This changes the `CourseSubRow` component so that it will now show the grade for a past `CourseRun` which the user passed.

#### How should this be manually tested?

There's a patch here: https://gist.github.com/aliceriot/d729233d17d33bc0567bd0897de916a7#file-mm_mock_api_12_14_16 which will set things up to test this with the data in `constants.js`. Here's how to use it:

```
curl https://gist.githubusercontent.com/aliceriot/d729233d17d33bc0567bd0897de916a7/raw/610744ad5ad3603622760492e99ed1b1946d7549/mm_mock_api_12_14_16 > mock_api.patch
git apply mock_api.patch
```

then when you visit the dashboard there should be a course in the `Master` program titled `Passed course, most recent run non-passed, older passed`, which will have two past course runs, one passed and one failed.

#### Screenshots (if appropriate)

![passed_two_course_runs](https://cloud.githubusercontent.com/assets/6207644/21193825/997d1fa6-c1fb-11e6-90b2-e4bcc6e453e9.png)
