### PR TITLE
Added coupon APIs

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -379,3 +379,40 @@ def is_coupon_redeemable(coupon, user):
         return any((mmtrack.has_verified_cert(run.edx_course_key) for run in course.courserun_set.all()))
 
     return True
+
+
+def pick_coupons(user):
+    """
+    Choose the coupon which would be used in redemptions by the user.
+
+    The heuristic is currently:
+     - choose attached coupons over automatic coupons
+     - choose the coupon which has been most recently attached, or most recently modified
+
+    Args:
+        user (django.contrib.auth.models.User): A user
+
+    Returns:
+        Coupon: The coupon which will be used by the user when redeeming runs in a program
+    """
+    sorted_attached_coupons = list(
+        Coupon.objects.filter(usercoupon__user=user).order_by('-usercoupon__updated_on')
+    )
+    sorted_automatic_coupons = list(
+        Coupon.objects.filter(Coupon.is_automatic_qset()).order_by('-updated_on')
+    )
+
+    # At this point there should only be coupons the user has attached (opted into by clicking a link)
+    # or automatic coupons, which there should only be a few. So the next iterations should not
+    # affect many rows in the DB.
+
+    coupons = []
+    # Only one coupon per program
+    program_ids = set()
+    for coupon in sorted_attached_coupons + sorted_automatic_coupons:
+        program_id = coupon.program.id
+        if program_id not in program_ids and is_coupon_redeemable(coupon, user):
+            coupons.append(coupon)
+            program_ids.add(program_id)
+
+    return coupons

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -5,6 +5,7 @@ from base64 import b64encode
 from datetime import datetime
 import hashlib
 import hmac
+from itertools import chain
 import logging
 from urllib.parse import quote_plus
 import uuid
@@ -395,12 +396,8 @@ def pick_coupons(user):
     Returns:
         Coupon: The coupon which will be used by the user when redeeming runs in a program
     """
-    sorted_attached_coupons = list(
-        Coupon.user_coupon_qset(user).order_by('-usercoupon__updated_on')
-    )
-    sorted_automatic_coupons = list(
-        Coupon.is_automatic_qset().order_by('-updated_on')
-    )
+    sorted_attached_coupons = Coupon.user_coupon_qset(user).order_by('-usercoupon__updated_on')
+    sorted_automatic_coupons = Coupon.is_automatic_qset().order_by('-updated_on')
 
     # At this point there should only be coupons the user has attached (opted into by clicking a link)
     # or automatic coupons, which there should only be a few. So the next iterations should not
@@ -409,7 +406,7 @@ def pick_coupons(user):
     coupons = []
     # Only one coupon per program
     program_ids = set()
-    for coupon in sorted_attached_coupons + sorted_automatic_coupons:
+    for coupon in chain(sorted_attached_coupons, sorted_automatic_coupons):
         program_id = coupon.program.id
         if program_id not in program_ids and is_coupon_redeemable(coupon, user):
             coupons.append(coupon)

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -396,10 +396,10 @@ def pick_coupons(user):
         Coupon: The coupon which will be used by the user when redeeming runs in a program
     """
     sorted_attached_coupons = list(
-        Coupon.objects.filter(usercoupon__user=user).order_by('-usercoupon__updated_on')
+        Coupon.user_coupon_qset(user).order_by('-usercoupon__updated_on')
     )
     sorted_automatic_coupons = list(
-        Coupon.objects.filter(Coupon.is_automatic_qset()).order_by('-updated_on')
+        Coupon.is_automatic_qset().order_by('-updated_on')
     )
 
     # At this point there should only be coupons the user has attached (opted into by clicking a link)

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -314,7 +314,7 @@ class Coupon(TimestampedModel):
                 True if the coupon is not automatic and it has already been redeemed by someone else
         """
         return (
-            not Coupon.objects.filter(id=self.id).filter(self.is_automatic_qset()) and
+            not Coupon.objects.filter(id=self.id).filter(self.is_automatic_qset()).exists() and
             RedeemedCoupon.objects.filter(
                 coupon=self,
                 order__status=Order.FULFILLED,

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -313,10 +313,13 @@ class Coupon(TimestampedModel):
             bool:
                 True if the coupon is not automatic and it has already been redeemed by someone else
         """
-        return not self.is_automatic and RedeemedCoupon.objects.filter(
-            coupon=self,
-            order__status=Order.FULFILLED,
-        ).exclude(order__user=user).exists()
+        return (
+            not Coupon.objects.filter(id=self.id).filter(self.is_automatic_qset()) and
+            RedeemedCoupon.objects.filter(
+                coupon=self,
+                order__status=Order.FULFILLED,
+            ).exclude(order__user=user).exists()
+        )
 
     def clean(self):
         """Validate amount and content_object"""

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -248,7 +248,9 @@ class Coupon(TimestampedModel):
 
     @property
     def program(self):
