### PR TITLE
Change default log level to INFO

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -324,8 +324,8 @@ else:
     ADMINS = ()
 
 # Logging configuration
-LOG_LEVEL = get_var('MICROMASTERS_LOG_LEVEL', 'DEBUG')
-DJANGO_LOG_LEVEL = get_var('DJANGO_LOG_LEVEL', 'DEBUG')
+LOG_LEVEL = get_var('MICROMASTERS_LOG_LEVEL', 'INFO')
+DJANGO_LOG_LEVEL = get_var('DJANGO_LOG_LEVEL', 'INFO')
 ES_LOG_LEVEL = get_var('ES_LOG_LEVEL', 'INFO')
 
 # For logging to a remote syslog host


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2030

#### What's this PR do?
Changes the default log level

#### How should this be manually tested?
Go into the heroku shell and load an object from the ORM. You shouldn't see any SQL statements output
