### PR TITLE
Correct spacing for course search facet

### DIFF
--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -132,6 +132,17 @@
       }
     }
 
+    .filter--courses {
+      .sk-item-list-option {
+        margin-bottom: 8px;
+
+        .sk-item-list-option__text {
+          margin-top: 2px;
+          line-height: 1.3;
+        }
+      }
+    }
+
     .filter--grade-average {
       .sk-panel__content {
         padding-right: 25px;


### PR DESCRIPTION
Fixes #2124. Corrects the spacing around the course search facet to account for course names that wrap to multiple lines.
<img width="611" alt="over-nine-thousand" src="https://cloud.githubusercontent.com/assets/132355/21200689/2e5ae436-c216-11e6-9210-f86d6f6083df.png">


