### PR TITLE
Add more Google Analytics events

### DIFF
--- a/static/js/components/ProfileProgressControls.js
+++ b/static/js/components/ProfileProgressControls.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import React from 'react';
 
 import SpinnerButton from './SpinnerButton';
@@ -7,6 +8,7 @@ import { FETCH_PROCESSING } from '../actions';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
 import type { Validator } from '../lib/validation/profile';
+import { sendGAEvent } from '../lib/google_analytics';
 
 export default class ProfileProgressControls extends React.Component {
   props: {
@@ -40,6 +42,10 @@ export default class ProfileProgressControls extends React.Component {
     saveProfileStep.call(this, validator, isLastTab).then(() => {
       if (programIdForEnrollment && addProgramEnrollment) {
         addProgramEnrollment(programIdForEnrollment);
+      }
+
+      if ( isLastTab ) {
+        sendGAEvent('profile-form', 'completed', SETTINGS.user.username);
       }
       this.context.router.push(nextUrl);
     });

--- a/static/js/components/inputs/SelectField.js
+++ b/static/js/components/inputs/SelectField.js
@@ -5,6 +5,7 @@ import VirtualizedSelect from 'react-virtualized-select';
 import { Creatable } from 'react-select';
 
 import { validationErrorSelector, classify } from '../../util/util';
+import { sendFormFieldEvent } from '../../lib/google_analytics';
 import type { Option } from '../../flow/generalTypes';
 import type { Validator, UIValidator } from '../../lib/validation/profile';
 import type {
@@ -71,6 +72,7 @@ class SelectField extends React.Component {
       updateValidationVisibility(keySet);
     }
     updateProfile(profile, validator);
+    sendFormFieldEvent(keySet);
   };
 
   className = (): string => {

--- a/static/js/components/inputs/inputs_test.js
+++ b/static/js/components/inputs/inputs_test.js
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import { mount } from 'enzyme';
 import VirtualizedSelect from 'react-virtualized-select';
 import R from 'ramda';
+import ga from 'react-ga';
 
 import { USER_PROFILE_RESPONSE } from '../../constants';
 import iso3166 from 'iso-3166-2';
@@ -32,7 +33,7 @@ describe('Profile inputs', () => {
   );
 
   describe('Select field', () => {
-    let selectField;
+    let selectField, gaEvent;
 
     let genderOptions = [
       {value: 'm', label: 'Male'},
@@ -52,6 +53,7 @@ describe('Profile inputs', () => {
     };
 
     beforeEach(() => {
+      gaEvent = sandbox.stub(ga, 'event');
       inputProps = {
         profile: {
           "account_privacy": "private",
@@ -171,6 +173,16 @@ describe('Profile inputs', () => {
         customOptions: [ expectedCustomOption ]
       });
       assert.include(selectField.find(VirtualizedSelect).props().options, expectedCustomOption);
+    });
+
+    it('should send a form field event to Google Analytics when onBlur is called', () => {
+      selectField = renderGenderSelectField().find(VirtualizedSelect);
+      selectField.props().onBlur();
+      assert(gaEvent.calledWith({
+        category: 'profile-form-field',
+        action: 'completed-gender',
+        label: 'jane'
+      }));
     });
   });
 

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -47,14 +47,14 @@ type UpdateProfile = (isEdit: boolean, profile: Profile, validator: Validator|UI
 
 class ProfileFormContainer extends React.Component {
   props: {
-    profiles:    Profiles,
-    children:    React$Element<*>[],
-    dispatch:    Dispatch,
-    history:     Object,
-    ui:          UIState,
-    params:      {[k: string]: string},
-    programs:    AvailableProgramsState,
-    currentProgramEnrollment: AvailableProgram,
+    profiles:                  Profiles,
+    children:                  React$Element<*>[],
+    dispatch:                  Dispatch,
+    history:                   Object,
+    ui:                        UIState,
+    params:                    {[k: string]: string},
+    programs:                  AvailableProgramsState,
+    currentProgramEnrollment:  AvailableProgram,
   };
 
   static contextTypes = {

--- a/static/js/lib/google_analytics.js
+++ b/static/js/lib/google_analytics.js
@@ -1,0 +1,30 @@
+// @flow
+/* global SETTINGS:false */
+import ga from 'react-ga';
+import R from 'ramda';
+
+const makeGAEvent = (category, action, label, value) => ({
+  category: category,
+  action: action,
+  label: label,
+  value: value
+});
+
+const removeNilValue = R.when(
+  R.compose(R.isNil, R.prop('value')),
+  R.dissoc('value')
+);
+
+const formatGAEvent = R.compose(removeNilValue, makeGAEvent);
+
+export const sendGAEvent = (category: string, action: string, label: string, value?: number) => {
+  ga.event(formatGAEvent(category, action, label, value));
+};
+
+const formatKeyset = R.join("-");
+
+export const sendFormFieldEvent = (keySet: Array<string>) => sendGAEvent(
+  'profile-form-field',
+  `completed-${formatKeyset(keySet)}`,
+  SETTINGS.user.username
+);

--- a/static/js/lib/google_analytics_test.js
+++ b/static/js/lib/google_analytics_test.js
@@ -1,0 +1,55 @@
+// @flow
+import sinon from 'sinon';
+import ga from 'react-ga';
+import { assert } from 'chai';
+
+import { sendGAEvent, sendFormFieldEvent } from './google_analytics';
+
+describe('Google Analytics', () => {
+  let event, sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    event = sandbox.stub(ga, 'event');
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('sendGAEvent', () => {
+    it('should send an event to GA properly', () => {
+      sendGAEvent(
+        'category',
+        'action',
+        'label',
+        1
+      );
+      assert(event.calledWith({
+        category: 'category',
+        action: 'action',
+        label: 'label',
+        value: 1
+      }), 'should be called with the right values');
+    });
+
+    it('should not include `value` if it is undefined', () => {
+      sendGAEvent('category', 'action', 'label');
+      assert(event.calledWith({
+        category: 'category',
+        action: 'action',
+        label: 'label',
+      }), "there should not be a value for 'value'");
+    });
+  });
+
+  describe('sendFormFieldEvent', () => {
+    it('should properly format the keySet and send to GA', () => {
+      let keySet = ['some', 'keys', 'wow'];
+      sendFormFieldEvent(keySet);
+      assert.ok(event.calledWith({
+        category: 'profile-form-field',
+        action: 'completed-some-keys-wow',
+        label: 'jane'
+      }));
+    });
+  });
+});

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -8,6 +8,7 @@ import R from 'ramda';
 
 import DateField from '../components/inputs/DateField';
 import { validationErrorSelector, classify } from './util';
+import { sendFormFieldEvent } from '../lib/google_analytics';
 import type { Validator, UIValidator } from '../lib/validation/profile';
 import type { Profile } from '../flow/profileTypes';
 import type { Option } from '../flow/generalTypes';
@@ -64,6 +65,7 @@ export function boundRadioGroupField(keySet: string[], label: string, options: O
     _.set(clone, keySet, value);
     updateValidationVisibility(keySet);
     updateProfile(clone, validator);
+    sendFormFieldEvent(keySet);
   };
 
   const value = String(_.get(profile, keySet));
@@ -118,6 +120,7 @@ export function boundTextField(
   let onBlur = () => {
     updateValidationVisibility(keySet);
     updateProfileValidation(profile, validator);
+    sendFormFieldEvent(keySet);
   };
 
   let getValue = () => {
@@ -159,6 +162,7 @@ export function boundDateField(keySet: string[], label: string, omitDay: boolean
   let onBlur = () => {
     updateValidationVisibility(keySet);
     updateProfileValidation(profile, validator);
+    sendFormFieldEvent(keySet);
   };
 
 
@@ -189,6 +193,7 @@ export function boundCheckbox(keySet: string[], label: string|React$Element<*>):
     _.set(clone, keySet, e.target.checked);
     updateValidationVisibility(keySet);
     updateProfile(clone, validator);
+    sendFormFieldEvent(keySet);
   };
 
   const style = {

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -2,7 +2,6 @@
 /* global SETTINGS:false */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ga from 'react-ga';
 import striptags from 'striptags';
 import _ from 'lodash';
 import iso3166 from 'iso-3166-2';
@@ -29,18 +28,6 @@ import type {
 } from '../flow/programTypes';
 import { workEntriesByDate } from './sorting';
 import type { CheckoutPayload } from '../flow/checkoutTypes';
-
-export function sendGoogleAnalyticsEvent(category: any, action: any, label: any, value: any) {
-  let event: any = {
-    category: category,
-    action: action,
-    label: label,
-  };
-  if (value !== undefined) {
-    event.value = value;
-  }
-  ga.event(event);
-}
 
 export const isProfileOfLoggedinUser = (profile: Profile): boolean => (
   SETTINGS.user && profile.username === SETTINGS.user.username


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1919 
closes #2040 

#### What's this PR do?

This adds a couple of new google analytics events, adding events for profile completion (clicking "I'm done") and for completing each form field.

#### How should this be manually tested?

You'll have to make a google analytics account and then set the `GA_TRACKING_ID` variable to the acocunt it. Then go through filling out the profile, and make sure that events show up which reference the form fields and have your username in the 'label' field.