-        """Get the program which all course keys for the coupon belong to"""
+        """
+        Get the program for the coupon's content_object.
+        """
         obj = self.content_object
         if isinstance(obj, Program):
             return obj

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -227,6 +227,26 @@ class CouponTests(TestCase):
         coupon_run = CouponFactory.create(content_object=run1)
         assert coupon_run.course_keys == [run1.edx_course_key]
 
+    def test_program(self):
+        """
+        Coupon.course_keys should return a list of all course run keys in a program, course, or course run
+        """
+        run1 = CourseRunFactory.create()
+        CourseRunFactory.create(course=run1.course)
+        run3 = CourseRunFactory.create(course__program=run1.course.program)
+        CourseRunFactory.create(course=run3.course)
+
+        coupon_program = CouponFactory.create(
+            content_object=run1.course.program,
+        )
+        assert coupon_program.program == run1.course.program
+
+        coupon_course = CouponFactory.create(content_object=run1.course)
+        assert coupon_course.program == run1.course.program
+
+        coupon_run = CouponFactory.create(content_object=run1)
+        assert coupon_run.program == run1.course.program
+
     def test_course_keys_invalid_content_object(self):
         """
         course_keys should error if we set content_object to an invalid value
@@ -238,6 +258,19 @@ class CouponTests(TestCase):
         coupon.refresh_from_db()
         with self.assertRaises(ImproperlyConfigured) as ex:
             _ = coupon.course_keys
+        assert ex.exception.args[0] == "content_object expected to be one of Program, Course, CourseRun"
+
+    def test_program_invalid_content_object(self):
+        """
+        program should error if we set content_object to an invalid value
+        """
+        coupon = CouponFactory.create()
+        profile_content_type = ContentType.objects.get_for_model(Profile)
+        # bypass clean()
+        Coupon.objects.filter(id=coupon.id).update(content_type=profile_content_type)
+        coupon.refresh_from_db()
+        with self.assertRaises(ImproperlyConfigured) as ex:
+            _ = coupon.program
         assert ex.exception.args[0] == "content_object expected to be one of Program, Course, CourseRun"
 
     def test_is_valid(self):
@@ -254,14 +287,16 @@ class CouponTests(TestCase):
 
     def test_is_automatic(self):
         """
-        Coupon.is_automatic should be true if the coupon type is DISCOUNTED_PREVIOUS_COURSE
+        Coupon.is_automatic_qset should be true if the coupon type is DISCOUNTED_PREVIOUS_COURSE
         """
-        assert CouponFactory.create(coupon_type=Coupon.STANDARD).is_automatic is False
+        coupon_not_automatic = CouponFactory.create(coupon_type=Coupon.STANDARD)
+        assert Coupon.objects.filter(Coupon.is_automatic_qset()).filter(id=coupon_not_automatic.id).exists() is False
         run = CourseRunFactory.create()
-        assert CouponFactory.create(
+        coupon_is_automatic = CouponFactory.create(
             coupon_type=Coupon.DISCOUNTED_PREVIOUS_COURSE,
             content_object=run.course,
-        ).is_automatic is True
+        )
+        assert Coupon.objects.filter(Coupon.is_automatic_qset()).filter(id=coupon_is_automatic.id).exists() is True
 
     @ddt.data(
         [Order.CREATED, True, True, False],

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -290,13 +290,13 @@ class CouponTests(TestCase):
         Coupon.is_automatic_qset should be true if the coupon type is DISCOUNTED_PREVIOUS_COURSE
         """
         coupon_not_automatic = CouponFactory.create(coupon_type=Coupon.STANDARD)
-        assert Coupon.objects.filter(Coupon.is_automatic_qset()).filter(id=coupon_not_automatic.id).exists() is False
+        assert Coupon.is_automatic_qset().filter(id=coupon_not_automatic.id).exists() is False
         run = CourseRunFactory.create()
         coupon_is_automatic = CouponFactory.create(
             coupon_type=Coupon.DISCOUNTED_PREVIOUS_COURSE,
             content_object=run.course,
         )
-        assert Coupon.objects.filter(Coupon.is_automatic_qset()).filter(id=coupon_is_automatic.id).exists() is True
+        assert Coupon.is_automatic_qset().filter(id=coupon_is_automatic.id).exists() is True
 
     @ddt.data(
         [Order.CREATED, True, True, False],

--- a/ecommerce/permissions.py
+++ b/ecommerce/permissions.py
@@ -6,6 +6,7 @@ import logging
 from rest_framework.permissions import BasePermission
 
 from ecommerce.api import generate_cybersource_sa_signature
+from profiles.api import get_social_username
 
 
 log = logging.getLogger(__name__)
@@ -30,4 +31,19 @@ class IsSignedByCyberSource(BasePermission):
                 request.data['signature'],
                 request.data,
             )
