### PR TITLE
Upgrade test dependencies

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -49,7 +49,7 @@ pytest-django==3.1.2
 pytest-pep8==1.0.6
 pytest-pylint==0.6.0
 pytest==3.0.5
-requests==2.12.4          # via bpython, codecov
+requests==2.11.1          # via bpython, codecov
 semantic-version==2.6.0
 simplegeneric==0.8.1      # via ipython
 six==1.10.0               # via astroid, bpython, nplusone, pip-tools, prompt-toolkit, pylint, pytest-pylint, traitlets

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,61 +6,62 @@
 #
 apipkg==1.4               # via execnet
 argparse==1.4.0           # via codecov
-astroid==1.4.8            # via pylint, pylint-plugin-utils
+astroid==1.4.9            # via pylint, pylint-plugin-utils
 blessings==1.6            # via curtsies
 blinker==1.4              # via nplusone
 bpython==0.16
 click==6.6                # via pip-tools
 codecov==2.0.5
-coverage==4.2             # via codecov, pytest-cov
+coverage==4.3.1           # via codecov, pytest-cov
 curtsies==0.2.11          # via bpython
 ddt==1.1.1
 decorator==4.0.10         # via ipython, traitlets
 django-debug-toolbar==1.6
-django==1.10.3            # via django-debug-toolbar
+Django==1.10.3            # via django-debug-toolbar
 execnet==1.4.1            # via pytest-cache
-fancycompleter==0.5       # via pdbpp
+fancycompleter==0.7       # via pdbpp
 first==2.0.1              # via pip-tools
-greenlet==0.4.10          # via bpython
+greenlet==0.4.11          # via bpython
 ipdb==0.10.1
 ipython-genutils==0.1.0   # via traitlets
 ipython==5.1.0
 isort==4.2.5              # via pylint
 lazy-object-proxy==1.2.2  # via astroid
-mccabe==0.5.2             # via pylint
+mccabe==0.5.3             # via pylint
 nplusone==0.7.3
 ordereddict==1.1          # via pdbpp
 pdbpp==0.8.3
 pep8==1.7.0               # via pytest-pep8
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
-pip-tools==1.7.0
+pip-tools==1.8.0
 pluggy==0.4.0             # via tox
-prompt-toolkit==1.0.8     # via ipython
+prompt-toolkit==1.0.9     # via ipython
 ptyprocess==0.5.1         # via pexpect
-py==1.4.31                # via pytest, tox
+py==1.4.32                # via pytest, tox
 pygments==2.1.3           # via bpython, ipython, pdbpp
 pylint-django==0.7.2
 pylint-plugin-utils==0.2.4  # via pylint-django
 pylint==1.6.4
 pytest-cache==1.0         # via pytest-pep8
 pytest-cov==2.4.0
-pytest-django==3.0.0
+pytest-django==3.1.2
 pytest-pep8==1.0.6
 pytest-pylint==0.6.0
-pytest==3.0.3
-requests==2.11.1          # via bpython, codecov
+pytest==3.0.5
+requests==2.12.4          # via bpython, codecov
 semantic-version==2.6.0
 simplegeneric==0.8.1      # via ipython
 six==1.10.0               # via astroid, bpython, nplusone, pip-tools, prompt-toolkit, pylint, pytest-pylint, traitlets
 sqlparse==0.2.2           # via django-debug-toolbar
-testfixtures==4.13.1
-tox==2.4.1
+testfixtures==4.13.3
+tox==2.5.0
 traitlets==4.3.1          # via ipython
-virtualenv==15.0.3        # via tox
+virtualenv==15.1.0        # via tox
 wcwidth==0.1.7            # via curtsies, prompt-toolkit
 wmctrl==0.3               # via pdbpp
 wrapt==1.10.8             # via astroid
 
-# The following packages are considered to be unsafe in a requirements file:
+# The following packages are commented out because they are
+# considered to be unsafe in a requirements file:
 # setuptools                # via ipdb, ipython


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2268

#### What's this PR do?
Upgrades test dependencies which incidentally fixes a pytest issue. I skipped upgrading Django since that conflicts with `requirements.txt` and it seems like it would require some extra work

#### How should this be manually tested?
Since these are only test dependencies we shouldn't need to do manual testing here, if the tests still pass