### PR TITLE
Check for OSError during image migration

### DIFF
--- a/profiles/migrations/0025_populate_image_small.py
+++ b/profiles/migrations/0025_populate_image_small.py
@@ -13,8 +13,11 @@ def populate_image_small(apps, schema_editor):
     Profile = apps.get_model('profiles.Profile')
     for profile in Profile.objects.all():
         if profile.image and not profile.image_small:
-            thumbnail = make_thumbnail(profile.image.file)
-            profile.image_small.save("{}.jpg".format(uuid4().hex), thumbnail)
+            try:
+                thumbnail = make_thumbnail(profile.image.file)
+                profile.image_small.save("{}.jpg".format(uuid4().hex), thumbnail)
+            except OSError:
+                pass
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2216

#### What's this PR do?
Silences `OSError` if it occurs during an image thumbnail conversion. In this case it leaves the `image_small` field `null` and moves on to the next one.
