### PR TITLE
Fix static asset handling

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -9,15 +9,4 @@ server {
         uwsgi_pass_request_headers on;
         uwsgi_pass_request_body on;
     }
-
-    location ~* /static/(.*$) {
-        try_files $uri $uri/ staticfiles/$1 staticfiles/$1/ =404;
-    }
-
-    location /static/debug_toolbar/ {
-        include uwsgi_params;
-        uwsgi_pass web:8077;
-        uwsgi_pass_request_headers on;
-        uwsgi_pass_request_body on;
-    }
 }

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -3,6 +3,10 @@ server {
     listen 8079;
     root /src;
 
+    location ~* /static/(.*$) {
+        try_files staticfiles/$1 =404;
+    }
+
     location / {
         include uwsgi_params;
         uwsgi_pass web:8077;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -3,10 +3,6 @@ server {
     listen 8079;
     root /src;
 
-    location ~* /static/(.*$) {
-        try_files /staticfiles/$1 =404;
-    }
-
     location / {
         include uwsgi_params;
         uwsgi_pass web:8077;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -4,7 +4,7 @@ server {
     root /src;
 
     location ~* /static/(.*$) {
-        try_files staticfiles/$1 =404;
+        try_files /staticfiles/$1 =404;
     }
 
     location / {

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -10,12 +10,8 @@ server {
         uwsgi_pass_request_body on;
     }
 
-    location @webpack {
-        proxy_pass http://watch:8078;
-    }
-
-    location ^~ /static/(.*$) {
-        try_files $uri $uri/ staticfiles/$1 staticfiles/$1/ @webpack =404;
+    location ~* /static/(.*$) {
+        try_files $uri $uri/ staticfiles/$1 staticfiles/$1/ =404;
     }
 
     location /static/debug_toolbar/ {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -35,7 +35,7 @@ http {
         }
 
         location ~* /static/(.*$) {
-            try_files $uri $uri/ staticfiles/$1$args staticfiles/$1/$args =404;
+            try_files $uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404;
         }
 
         location / {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -35,7 +35,7 @@ http {
         }
 
         location ~* /static/(.*$) {
-            try_files $uri $uri/ staticfiles/$1 staticfiles/$1/ =404;
+            try_files $uri $uri/ staticfiles/$1$args staticfiles/$1/$args =404;
         }
 
         location / {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -35,7 +35,7 @@ http {
         }
 
         location ^~ /static/(.*$) {
-            try_files $uri $uri/ staticfiles/$1$args staticfiles/$1/$args =404;
+            try_files $uri $uri/ staticfiles/$1 staticfiles/$1/ =404;
         }
 
         location / {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -35,7 +35,7 @@ http {
         }
 
         location ^~ /static/(.*$) {
-            try_files $uri $uri/ staticfiles/$1 staticfiles/$1/ =404;
+            try_files $uri $uri/ staticfiles/$1$args staticfiles/$1/$args =404;
         }
 
         location / {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -34,7 +34,7 @@ http {
             return 301 'https://micromasters.mit.edu';
         }
 
-        location ^~ /static/(.*$) {
+        location ~* /static/(.*$) {
             try_files $uri $uri/ staticfiles/$1 staticfiles/$1/ =404;
         }
 

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -25,7 +25,7 @@ pidfile=/tmp/micromasters-mast.pid
 vacuum=True
 enable-threads = true
 single-interpreter = true
-static-map = /static=./static
+static-map = /static=./staticfiles
 offload-threads = 2
 thunder-lock =
 if-env = HTTP_AUTH_CREDENTIALS

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -25,6 +25,7 @@ pidfile=/tmp/micromasters-mast.pid
 vacuum=True
 enable-threads = true
 single-interpreter = true
+static-map = /static=./staticfiles
 offload-threads = 2
 thunder-lock =
 if-env = HTTP_AUTH_CREDENTIALS

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -25,7 +25,6 @@ pidfile=/tmp/micromasters-mast.pid
 vacuum=True
 enable-threads = true
 single-interpreter = true
-static-map = /static=./staticfiles
 offload-threads = 2
 thunder-lock =
 if-env = HTTP_AUTH_CREDENTIALS


### PR DESCRIPTION
#### What are the relevant tickets?
None
#### What's this PR do?
- Updates nginx config to properly handle static assets for production, and removes static asset handling for dev, where Django will handle all static assets
- Removes `static-map` directive for `uwsgi`

When we turned on Cloudfront `STATIC_URL` was changed to an absolute URL from a relative one. This caused Django not to serve static assets anymore, and our nginx config wasn't matching static URLs properly. With this change nginx should handle all static file handling for production.

#### How should this be manually tested?
In the PR build go to https://micromasters-ci-pr-2172.herokuapp.com/cms/. You should see a broken login page and you should see cloudfront URLs for JS static assets in script tags, starting with `FAKE.`

In the PR build go to https://micromasters-ci-pr-2172.herokuapp.com/static/wagtailadmin/js/vendor/jquery-2.2.1.js. You should see a valid JS file and not a 404 error.

Also make sure your dev environment is still functioning properly, including Django Debug toolbar and `/cms/`