### PR TITLE
Updated alter_data commands and fixed various issues

### DIFF
--- a/seed_data/management/commands/alter_data.py
+++ b/seed_data/management/commands/alter_data.py
@@ -4,7 +4,7 @@ Management commands that can be used to fine-tune course/program data
 """
 from decimal import Decimal
 import json
-from django.core.management import BaseCommand
+from django.core.management import BaseCommand, CommandError
 from django.db import transaction
 
 from courses.models import Program, CourseRun
@@ -18,6 +18,7 @@ from seed_data.utils import (
 from seed_data.lib import (
     CACHED_HANDLERS,
     CourseFinder,
+    CourseRunFinder,
     UserFinder,
     course_state_editor,
     needs_non_fa_program,
@@ -35,61 +36,54 @@ USAGE_DETAILS = (
     """
     Example commands:
 
-    # Turn financial aid off/on for a program with a title that contains 'Analog'
-    alter_data --action=turn_financial_aid_off --program-title="Analog"
-    alter_data --action=turn_financial_aid_on --program-title="Analog"
+    # Get some convenient information about a course and a given user's enrollments/grades in that course
+    alter_data course_info --username=staff --program-title='Analog' --course-title='100'
 
     # For a user with a username 'staff', set the 'Analog Learning' 100-level course to enrolled
-    alter_data --action=set_course_to_enrolled --username=staff --program-title='Analog' --course-title='100'
+    alter_data set_to_enrolled --username=staff --program-title='Analog' --course-title='100'
 
     # Set the 'Analog Learning' 200-level course to failed with a specific grade
-    alter_data --action=set_course_to_failed --username=staff --program-title='Analog' --course-title='200' --grade=45
+    alter_data set_to_failed --username=staff --program-title='Analog' --course-title='200' --grade=45
 
     # Set the 'Analog Learning' 300-level course to enrolled
-    alter_data --action=set_course_to_enrolled --username=staff --program-title='Analog' --course-title='300'
+    alter_data set_to_enrolled --username=staff --program-title='Analog' --course-title='300'
 
     # Set the 'Analog Learning' 300-level course to enrolled, and set it to start in the future
     """
-    "alter_data --action=set_course_to_enrolled --username=staff --program-title='Analog' --course-title='300' "
+    "alter_data set_to_enrolled --username=staff --program-title='Analog' --course-title='300' "
     "--in-future"
     """
 
     # Set the 'Analog Learning' 300-level course to enrolled, but in need of upgrade (aka 'audit')
-    alter_data --action=set_course_to_needs_upgrade --username=staff --program-title='Analog' --course-title='300'
+    alter_data set_to_needs_upgrade --username=staff --program-title='Analog' --course-title='300'
 
     # (Another way to achieve the result of the above command...)
-    alter_data --action=set_course_to_enrolled --username=staff --program-title='Analog' --course-title='100' --audit
+    alter_data set_to_enrolled --username=staff --program-title='Analog' --course-title='100' --audit
 
     # Set the 'Analog Learning' 300-level course to enrolled and in need of upgrade, but past the deadline
-    """
-    "alter_data --action=set_course_to_needs_upgrade --username=staff --program-title='Analog' "
-    "--course-title='300' --missed-deadline"
-    """
+    alter_data set_to_needs_upgrade --username=staff --program-title='Analog' --course-title='300' --missed-deadline
 
     # Set the 'Analog Learning' 100-level course to have an offered course run (and no enrollments)
-    alter_data --action=set_course_to_offered --username=staff --program-title='Analog' --course-title='100'
+    alter_data set_to_offered --username=staff --program-title='Analog' --course-title='100'
 
     # Set the 'Analog Learning' 100-level course to have an offered course run with a fuzzy start date
-    alter_data --action=set_course_to_offered --username=staff --program-title='Analog' --course-title='100' --fuzzy
+    alter_data set_to_offered --username=staff --program-title='Analog' --course-title='100' --fuzzy
 
     # Add a past failed course run with a specific grade
-    alter_data --action=add_past_failed_run --username=staff --program-title='Analog' --course-title='100' --grade=30
+    alter_data add_past_failed_run --username=staff --program-title='Analog' --course-title='100' --grade=30
 
-    # Add a past failed course run, even if a previous failed run already exists
-    """
-    "alter_data --action=add_past_failed_run --username=staff --program-title='Analog' --course-title='100' "
-    "--add-if-exists"
-    """
+    # Add a past passed course run with a default grade
+    alter_data add_past_passed_run --username=staff --program-title='Analog' --course-title='100'
 
