### PR TITLE
Fixed casing on CDD column name

### DIFF
--- a/exams/pearson.py
+++ b/exams/pearson.py
@@ -124,7 +124,7 @@ def _profile_country_to_alpha3(profile):
 
 
 write_cdd_file = _tsv_writer([
-    ('ClientCandidateId', 'student_id'),
+    ('ClientCandidateID', 'student_id'),
     ('FirstName', 'romanized_first_name'),
     ('LastName', 'romanized_last_name'),
     ('Email', 'user.email'),

--- a/exams/pearson_test.py
+++ b/exams/pearson_test.py
@@ -70,7 +70,7 @@ class ExamPearsonTest(TestCase):
         content = file.getvalue()
 
         assert content == (
-            "ClientCandidateId\tFirstName\tLastName\t"
+            "ClientCandidateID\tFirstName\tLastName\t"
             "Email\tAddress1\tAddress2\tAddress3\t"
             "City\tState\tPostalCode\tCountry\t"
             "Phone\tPhoneCountryCode\tLastUpdate\r\n"


### PR DESCRIPTION
#### What's this PR do?

Fixes casing issue on CDD column name. `ClientCandidateId` -> `ClientCandidateID`.