### PR TITLE
Use dialogActions for photo upload dialog

### DIFF
--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -9,6 +9,7 @@ import Spinner from 'react-mdl/lib/Spinner';
 import CropperWrapper from './CropperWrapper';
 import { FETCH_PROCESSING } from '../actions';
 import type { ImageUploadState } from '../reducers/image_upload';
+import { dialogActions } from './inputs/util';
 
 const onDrop = R.curry((startPhotoEdit, files) => startPhotoEdit(...files));
 
@@ -91,25 +92,17 @@ const ProfileImageUploader = ({
     autoScrollBodyContent={true}
     contentStyle={{ maxWidth: '620px' }}
     open={photoDialogOpen}
-    actions = {[
-      <Button
-        type='button'
-        className='secondary-button cancel-button'
-        key="cancel"
-        onClick={() => {
-          setDialogVisibility(false);
-          clearPhotoEdit();
-        }}>
-        Cancel
-      </Button>,
-      <Button
-        type='button'
-        className={`save-button ${disabled ? 'secondary-button disabled' : 'primary-button'}`}
-        key="save"
-        onClick={disabled ? undefined: updateUserPhoto}>
-        Save
-      </Button>
-    ]}
+    actions = { dialogActions(
+      () => {
+        setDialogVisibility(false);
+        clearPhotoEdit();
+      },
+      updateUserPhoto,
+      false,
+      'Save',
+      '',
+      disabled,
+    ) }
   >
    { imageError(error) }
    { dialogContents(

--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -3,7 +3,6 @@ import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import R from 'ramda';
 import Dropzone from 'react-dropzone';
-import Button from 'react-mdl/lib/Button';
 import Spinner from 'react-mdl/lib/Spinner';
 
 import CropperWrapper from './CropperWrapper';

--- a/static/js/components/inputs/util.js
+++ b/static/js/components/inputs/util.js
@@ -23,7 +23,7 @@ export const dialogActions = (
     disabled={disabled}
     type='button'
     key='save'
-    className={`primary-button save-button ${saveClass}`}
+    className={`${disabled ? 'secondary-button' : 'primary-button'} save-button ${saveClass}`}
     onClick={onSave}>
     {text}
   </SpinnerButton>

--- a/static/js/components/inputs/util_test.js
+++ b/static/js/components/inputs/util_test.js
@@ -6,12 +6,13 @@ import { dialogActions } from './util';
 describe('input functions', () => {
 
   describe('dialogActions', () => {
+    let onCancel = () => null;
+    let onSave = () => null;
+    let inFlight = true;
+    let newClass = "new-class";
+    let newText = "New Text";
+
     it('renders properly', () => {
-      let onCancel = () => null;
-      let onSave = () => null;
-      let inFlight = true;
-      let newClass = "new-class";
-      let newText = "New Text";
       let actions = dialogActions(onCancel, onSave, inFlight, newText, newClass);
       assert.lengthOf(actions, 2);
       let [cancelButton, saveButton] = actions;
@@ -20,6 +21,21 @@ describe('input functions', () => {
       assert.equal(cancelButton.props.children, "Cancel");
 
       assert.equal(saveButton.props.className, `primary-button save-button ${newClass}`);
+      assert.equal(saveButton.props.onClick, onSave);
+      assert.equal(saveButton.props.children, newText);
+      assert.equal(saveButton.props.spinning, inFlight);
+      assert.equal(saveButton.type.name, "SpinnerButton");
+    });
+
+    it("uses secondary-button if it's disabled", () => {
+      let actions = dialogActions(onCancel, onSave, inFlight, newText, newClass, true);
+      assert.lengthOf(actions, 2);
+      let [cancelButton, saveButton] = actions;
+      assert.equal(cancelButton.props.className, "secondary-button cancel-button");
+      assert.equal(cancelButton.props.onClick, onCancel);
+      assert.equal(cancelButton.props.children, "Cancel");
+
+      assert.equal(saveButton.props.className, `secondary-button save-button ${newClass}`);
       assert.equal(saveButton.props.onClick, onSave);
       assert.equal(saveButton.props.children, newText);
       assert.equal(saveButton.props.spinning, inFlight);

--- a/static/js/containers/ProfileImage_test.js
+++ b/static/js/containers/ProfileImage_test.js
@@ -145,7 +145,8 @@ describe('ProfileImage', () => {
         helper.store.dispatch(setPhotoDialogVisibility(true));
         let dialog = document.querySelector(".photo-upload-dialog");
         let saveButton = dialog.querySelector('.save-button');
-        assert.isTrue(saveButton.className.includes('disabled'));
+        assert.isTrue(saveButton.disabled);
+        assert.isFalse(saveButton.innerHTML.includes("mdl-spinner"));
         TestUtils.Simulate.click(saveButton);
         assert.isFalse(updateProfileImageStub.called);
         assert.isNull(dialog.querySelector('.mdl-spinner'));
@@ -171,7 +172,8 @@ describe('ProfileImage', () => {
         helper.store.dispatch(requestPatchUserPhoto(SETTINGS.user.username));
         let dialog = document.querySelector(".photo-upload-dialog");
         let saveButton = dialog.querySelector('.save-button');
-        assert.include(saveButton.className, 'disabled');
+        assert.isTrue(saveButton.disabled);
+        assert.isFalse(saveButton.innerHTML.includes("mdl-spinner"));
         TestUtils.Simulate.click(saveButton);
         assert.isFalse(updateProfileImageStub.called);
       });


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1752

#### What's this PR do?
Refactors dialog buttons to use the `dialogActions` function we use everywhere else