-    # Add a past passed course run with a specific grade
-    """
-    "alter_data --action=add_past_passed_run --username=staff --program-title='Analog' --course-title='100'"
-    "--add-if-exists"
-    """
-
+    # Set a specific course run to failed
+    alter_data set_to_failed --username=staff --course-run-key='MITx+Analog+Learning+100+Dec_2016'
 
     # Add an enrollable future course run for a program called 'Test Program' and a course called 'Test Course'
-    alter_data --action=add_future_run --username=staff --program-title='Test Program' --course-title='Test Course'
+    alter_data add_future_run --username=staff --program-title='Test Program' --course-title='Test Course'
+
+    # Turn financial aid off/on for a program for the 'Analog Learning' program
+    alter_data turn_financial_aid_off --program-title='Analog'
+    alter_data turn_financial_aid_on --program-title='Analog'
     """
 )
 
@@ -98,9 +92,10 @@ NEW_COURSE_RUN_PREFIX = 'new-course-run'
 
 @course_state_editor
 @needs_non_fa_program
-def set_course_to_passed(user=None, course_run=None, grade=DEFAULT_GRADE):
+def set_to_passed(user=None, course_run=None, grade=DEFAULT_GRADE):
     """Sets a course to have a passed course run"""
-    set_course_run_past(course_run, save=True)
+    if not course_run.is_past:
+        set_course_run_past(course_run, save=True)
     CachedEnrollmentHandler(user).set_or_create(course_run=course_run)
     CachedCertificateHandler(user).set_or_create(course_run=course_run, grade=grade)
     return course_run
@@ -108,9 +103,10 @@ def set_course_to_passed(user=None, course_run=None, grade=DEFAULT_GRADE):
 
 @course_state_editor
 @needs_non_fa_program
-def set_course_to_failed(user=None, course_run=None, grade=DEFAULT_FAILED_GRADE):
+def set_to_failed(user=None, course_run=None, grade=DEFAULT_FAILED_GRADE):
     """Sets a course to have a failed course run"""
-    set_course_run_past(course_run, save=True)
+    if not course_run.is_past:
+        set_course_run_past(course_run, save=True)
     CachedEnrollmentHandler(user).set_or_create(course_run=course_run)
     CachedCurrentGradeHandler(user).set_or_create(course_run=course_run, grade=grade)
     return course_run
@@ -118,8 +114,8 @@ def set_course_to_failed(user=None, course_run=None, grade=DEFAULT_FAILED_GRADE)
 
 @course_state_editor
 @accepts_or_calculates_now
-def set_course_to_offered(user=None, course_run=None, now=None,  # pylint: disable=unused-argument
-                          in_future=False, fuzzy=False):
+def set_to_offered(user=None, course_run=None, now=None,  # pylint: disable=unused-argument
+                   in_future=False, fuzzy=False):
     """Sets a course to have an offered course run that a given user is not enrolled in"""
     if fuzzy:
         course_run.fuzzy_start_date = 'Spring 2017'
@@ -136,8 +132,8 @@ def set_course_to_offered(user=None, course_run=None, now=None,  # pylint: disab
 
 
 @course_state_editor
-def set_course_to_enrolled(user=None, course_run=None, in_future=False,  # pylint: disable=too-many-arguments
-                           grade=None, audit=False, missed_deadline=False):
+def set_to_enrolled(user=None, course_run=None, in_future=False,  # pylint: disable=too-many-arguments
+                    grade=None, audit=False, missed_deadline=False):
     """Sets a course to have a currently-enrolled course run"""
     enrollable_setting = dict(enrollable_past=True) if missed_deadline else dict(enrollable_now=True)
     if in_future:
@@ -151,10 +147,10 @@ def set_course_to_enrolled(user=None, course_run=None, in_future=False,  # pylin
 
 
 @course_state_editor
-def set_course_to_needs_upgrade(**kwargs):
+def set_to_needs_upgrade(**kwargs):
     """Sets a course to have an enrolled course run that needs to be upgraded (aka 'audit')"""
     kwargs.update(dict(audit=True, in_future=False))
-    return set_course_to_enrolled(**kwargs)
+    return set_to_enrolled(**kwargs)
 
 
 @accepts_or_calculates_now
@@ -177,14 +173,13 @@ def add_future_run(user=None, course=None, now=None):  # pylint: disable=unused-
     return new_course_run
 
 
-def clear_future_runs(user=None, course=None):  # pylint: disable=unused-argument
-    """Clears future enrollable course runs that were added by this script"""
+def clear_added_runs(user=None, course=None):  # pylint: disable=unused-argument
+    """Clears course runs that were added by this script"""
     return CourseRun.objects.filter(course=course, edx_course_key__startswith=NEW_COURSE_RUN_PREFIX).delete()
 
 
-def get_past_course_run(user=None, course=None, now=None, add_if_exists=False):
-    """Loop through past course runs and find one without CachedCurrentGrade data"""
-    chosen_past_run = None
+def get_past_ungraded_course_run(user=None, course=None, now=None):
+    """Loop through past course runs and find one without grade data"""
     past_runs = CourseRun.objects.filter(
         course=course,
         end_date__lt=now,
@@ -192,43 +187,29 @@ def get_past_course_run(user=None, course=None, now=None, add_if_exists=False):
     for past_run in past_runs:
         if not (CachedCurrentGradeHandler(user).exists(past_run) or
                 CachedCertificateHandler(user).exists(past_run)):
-            chosen_past_run = past_run
-        elif not add_if_exists:
-            raise Exception("Past failed/passed course run already exists (id: {}, title: {})".format(
-                past_run.id,
-                past_run.title
-            ))
-    if not chosen_past_run:
-        raise Exception("Can't find past run w/o CachedCurrentGrade")
-    return chosen_past_run
+            return past_run
+    raise CommandError("Can't find past run that isn't already passed/failed for Course '{}'".format(course.title))
 
 
 @accepts_or_calculates_now
-def add_past_failed_run(user=None, course=None, now=None, grade=DEFAULT_FAILED_GRADE, add_if_exists=False):
+def add_past_failed_run(user=None, course=None, now=None, grade=DEFAULT_FAILED_GRADE):
     """Adds a past failed course run for a given user and course"""
-    chosen_past_run = get_past_course_run(user, course, now, add_if_exists)
-
-    # Add enrollment and failed grade for course run
-    CachedEnrollmentHandler(user).set_or_create(course_run=chosen_past_run)
-    CachedCurrentGradeHandler(user).set_or_create(course_run=chosen_past_run, grade=grade)
-    return chosen_past_run
+    ungraded_past_run = get_past_ungraded_course_run(user, course, now)
+    return set_to_failed(user=user, course_run=ungraded_past_run, grade=grade)
 
 
 @accepts_or_calculates_now
-def add_past_passed_run(user=None, course=None, now=None, grade=DEFAULT_GRADE, add_if_exists=False):
+def add_past_passed_run(user=None, course=None, now=None, grade=DEFAULT_GRADE):
     """Adds a past passed course run for a given user and course"""
-    chosen_past_run = get_past_course_run(user, course, now, add_if_exists)
-    # Add enrollment and  certificate for course run
-    CachedEnrollmentHandler(user).set_or_create(course_run=chosen_past_run)
-    CachedCertificateHandler(user).set_or_create(course_run=chosen_past_run, grade=grade)
-
-    return chosen_past_run
+    ungraded_past_run = get_past_ungraded_course_run(user, course, now)
+    return set_to_passed(user=user, course_run=ungraded_past_run, grade=grade)
 
 
-def _formatted_datetime(dt, dt_format='%m/%d/%Y'):
+def _formatted_datetime(dt):
+    """Returns a string of a given datetime to be printed in command output"""
     if not dt:
         return None
-    return localized_datetime(dt).strftime(dt_format)
+    return localized_datetime(dt).isoformat()
 
 
 def course_info(user=None, course=None):
@@ -260,18 +241,19 @@ def course_info(user=None, course=None):
 
 COURSE_COMMAND_FUNCTIONS = {
     func.__name__: func for func in [
-        set_course_to_offered,
-        set_course_to_passed,
-        set_course_to_failed,
-        set_course_to_enrolled,
-        set_course_to_needs_upgrade,
+        set_to_offered,
+        set_to_passed,
+        set_to_failed,
+        set_to_enrolled,
+        set_to_needs_upgrade,
         add_future_run,
-        clear_future_runs,
+        clear_added_runs,
         add_past_failed_run,
         add_past_passed_run,
         course_info,
     ]
 }
+EXAMPLE_USAGE_COMMAND_NAME = 'examples'
 
 ADDITIONAL_PARAMS = {
     'grade': {
@@ -294,10 +276,6 @@ ADDITIONAL_PARAMS = {
         'type': bool,
         'help': "Include if you want the course run to be an audit (ie: the user hasn't paid yet, needs to upgrade)"
     },
-    'add_if_exists': {
-        'type': bool,
-        'help': "Include if you want to set a past run to failed even if there is an existing failed run"
-    },
 }
 
 
@@ -305,26 +283,22 @@ class Command(BaseCommand):
     """
     Fine-tune course/program data (and associated enrollments/grades/etc) for a user.
     """
-    help = "Fine-tune course/program data (and associated enrollments/grades/etc) for a user."
+    help = """
+    Fine-tune course/program data (and associated enrollments/grades/etc) for a user.
+    For detailed usage examples, run the command with '{0}' (ie: 'manage.py alter_data {0}')
+    """.format(EXAMPLE_USAGE_COMMAND_NAME)
 
     def add_arguments(self, parser):
-        # Add argument to show example commands
-        parser.add_argument(
-            '--usage',
-            action='store_true',
-            default=None,
-            help='Show usage details/example commands'
-        )
         # Add arguments for allowed actions
         allowed_action_names = list(COURSE_COMMAND_FUNCTIONS.keys())
-        allowed_action_names.extend(['turn_financial_aid_off', 'turn_financial_aid_on'])
+        allowed_action_names.extend(['turn_financial_aid_off', 'turn_financial_aid_on', EXAMPLE_USAGE_COMMAND_NAME])
         parser.add_argument(
-            '--action',
+            'action',
             choices=allowed_action_names,
-            help='Program-/Course-related action'
+            help='Program-/Course-related action (choose one)'
         )
         # Add arguments for parameters that will be used to find Courses/Users
-        for finder_cls in {CourseFinder, UserFinder}:
+        for finder_cls in {CourseFinder, CourseRunFinder, UserFinder}:
             for param_key in finder_cls.param_keys:
                 parser.add_argument(
                     '--{}'.format(param_key.replace('_', '-')),
@@ -348,7 +322,7 @@ class Command(BaseCommand):
         return filter_dict_none_values(filter_dict_by_key_set(options, desired_key_set))
 
     def handle(self, *args, **options):
-        if options['usage']:
+        if options['action'] == EXAMPLE_USAGE_COMMAND_NAME:
             self.stdout.write(USAGE_DETAILS)
         elif 'turn_financial_aid_' in options['action']:
             program = Program.objects.get(title__contains=options['program_title'])
@@ -356,22 +330,28 @@ class Command(BaseCommand):
             set_program_financial_aid(program, set_to=set_to)
         else:
             action_func = COURSE_COMMAND_FUNCTIONS[options['action']]
+            action_params = {}
             user_finder_params = self.filter_options(options, UserFinder.param_keys)
-            user = UserFinder().find(**user_finder_params)
+            action_params['user'] = UserFinder.find(**user_finder_params)
             course_finder_params = self.filter_options(options, CourseFinder.param_keys)
-            course = CourseFinder().find(**course_finder_params)
+            if course_finder_params:
+                action_params['course'] = CourseFinder.find(**course_finder_params)
+            course_run_finder_params = self.filter_options(options, CourseRunFinder.param_keys)
+            if course_run_finder_params:
+                action_params['course_run'] = CourseRunFinder.find(**course_run_finder_params)
             additional_params = self.filter_options(options, ADDITIONAL_PARAMS.keys())
             # Coerce 'grade' to decimal if it exists
             if 'grade' in additional_params:
                 additional_params['grade'] = Decimal(int(additional_params['grade'])/100)
             # Execute the action
-            result = action_func(user=user, course=course, **additional_params)
+            action_params.update(additional_params)
+            result = action_func(**action_params)
             if isinstance(result, CourseRun):
                 self.stdout.write("Course run changed: (id: {}, edx_course_key: {})\nUser: {}; Course: {}".format(
                     result.id,
                     result.edx_course_key,
-                    user.username,
-                    course.title
+                    action_params['user'].username,
+                    result.course.title
                 ))
             elif isinstance(result, dict):
                 self.stdout.write(json.dumps(result, indent=2))


### PR DESCRIPTION
#### What are the relevant tickets?

No tickets. 

#### What's this PR do?

Fixes a bunch of outstanding issues with alter_data and adds a few simple new options. Here's a list of the fixes:

1. Changed the 'action' parameter to be a positional argument b/c it's required
1. Added to ability to target specific course runs if that's what the user wants to do. (eg: `alter_data set_to_failed --username=staff --course-run-key='MITx+Analog+Learning+100+Dec_2016'`)
1. Made usage details and example commands more helpful
1. Renamed a bunch of functions/variables to be more clear
1. Got rid of the '--add-if-exists' option for adding past failed/past runs. It wasn't helping, so that's done by default now

#### How should this be manually tested?

Run through a few of the example commands printed by `alter_data examples`, tweak a few arguments here and there, and check on the results either using `alter_data course_info --username=YOUR_USER --course-title='SOME_COURSE_TITLE'` or loading the dashboard page in the app

