### PR TITLE
Added Facet by Company

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 static/js/dashboard_routes.js
+static/js/components/search/ModifiedMultiSelect.js

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "sass-lint": "^1.10.2",
     "sass-loader": "^4.1.0",
     "searchkit": "0.10.0",
+    "searchkit-multiselect": "^0.0.1",
     "sinon": "1.17.4",
     "slick-carousel": "^1.6.0",
     "striptags": "2.1.1",

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -181,13 +181,26 @@ def serialize_program_enrolled_user(program_enrollment):
         'email': user.email
     }
     try:
-        serialized['profile'] = ProfileSerializer(user.profile).data
+        serialized['profile'] = current_work_history(ProfileSerializer(user.profile).data)
     except Profile.DoesNotExist:
         # Just in case
         pass
 
     serialized['program'] = UserProgramSearchSerializer.serialize(program_enrollment)
     return serialized
+
+
+def current_work_history(profile):
+    """
+    Remove work_history objects that are not current
+    """
+    current_employment = []
+    for work in profile['work_history']:
+        if not work['end_date']:
+            current_employment.append(work)
+
+    profile['work_history'] = current_employment
+    return profile
 
 
 def refresh_index():

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -181,7 +181,7 @@ def serialize_program_enrolled_user(program_enrollment):
         'email': user.email
     }
     try:
-        serialized['profile'] = current_work_history(ProfileSerializer(user.profile).data)
+        serialized['profile'] = filter_current_work(ProfileSerializer(user.profile).data)
     except Profile.DoesNotExist:
         # Just in case
         pass
@@ -190,17 +190,17 @@ def serialize_program_enrolled_user(program_enrollment):
     return serialized
 
 
-def current_work_history(profile):
+def filter_current_work(profile):
     """
     Remove work_history objects that are not current
+    Args:
+        profile (dict): serialized user Profile
+    Returns:
+        dict: Profile with filtered current work_history list
     """
-    current_employment = []
-    for work in profile['work_history']:
-        if not work['end_date']:
-            current_employment.append(work)
-
-    profile['work_history'] = current_employment
-    return profile
+    mod_profile = dict(profile)
+    mod_profile['work_history'] = [work for work in mod_profile['work_history'] if not work['end_date']]
+    return mod_profile
 
 
 def refresh_index():

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -12,7 +12,6 @@ import {
   ResetFilters,
   RangeFilter,
   SortingSelector,
-  MenuFilter
 } from 'searchkit';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Card from 'react-mdl/lib/Card/Card';
@@ -271,7 +270,13 @@ export default class LearnerSearch extends SearchkitComponent {
             showHistogram={false}
             title="# of Courses Passed" />
         </FilterVisibilityToggle>
-        <WorkHistoryFilter currentProgramEnrollment={currentProgram} />
+        <FilterVisibilityToggle
+          {...this.props}
+          filterName="company-name"
+        >
+          <WorkHistoryFilter id="company_name" />
+        </FilterVisibilityToggle>
+
       </Card>
     );
   };

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -12,7 +12,9 @@ import {
   ResetFilters,
   RangeFilter,
   SortingSelector,
+  MenuFilter
 } from 'searchkit';
+import MultiSelect from 'searchkit-multiselect';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Card from 'react-mdl/lib/Card/Card';
 import iso3166 from 'iso-3166-2';
@@ -268,6 +270,20 @@ export default class LearnerSearch extends SearchkitComponent {
             max={this.getNumberOfCoursesInProgram()}
             showHistogram={false}
             title="# of Courses Passed" />
+        </FilterVisibilityToggle>
+        <FilterVisibilityToggle
+          {...this.props}
+          filterName="company-name"
+        >
+          <RefinementListFilter
+            field="profile.work_history.company_name"
+            title="Company"
+            id="company_name"
+            operator="OR"
+            fieldOptions={{type: 'nested', options: { path: 'profile.work_history' } }}
+            listComponent={MultiSelect}
+            size={20}
+          />
         </FilterVisibilityToggle>
       </Card>
     );

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -14,7 +14,6 @@ import {
   SortingSelector,
   MenuFilter
 } from 'searchkit';
