### PR TITLE
add eslint rules for mocha

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,6 +44,14 @@
     "flowtype/no-dupe-keys": [2],
     "flowtype/no-primitive-constructor-types": [2],
     "flowtype/object-type-delimiter": [2, "comma"],
+    "mocha/no-exclusive-tests": [2],
+    "mocha/no-skipped-tests": [2],
+    "mocha/no-sibling-hooks": [2],
+    "mocha/no-global-tests": [2],
+    "mocha/handle-done-callback": [2],
+    "mocha/no-top-level-hooks": [2],
+    "mocha/no-identical-title": [2],
+    "mocha/no-nested-tests": [2],
   },
   "env": {
     "es6": true,
@@ -58,6 +66,7 @@
     "babel",
     "react",
     "flowtype",
-    "flow-vars"
+    "flow-vars",
+    "mocha"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-flow-vars": "^0.5.0",
     "eslint-plugin-flowtype": "^2.28.2",
+    "eslint-plugin-mocha": "^4.8.0",
     "eslint-plugin-react": "^6.7.1",
     "express": "^4.14.0",
     "fetch-mock": "4.4.0",

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -28,7 +28,7 @@ if (!Object.entries) {
 require('jsdom-global')();
 
 // cleanup after each test run
-afterEach(function (){
+afterEach(function (){ // eslint-disable-line mocha/no-top-level-hooks
   document.body.innerHTML = '';
   global.SETTINGS = _createSettings();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,6 +2055,12 @@ eslint-plugin-flowtype@^2.28.2:
   dependencies:
     lodash "^4.15.0"
 
+eslint-plugin-mocha@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-4.8.0.tgz#7627b35a61e5a720412da96eab06f0e03a1dcdb6"
+  dependencies:
+    ramda "^0.22.1"
+
 eslint-plugin-react@^6.7.1:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.8.0.tgz#741ab5438a094532e5ce1bbb935d6832356f492d"


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2229 

#### What's this PR do?

This adds a new eslint plugin (for mocha) and turns on some new eslint rules defined in that plugin. Should catch anyone doing a `describe.only` or similar things.