### PR TITLE
Added minimal .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
#### What's this PR do?

Adds a `.editorconfig` file, which informs editors/ides of some basic code styles. In this case I'd only added settings for Python and JS files to be space-indented with 4 and 2 spaces respectively. I also put in no trailing newline at EOF for Python since our linter enforces that too. 