-import MultiSelect from 'searchkit-multiselect';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Card from 'react-mdl/lib/Card/Card';
 import iso3166 from 'iso-3166-2';
@@ -25,6 +24,7 @@ import ProgramFilter from './ProgramFilter';
 import LearnerResult from './search/LearnerResult';
 import CountryRefinementOption from './search/CountryRefinementOption';
 import PatchedMenuFilter from './search/PatchedMenuFilter';
+import WorkHistoryFilter from './search/WorkHistoryFilter';
 import CustomPaginationDisplay from './search/CustomPaginationDisplay';
 import CustomResetFiltersDisplay from './search/CustomResetFiltersDisplay';
 import CustomSortingSelect from './search/CustomSortingSelect';
@@ -271,20 +271,7 @@ export default class LearnerSearch extends SearchkitComponent {
             showHistogram={false}
             title="# of Courses Passed" />
         </FilterVisibilityToggle>
-        <FilterVisibilityToggle
-          {...this.props}
-          filterName="company-name"
-        >
-          <RefinementListFilter
-            field="profile.work_history.company_name"
-            title="Company"
-            id="company_name"
-            operator="OR"
-            fieldOptions={{type: 'nested', options: { path: 'profile.work_history' } }}
-            listComponent={MultiSelect}
-            size={20}
-          />
-        </FilterVisibilityToggle>
+        <WorkHistoryFilter currentProgramEnrollment={currentProgram} />
       </Card>
     );
   };

