### PR TITLE
Added access control header for static assets

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -35,6 +35,7 @@ http {
         }
 
         location ~* /static/(.*$) {
+            add_header Access-Control-Allow-Origin *;
             try_files $uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404;
         }
 


### PR DESCRIPTION
**Added access control header for static assets**
CMS and Admin are generating CORS errors when served through
cloudfront. Adding access control header for all static assets.