### PR TITLE
Disable skip financial aid button during API activity

### DIFF
--- a/static/js/components/SkipFinancialAidDialog.js
+++ b/static/js/components/SkipFinancialAidDialog.js
@@ -1,30 +1,9 @@
 // @flow
 import React from 'react';
 import Dialog from 'material-ui/Dialog';
-import Button from 'react-mdl/lib/Button';
 
 import { FETCH_PROCESSING } from '../actions';
-import SpinnerButton from './SpinnerButton';
-
-const skipActions = (cancel, skip, fetchAddStatus, fetchSkipStatus) => (
-  <div className="actions">
-    <Button
-      type='button'
-      className="secondary-button cancel-button"
-      onClick={cancel}>
-      Cancel
-    </Button>
-    <SpinnerButton
-      component={Button}
-      spinning={fetchSkipStatus === FETCH_PROCESSING}
-      disabled={fetchAddStatus === FETCH_PROCESSING}
-      type='button'
-      className="primary-button save-button skip-button"
-      onClick={skip}>
-      Pay Full Price
-    </SpinnerButton>
-  </div>
-);
+import { dialogActions } from './inputs/util';
 
 type SkipProps = {
   cancel:           () => void,
@@ -43,7 +22,14 @@ const SkipFinancialAidDialog = ({cancel, skip, open, fullPrice, fetchAddStatus, 
     className="skip-financial-aid-dialog-wrapper"
     open={open}
     onRequestClose={cancel}
-    actions={skipActions(cancel, skip, fetchAddStatus, fetchSkipStatus)}
+    actions={dialogActions(
+      cancel,
+      skip,
+      fetchSkipStatus === FETCH_PROCESSING,
+      'Pay Full Price',
+      'skip-button',
+      fetchAddStatus === FETCH_PROCESSING
+    )}
   >
     You may qualify for a reduced cost. Clicking "Pay Full Price"
     means that you are declining this option and you will pay the

--- a/static/js/components/SkipFinancialAidDialog.js
+++ b/static/js/components/SkipFinancialAidDialog.js
@@ -3,7 +3,10 @@ import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import Button from 'react-mdl/lib/Button';
 
-const skipActions = (cancel, skip) => (
+import { FETCH_PROCESSING } from '../actions';
+import SpinnerButton from './SpinnerButton';
+
+const skipActions = (cancel, skip, fetchAddStatus, fetchSkipStatus) => (
   <div className="actions">
     <Button
       type='button'
@@ -11,23 +14,28 @@ const skipActions = (cancel, skip) => (
       onClick={cancel}>
       Cancel
     </Button>
-    <Button
+    <SpinnerButton
+      component={Button}
+      spinning={fetchSkipStatus === FETCH_PROCESSING}
+      disabled={fetchAddStatus === FETCH_PROCESSING}
       type='button'
-      className="primary-button save-button"
+      className="primary-button save-button skip-button"
       onClick={skip}>
       Pay Full Price
-    </Button>
+    </SpinnerButton>
   </div>
 );
 
 type SkipProps = {
-  cancel:     () => void,
-  skip:       () => void,
-  open:       boolean,
-  fullPrice:  React$Element<*>,
+  cancel:           () => void,
+  skip:             () => void,
+  open:             boolean,
+  fullPrice:        React$Element<*>,
+  fetchAddStatus?:  string,
+  fetchSkipStatus?: string,
 }
 
-const SkipFinancialAidDialog = ({cancel, skip, open, fullPrice}: SkipProps) => (
+const SkipFinancialAidDialog = ({cancel, skip, open, fullPrice, fetchAddStatus, fetchSkipStatus}: SkipProps) => (
   <Dialog
     title="Are you sure?"
     titleClassName="dialog-title"
@@ -35,7 +43,7 @@ const SkipFinancialAidDialog = ({cancel, skip, open, fullPrice}: SkipProps) => (
     className="skip-financial-aid-dialog-wrapper"
     open={open}
     onRequestClose={cancel}
-    actions={skipActions(cancel, skip)}
+    actions={skipActions(cancel, skip, fetchAddStatus, fetchSkipStatus)}
   >
     You may qualify for a reduced cost. Clicking "Pay Full Price"
     means that you are declining this option and you will pay the

--- a/static/js/components/SpinnerButton.js
+++ b/static/js/components/SpinnerButton.js
@@ -22,14 +22,16 @@ export default class SpinnerButton extends React.Component {
       ...otherProps
     } = this.props;
 
-    if (spinning) {
+    if (spinning && !disabled) {
       if (!className) {
         className = '';
       }
       className = `${className} disabled-with-spinner`;
-      onClick = undefined;
       children = <Spinner singleColor />;
       disabled = true;
+    }
+    if (disabled) {
+      onClick = undefined;
     }
 
     return <ComponentVariable

--- a/static/js/components/SpinnerButton_test.js
+++ b/static/js/components/SpinnerButton_test.js
@@ -43,7 +43,6 @@ describe("SpinnerButton", () => {
   it('replaces children with a Spinner, disables onClick and updates className when spinning is true', () => {
     let onClick = sandbox.stub();
     let props = {
-      disabled: true,
       "data-x": "y",
     };
     let wrapper = shallow(<SpinnerButton
@@ -61,7 +60,22 @@ describe("SpinnerButton", () => {
 
     assert.isUndefined(buttonProps.onClick);
     assert.equal(buttonProps.className, "class1 class2 disabled-with-spinner");
+    assert.equal(buttonProps['data-x'], 'y');
     assert.isTrue(buttonProps.disabled);
     assert.equal(button.children().text(), "<Spinner />");
+  });
+
+  it("does not show the spinner when it's disabled", () => {
+    let wrapper = shallow(<SpinnerButton
+      disabled={true}
+      spinning={true}
+      onClick={sandbox.stub()}
+      component="button"
+    />);
+    let buttonProps = wrapper.find("button").props();
+
+    assert.equal(buttonProps.className, undefined);
+    assert.isTrue(buttonProps.disabled);
+    assert.equal(buttonProps.onClick, undefined);
   });
 });

--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -11,6 +11,7 @@ import { FETCH_PROCESSING } from '../../actions';
 import SpinnerButton from '../SpinnerButton';
 import type { CoursePrice } from '../../flow/dashboardTypes';
 import type { Program } from '../../flow/programTypes';
+import type { FinancialAidState } from '../../reducers/financial_aid';
 import type {
   DocumentsState,
 } from '../../reducers/documents';
@@ -34,6 +35,7 @@ export default class FinancialAidCard extends React.Component {
   props: {
     coursePrice:                    CoursePrice,
     documents:                      DocumentsState,
+    financialAid:                   FinancialAidState,
     openFinancialAidCalculator:     () => void,
     program:                        Program,
     setConfirmSkipDialogVisibility: (b: boolean) => void,
@@ -234,6 +236,7 @@ export default class FinancialAidCard extends React.Component {
       ui: { skipDialogVisibility },
       setConfirmSkipDialogVisibility,
       skipFinancialAid,
+      financialAid,
     } = this.props;
 
     let contents;
@@ -249,6 +252,8 @@ export default class FinancialAidCard extends React.Component {
         cancel={() => setConfirmSkipDialogVisibility(false)}
         skip={() => skipFinancialAid(program.id)}
         fullPrice={price(maxPossibleCost)}
+        fetchAddStatus={financialAid.fetchAddStatus}
+        fetchSkipStatus={financialAid.fetchSkipStatus}
       />
       <CardTitle>Pricing Based on Income</CardTitle>
       <div>

--- a/static/js/components/dashboard/FinancialAidCard_test.js
+++ b/static/js/components/dashboard/FinancialAidCard_test.js
@@ -56,6 +56,7 @@ describe("FinancialAidCard", () => {
           setConfirmSkipDialogVisibility={setSkipDialogStub}
           skipFinancialAid={sandbox.stub()}
           setDocsInstructionsVisibility={sandbox.stub()}
+          financialAid={{}}
           {...props}
         />
       </MuiThemeProvider>

--- a/static/js/components/inputs/util.js
+++ b/static/js/components/inputs/util.js
@@ -8,7 +8,7 @@ import SpinnerButton from '../SpinnerButton';
  * Helper function to create dialog action buttons, with a SpinnerButton for the save button
  */
 export const dialogActions = (
-  onCancel: Function, onSave: Function, inFlight: bool, text: string='Save', saveClass: string=''
+  onCancel: Function, onSave: Function, inFlight: bool, text: string='Save', saveClass: string='', disabled: bool=false
 ) => ([
   <Button
     type='cancel'
@@ -20,6 +20,7 @@ export const dialogActions = (
   <SpinnerButton
     component={Button}
     spinning={inFlight}
+    disabled={disabled}
     type='button'
     key='save'
     className={`primary-button save-button ${saveClass}`}

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -262,6 +262,7 @@ class DashboardPage extends React.Component {
       ui,
       courseEnrollments,
       checkout,
+      financialAid,
     } = this.props;
     const loaded = dashboard.fetchStatus !== FETCH_PROCESSING && prices.fetchStatus !== FETCH_PROCESSING;
     let errorMessage;
@@ -292,6 +293,7 @@ class DashboardPage extends React.Component {
           setConfirmSkipDialogVisibility={this.setConfirmSkipDialogVisibility}
           setDocsInstructionsVisibility={this.setDocsInstructionsVisibility}
           ui={ui}
+          financialAid={financialAid}
         />;
       }
 
@@ -350,6 +352,7 @@ const mapStateToProps = (state) => {
     orderReceipt: state.orderReceipt,
     courseEnrollments: state.courseEnrollments,
     checkout: state.checkout,
+    financialAid: state.financialAid,
   };
 };
 

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -55,6 +55,7 @@ import type {
 } from '../reducers/documents';
 import type { CoursePricesState, DashboardState } from '../flow/dashboardTypes';
 import type { AvailableProgram, CourseEnrollmentsState } from '../flow/enrollmentTypes';
+import type { FinancialAidState } from '../reducers/financial_aid';
 import type { ProfileGetResult } from '../flow/profileTypes';
 import type { Course, CourseRun } from '../flow/programTypes';
 import type { CheckoutState } from '../reducers';
@@ -80,6 +81,7 @@ class DashboardPage extends React.Component {
     orderReceipt:             OrderReceiptState,
     courseEnrollments:        CourseEnrollmentsState,
     checkout:                 CheckoutState,
+    financialAid:             FinancialAidState,
   };
 
   componentDidMount() {

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -174,10 +174,10 @@ const FinancialAidCalculator = ({
     onRequestClose={closeDialogAndCancel}
     actions={calculatorActions(
       openConfirmSkipDialog,
-       closeDialogAndCancel,
-        () => saveFinancialAid(financialAid),
-        fetchAddStatus,
-        fetchSkipStatus,
+      closeDialogAndCancel,
+      () => saveFinancialAid(financialAid),
+      fetchAddStatus,
+      fetchSkipStatus,
     )}
   >
     <div className="copy">

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -93,13 +93,20 @@ const checkBox = (update, current) => (
   />
 );
 
-const calculatorActions = (openSkipDialog, cancel, save, fetchAddStatus) => {
+const calculatorActions = (openSkipDialog, cancel, save, fetchAddStatus, fetchSkipStatus) => {
   return <div className="actions">
     <button className="mm-minor-action full-price" onClick={openSkipDialog}>
       Skip this and Pay Full Price
     </button>
     <div className="buttons">
-      { dialogActions(cancel, save, fetchAddStatus === FETCH_PROCESSING, 'Calculate', 'calculate-cost-button') }
+      { dialogActions(
+        cancel,
+        save,
+        fetchAddStatus === FETCH_PROCESSING,
+        'Calculate',
+        'calculate-cost-button',
+        fetchSkipStatus === FETCH_PROCESSING
+      ) }
     </div>
   </div>;
 };
@@ -139,7 +146,7 @@ const FinancialAidCalculator = ({
   calculatorDialogVisibility,
   closeDialogAndCancel,
   financialAid,
-  financialAid: { validation, fetchError, fetchAddStatus },
+  financialAid: { validation, fetchError, fetchAddStatus, fetchSkipStatus },
   saveFinancialAid,
   updateCalculatorEdit,
   currentProgramEnrollment: { title, id },
@@ -166,7 +173,11 @@ const FinancialAidCalculator = ({
     autoScrollBodyContent={true}
     onRequestClose={closeDialogAndCancel}
     actions={calculatorActions(
-      openConfirmSkipDialog, closeDialogAndCancel, () => saveFinancialAid(financialAid), fetchAddStatus
+      openConfirmSkipDialog,
+       closeDialogAndCancel,
+        () => saveFinancialAid(financialAid),
+        fetchAddStatus,
+        fetchSkipStatus,
     )}
   >
     <div className="copy">

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -12,6 +12,7 @@ import * as api from '../lib/api';
 import { modifyTextField, modifySelectField, clearSelectField } from '../util/test_utils';
 import { DASHBOARD_RESPONSE, FINANCIAL_AID_PARTIAL_RESPONSE } from '../constants';
 import {
+  requestSkipFinancialAid,
   requestAddFinancialAid,
 
   START_CALCULATOR_EDIT,
@@ -241,7 +242,7 @@ describe('FinancialAidCalculator', () => {
       }
 
       return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
-        wrapper.find('.pricing-actions').find('.dashboard-button').simulate('click');
+        wrapper.find('.pricing-actions').find('.calculate-cost-button').simulate('click');
         let calculator = document.querySelector('.financial-aid-calculator');
         TestUtils.Simulate.change(calculator.querySelector('.mdl-checkbox__input'));
         modifyTextField(document.querySelector('#user-salary-input'), '1000');

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -242,7 +242,7 @@ describe('FinancialAidCalculator', () => {
       }
 
       return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
-        wrapper.find('.pricing-actions').find('.calculate-cost-button').simulate('click');
+        wrapper.find('.pricing-actions').find('.dashboard-button').simulate('click');
         let calculator = document.querySelector('.financial-aid-calculator');
         TestUtils.Simulate.change(calculator.querySelector('.mdl-checkbox__input'));
         modifyTextField(document.querySelector('#user-salary-input'), '1000');

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -12,7 +12,6 @@ import * as api from '../lib/api';
 import { modifyTextField, modifySelectField, clearSelectField } from '../util/test_utils';
 import { DASHBOARD_RESPONSE, FINANCIAL_AID_PARTIAL_RESPONSE } from '../constants';
 import {
-  requestSkipFinancialAid,
   requestAddFinancialAid,
 
   START_CALCULATOR_EDIT,

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -13,6 +13,7 @@ import { modifyTextField, modifySelectField, clearSelectField } from '../util/te
 import { DASHBOARD_RESPONSE, FINANCIAL_AID_PARTIAL_RESPONSE } from '../constants';
 import {
   requestAddFinancialAid,
+  requestSkipFinancialAid,
 
   START_CALCULATOR_EDIT,
   UPDATE_CALCULATOR_EDIT,
@@ -29,6 +30,7 @@ import {
   setCurrentProgramEnrollment,
 } from '../actions/programs';
 import {
+  setConfirmSkipDialogVisibility,
   SET_CALCULATOR_DIALOG_VISIBILITY,
   SET_CONFIRM_SKIP_DIALOG_VISIBILITY,
 } from '../actions/ui';
@@ -99,13 +101,50 @@ describe('FinancialAidCalculator', () => {
         let calculator = document.querySelector('.financial-aid-calculator-wrapper');
         TestUtils.Simulate.click(calculator.querySelector('.full-price'));
         let confirmDialog = document.querySelector('.skip-financial-aid-dialog-wrapper');
-        TestUtils.Simulate.click(confirmDialog.querySelector('.save-button'));
+        TestUtils.Simulate.click(confirmDialog.querySelector('.skip-button'));
       }).then(() => {
         assert(
           skipFinancialAidStub.calledWith(program.id),
           'should skip with the right program id'
         );
       });
+    });
+  });
+
+  for (let activity of [true, false]) {
+    it(`has proper spinner state for the skip dialog save button for activity=${activity.toString()}`, () => {
+      skipFinancialAidStub.returns(Promise.resolve(FINANCIAL_AID_PARTIAL_RESPONSE));
+      helper.store.dispatch(setConfirmSkipDialogVisibility(true));
+      if (activity) {
+        helper.store.dispatch(requestSkipFinancialAid());
+      }
+
+      return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
+        let confirmDialog = document.querySelector('.skip-financial-aid-dialog-wrapper');
+        let skipButton = confirmDialog.querySelector('.skip-button');
+
+        assert.equal(skipButton.className.includes('disabled-with-spinner'), activity);
+        assert(skipButton.innerHTML.includes(activity ? 'mdl-spinner' : 'Pay Full Price'));
+        TestUtils.Simulate.click(skipButton);
+        assert.equal(skipFinancialAidStub.calledWith(program.id), !activity);
+      });
+    });
+  }
+
+  it(`disables the button if fetchAddStatus is in progress`, () => {
+    skipFinancialAidStub.returns(Promise.resolve(FINANCIAL_AID_PARTIAL_RESPONSE));
+    helper.store.dispatch(setConfirmSkipDialogVisibility(true));
+    helper.store.dispatch(requestAddFinancialAid());
+
+    return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
+      let confirmDialog = document.querySelector('.skip-financial-aid-dialog-wrapper');
+      let skipButton = confirmDialog.querySelector('.skip-button');
+
+      assert.isFalse(skipButton.className.includes('disabled-with-spinner'));
+      assert.isTrue(skipButton.disabled);
+      assert.equal(skipButton.innerHTML, 'Pay Full Price');
+      TestUtils.Simulate.click(skipButton);
+      assert.isFalse(skipFinancialAidStub.calledWith(program.id));
     });
   });
 
@@ -248,6 +287,7 @@ describe('FinancialAidCalculator', () => {
 
         let saveButton = calculator.querySelector('.save-button');
         assert.equal(saveButton.className.includes('disabled-with-spinner'), activity);
+        assert.equal(saveButton.disabled, activity);
         assert(saveButton.innerHTML.includes(activity ? 'mdl-spinner' : 'Calculate'));
 
         TestUtils.Simulate.click(saveButton);
@@ -259,6 +299,27 @@ describe('FinancialAidCalculator', () => {
       });
     });
   }
+
+  it(`should be disabled if the skip button is in progress`, () => {
+    addFinancialAidStub.returns(Promise.resolve(FINANCIAL_AID_PARTIAL_RESPONSE));
+    helper.store.dispatch(requestSkipFinancialAid());
+
+    return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
+      wrapper.find('.pricing-actions').find('.dashboard-button').simulate('click');
+      let calculator = document.querySelector('.financial-aid-calculator');
+      TestUtils.Simulate.change(calculator.querySelector('.mdl-checkbox__input'));
+      modifyTextField(document.querySelector('#user-salary-input'), '1000');
+
+      let saveButton = calculator.querySelector('.save-button');
+      assert.isFalse(saveButton.className.includes('disabled-with-spinner'));
+      assert.equal(saveButton.innerHTML, 'Calculate');
+      assert.isTrue(saveButton.disabled);
+
+      TestUtils.Simulate.click(saveButton);
+    }).then(() => {
+      assert.isFalse(addFinancialAidStub.calledWith('1000', 'USD', program.id));
+    });
+  });
 
   it('should show an error if the financial aid request fails', () => {
     addFinancialAidStub.returns(Promise.reject({
@@ -321,4 +382,3 @@ if you continue to have problems.`
     assert.lengthOf(wrapper.find(".financial-aid-calculator"), 0);
   });
 });
-

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -119,7 +119,7 @@ describe('FinancialAidCalculator', () => {
         helper.store.dispatch(requestSkipFinancialAid());
       }
 
-      return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
+      return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(() => {
         let confirmDialog = document.querySelector('.skip-financial-aid-dialog-wrapper');
         let skipButton = confirmDialog.querySelector('.skip-button');
 
@@ -136,7 +136,7 @@ describe('FinancialAidCalculator', () => {
     helper.store.dispatch(setConfirmSkipDialogVisibility(true));
     helper.store.dispatch(requestAddFinancialAid());
 
-    return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
+    return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(() => {
       let confirmDialog = document.querySelector('.skip-financial-aid-dialog-wrapper');
       let skipButton = confirmDialog.querySelector('.skip-button');
 


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1752
#### What's this PR do?
- Disable skip financial aid button during API activity
- Disable skip or add financial aid buttons when the other one has API activity going on, without showing a spinner
