### PR TITLE
Remove static and webpack-related config

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -10,18 +10,7 @@ server {
         uwsgi_pass_request_body on;
     }
 
-    location @webpack {
-        proxy_pass http://watch:8078;
-    }
-
     location ^~ /static/(.*$) {
-        try_files $uri $uri/ staticfiles/$1 staticfiles/$1/ @webpack =404;
-    }
-
-    location /static/debug_toolbar/ {
-        include uwsgi_params;
-        uwsgi_pass web:8077;
-        uwsgi_pass_request_headers on;
-        uwsgi_pass_request_body on;
+        try_files $uri $uri/ staticfiles/$1 staticfiles/$1/ =404;
     }
 }

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -9,8 +9,4 @@ server {
         uwsgi_pass_request_headers on;
         uwsgi_pass_request_body on;
     }
-
-    location ^~ /static/(.*$) {
-        try_files $uri $uri/ staticfiles/$1 staticfiles/$1/ =404;
-    }
 }

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -34,10 +34,6 @@ http {
             return 301 'https://micromasters.mit.edu';
         }
 
-        location ^~ /static/(.*$) {
-            try_files $uri $uri/ staticfiles/$1$args staticfiles/$1/$args =404;
-        }
-
         location / {
             uwsgi_param QUERY_STRING $query_string;
             uwsgi_param REQUEST_METHOD $request_method;


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Removes some config from the nginx config files. It seems like nginx should not know about webpack at all, and it seems like uwsgi is handling references to `/static/`. @blarghmatey can you take a look and see if this makes sense?