--- a/static/js/components/search/FilterVisibilityToggle.js
+++ b/static/js/components/search/FilterVisibilityToggle.js
@@ -7,7 +7,8 @@ import Icon from 'react-mdl/lib/Icon';
 const FILTER_ID_ADJUST = {
   "birth_location": "profile.birth_country5",
   "semester": "program.semester_enrollments.semester4",
-  "education_level": "profile.education.degree_name7"
+  "education_level": "profile.education.degree_name7",
+  "company_name": "profile.work_history.company_name8"
 };
 
 export default class FilterVisibilityToggle extends SearchkitComponent {

--- a/static/js/components/search/FilterVisibilityToggle.js
+++ b/static/js/components/search/FilterVisibilityToggle.js
@@ -8,7 +8,7 @@ const FILTER_ID_ADJUST = {
   "birth_location": "profile.birth_country5",
   "semester": "program.semester_enrollments.semester4",
   "education_level": "profile.education.degree_name7",
-  "company_name": "profile.work_history.company_name10"
+  "company_name": "profile.work_history.company_name11"
 };
 
 export default class FilterVisibilityToggle extends SearchkitComponent {

--- a/static/js/components/search/FilterVisibilityToggle.js
+++ b/static/js/components/search/FilterVisibilityToggle.js
@@ -8,7 +8,7 @@ const FILTER_ID_ADJUST = {
   "birth_location": "profile.birth_country5",
   "semester": "program.semester_enrollments.semester4",
   "education_level": "profile.education.degree_name7",
-  "company_name": "profile.work_history.company_name8"
+  "company_name": "profile.work_history.company_name10"
 };
 
 export default class FilterVisibilityToggle extends SearchkitComponent {

--- a/static/js/components/search/ModifiedMultiSelect.js
+++ b/static/js/components/search/ModifiedMultiSelect.js
@@ -2,28 +2,29 @@
  * Created by anna on 1/9/17.
  */
 import React from 'react';
-
-const Select = require('react-select');
-
+import Select from 'react-select';
+import _ from 'lodash';
 
 
 export default class ModifiedMultiSelect extends React.Component {
 
   constructor(props){
     super(props);
-    this.handleChange = this.handleChange.bind(this)
+    this.handleChange = this.handleChange.bind(this);
   }
 
   handleChange(selectedOptions = []) {
-    this.props.setItems(selectedOptions.map(el => el.value))
+    this.props.setItems(selectedOptions.map(el => el.value));
   }
   render(){
-    const { placeholder, clearable = true, items, selectedItems = [], disabled, showCount, setItems } = this.props
+    const { placeholder, clearable = true, items, selectedItems = [], disabled, showCount } = this.props;
 
     const options = items.map((option) => {
       let label = option.title || option.label || option.key;
-      if (showCount) label += ` (${option.company_name_count.doc_count}) `
-      return { value: option.key, label}
+      if (showCount && !_.isNil(option.company_name_count)){
+        label += ` (${option.company_name_count.doc_count}) `;
+      }
+      return { value: option.key, label };
     });
 
     return (
@@ -34,7 +35,7 @@ export default class ModifiedMultiSelect extends React.Component {
         valueRenderer={(v) => v.value}
         clearable={clearable}
         onChange={this.handleChange} />
-    )
+    );
   }
 
 }

--- a/static/js/components/search/ModifiedMultiSelect.js
+++ b/static/js/components/search/ModifiedMultiSelect.js
@@ -1,0 +1,40 @@
+/**
+ * Created by anna on 1/9/17.
+ */
+import React from 'react';
+
+const Select = require('react-select');
+
+
+
+export default class ModifiedMultiSelect extends React.Component {
+
+  constructor(props){
+    super(props);
+    this.handleChange = this.handleChange.bind(this)
+  }
+
+  handleChange(selectedOptions = []) {
+    this.props.setItems(selectedOptions.map(el => el.value))
+  }
+  render(){
+    const { placeholder, clearable = true, items, selectedItems = [], disabled, showCount, setItems } = this.props
+
+    const options = items.map((option) => {
+      let label = option.title || option.label || option.key;
+      if (showCount) label += ` (${option.company_name_count.doc_count}) `
+      return { value: option.key, label}
+    });
+
+    return (
+      <Select multi disabled={disabled}
+        value={selectedItems}
+        placeholder={placeholder}
+        options={options}
+        valueRenderer={(v) => v.value}
+        clearable={clearable}
+        onChange={this.handleChange} />
+    )
+  }
+
+}

--- a/static/js/components/search/WorkHistoryFilter.js
+++ b/static/js/components/search/WorkHistoryFilter.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   AnonymousAccessor,
-  TermQuery,
   SearchkitComponent,
   RefinementListFilter,
   NestedBucket,
@@ -20,22 +19,26 @@ export default class WorkHistoryFilter extends SearchkitComponent{
   };
 
   _accessor = new AnonymousAccessor(query => {
-    const { currentProgramEnrollment } = this.props;
+    /**
+     *  Modify query to perform aggregation on unique users,
+     *  to avoid duplicate counts of multiple work histories
+     *  at one company of the same user
+     **/
 
     let cardinality = CardinalityMetric("count", 'user_id');
-    let aggs_container = AggsContainer('company_name_count',{"reverse_nested": {}}, [cardinality]);
-    let terms_bucket = TermsBucket(
+    let aggsContainer = AggsContainer('company_name_count',{"reverse_nested": {}}, [cardinality]);
+    let termsBucket = TermsBucket(
       'profile.work_history.company_name',
       'profile.work_history.company_name',
       {'size': 20, "order": {"company_name_count": "desc"}},
-      aggs_container
+      aggsContainer
     );
 
-    let nested_bucket = NestedBucket('inner', 'profile.work_history', terms_bucket);
+    let nestedBucket = NestedBucket('inner', 'profile.work_history', termsBucket);
     return query.setAggs(FilterBucket(
       'profile.work_history.company_name11',
-      TermQuery("program.id", currentProgramEnrollment.id),
-      nested_bucket
+      {},
+      nestedBucket
     ));
   });
 

--- a/static/js/components/search/WorkHistoryFilter.js
+++ b/static/js/components/search/WorkHistoryFilter.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import {
+  AnonymousAccessor,
+  TermQuery,
+  SearchkitComponent,
+  RefinementListFilter,
+  NestedBucket,
+  TermsBucket,
+  AggsContainer,
+  CardinalityMetric,
+  FilterBucket,
+} from 'searchkit';
+
+import ModifiedMultiSelect from './ModifiedMultiSelect';
+import type { AvailableProgram } from '../../flow/enrollmentTypes';
+
+export default class WorkHistoryFilter extends SearchkitComponent{
+  props: {
+    currentProgramEnrollment: AvailableProgram,
+  };
+
+  _accessor = new AnonymousAccessor(query => {
+    const { currentProgramEnrollment } = this.props;
+
+    let cardinality = CardinalityMetric("count", 'user_id');
+    let aggs_container = AggsContainer('company_name_count',{"reverse_nested": {}}, [cardinality]);
+    let terms_bucket = TermsBucket(
+      'profile.work_history.company_name',
+      'profile.work_history.company_name',
+      {'size': 20, "order": {"company_name_count": "desc"}},
+      aggs_container
+    );
+    let nested_bucket = NestedBucket('inner', 'profile.work_history', terms_bucket);
+
+    return query.setAggs(FilterBucket(
+      'profile.work_history.company_name11',
+      TermQuery("program.id", currentProgramEnrollment.id),
+      nested_bucket
+    ));
+
+  });
+
+
+  defineAccessor() {
+    return this._accessor;
+  }
+
+  render() {
+    return (
+      <RefinementListFilter
+        field="profile.work_history.company_name"
+        title="Company"
+        id="company_name"
+        operator="OR"
+        fieldOptions={{type: 'nested', options: { path: 'profile.work_history'}}}
+        listComponent={ModifiedMultiSelect}
+        size={20}
+      />
+    );
+  }
+}

--- a/static/js/components/search/WorkHistoryFilter.js
+++ b/static/js/components/search/WorkHistoryFilter.js
@@ -30,14 +30,13 @@ export default class WorkHistoryFilter extends SearchkitComponent{
       {'size': 20, "order": {"company_name_count": "desc"}},
       aggs_container
     );
-    let nested_bucket = NestedBucket('inner', 'profile.work_history', terms_bucket);
 
+    let nested_bucket = NestedBucket('inner', 'profile.work_history', terms_bucket);
     return query.setAggs(FilterBucket(
       'profile.work_history.company_name11',
       TermQuery("program.id", currentProgramEnrollment.id),
       nested_bucket
     ));
-
   });
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5333,7 +5333,7 @@ react-router@^3.0.0:
     loose-envify "^1.2.0"
     warning "^3.0.0"
 
-react-select@^1.0.0-beta14, react-select@^1.0.0-rc.1:
+react-select@^1.0.0-beta12, react-select@^1.0.0-beta14, react-select@^1.0.0-rc.1:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.0.0-rc.2.tgz#9fc11b149a3dc1ac831289d21b40a59742f82f8d"
   dependencies:
@@ -5812,6 +5812,12 @@ sass-loader@^4.1.0:
 sax@^1.1.4, sax@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+
+searchkit-multiselect@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/searchkit-multiselect/-/searchkit-multiselect-0.0.1.tgz#ae53fd6d0e77a3c80a965305591a22db42a0e1f5"
+  dependencies:
+    react-select "^1.0.0-beta12"
 
 searchkit@0.10.0:
   version "0.10.0"


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #863
#### What's this PR do?
Added a MultiSelect 'Company' filter to search for users that currently work at a company.
#### Where should the reviewer start?

#### How should this be manually tested?
To test this, run the `recreate_index` command. Go to learners search and test the Company filter.
To test that a user does not appear under company name for a previous position, you can add another previous position for a user who currently works for 'Google':
```
from profiles.models import Profile, Employment
p= Profile.objects.filter(first_name="Rose",last_name="Li")[0]
Employment.objects.create(
  profile=u,
  city="Delisle", 
  state_or_territory="CA-MB", country= "CA", 
  company_name="Volvo",
  position= "Mechanic", industry="Automotive",
  end_date='2014-05-07',
  start_date="2013-08-08")
```
#### Any background context you want to provide?

#### Screenshots (if appropriate)
![screen shot 2017-01-05 at 5 55 11 pm](https://cloud.githubusercontent.com/assets/7574259/21700787/25becbce-d370-11e6-9596-d13f70c00845.png)

![screen shot 2017-01-05 at 5 56 08 pm](https://cloud.githubusercontent.com/assets/7574259/21700827/4efbab74-d370-11e6-84e3-87e9e65d7c77.png)


#### What GIF best describes this PR or how it makes you feel?
