### PR TITLE
Implement lazy loading for UserChip

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -107,3 +107,6 @@ export const setDocsInstructionsVisibility = createAction(SET_DOCS_INSTRUCTIONS_
 
 export const SET_NAV_DRAWER_OPEN = 'SET_NAV_DRAWER_OPEN';
 export const setNavDrawerOpen = createAction(SET_NAV_DRAWER_OPEN);
+
+export const SET_USER_CHIP_VISIBILITY = 'SET_USER_CHIP_VISIBILITY';
+export const setUserChipVisibility = createAction(SET_USER_CHIP_VISIBILITY);

--- a/static/js/actions/ui_test.js
+++ b/static/js/actions/ui_test.js
@@ -28,6 +28,7 @@ import {
   SET_CONFIRM_SKIP_DIALOG_VISIBILITY,
   SET_DOCS_INSTRUCTIONS_VISIBILITY,
   SET_NAV_DRAWER_OPEN,
+  SET_USER_CHIP_VISIBILITY,
 
   clearUI,
   updateDialogText,
@@ -58,6 +59,7 @@ import {
   setConfirmSkipDialogVisibility,
   setDocsInstructionsVisibility,
   setNavDrawerOpen,
+  setUserChipVisibility,
 } from '../actions/ui';
 import { assertCreatedActionHelper } from './util';
 
@@ -93,6 +95,7 @@ describe('generated UI action helpers', () => {
       [setDocsInstructionsVisibility, SET_DOCS_INSTRUCTIONS_VISIBILITY],
       [setWorkHistoryAnswer, SET_WORK_HISTORY_ANSWER],
       [setNavDrawerOpen, SET_NAV_DRAWER_OPEN],
+      [setUserChipVisibility, SET_USER_CHIP_VISIBILITY],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/components/search/LearnerResult.js
+++ b/static/js/components/search/LearnerResult.js
@@ -1,33 +1,50 @@
 // @flow
 import React from 'react';
+import { connect } from 'react-redux';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import _ from 'lodash';
+import type { Dispatch } from 'redux';
+
+import { setUserChipVisibility } from '../../actions/ui';
 import ProfileImage from '../../containers/ProfileImage';
 import UserChip from '../UserChip';
 import { getUserDisplayName, getLocation } from '../../util/util';
 import type { SearchResult } from '../../flow/searchTypes';
 
-export default class LearnerResult extends React.Component {
-  props: {
-    result: { _source: SearchResult }
-  };
+type LearnerResultProps = {
+  result: { _source: SearchResult },
+  setUserChipVisibility: (username: ?string) => void,
+  userChipVisibility: ?string,
+};
+
+class LearnerResult extends React.Component {
+  props: LearnerResultProps;
 
   static hasGrade = program => (
     _.has(program, 'grade_average') && _.isNumber(program.grade_average)
   );
 
   render () {
-    const { result: { _source: { profile, program } } } = this.props;
+    const {
+      result: { _source: { profile, program } },
+      setUserChipVisibility,
+      userChipVisibility,
+    } = this.props;
     return (
       <Grid className="search-grid learner-result">
-        <Cell col={1}>
+        <Cell col={1} className="learner-avatar">
           <ProfileImage profile={profile} useSmall={true} />
         </Cell>
-        <Cell col={3} className="learner-name centered">
-          <span>
+        <Cell
+          col={3}
+          className="learner-name centered"
+          onMouseLeave={() => setUserChipVisibility(null)}
+          onMouseEnter={() => setUserChipVisibility(profile.username)}
+        >
+          <span className="display-name">
             { getUserDisplayName(profile) }
           </span>
-          <UserChip profile={profile} />
+          {profile.username === userChipVisibility ? <UserChip profile={profile} /> : null}
         </Cell>
         <Cell col={4} className="centered learner-location">
           <span>
@@ -45,3 +62,21 @@ export default class LearnerResult extends React.Component {
     );
   }
 }
+
+const mapStateToProps = state => {
+  return {
+    userChipVisibility: state.ui.userChipVisibility,
+  };
+};
+
+const mapDispatchToProps = (dispatch: Dispatch, ownProps: LearnerResultProps) => {
+  return {
+    setUserChipVisibility: (username: ?string): void => {
+      if (ownProps.userChipVisibility !== username) {
+        dispatch(setUserChipVisibility(username));
+      }
+    },
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(LearnerResult);

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -40,6 +40,7 @@ import {
   SET_DOCS_INSTRUCTIONS_VISIBILITY,
   SET_NAV_DRAWER_OPEN,
   SET_PROGRAM,
+  SET_USER_CHIP_VISIBILITY,
 } from '../actions/ui';
 import type { ToastMessage } from '../flow/generalTypes';
 import type { Action } from '../flow/reduxTypes';
@@ -82,6 +83,7 @@ export type UIState = {
   skipDialogVisibility:             boolean,
   docsInstructionsVisibility:       boolean,
   navDrawerOpen:                    boolean,
+  userChipVisibility:               ?string,
 };
 
 export const INITIAL_UI_STATE: UIState = {
@@ -115,6 +117,7 @@ export const INITIAL_UI_STATE: UIState = {
   skipDialogVisibility: false,
   docsInstructionsVisibility: false,
   navDrawerOpen: false,
+  userChipVisibility: null,
 };
 
 export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
@@ -278,6 +281,8 @@ export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
     return { ...state, docsInstructionsVisibility: action.payload };
   case SET_NAV_DRAWER_OPEN:
     return { ...state, navDrawerOpen: action.payload };
+  case SET_USER_CHIP_VISIBILITY:
+    return { ...state, userChipVisibility: action.payload };
   default:
     return state;
   }

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -32,6 +32,7 @@ import {
   setConfirmSkipDialogVisibility,
   setDocsInstructionsVisibility,
   setNavDrawerOpen,
+  setUserChipVisibility,
 } from '../actions/ui';
 import { INITIAL_UI_STATE } from '../reducers/ui';
 import rootReducer from '../reducers';
@@ -210,5 +211,9 @@ describe('ui reducers', () => {
     it('should let you set the nav drawer visibility', () => {
       assertReducerResultState(setNavDrawerOpen, ui => ui.navDrawerOpen, false);
     });
+  });
+
+  it('should let you set the user chip visibility', () => {
+    assertReducerResultState(setUserChipVisibility, ui => ui.userChipVisibility, null);
   });
 });

--- a/static/scss/user-chip.scss
+++ b/static/scss/user-chip.scss
@@ -2,7 +2,7 @@
   min-height: 0;
   width: 385px;
   position: absolute;
-  display: none;
+  display: block;
   top: 10%;
   left: 250px;
   padding: 12px 24px 16px;
@@ -65,10 +65,3 @@
   }
 
 }
-
-.learner-result > .learner-name:hover {
-  .mdl-card.user-chip {
-    display: block;
-  }
-}
-


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #2213

#### What's this PR do?
Removes CSS hover rule for user chip and replaces it with explicit state in redux. This means the DOM elements are only mounted when the user hovers over the name, which means the image on the UserChip is only loaded on first mouseenter.

#### How should this be manually tested?
Make sure hovering over the name still produces the user chip. Hovering over the user chip itself should also keep the user chip visible.