+            return False
+
+
+class IsLoggedInUser(BasePermission):
+    """
+    Confirms that the username in the request body is the same as the logged in user's.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Returns true if the username in the request body matches the logged in user.
+        """
+        try:
+            return request.data['username'] == get_social_username(request.user)
+        except KeyError:
             return False

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -1,0 +1,12 @@
+"""Serializers for ecommerce REST APIs"""
+
+from rest_framework import serializers
+
+from ecommerce.models import Coupon
+
+
+class CouponSerializer(serializers.ModelSerializer):
+    """Serializer for Coupon"""
+    class Meta:  # pylint: disable=missing-docstring
+        model = Coupon
+        fields = ('coupon_code', 'content_type', 'amount_type', 'amount',)

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -12,7 +12,7 @@ class CouponSerializer(serializers.ModelSerializer):
 
     class Meta:  # pylint: disable=missing-docstring
         model = Coupon
-        fields = ('coupon_code', 'content_type', 'amount_type', 'amount', 'program_id',)
+        fields = ('coupon_code', 'content_type', 'amount_type', 'amount', 'program_id', 'object_id',)
 
     def get_program_id(self, coupon):  # pylint: disable=no-self-use
         """Get program id from coupon program"""

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -14,10 +14,10 @@ class CouponSerializer(serializers.ModelSerializer):
         model = Coupon
         fields = ('coupon_code', 'content_type', 'amount_type', 'amount', 'program_id',)
 
-    def get_program_id(self, coupon):
+    def get_program_id(self, coupon):  # pylint: disable=no-self-use
         """Get program id from coupon program"""
         return coupon.program.id
 
-    def get_content_type(self, coupon):
+    def get_content_type(self, coupon):  # pylint: disable=no-self-use
         """Get the content type as a string"""
         return coupon.content_type.model

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -7,6 +7,17 @@ from ecommerce.models import Coupon
 
 class CouponSerializer(serializers.ModelSerializer):
     """Serializer for Coupon"""
+    program_id = serializers.SerializerMethodField()
+    content_type = serializers.SerializerMethodField()
+
     class Meta:  # pylint: disable=missing-docstring
         model = Coupon
-        fields = ('coupon_code', 'content_type', 'amount_type', 'amount',)
+        fields = ('coupon_code', 'content_type', 'amount_type', 'amount', 'program_id',)
+
+    def get_program_id(self, coupon):
+        """Get program id from coupon program"""
+        return coupon.program.id
+
+    def get_content_type(self, coupon):
+        """Get the content type as a string"""
+        return coupon.content_type.model

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -23,6 +23,7 @@ class SerializerTests(TestCase):
             'content_type': 'program',
             'coupon_code': coupon.coupon_code,
             'program_id': coupon.program.id,
+            'object_id': coupon.object_id,
         }
 
     def test_coupon_course(self):
@@ -36,6 +37,7 @@ class SerializerTests(TestCase):
             'content_type': 'course',
             'coupon_code': coupon.coupon_code,
             'program_id': coupon.program.id,
+            'object_id': coupon.object_id,
         }
 
     def test_coupon_run(self):
@@ -49,4 +51,5 @@ class SerializerTests(TestCase):
             'content_type': 'courserun',
             'coupon_code': coupon.coupon_code,
             'program_id': coupon.program.id,
