### PR TITLE
changed watch travis docker container to point back at mm_watch_travis

### DIFF
--- a/travis/Dockerfile-travis-watch
+++ b/travis/Dockerfile-travis-watch
@@ -1,4 +1,4 @@
-FROM mitodl/mm_watch_travis_yarn
+FROM mitodl/mm_watch_travis
 
 WORKDIR /src
 


### PR DESCRIPTION
This undoes a change I introduced in https://github.com/mitodl/micromasters/commit/a5520933512dce04f57ade6ce8a5c179e2ef4828 - I changed things around so that the JavaScript docker file for travis inherited from `mm_watch_travis_yarn`. I changed that so I could push up a new container which had `yarn` in it without messing with master at all.

Since that commit is in master, we don't need this separation anymore, so this PR will point the travis JavaScript dockerfile back at `mm_watch_travis`. I ran the `travis/update-docker-hub.sh` script already, so `mm_watch_travis` has yarn installed.

To review this, just make sure that the tests all pass and everything looks normal on travis.
