### PR TITLE
Show spinner only on currently active button

### DIFF
--- a/static/js/components/EmailCompositionDialog_test.js
+++ b/static/js/components/EmailCompositionDialog_test.js
@@ -84,7 +84,7 @@ describe('EmailCompositionDialog', () => {
 
     // assert that inFlight is true
     assert.isTrue(dialogActionsSpy.lastCall.args[2]);
-    assert.equal(dialogActionsSpy.lastCall.args[3], 'Send');
+    assert.equal(dialogActionsSpy.callCount, 1);
   });
 
   ['subject', 'body'].forEach(field => {

--- a/static/js/components/EmailCompositionDialog_test.js
+++ b/static/js/components/EmailCompositionDialog_test.js
@@ -6,6 +6,7 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import TestUtils from 'react-addons-test-utils';
 
+import * as inputUtil from '../components/inputs/util';
 import { FETCH_PROCESSING } from '../actions';
 import { INITIAL_EMAIL_STATE, NEW_EMAIL_EDIT } from '../reducers/email';
 import { modifyTextField } from '../util/test_utils';
@@ -72,6 +73,7 @@ describe('EmailCompositionDialog', () => {
   });
 
   it('should show a disabled spinner button if email send is in progress', () => {
+    let dialogActionsSpy = sandbox.spy(inputUtil, 'dialogActions');
     renderDialog({
       email: {
         ...INITIAL_EMAIL_STATE,
@@ -80,11 +82,9 @@ describe('EmailCompositionDialog', () => {
       }
     });
 
-    let saveButton = getDialog().querySelector('.save-button');
-    TestUtils.Simulate.click(saveButton);
-    assert.isFalse(sendEmail.called, "called sendSearchResultMail method");
-    assert.isTrue(saveButton.innerHTML.includes("mdl-spinner"));
-    assert.isTrue(saveButton.className.includes("disabled-with-spinner"));
+    // assert that inFlight is true
+    assert.isTrue(dialogActionsSpy.lastCall.args[2]);
+    assert.equal(dialogActionsSpy.lastCall.args[3], 'Send');
   });
 
   ['subject', 'body'].forEach(field => {

--- a/static/js/components/EmailCompositionDialog_test.js
+++ b/static/js/components/EmailCompositionDialog_test.js
@@ -83,7 +83,7 @@ describe('EmailCompositionDialog', () => {
     });
 
     // assert that inFlight is true
-    assert.isTrue(dialogActionsSpy.lastCall.args[2]);
+    assert.isTrue(dialogActionsSpy.calledWith(sinon.match.any, sinon.match.any, true));
     assert.equal(dialogActionsSpy.callCount, 1);
   });
 

--- a/static/js/components/SpinnerButton.js
+++ b/static/js/components/SpinnerButton.js
@@ -34,15 +34,14 @@ export default class SpinnerButton extends React.Component {
 
   isDisabled = () => (this.props.disabled || this.props.spinning) ? true : undefined;
 
-  // wrap onClick to return undefined if disabled and to set recentlyClicked if clicked
-  onClickWrapper = () => (
-    this.isDisabled() ? undefined : (...args) => {
-      this.setState({
-        recentlyClicked: true
-      });
-      return this.props.onClick(...args);
-    }
-  );
+  // If button is not disabled and has an onClick handler, make sure to set recentlyClicked
+  // so we display the spinner
+  onClick = (...args) => {
+    this.setState({
+      recentlyClicked: true
+    });
+    return this.props.onClick(...args);
+  };
 
   render() {
     let {
@@ -67,7 +66,7 @@ export default class SpinnerButton extends React.Component {
       className={className}
       disabled={this.isDisabled()}
       {...otherProps}
-      onClick={this.onClickWrapper()}
+      onClick={this.isDisabled() ? undefined : this.onClick}
     >
       {children}
     </ComponentVariable>;

--- a/static/js/components/SpinnerButton.js
+++ b/static/js/components/SpinnerButton.js
@@ -1,15 +1,36 @@
 import React from 'react';
 import Spinner from 'react-mdl/lib/Spinner';
 
+type SpinnerButtonProps = {
+  spinning: bool,
+  component: React.Component<*, *, *>,
+  className?: string,
+  onClick?: Function,
+  children?: any,
+  disabled?: ?bool,
+};
+
 export default class SpinnerButton extends React.Component {
-  props: {
-    spinning: bool,
-    component: React.Component<*, *, *>,
-    className?: string,
-    onClick?: Function,
-    children?: any,
-    disabled?: ?bool,
-  };
+  props: SpinnerButtonProps;
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      // This keeps track of if a button was recently clicked, to indicate
+      // that props.spinning is relevant to this button. If a button was not
+      // clicked but spinning=true, it will be ignored.
+      recentlyClicked: false
+    };
+  }
+
+  componentWillReceiveProps(nextProps: SpinnerButtonProps) {
+    if (!nextProps.spinning && this.props.spinning) {
+      // spinning has finished, so reset the state
+      this.setState({
+        recentlyClicked: false
+      });
+    }
+  }
 
   render() {
     let {
@@ -21,17 +42,30 @@ export default class SpinnerButton extends React.Component {
       disabled,
       ...otherProps
     } = this.props;
+    const { recentlyClicked } = this.state;
 
     if (spinning && !disabled) {
-      if (!className) {
-        className = '';
+      if (recentlyClicked) {
+        if (!className) {
+          className = '';
+        }
+        className = `${className} disabled-with-spinner`;
+        children = <Spinner singleColor/>;
       }
-      className = `${className} disabled-with-spinner`;
-      children = <Spinner singleColor />;
       disabled = true;
     }
     if (disabled) {
       onClick = undefined;
+    }
+
+    if (onClick) {
+      let oldOnClick = onClick;
+      onClick = (...args) => {
+        this.setState({
+          recentlyClicked: true
+        });
+        return oldOnClick(...args);
+      };
     }
 
     return <ComponentVariable

--- a/static/js/components/SpinnerButton.js
+++ b/static/js/components/SpinnerButton.js
@@ -35,7 +35,7 @@ export default class SpinnerButton extends React.Component {
   isDisabled = () => (this.props.disabled || this.props.spinning) ? true : undefined;
 
   // wrap onClick to return undefined if disabled and to set recentlyClicked if clicked
-  onClickWrapper = e => (
+  onClickWrapper = () => (
     this.isDisabled() ? undefined : (...args) => {
       this.setState({
         recentlyClicked: true

--- a/static/js/components/SpinnerButton.js
+++ b/static/js/components/SpinnerButton.js
@@ -32,7 +32,7 @@ export default class SpinnerButton extends React.Component {
     }
   }
 
-  isDisabled = () => (this.props.disabled || this.props.spinning) ? true : undefined;
+  isDisabled = () => this.props.disabled || this.props.spinning || undefined;
 
   // If button is not disabled and has an onClick handler, make sure to set recentlyClicked
   // so we display the spinner

--- a/static/js/components/SpinnerButton.js
+++ b/static/js/components/SpinnerButton.js
@@ -32,47 +32,42 @@ export default class SpinnerButton extends React.Component {
     }
   }
 
+  isDisabled = () => (this.props.disabled || this.props.spinning) ? true : undefined;
+
+  // wrap onClick to return undefined if disabled and to set recentlyClicked if clicked
+  onClickWrapper = e => (
+    this.isDisabled() ? undefined : (...args) => {
+      this.setState({
+        recentlyClicked: true
+      });
+      return this.props.onClick(...args);
+    }
+  );
+
   render() {
     let {
       component: ComponentVariable,
       spinning,
       className,
-      onClick,
       children,
       disabled,
       ...otherProps
     } = this.props;
     const { recentlyClicked } = this.state;
 
-    if (spinning && !disabled) {
-      if (recentlyClicked) {
-        if (!className) {
-          className = '';
-        }
-        className = `${className} disabled-with-spinner`;
-        children = <Spinner singleColor/>;
+    if (spinning && !disabled && recentlyClicked) {
+      if (!className) {
+        className = '';
       }
-      disabled = true;
-    }
-    if (disabled) {
-      onClick = undefined;
-    }
-
-    if (onClick) {
-      let oldOnClick = onClick;
-      onClick = (...args) => {
-        this.setState({
-          recentlyClicked: true
-        });
-        return oldOnClick(...args);
-      };
+      className = `${className} disabled-with-spinner`;
+      children = <Spinner singleColor/>;
     }
 
     return <ComponentVariable
       className={className}
-      onClick={onClick}
-      disabled={disabled}
+      disabled={this.isDisabled()}
       {...otherProps}
+      onClick={this.onClickWrapper()}
     >
       {children}
     </ComponentVariable>;

--- a/static/js/components/SpinnerButton_test.js
+++ b/static/js/components/SpinnerButton_test.js
@@ -34,7 +34,9 @@ describe("SpinnerButton", () => {
     let button = wrapper.find("button");
     let buttonProps = button.props();
     for (let key of Object.keys(props)) {
-      assert.deepEqual(buttonProps[key], props[key]);
+      if (key !== 'onClick') {
+        assert.deepEqual(buttonProps[key], props[key]);
+      }
     }
     assert.equal(button.children().text(), "childText");
     assert.isUndefined(buttonProps.disabled);
@@ -51,7 +53,12 @@ describe("SpinnerButton", () => {
       onClick={onClick}
       className="class1 class2"
       {...props}
-    />);
+    >
+      text
+    </SpinnerButton>);
+    wrapper.setState({
+      recentlyClicked: true
+    });
     let button = wrapper.find("Button");
     let buttonProps = button.props();
     for (let key of Object.keys(props)) {
@@ -71,11 +78,64 @@ describe("SpinnerButton", () => {
       spinning={true}
       onClick={sandbox.stub()}
       component="button"
-    />);
+    >
+      text
+    </SpinnerButton>);
     let buttonProps = wrapper.find("button").props();
 
     assert.equal(buttonProps.className, undefined);
     assert.isTrue(buttonProps.disabled);
     assert.equal(buttonProps.onClick, undefined);
+    assert.equal("text", wrapper.find("button").text());
+  });
+
+  it('sets recentlyClicked to true when the button is clicked', () => {
+    let onClick = sandbox.stub();
+    let wrapper = shallow(
+      <SpinnerButton
+        component="button"
+        onClick={onClick}
+        spinning={false}
+      />
+    );
+    assert.isFalse(wrapper.state().recentlyClicked);
+    let buttonProps = wrapper.find("button").props();
+    buttonProps.onClick("args");
+    assert.isTrue(onClick.calledWith("args"));
+    assert.isTrue(wrapper.state().recentlyClicked);
+  });
+
+  it('is disabled if spinning is true but recentlyClicked is false', () => {
+    let onClick = sandbox.stub();
+    let wrapper = shallow(
+      <SpinnerButton
+        spinning={true}
+        component="button"
+        onClick={onClick}
+      >
+        text
+      </SpinnerButton>
+    );
+    let buttonProps = wrapper.find("button").props();
+    assert.equal(buttonProps.className, undefined);
+    assert.isTrue(buttonProps.disabled);
+    assert.equal(buttonProps.onClick, undefined);
+    assert.equal("text", wrapper.find("button").text());
+  });
+
+  it('sets recentlyClicked back to false if the spinning prop changes back to false', () => {
+    let wrapper = shallow(
+      <SpinnerButton
+        component="button"
+        spinning={true}
+      />
+    );
+    wrapper.setState({
+      recentlyClicked: true
+    });
+    wrapper.setProps({
+      spinning: false
+    });
+    assert.isFalse(wrapper.state().recentlyClicked);
   });
 });

--- a/static/js/components/SpinnerButton_test.js
+++ b/static/js/components/SpinnerButton_test.js
@@ -105,7 +105,7 @@ describe("SpinnerButton", () => {
     assert.isTrue(wrapper.state().recentlyClicked);
   });
 
-  it('is disabled if spinning is true but recentlyClicked is false', () => {
+  it('does not show the spinner if spinning is true but recentlyClicked is false', () => {
     let onClick = sandbox.stub();
     let wrapper = shallow(
       <SpinnerButton

--- a/static/js/components/UserPageAboutMeDialog_test.js
+++ b/static/js/components/UserPageAboutMeDialog_test.js
@@ -94,7 +94,6 @@ describe('UserPageAboutMeDialog', () => {
       profilePatchStatus: FETCH_PROCESSING
     });
     // assert that inFlight is true
-    console.log("calls", dialogActionsSpy.calls);
     assert.isTrue(dialogActionsSpy.lastCall.args[2]);
     assert.equal(dialogActionsSpy.callCount, 1);
   });

--- a/static/js/components/UserPageAboutMeDialog_test.js
+++ b/static/js/components/UserPageAboutMeDialog_test.js
@@ -96,5 +96,6 @@ describe('UserPageAboutMeDialog', () => {
     // assert that inFlight is true
     console.log("calls", dialogActionsSpy.calls);
     assert.isTrue(dialogActionsSpy.lastCall.args[2]);
+    assert.equal(dialogActionsSpy.callCount, 1);
   });
 });

--- a/static/js/components/UserPageAboutMeDialog_test.js
+++ b/static/js/components/UserPageAboutMeDialog_test.js
@@ -6,6 +6,7 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import TestUtils from 'react-addons-test-utils';
 
+import * as inputUtil from '../components/inputs/util';
 import { FETCH_PROCESSING } from '../actions';
 import UserPageAboutMeDialog from './UserPageAboutMeDialog';
 import { USER_PROFILE_RESPONSE } from '../constants';
@@ -88,13 +89,12 @@ describe('UserPageAboutMeDialog', () => {
   });
 
   it('disables the save button during profile update', () => {
+    let dialogActionsSpy = sandbox.spy(inputUtil, 'dialogActions');
     renderDialog({
       profilePatchStatus: FETCH_PROCESSING
     });
-    let saveButton = getDialog().querySelector(".save-button");
-    assert(saveButton.className.includes("disabled-with-spinner"));
-    assert(saveButton.querySelector(".mdl-spinner"));
-    TestUtils.Simulate.click(saveButton);
-    assert.equal(saveProfile.callCount, 0);
+    // assert that inFlight is true
+    console.log("calls", dialogActionsSpy.calls);
+    assert.isTrue(dialogActionsSpy.lastCall.args[2]);
   });
 });

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -123,7 +123,7 @@ describe('FinancialAidCalculator', () => {
       }
       return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(() => {
         // assert inFlight arg
-        console.log(dialogActionsSpy.callCount);
+        console.log("dialogActionsSpy", dialogActionsSpy.lastCall);
         assert.equal(dialogActionsSpy.lastCall.args[2], activity);
         assert.equal(dialogActionsSpy.lastCall.args[3], "Enroll");
       });

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -32,7 +32,6 @@ import {
   setCurrentProgramEnrollment,
 } from '../actions/programs';
 import {
-  setCalculatorDialogVisibility,
   setConfirmSkipDialogVisibility,
   SET_CALCULATOR_DIALOG_VISIBILITY,
   SET_CONFIRM_SKIP_DIALOG_VISIBILITY,

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import TestUtils from 'react-addons-test-utils';
 import { render } from 'enzyme';
 import { Provider } from 'react-redux';
+import sinon from 'sinon';
 
 import * as inputUtil from '../components/inputs/util';
 import FinancialAidCalculator from '../containers/FinancialAidCalculator';
@@ -31,6 +32,7 @@ import {
   setCurrentProgramEnrollment,
 } from '../actions/programs';
 import {
+  setCalculatorDialogVisibility,
   setConfirmSkipDialogVisibility,
   SET_CALCULATOR_DIALOG_VISIBILITY,
   SET_CONFIRM_SKIP_DIALOG_VISIBILITY,
@@ -123,9 +125,7 @@ describe('FinancialAidCalculator', () => {
       }
       return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(() => {
         // assert inFlight arg
-        console.log("dialogActionsSpy", dialogActionsSpy.lastCall);
-        assert.equal(dialogActionsSpy.lastCall.args[2], activity);
-        assert.equal(dialogActionsSpy.lastCall.args[3], "Enroll");
+        assert.isTrue(dialogActionsSpy.calledWith(sinon.match.any, sinon.match.any, activity, "Pay Full Price"));
       });
     });
   }
@@ -273,16 +273,14 @@ describe('FinancialAidCalculator', () => {
 
   for (let activity of [true, false]) {
     it(`has appropriate state for financial aid submit button, activity=${activity.toString()}`, () => {
-      addFinancialAidStub.returns(Promise.resolve(FINANCIAL_AID_PARTIAL_RESPONSE));
+      let dialogActionsSpy = helper.sandbox.spy(inputUtil, 'dialogActions');
+
       if (activity) {
         helper.store.dispatch(requestAddFinancialAid());
       }
-
-      return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
-        let buttonProps = wrapper.find('.pricing-actions').find('SpinnerButton').filterWhere(
-          button => button.props().className.includes("dashboard-button")
-        ).props();
-        assert.equal(buttonProps.spinning, activity);
+      addFinancialAidStub.returns(Promise.resolve(FINANCIAL_AID_PARTIAL_RESPONSE));
+      return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(() => {
+        assert.isTrue(dialogActionsSpy.calledWith(sinon.match.any, sinon.match.any, activity, "Calculate"));
       });
     });
   }

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -207,17 +207,17 @@ describe("ProfilePage", function() {
     });
   });
 
-  it('disables the button and shows a spinner when profile patch is processing', () => {
-    return renderComponent('/profile/personal', SUCCESS_ACTIONS).then(([wrapper]) => {
-      helper.store.dispatch(requestPatchUserProfile(SETTINGS.user.username));
-
-      let next = wrapper.find(".next");
-      assert(next.props().className.includes("disabled-with-spinner"));
-      next.simulate("click");
-      assert.isFalse(patchUserProfileStub.called);
-      assert.lengthOf(next.find(".mdl-spinner"), 1);
+  for (let activity of [true, false]) {
+    it(`has proper button state when the profile patch is processing when activity=${String(activity)}`, () => {
+      return renderComponent('/profile/personal', SUCCESS_ACTIONS).then(([wrapper]) => {
+        if (activity) {
+          helper.store.dispatch(requestPatchUserProfile(SETTINGS.user.username));
+        }
+        let next = wrapper.find("SpinnerButton");
+        assert.equal(activity, next.props().spinning);
+      });
     });
-  });
+  }
 
   it('should enroll the user when they go to the next page', () => {
     let addEnrollmentStub = helper.sandbox.stub(api, 'addProgramEnrollment');

--- a/static/js/containers/SettingsPage_test.js
+++ b/static/js/containers/SettingsPage_test.js
@@ -116,15 +116,17 @@ describe("SettingsPage", function() {
       });
     });
 
-    it('disables the button and shows a spinner when profile patch is processing', () => {
-      return renderComponent('/settings', userActions).then(([wrapper]) => {
-        helper.store.dispatch(requestPatchUserProfile(SETTINGS.user.username));
+    for (let activity of [true, false]) {
+      it(`has proper button state when when profile patch activity is ${String(activity)}`, () => {
+        return renderComponent('/settings', userActions).then(([wrapper]) => {
+          if (activity) {
+            helper.store.dispatch(requestPatchUserProfile(SETTINGS.user.username));
+          }
 
-        let next = wrapper.find(".next");
-        assert(next.props().className.includes("disabled-with-spinner"));
-        next.simulate("click");
-        assert.isFalse(patchUserProfileStub.called);
+          let next = wrapper.find("SpinnerButton");
+          assert.equal(next.props().spinning, activity);
+        });
       });
-    });
+    }
   });
 });

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -5,6 +5,7 @@ import { assert } from 'chai';
 import _ from 'lodash';
 import moment from 'moment';
 
+import * as inputUtil from '../components/inputs/util';
 import {
   RECEIVE_GET_USER_PROFILE_SUCCESS,
   REQUEST_GET_USER_PROFILE,
@@ -455,26 +456,12 @@ describe("UserPage", function() {
           patchUserProfileStub.returns(Promise.resolve(USER_PROFILE_RESPONSE));
 
           helper.store.dispatch(setShowEducationDeleteDialog(true));
-          if (activity) {
-            helper.store.dispatch(requestPatchUserProfile());
-          }
+          let dialogActionsSpy = helper.sandbox.spy(inputUtil, 'dialogActions');
           return renderComponent(`/learner/${username}`, userActions).then(() => {
-            let dialog = document.querySelector('.deletion-confirmation-dialog');
-            let button = dialog.querySelector(".delete-button");
-
-            let actions = activity ? [REQUEST_PATCH_USER_PROFILE] : [];
-
-            return listenForActions(actions, () => {
-              if (activity) {
-                helper.store.dispatch(requestPatchUserProfile(username));
-              }
-            }).then(() => {
-              assert.equal(button.className.includes("disabled-with-spinner"), activity);
-              assert.equal(button.innerHTML.includes("mdl-spinner"), activity);
-
-              TestUtils.Simulate.click(button);
-              assert.equal(patchUserProfileStub.called, !activity);
-            });
+            if (activity) {
+              helper.store.dispatch(requestPatchUserProfile(username));
+            }
+            assert.equal(dialogActionsSpy.lastCall.args[2], activity);
           });
         });
       }
@@ -581,29 +568,18 @@ describe("UserPage", function() {
         });
       });
 
-      it('should disable the save button while a PATCH is in progress', () => {
-        const username = SETTINGS.user.username;
-        return renderComponent(`/learner/${username}`, userActions).then(([, div]) => {
-          let addButton = div.querySelector(".add-education-button");
-
-          TestUtils.Simulate.click(addButton);
-
-          let dialog = document.querySelector('.education-dialog');
-
-          return listenForActions([
-            REQUEST_PATCH_USER_PROFILE,
-          ], () => {
-            helper.store.dispatch(requestPatchUserProfile(username));
-          }).then(() => {
-            let button = dialog.querySelector(".save-button");
-            assert(button.className.includes("disabled-with-spinner"));
-            assert(button.querySelector(".mdl-spinner"));
-
-            TestUtils.Simulate.click(button);
-            assert.isFalse(patchUserProfileStub.called);
+      for (const activity of [true, false]) {
+        it(`should have proper button state when activity=${activity}`, () => {
+          const username = SETTINGS.user.username;
+          let dialogActionsSpy = helper.sandbox.spy(inputUtil, 'dialogActions');
+          return renderComponent(`/learner/${username}`, userActions).then(([]) => {
+            if (activity) {
+              helper.store.dispatch(requestPatchUserProfile(username));
+            }
+            assert.equal(dialogActionsSpy.lastCall.args[2], activity);
           });
         });
-      });
+      }
     });
 
     describe("Employment History", () => {
@@ -712,23 +688,12 @@ describe("UserPage", function() {
           patchUserProfileStub.returns(Promise.resolve(USER_PROFILE_RESPONSE));
 
           helper.store.dispatch(setShowWorkDeleteDialog(true));
+          let dialogActionsSpy = helper.sandbox.spy(inputUtil, 'dialogActions');
           return renderComponent(`/learner/${username}`, userActions).then(() => {
-            let dialog = document.querySelector('.deletion-confirmation-dialog');
-            let button = dialog.querySelector(".delete-button");
-
-            let actions = activity ? [REQUEST_PATCH_USER_PROFILE] : [];
-
-            return listenForActions(actions, () => {
-              if (activity) {
-                helper.store.dispatch(requestPatchUserProfile(username));
-              }
-            }).then(() => {
-              assert.equal(button.className.includes("disabled-with-spinner"), activity);
-              assert.equal(button.innerHTML.includes("mdl-spinner"), activity);
-
-              TestUtils.Simulate.click(button);
-              assert.equal(patchUserProfileStub.called, !activity);
-            });
+            if (activity) {
+              helper.store.dispatch(requestPatchUserProfile(username));
+            }
+            assert.equal(dialogActionsSpy.lastCall.args[2], activity);
           });
         });
       }
@@ -845,29 +810,18 @@ describe("UserPage", function() {
         });
       });
 
-      it('should disable the save button while a PATCH is in progress', () => {
-        const username = SETTINGS.user.username;
-        return renderComponent(`/learner/${username}`, userActions).then(([, div]) => {
-          let addButton = div.querySelector(".add-employment-button");
-
-          TestUtils.Simulate.click(addButton);
-
-          let dialog = document.querySelector('.employment-dialog');
-
-          return listenForActions([
-            REQUEST_PATCH_USER_PROFILE,
-          ], () => {
-            helper.store.dispatch(requestPatchUserProfile(username));
-          }).then(() => {
-            let button = dialog.querySelector(".save-button");
-            assert(button.className.includes("disabled-with-spinner"));
-            assert(button.querySelector(".mdl-spinner"));
-
-            TestUtils.Simulate.click(button);
-            assert.isFalse(patchUserProfileStub.called);
+      for (let activity of [true, false]) {
+        it(`should have proper save button spinner state when activity=${activity}`, () => {
+          const username = SETTINGS.user.username;
+          let dialogActionsSpy = helper.sandbox.spy(inputUtil, 'dialogActions');
+          return renderComponent(`/learner/${username}`, userActions).then(() => {
+            if (activity) {
+              helper.store.dispatch(requestPatchUserProfile(username));
+            }
+            assert.equal(dialogActionsSpy.lastCall.args[2], activity);
           });
         });
-      });
+      }
     });
 
     describe('Personal Info', () => {
@@ -992,29 +946,18 @@ describe("UserPage", function() {
         });
       });
 
-      it('should disable the save button while a PATCH is in progress', () => {
-        const username = SETTINGS.user.username;
-        return renderComponent(`/learner/${username}`, userActions).then(([, div]) => {
-          let addButton = div.querySelector(".edit-personal-info-button");
-
-          TestUtils.Simulate.click(addButton);
-
-          let dialog = document.querySelector('.personal-dialog');
-
-          return listenForActions([
-            REQUEST_PATCH_USER_PROFILE,
-          ], () => {
-            helper.store.dispatch(requestPatchUserProfile(username));
-          }).then(() => {
-            let button = dialog.querySelector(".save-button");
-            assert(button.className.includes("disabled-with-spinner"));
-            assert(button.querySelector(".mdl-spinner"));
-
-            TestUtils.Simulate.click(button);
-            assert.isFalse(patchUserProfileStub.called);
+      for (const activity of [true, false]) {
+        it(`should have proper button spinner state while a PATCH is in progress for activity=${activity}`, () => {
+          const username = SETTINGS.user.username;
+          const dialogActionsSpy = helper.sandbox.spy(inputUtil, 'dialogActions');
+          return renderComponent(`/learner/${username}`, userActions).then(() => {
+            if (activity) {
+              helper.store.dispatch(requestPatchUserProfile(username));
+            }
+            assert.equal(dialogActionsSpy.lastCall.args[2], activity);
           });
         });
-      });
+      }
     });
 
     it("should show all edit, delete icons for an authenticated user's own page" , () => {

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -461,6 +461,7 @@ describe("UserPage", function() {
             if (activity) {
               helper.store.dispatch(requestPatchUserProfile(username));
             }
+            assert.equal(dialogActionsSpy.callCount, 1);
             assert.equal(dialogActionsSpy.lastCall.args[2], activity);
           });
         });

--- a/static/js/containers/UserPage_test.js
+++ b/static/js/containers/UserPage_test.js
@@ -4,6 +4,7 @@ import TestUtils from 'react-addons-test-utils';
 import { assert } from 'chai';
 import _ from 'lodash';
 import moment from 'moment';
+import sinon from 'sinon';
 
 import * as inputUtil from '../components/inputs/util';
 import {
@@ -461,8 +462,7 @@ describe("UserPage", function() {
             if (activity) {
               helper.store.dispatch(requestPatchUserProfile(username));
             }
-            assert.equal(dialogActionsSpy.callCount, 1);
-            assert.equal(dialogActionsSpy.lastCall.args[2], activity);
+            assert.isTrue(dialogActionsSpy.calledWith(sinon.match.any, sinon.match.any, activity, "Delete"));
           });
         });
       }
@@ -570,14 +570,14 @@ describe("UserPage", function() {
       });
 
       for (const activity of [true, false]) {
-        it(`should have proper button state when activity=${activity}`, () => {
+        it(`should have proper save button state when activity=${activity}`, () => {
           const username = SETTINGS.user.username;
           let dialogActionsSpy = helper.sandbox.spy(inputUtil, 'dialogActions');
-          return renderComponent(`/learner/${username}`, userActions).then(([]) => {
+          return renderComponent(`/learner/${username}`, userActions).then(() => {
             if (activity) {
               helper.store.dispatch(requestPatchUserProfile(username));
             }
-            assert.equal(dialogActionsSpy.lastCall.args[2], activity);
+            assert.isTrue(dialogActionsSpy.calledWith(sinon.match.any, sinon.match.any, activity));
           });
         });
       }
@@ -694,7 +694,7 @@ describe("UserPage", function() {
             if (activity) {
               helper.store.dispatch(requestPatchUserProfile(username));
             }
-            assert.equal(dialogActionsSpy.lastCall.args[2], activity);
+            assert.isTrue(dialogActionsSpy.calledWith(sinon.match.any, sinon.match.any, activity, "Delete"));
           });
         });
       }
@@ -819,7 +819,7 @@ describe("UserPage", function() {
             if (activity) {
               helper.store.dispatch(requestPatchUserProfile(username));
             }
-            assert.equal(dialogActionsSpy.lastCall.args[2], activity);
+            assert.isTrue(dialogActionsSpy.calledWith(sinon.match.any, sinon.match.any, activity));
           });
         });
       }
@@ -955,7 +955,7 @@ describe("UserPage", function() {
             if (activity) {
               helper.store.dispatch(requestPatchUserProfile(username));
             }
-            assert.equal(dialogActionsSpy.lastCall.args[2], activity);
+            assert.isTrue(dialogActionsSpy.calledWith(sinon.match.any, sinon.match.any, activity));
           });
         });
       }

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -177,6 +177,11 @@
     color: $link-hover;
     text-decoration: underline;
   }
+
+  &[disabled] {
+    color: $font-gray-disabled;
+    text-decoration: none;
+  }
 }
 
 .dashboard-button {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2140

#### What's this PR do?
Stores state on whether the button was recently clicked. Only buttons which are recently clicked show the spinner, otherwise the button is disabled.

#### How should this be manually tested?
Set your network throttling to simulate a slow connection, and configure your dashboard to show more than one course which has the enroll link. Mocking the functions in api.js might be useful here. Then click one of the enroll buttons. Only that button should have the spinner, and the other enroll buttons should be disabled. When the API call completes, the buttons should all be enabled again.

#### Screenshots (if appropriate)
![screenshot from 2016-12-29 16-36-07](https://cloud.githubusercontent.com/assets/863262/21555867/057c506a-cdea-11e6-901f-72f84d13092a.png)

![screenshot from 2016-12-29 16-35-46](https://cloud.githubusercontent.com/assets/863262/21555870/0c450324-cdea-11e6-87e3-45b6034e441f.png)
The dot on top here is actually part of the spinner

#### What GIF best describes this PR or how it makes you feel?
![](http://i.giphy.com/uetfmGVmMSr3a.gif)