### PR TITLE
Upgrade Wagtail to 1.8

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,4 +26,4 @@ redis==2.10.5
 requests
 static3==0.5.1
 uwsgi
-wagtail==1.7
+wagtail==1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,5 +52,5 @@ static3==0.5.1
 unidecode==0.4.19         # via wagtail
 urllib3==1.19             # via elasticsearch
 uwsgi==2.0.14
-wagtail==1.7
+wagtail==1.8
 willow==0.4               # via wagtail


### PR DESCRIPTION
Follow-up to #1635. [ChangeLog is here.](https://github.com/wagtail/wagtail/blob/master/CHANGELOG.txt) Doesn't look like there's any big changes that will affect us in this upgrade.

This pull request is not urgent. It is only to keep us up-to-date on the upgrade treadmill.