+            'object_id': coupon.object_id,
         }

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -1,0 +1,52 @@
+"""
+Tests for ecommerce serializers
+"""
+from django.test import TestCase
+
+from courses.factories import CourseRunFactory
+from ecommerce.factories import CouponFactory
+from ecommerce.serializers import CouponSerializer
+
+
+# pylint: disable=no-self-use
+class SerializerTests(TestCase):
+    """Tests for ecommerce serializers"""
+
+    def test_coupon_program(self):
+        """
+        Test coupon serializer
+        """
+        coupon = CouponFactory.create(content_object=CourseRunFactory.create().course.program)
+        assert CouponSerializer(coupon).data == {
+            'amount': str(coupon.amount),
+            'amount_type': coupon.amount_type,
+            'content_type': 'program',
+            'coupon_code': coupon.coupon_code,
+            'program_id': coupon.program.id,
+        }
+
+    def test_coupon_course(self):
+        """
+        Test coupon serializer
+        """
+        coupon = CouponFactory.create(content_object=CourseRunFactory.create().course)
+        assert CouponSerializer(coupon).data == {
+            'amount': str(coupon.amount),
+            'amount_type': coupon.amount_type,
+            'content_type': 'course',
+            'coupon_code': coupon.coupon_code,
+            'program_id': coupon.program.id,
+        }
+
+    def test_coupon_run(self):
+        """
+        Test coupon serializer
+        """
+        coupon = CouponFactory.create(content_object=CourseRunFactory.create())
+        assert CouponSerializer(coupon).data == {
+            'amount': str(coupon.amount),
+            'amount_type': coupon.amount_type,
+            'content_type': 'courserun',
+            'coupon_code': coupon.coupon_code,
+            'program_id': coupon.program.id,
+        }

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -2,10 +2,18 @@
 from django.conf.urls import url
 from ecommerce.views import (
     CheckoutView,
+    CouponsView,
     OrderFulfillmentView,
+    UserCouponsView,
 )
 
 urlpatterns = [
     url(r'^api/v0/checkout/$', CheckoutView.as_view(), name='checkout'),
+    url(r'^api/v0/coupons/$', CouponsView.as_view({'get': 'list'}), name='coupon-list'),
+    url(
+        r'^api/v0/coupons/(?P<code>[-\w.]+)?/users/$',
+        UserCouponsView.as_view(),
+        name='coupon-user-create',
+    ),
     url(r'^api/v0/order_fulfillment/$', OrderFulfillmentView.as_view(), name='order-fulfillment'),
 ]

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -23,6 +23,7 @@ from ecommerce.api import (
     generate_cybersource_sa_payload,
     get_new_order_by_reference_number,
     is_coupon_redeemable,
+    pick_coupons,
 )
 from ecommerce.models import (
     Coupon,
@@ -180,12 +181,7 @@ class CouponsView(ListModelMixin, GenericViewSet):
 
     def get_queryset(self):
         """List coupons which a user is allowed to see"""
-        return [
-            coupon for coupon in Coupon.objects.all()
-            if is_coupon_redeemable(coupon, self.request.user) and (
-                coupon.is_automatic or UserCoupon.objects.filter(user=self.request.user, coupon=coupon).exists()
-            )
-        ]
+        return pick_coupons(self.request.user)
 
     serializer_class = CouponSerializer
 

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -178,12 +178,11 @@ class CouponsView(ListModelMixin, GenericViewSet):
         TokenAuthentication,
     )
     permission_classes = (IsAuthenticated,)
+    serializer_class = CouponSerializer
 
     def get_queryset(self):
         """List coupons which a user is allowed to see"""
         return pick_coupons(self.request.user)
-
-    serializer_class = CouponSerializer
 
 
 class UserCouponsView(APIView):

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -200,10 +200,8 @@ class UserCouponsView(APIView):
         TokenAuthentication,
     )
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request, code, *args, **kwargs):
         """Attach a coupon to a user"""
-        code = self.kwargs['code']
-
         with transaction.atomic():
             coupon = get_object_or_404(Coupon, coupon_code=code)
             if not is_coupon_redeemable(coupon, self.request.user):

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -200,6 +200,7 @@ class UserCouponsView(APIView):
         with transaction.atomic():
             coupon = get_object_or_404(Coupon, coupon_code=code)
             if not is_coupon_redeemable(coupon, self.request.user):
+                # Coupon is not redeemable. Return a 404 to prevent the user from
                 raise Http404
 
             UserCoupon.objects.get_or_create(
@@ -207,4 +208,9 @@ class UserCouponsView(APIView):
                 user=self.request.user,
             )
 
-            return Response(status=HTTP_200_OK)
+            return Response(
+                status=HTTP_200_OK,
+                data={
+                    'message': 'Attached user to coupon successfully.'
+                }
+            )

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -377,6 +377,9 @@ class CouponTests(ESTestCase):
         assert resp.status_code == status.HTTP_200_OK
         assert UserCoupon.objects.count() == 1
         assert UserCoupon.objects.filter(user=self.user, coupon=self.coupon).exists()
+        assert resp.json() == {
+            'message': 'Attached user to coupon successfully.'
+        }
 
     def test_empty_dict(self):
         """


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2237 

#### What's this PR do?
Adds REST APIs for getting information about coupons and to attach a user to a coupon.

#### How should this be manually tested?
Create a coupon using the Django shell using the `CouponFactory`. Go to `/api/v0/coupons/`. You should see an empty list. Add the coupon to your user using `UserCoupon.objects.create(coupon=coupon, user=user)` in the shell. Look at `/api/v0/coupons/` again and you should see one coupon.

In the shell delete the `UserCoupon` by running `UserCoupon.objects.filter(user=user, coupon=coupon).delete()`. Go to `/api/v0/coupons/<code>/users/` and POST to that API with `{"username": "your-username-here"}`. In the shell verify that the `UserCoupon` was created via `UserCoupon.objects.filter(user=user, coupon=coupon).exists()`
