### PR TITLE
Remove `foo: Function = () =>` annotations

### DIFF
--- a/static/js/components/ConfirmDeletion.js
+++ b/static/js/components/ConfirmDeletion.js
@@ -15,7 +15,7 @@ export default class ConfirmDeletion extends React.Component {
     itemText:     string,
   };
 
-  deleteAndClose: Function = (): void => {
+  deleteAndClose = (): void => {
     const { close, deleteFunc } = this.props;
     deleteFunc().then(close);
   };

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -74,7 +74,7 @@ class EducationForm extends ProfileFormFields {
     updateValidationVisibility:       (xs: Array<string>) => void,
   };
 
-  openEditEducationForm: Function = (index: number): void => {
+  openEditEducationForm = (index: number): void => {
     const {
       profile,
       setEducationDialogIndex,
@@ -88,7 +88,7 @@ class EducationForm extends ProfileFormFields {
     setEducationDialogVisibility(true);
   };
 
-  openNewEducationForm: Function = (level: string): void => {
+  openNewEducationForm = (level: string): void => {
     const {
       profile,
       updateProfile,
@@ -107,7 +107,7 @@ class EducationForm extends ProfileFormFields {
     setEducationDialogVisibility(true);
   };
 
-  deleteEducationEntry: Function = (): Promise<*> => {
+  deleteEducationEntry = (): Promise<*> => {
     const { saveProfile, profile, ui } = this.props;
     let clone = _.cloneDeep(profile);
     if (ui.deletionIndex !== undefined && ui.deletionIndex !== null) {
@@ -116,7 +116,7 @@ class EducationForm extends ProfileFormFields {
     return saveProfile(educationValidation, clone, ui);
   };
 
-  educationLevelRadioSwitch: Function = (level: Object): React$Element<*> => {
+  educationLevelRadioSwitch = (level: Option): React$Element<*> => {
     const {
       ui: { educationLevelAnswers }
     } = this.props;
@@ -210,7 +210,7 @@ class EducationForm extends ProfileFormFields {
     }
   }
 
-  educationRow: Function = R.curry((showLevel: boolean, [index, education]: [number, EducationEntry]) => {
+  educationRow = R.curry((showLevel: boolean, [index, education]: [number, EducationEntry]) => {
     const { errors, profile } = this.props;
     if (!('id' in education)) {
       // don't show new educations, wait until we saved on the server before showing them
@@ -263,7 +263,7 @@ class EducationForm extends ProfileFormFields {
     );
   }
 
-  clearEducationEdit: Function = (): void => {
+  clearEducationEdit = (): void => {
     const {
       setEducationDialogVisibility,
       setEducationDegreeLevel,
@@ -277,18 +277,18 @@ class EducationForm extends ProfileFormFields {
     clearProfileEdit(username);
   };
 
-  saveEducationForm: Function = (): void => {
+  saveEducationForm = (): void => {
     const { saveProfile, profile, ui } = this.props;
     saveProfile(educationValidation, profile, ui).then(this.clearEducationEdit);
   };
 
-  openEducationDeleteDialog: Function = (index: number): void => {
+  openEducationDeleteDialog = (index: number): void => {
     const { setDeletionIndex, setShowEducationDeleteDialog } = this.props;
     setDeletionIndex(index);
     setShowEducationDeleteDialog(true);
   };
 
-  editEducationForm: Function = (): void => {
+  editEducationForm = (): void => {
     const {
       ui: { educationDialogIndex },
       showSwitch,

--- a/static/js/components/EducationTab.js
+++ b/static/js/components/EducationTab.js
@@ -15,7 +15,7 @@ class EducationTab extends React.Component {
     profilePatchStatus:    ?string,
     ui:                    UIState,
     saveProfile:           SaveProfileFunc,
-    addProgramEnrollment:  Function,
+    addProgramEnrollment:  (p: number) => void,
     dispatch:              Function,
   };
 

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -60,7 +60,7 @@ class EmploymentForm extends ProfileFormFields {
     validator:                        Validator|UIValidator,
   };
 
-  openNewWorkHistoryForm: Function = (): void => {
+  openNewWorkHistoryForm = (): void => {
     const {
       updateProfile,
       profile,
@@ -77,7 +77,7 @@ class EmploymentForm extends ProfileFormFields {
     setWorkDialogVisibility(true);
   };
 
-  openEditWorkHistoryForm: Function = (index: number): void => {
+  openEditWorkHistoryForm = (index: number): void => {
     const {
       setWorkDialogVisibility,
       setWorkDialogIndex,
@@ -86,7 +86,7 @@ class EmploymentForm extends ProfileFormFields {
     setWorkDialogVisibility(true);
   };
 
-  deleteWorkHistoryEntry: Function = (): Promise<*> => {
+  deleteWorkHistoryEntry = (): Promise<*> => {
     const { saveProfile, profile, ui } = this.props;
     let clone = _.cloneDeep(profile);
     if (ui.deletionIndex !== undefined && ui.deletionIndex !== null) {
@@ -95,14 +95,14 @@ class EmploymentForm extends ProfileFormFields {
     return saveProfile(employmentValidation, clone, ui);
   };
 
-  saveWorkHistoryEntry: Function = (): void => {
+  saveWorkHistoryEntry = (): void => {
     const { saveProfile, profile, ui } = this.props;
     saveProfile(employmentValidation, profile, ui).then(() => {
       this.closeWorkDialog();
     });
   };
 
-  closeWorkDialog: Function = (): void => {
+  closeWorkDialog = (): void => {
     const {
       setWorkDialogVisibility,
       clearProfileEdit,
@@ -112,7 +112,7 @@ class EmploymentForm extends ProfileFormFields {
     clearProfileEdit(username);
   };
 
-  openWorkDeleteDialog: Function = (index: number): void => {
+  openWorkDeleteDialog = (index: number): void => {
     const { setDeletionIndex, setShowWorkDeleteDialog } = this.props;
     setDeletionIndex(index);
     setShowWorkDeleteDialog(true);
@@ -286,7 +286,7 @@ class EmploymentForm extends ProfileFormFields {
     );
   }
 
-  handleRadioClick: Function = (value: string): void => {
+  handleRadioClick = (value: string): void => {
     const {
       setWorkHistoryAnswer,
       ui: { workHistoryAnswer }

--- a/static/js/components/EmploymentTab.js
+++ b/static/js/components/EmploymentTab.js
@@ -20,7 +20,7 @@ class EmploymentTab extends React.Component {
     profile:               Profile,
     profilePatchStatus:    ?string,
     ui:                    UIState,
-    addProgramEnrollment:  Function,
+    addProgramEnrollment:  (p: number) => void,
     dispatch:              Function,
   };
 

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -101,7 +101,7 @@ export default class LearnerSearch extends SearchkitComponent {
 
   searchkitTranslations: Object = makeSearchkitTranslations();
 
-  renderSearchHeader: Function = (openEmailComposer: Function): React$Element<*>|null => {
+  renderSearchHeader = (openEmailComposer: Function): React$Element<*>|null => {
     if (_.isNull(this.getResults())) {
       return null;
     }
@@ -131,7 +131,7 @@ export default class LearnerSearch extends SearchkitComponent {
     );
   };
 
-  renderFacets: Function = (currentProgram: AvailableProgram): React$Element<*> => {
+  renderFacets = (currentProgram: AvailableProgram): React$Element<*> => {
     if (_.isNull(this.getResults())) {
       return (
         <Card className="fullwidth" shadow={1}>

--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -53,12 +53,12 @@ export default class Navbar extends React.Component {
     <span className="mdl-layout-title" key="header-text-link"><Link to={link}>MITx MicroMasters</Link></span>
   ]);
 
-  userMenu: Function = (): void|React$Element<*> => {
+  userMenu = (): void|React$Element<*> => {
     const { empty } = this.props;
     return empty === true ? undefined : <UserMenu />;
   };
 
-  programSelector: Function = (): React$Element<*> => {
+  programSelector = (): React$Element<*> => {
     const { pathname } = this.props;
     return (
       <ProgramSelector
@@ -68,7 +68,7 @@ export default class Navbar extends React.Component {
     );
   };
 
-  navDrawer: Function = (drawerClass: string): React$Element<*>|null => {
+  navDrawer = (drawerClass: string): React$Element<*>|null => {
     if (!SETTINGS.user) {
       return null;
     }

--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -41,7 +41,7 @@ const personalTabValidator = combineValidators(
 
 export default class PersonalTab extends React.Component {
   props: {
-    addProgramEnrollment:     Function,
+    addProgramEnrollment:     (p: number) => void,
     currentProgramEnrollment: AvailableProgram,
     errors:                   ValidationErrors,
     nextStep:                 () => void,

--- a/static/js/components/ProfileProgressControls.js
+++ b/static/js/components/ProfileProgressControls.js
@@ -6,28 +6,29 @@ import { saveProfileStep } from '../util/profile_edit';
 import { FETCH_PROCESSING } from '../actions';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
+import type { Validator } from '../lib/validation/profile';
 
 export default class ProfileProgressControls extends React.Component {
   props: {
-    nextUrl?:      string,
-    prevUrl?:      string,
-    nextBtnLabel: string,
-    isLastTab:    boolean,
-    validator:    Function,
-    profile:      Profile,
-    profilePatchStatus: ?string,
-    ui:           UIState,
-    saveProfile:  SaveProfileFunc,
-    programIdForEnrollment: ?number,
-    addProgramEnrollment: Function,
+    addProgramEnrollment:    (p: number) => void,
+    isLastTab:               boolean,
+    nextBtnLabel:            string,
+    nextUrl?:                string,
+    prevUrl?:                string,
+    profile:                 Profile,
+    profilePatchStatus:      ?string,
+    programIdForEnrollment?:  ?number,
+    saveProfile:             SaveProfileFunc,
+    ui:                      UIState,
+    validator:               Validator,
   };
 
-  stepBack: Function = (): void => {
+  stepBack = (): void => {
     const { prevUrl } = this.props;
     this.context.router.push(prevUrl);
   };
 
-  saveAndContinue: Function = (): void => {
+  saveAndContinue = (): void => {
     const {
       nextUrl,
       isLastTab,

--- a/static/js/components/ProgressWidget.js
+++ b/static/js/components/ProgressWidget.js
@@ -13,7 +13,7 @@ export default class ProgressWidget extends React.Component {
     program: Program
   };
 
-  circularProgressWidget: Function = (
+  circularProgressWidget = (
     radius: number,
     strokeWidth: number,
     totalPassedCourses: number,

--- a/static/js/components/User.js
+++ b/static/js/components/User.js
@@ -26,7 +26,7 @@ export default class User extends React.Component {
     setUserPageAboutMeDialogVisibility: () => void,
   };
 
-  toggleShowPersonalDialog: Function = (): void => {
+  toggleShowPersonalDialog = (): void => {
     const {
       setUserPageDialogVisibility,
       ui: { userPageDialogVisibility },
@@ -36,7 +36,7 @@ export default class User extends React.Component {
     startProfileEdit();
   };
 
-  toggleShowAboutMeDialog: Function = (): void => {
+  toggleShowAboutMeDialog = (): void => {
     const {
       setUserPageAboutMeDialogVisibility,
       ui: { userPageAboutMeDialogVisibility },

--- a/static/js/components/UserInfoCard.js
+++ b/static/js/components/UserInfoCard.js
@@ -24,7 +24,7 @@ export default class UserInfoCard extends React.Component {
     <span className="profile-email">{email}</span>
   );
 
-  renderAboutMeSection: Function = (
+  renderAboutMeSection = (
     profile: Profile, toggleShowAboutMeDialog: Function
   ): React$Element<*> => {
     let aboutMeContent = userPrivilegeCheck(

--- a/static/js/components/UserPageAboutMeDialog.js
+++ b/static/js/components/UserPageAboutMeDialog.js
@@ -20,7 +20,7 @@ export default class UserPageAboutMeDialog extends ProfileFormFields {
     validator:                            Validator,
   };
 
-  closeAboutMeDialog: Function = (): void => {
+  closeAboutMeDialog = (): void => {
     const {
       setUserPageAboutMeDialogVisibility,
       clearProfileEdit,
@@ -30,7 +30,7 @@ export default class UserPageAboutMeDialog extends ProfileFormFields {
     clearProfileEdit(username);
   };
 
-  saveAboutMeInfo: Function = (): void => {
+  saveAboutMeInfo = (): void => {
     const { profile, ui, saveProfile, validator } = this.props;
     saveProfile(validator, profile, ui).then(() => {
       this.closeAboutMeDialog();

--- a/static/js/components/UserPagePersonalDialog.js
+++ b/static/js/components/UserPagePersonalDialog.js
@@ -19,7 +19,7 @@ export default class UserPagePersonalDialog extends React.Component {
     clearProfileEdit:             () => void,
   };
 
-  closePersonalDialog: Function = (): void => {
+  closePersonalDialog = (): void => {
     const {
       setUserPageDialogVisibility,
       clearProfileEdit,
@@ -29,7 +29,7 @@ export default class UserPagePersonalDialog extends React.Component {
     clearProfileEdit(username);
   };
 
-  savePersonalInfo: Function = (): void => {
+  savePersonalInfo = (): void => {
     const { profile, ui, saveProfile } = this.props;
     saveProfile(personalValidation, profile, ui).then(() => {
       this.closePersonalDialog();

--- a/static/js/components/inputs/CountrySelectField.js
+++ b/static/js/components/inputs/CountrySelectField.js
@@ -47,7 +47,7 @@ export default class CountrySelectField extends React.Component {
     validator:                  Validator|UIValidator,
   };
 
-  onChange: Function = (selection: Option): void => {
+  onChange = (selection: Option): void => {
     const { stateKeySet, countryKeySet, updateProfile, validator, profile } = this.props;
     // clear state field when country field changes
     let clone = _.cloneDeep(profile);

--- a/static/js/components/search/CountryRefinementOption.js
+++ b/static/js/components/search/CountryRefinementOption.js
@@ -10,7 +10,7 @@ export default class CountryRefinementOption extends React.Component {
     count:    number,
   };
 
-  countryName: Function = (countryCode: string): string => (
+  countryName = (countryCode: string): string => (
     iso3166.country(countryCode).name
   );
 

--- a/static/js/components/search/CustomNoHits_test.js
+++ b/static/js/components/search/CustomNoHits_test.js
@@ -23,7 +23,7 @@ describe('CustomNoHits', () => {
     makeStrippedHtml(<CustomNoHits />)
   );
 
-  const stubCommon: Function = (): void => {
+  const stubCommon = (): void => {
     sandbox.stub(CustomNoHits.prototype, 'componentWillMount');
     sandbox.stub(CustomNoHits.prototype, 'getSuggestion').returns("NoHits.NoResultsFound");
     sandbox.stub(CustomNoHits.prototype, 'translate').returns("No results found for search students");

--- a/static/js/components/search/FilterVisibilityToggle.js
+++ b/static/js/components/search/FilterVisibilityToggle.js
@@ -13,15 +13,15 @@ export default class FilterVisibilityToggle extends SearchkitComponent {
     filterName:             string,
     checkFilterVisibility:  (filterName: string) => boolean,
     setFilterVisibility:    (filterName: string, visibility: boolean) => void,
-    children:               React$Element<*>[],
+    children:               React$Element<*>,
   };
 
-  openClass: Function = (): string => {
+  openClass = (): string => {
     const { filterName, checkFilterVisibility } = this.props;
     return checkFilterVisibility(filterName) ? "" : "closed";
   };
 
-  getChildFacetDocCount: Function = (results: Object, resultId: string): number => {
+  getChildFacetDocCount = (results: Object, resultId: string): number => {
     const elementResult = _.get(results, ['aggregations', resultId]);
     if (elementResult['inner']) {
       return elementResult['inner']['doc_count'];
@@ -30,7 +30,7 @@ export default class FilterVisibilityToggle extends SearchkitComponent {
     }
   };
 
-  isInResults: Function = (id: string): boolean => {
+  isInResults = (id: string): boolean => {
     let results = this.getResults();
     if (results) {
       const resultId = FILTER_ID_ADJUST[id] || id;
@@ -42,7 +42,7 @@ export default class FilterVisibilityToggle extends SearchkitComponent {
     return false;
   };
 
-  openStateIcon: Function = (children: React$Element<*>): React$Element<*>|null => {
+  openStateIcon = (children: React$Element<*>): React$Element<*>|null => {
     if (!this.isInResults(children.props.id)) {
       return null;
     }
@@ -54,7 +54,7 @@ export default class FilterVisibilityToggle extends SearchkitComponent {
     />;
   };
 
-  toggleFilterVisibility: Function = (): void => {
+  toggleFilterVisibility = (): void => {
     const {
       filterName,
       checkFilterVisibility,

--- a/static/js/containers/LearnerSearchPage.js
+++ b/static/js/containers/LearnerSearchPage.js
@@ -41,27 +41,27 @@ class LearnerSearchPage extends React.Component {
     ui:                       UIState,
   };
 
-  checkFilterVisibility: Function = (filterName: string): boolean => {
+  checkFilterVisibility = (filterName: string): boolean => {
     const { ui: { searchFilterVisibility } } = this.props;
     let visibility = searchFilterVisibility[filterName];
     return visibility === undefined ? SEARCH_FILTER_DEFAULT_VISIBILITY : visibility;
   };
 
-  setFilterVisibility: Function = (filterName: string, visibility: boolean): void => {
+  setFilterVisibility = (filterName: string, visibility: boolean): void => {
     const { ui: { searchFilterVisibility }, dispatch } = this.props;
     let clone = _.clone(searchFilterVisibility);
     clone[filterName] = visibility;
     dispatch(setSearchFilterVisibility(clone));
   };
 
-  openEmailComposer: Function = (searchkit) => {
+  openEmailComposer = (searchkit) => {
     const { dispatch } = this.props;
     const query = searchkit.query.query;
     dispatch(startEmailEdit(query));
     dispatch(setEmailDialogVisibility(true));
   };
 
-  closeEmailComposerAndCancel: Function = () => {
+  closeEmailComposerAndCancel = () => {
     const { dispatch } = this.props;
     dispatch(clearEmailEdit());
     dispatch(setEmailDialogVisibility(false));
@@ -85,7 +85,7 @@ class LearnerSearchPage extends React.Component {
     }
   };
 
-  updateEmailEdit: Function = R.curry((fieldName, e) => {
+  updateEmailEdit = R.curry((fieldName, e) => {
     const { email: { email, validationErrors }, dispatch } = this.props;
     let emailClone = R.clone(email);
     emailClone[fieldName] = e.target.value;

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -70,14 +70,14 @@ class ProfileFormContainer extends React.Component {
     };
   };
 
-  fetchProfile: Function = (username: string): void => {
+  fetchProfile = (username: string): void => {
     const { dispatch, profiles } = this.props;
     if (profiles[username] === undefined || profiles[username].getStatus === undefined) {
       dispatch(fetchUserProfile(username));
     }
   };
 
-  updateProfileValidation: Function = (profile: Profile, validator: Validator|UIValidator): void => {
+  updateProfileValidation = (profile: Profile, validator: Validator|UIValidator): void => {
     const username = SETTINGS.user.username;
     const { dispatch, ui } = this.props;
     let errors = validator(profile, ui);
@@ -97,7 +97,7 @@ class ProfileFormContainer extends React.Component {
     }
   };
 
-  updateValidationVisibility: Function = keySet => {
+  updateValidationVisibility = (keySet: Array<string>) => {
     const { dispatch, profiles } = this.props;
     const username = SETTINGS.user.username;
     if ( !profiles[username].edit ) {
@@ -107,7 +107,7 @@ class ProfileFormContainer extends React.Component {
     }
   };
 
-  startProfileEdit: Function = () => {
+  startProfileEdit = () => {
     const { dispatch } = this.props;
     const username = SETTINGS.user.username;
     dispatch(startProfileEdit(username));
@@ -152,7 +152,7 @@ class ProfileFormContainer extends React.Component {
     dispatch(setProgram(program));
   };
 
-  simpleActionHelpers: Function = (): ActionHelpers => {
+  simpleActionHelpers = (): ActionHelpers => {
     const { dispatch } = this.props;
     return createSimpleActionHelpers(dispatch, [
       ['clearProfileEdit', clearProfileEdit],
@@ -171,7 +171,7 @@ class ProfileFormContainer extends React.Component {
     ]);
   };
 
-  asyncActionHelpers: Function = (): AsyncActionHelpers => {
+  asyncActionHelpers = (): AsyncActionHelpers => {
     const { dispatch } = this.props;
     return createAsyncActionHelpers(dispatch, [
       ['setWorkHistoryEdit', setWorkHistoryEdit],
@@ -229,7 +229,7 @@ class ProfileFormContainer extends React.Component {
     };
   };
 
-  childrenWithProps: Function = (profileFromStore: ProfileGetResult) => {
+  childrenWithProps = (profileFromStore: ProfileGetResult) => {
     return React.Children.map(this.props.children, (child) => (
       React.cloneElement(child, this.profileProps(profileFromStore))
     ));

--- a/static/js/containers/UserMenu.js
+++ b/static/js/containers/UserMenu.js
@@ -21,18 +21,18 @@ class UserMenu extends React.Component {
     ui:       UIState,
   };
 
-  openStateIcon: Function = (): React$Element<*> => {
+  openStateIcon = (): React$Element<*> => {
     const { ui: { userMenuOpen } } = this.props;
     return <Icon name={`${userMenuOpen ? "arrow_drop_up" : "arrow_drop_down"}`} />;
   };
 
-  toggleMenuOpen: Function = (): void => {
+  toggleMenuOpen = (): void => {
     const { ui: { userMenuOpen }, dispatch } = this.props;
     const setMenuOpenState = createActionHelper(dispatch, setUserMenuOpen);
     setMenuOpenState(!userMenuOpen);
   };
 
-  linkMenu: Function = (): React$Element<*> => {
+  linkMenu = (): React$Element<*> => {
     const { ui: { userMenuOpen } } = this.props;
     return (
       <div className={`user-menu-dropdown ${userMenuOpen ? "open" : ""}`}>

--- a/static/js/containers/UserPage.js
+++ b/static/js/containers/UserPage.js
@@ -32,14 +32,16 @@ class UserPage extends ProfileFormContainer {
     const { params: { username }, profiles } = this.props;
 
     let profile = {};
+    let children = null;
     let loaded = false;
     if (profiles[username] !== undefined) {
       profile = profiles[username];
       loaded = profiles[username].getStatus !== FETCH_PROCESSING;
+      children = this.childrenWithProps(profile);
     }
     const { errorInfo } = profile;
     return <Loader loaded={loaded}>
-      {errorInfo && loaded ? <ErrorMessage errorInfo={errorInfo} /> : this.childrenWithProps(profile)}
+      {errorInfo && loaded ? <ErrorMessage errorInfo={errorInfo} /> : children }
     </Loader>;
   }
 }

--- a/static/js/flow/profileTypes.js
+++ b/static/js/flow/profileTypes.js
@@ -4,16 +4,16 @@ import type { UIState } from '../reducers/ui';
 import type { APIErrorInfo } from './generalTypes';
 
 export type EducationEntry = {
-  id?: ?number,
-  degree_name: string,
-  graduation_date: string,
-  graduation_date_edit?: DateEdit,
-  field_of_study: ?string,
-  online_degree: boolean,
-  school_name: ?string,
-  school_city: ?string,
-  school_state_or_territory: ?string,
-  school_country: ?string,
+  id?:                        ?number,
+  degree_name:                string,
+  graduation_date:            string,
+  graduation_date_edit?:      DateEdit,
+  field_of_study:             ?string,
+  online_degree:              boolean,
+  school_name:                ?string,
+  school_city:                ?string,
+  school_state_or_territory:  ?string,
+  school_country:             ?string,
 };
 
 export type DateEdit = {
@@ -22,17 +22,17 @@ export type DateEdit = {
 };
 
 export type WorkHistoryEntry = {
-  id?: ?number,
-  position: string,
-  industry: string,
-  company_name: string,
-  start_date: string,
-  start_date_edit?: string|DateEdit,
-  end_date: ?string,
-  end_date_edit?: DateEdit,
-  city?: ?string,
-  country?: ?string,
-  state_or_territory?: ?string,
+  id?:                  ?number,
+  position:             string,
+  industry:             string,
+  company_name:         string,
+  start_date:           string,
+  start_date_edit?:     string|DateEdit,
+  end_date:             ?string,
+  end_date_edit?:       DateEdit,
+  city?:                ?string,
+  country?:             ?string,
+  state_or_territory?:  ?string,
 };
 
 export type ValidationErrors = {
@@ -41,23 +41,23 @@ export type ValidationErrors = {
 };
 
 export type Profile = {
-  first_name: string,
-  education: EducationEntry[],
-  work_history: WorkHistoryEntry[],
-  getStatus: string,
-  email: string,
-  date_of_birth: string,
-  edx_level_of_education: string,
-  username: string,
-  preferred_name: string,
-  pretty_printed_student_id: string,
-  city: string,
-  country: string,
-  state_or_territory: string,
-  email_optin: boolean,
-  agreed_to_terms_of_service: boolean,
-  image: ?string,
-  about_me: ?string,
+  first_name:                  string,
+  education:                   EducationEntry[],
+  work_history:                WorkHistoryEntry[],
+  getStatus:                   string,
+  email:                       string,
+  date_of_birth:               string,
+  edx_level_of_education:      string,
+  username:                    string,
+  preferred_name:              string,
+  pretty_printed_student_id:   string,
+  city:                        string,
+  country:                     string,
+  state_or_territory:          string,
+  email_optin:                 boolean,
+  agreed_to_terms_of_service:  boolean,
+  image:                       ?string,
+  about_me:                    ?string,
 };
 
 export type Profiles = {

--- a/static/js/lib/redux.js
+++ b/static/js/lib/redux.js
@@ -34,10 +34,10 @@ export function createSimpleActionHelpers(dispatch: Dispatch, actionList: Action
  * returns an array of async action helpers from async action creators (those
  * that return a function taking dispatch as an argument)
  */
-export type AsyncActionHelpers = Array<{[k: string]: AsyncActionHelper}>;
+export type AsyncActionHelpers = {[k: string]: AsyncActionHelper};
 export type AsyncActionManifest = Array<[string, AsyncActionCreator<any>]>;
 export function createAsyncActionHelpers(dispatch: Dispatch, actionList: AsyncActionManifest): AsyncActionHelpers {
-  return actionList.map(([name, actionCreator]) => (
-    { [name]: createActionHelper(dispatch, actionCreator) }
-  ));
+  return R.fromPairs(actionList.map(([name, actionCreator]) => (
+     [name, createActionHelper(dispatch, actionCreator)]
+  )));
 }

--- a/static/js/lib/redux_test.js
+++ b/static/js/lib/redux_test.js
@@ -85,15 +85,15 @@ describe('redux helpers', () => {
       actions = createAsyncActionHelpers(asyncDispatch, actionList);
     });
 
-    it('should return an array of objects containing functions', () => {
-      assert.isArray(actions);
-      let [ { asyncActionCreator } ] = actions;
+    it('should return an object containing functions', () => {
+      assert.isObject(actions);
+      let { asyncActionCreator } = actions;
       assert.isFunction(asyncActionCreator);
     });
 
 
-    it('should return an array of asyncActionCreators', () => {
-      let [ { asyncActionCreator } ] = actions;
+    it('should return an object full of asyncActionCreators', () => {
+      let { asyncActionCreator } = actions;
       let dispatched = asyncActionCreator(2);
       assert.isFulfilled(dispatched);
       assert(dispatchSpy.calledWith({

--- a/static/js/util/ProfileFormFields.js
+++ b/static/js/util/ProfileFormFields.js
@@ -25,7 +25,7 @@ export default class ProfileFormFields extends React.Component {
   boundRadioGroupField: Function;
   boundCheckbox: Function;
 
-  defaultInputComponentProps: Function = (): Object => {
+  defaultInputComponentProps = (): Object => {
     return {
       profile: this.props.profile,
       updateProfile: this.props.updateProfile,
@@ -53,7 +53,7 @@ export default class ProfileFormFields extends React.Component {
     updateValidationVisibility:   React.PropTypes.func,
   };
 
-  closeConfirmDeleteDialog: Function = (): void => {
+  closeConfirmDeleteDialog = (): void => {
     const {
       setDeletionIndex,
       setShowEducationDeleteDialog,


### PR DESCRIPTION
#### What's this PR do?

We had a lot of arrow functions declared on classes, annotated with the `Function` type, like this:

```js
class Foo {
  bar: Function = () => (
    'potatoes'
  );
}
```

Turns out that annotating functions like that is sort of equivalent to annotating them with the `any` type, meaning that the return types and so on aren't checked. Not good!

We had to do this previously because at a certain point Flow didn't properly support annotating that syntax, but now it can.

Anyway, I removed any annotation of an arrow function with `Function` and fixed all the flow errors which cropped up in that process (quite a few).

#### Where should the reviewer start?

Read over the changes, make sure my regex to remove the `Function` annotations wasn't messed up somehow, and make sure the changes make sense, in general.

#### testing

I think just make sure there are no regressions.