### PR TITLE
Move the zendesk widget tag

### DIFF
--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -19,9 +19,6 @@
       {% render_bundle "style_public" %}
     {% endif %}
     {% render_bundle "style" %}
-    {% if has_zendesk_widget %}
-      {% render_bundle "zendesk_widget" %}
-    {% endif %}
     <title>{% block title %}{% endblock %}</title>
     <meta name="description" content="{% block description %}{% endblock %}">
     <meta name="keywords" content="{% block keywords %}{% endblock %}">
@@ -71,5 +68,8 @@
         footer.style.display = "";
       }
     </script>
+    {% if has_zendesk_widget %}
+      {% render_bundle "zendesk_widget" %}
+    {% endif %}
   </body>
 </html>


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2162 

#### What's this PR do?

just moves the zendesk widget `<script />` tag down, so the request it non-blocking.

#### How should this be manually tested?

Just confirm the zendesk widget still shoes up