### PR TITLE
Upgrade Ramda to 0.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "node-sass": "^4.1.0",
     "object.entries": "1.0.3",
     "postcss-loader": "^1.1.1",
-    "ramda": "^0.22.1",
+    "ramda": "^0.23.0",
     "raven-js": "^3.8.1",
     "react": "^15.4.0",
     "react-addons-shallow-compare": "^15.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4857,6 +4857,10 @@ ramda@^0.22.1:
   version "0.22.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.22.1.tgz#031da0c3df417c5b33c96234757eb37033f36a0e"
 
+ramda@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.23.0.tgz#ccd13fff73497a93974e3e86327bfd87bd6e8e2b"
+
 randomatic@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"


### PR DESCRIPTION
This upgrade will allow us to use the `R.forEachObjIndexed` function, which @aliceriot suggested I use in an improvement for #2167. [ChangeLog is here.](https://github.com/ramda/ramda/issues/2029) I expect that this is a very low-risk upgrade.

For manual testing, it should be sufficient to load up the application and click around a bit, particularly the Javascript-heavy pages on our site. If everything seems to work, it's probably fine.