### PR TITLE
Fixed progress widget ignores prior (passed) runs issue

### DIFF
--- a/static/js/components/ProgressWidget_test.js
+++ b/static/js/components/ProgressWidget_test.js
@@ -81,7 +81,44 @@ export const program = {
       "title": "EDX Demo course",
       "description": "",
       "id": 3
-    }
+    },
+    {
+      "prerequisites": "",
+      "runs": [],
+      "position_in_program": 2,
+      "title": "EDX Demo course",
+      "description": "",
+      "id": 4
+    },
+    {
+      "prerequisites": "",
+      "runs": [
+        {
+          "position": 1,
+          "title": "Gio Test Course #14",
+          "course_id": "course-v1:odl+GIO101+FALL14",
+          "status": STATUS_NOT_PASSED,
+          "id": 5,
+          "course_start_date": "2016-08-22T11:48:27Z",
+          "fuzzy_start_date": "Fall 2016",
+          "course_end_date": "2016-09-09T10:20:10Z"
+        },
+        {
+          "position": 2,
+          "title": "Gio Test Course #16",
+          "course_id": "course-v1:odl+GIO101+FALL16",
+          "status": STATUS_PASSED,
+          "id": 6,
+          "course_start_date": "2016-08-22T11:48:27Z",
+          "fuzzy_start_date": "Fall 2017",
+          "course_end_date": "2017-09-09T10:20:10Z"
+        }
+      ],
+      "position_in_program": 1,
+      "title": "8.MechCx Advanced Introductory Classical Mechanics",
+      "description": "",
+      "id": 5
+    },
   ],
   "id": 3
 };
@@ -94,7 +131,7 @@ describe('ProgressWidget', () => {
     assert.equal(wrapper.find(".text-course-complete").children().text(), "Courses complete");
     assert.equal(
       wrapper.find(".circular-progress-widget-txt").text(),
-      "2/3"
+      "3/5"
     );
     assert.equal(
       wrapper.find(".heading-paragraph").text(),

--- a/static/js/components/ProgressWidget_test.js
+++ b/static/js/components/ProgressWidget_test.js
@@ -41,11 +41,21 @@ export const program = {
           "position": 1,
           "title": "Gio Test Course #14",
           "course_id": "course-v1:odl+GIO101+FALL14",
-          "status": STATUS_NOT_PASSED,
+          "status": STATUS_PASSED,
           "id": 2,
           "course_start_date": "2016-08-22T11:48:27Z",
-          "fuzzy_start_date": "Fall 2017",
+          "fuzzy_start_date": "Fall 2016",
           "course_end_date": "2016-09-09T10:20:10Z"
+        },
+        {
+          "position": 2,
+          "title": "Gio Test Course #16",
+          "course_id": "course-v1:odl+GIO101+FALL16",
+          "status": STATUS_NOT_PASSED,
+          "id": 4,
+          "course_start_date": "2016-08-22T11:48:27Z",
+          "fuzzy_start_date": "Fall 2017",
+          "course_end_date": "2017-09-09T10:20:10Z"
         }
       ],
       "position_in_program": 1,
@@ -84,7 +94,7 @@ describe('ProgressWidget', () => {
     assert.equal(wrapper.find(".text-course-complete").children().text(), "Courses complete");
     assert.equal(
       wrapper.find(".circular-progress-widget-txt").text(),
-      "1/3"
+      "2/3"
     );
     assert.equal(
       wrapper.find(".heading-paragraph").text(),

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -386,6 +386,7 @@ export function programCourseInfo(program: Program): Object {
   if (program.courses) {
     totalCourses = program.courses.length;
     passedCourses = program.courses.filter(
+      // returns true if any course run has a `status` property set to STATUS_PASSED.
       course => _.some(course.runs, ["status", STATUS_PASSED])
     );
     totalPassedCourses = passedCourses.length;

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -386,7 +386,7 @@ export function programCourseInfo(program: Program): Object {
   if (program.courses) {
     totalCourses = program.courses.length;
     passedCourses = program.courses.filter(
-      course => course.runs.length > 0 && course.runs[0].status === STATUS_PASSED
+      course => _.some(course.runs, ["status", STATUS_PASSED])
     );
     totalPassedCourses = passedCourses.length;
   }

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -462,8 +462,8 @@ describe('utility functions', () => {
       const programInfoActual = programCourseInfo(program);
 
       assert.deepEqual(programInfoActual, {
-        totalPassedCourses: 2,
-        totalCourses: 3
+        totalPassedCourses: 3,
+        totalCourses: 5
       });
     });
   });

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -462,7 +462,7 @@ describe('utility functions', () => {
       const programInfoActual = programCourseInfo(program);
 
       assert.deepEqual(programInfoActual, {
-        totalPassedCourses: 1,
+        totalPassedCourses: 2,
         totalCourses: 3
       });
     });


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixed https://github.com/mitodl/micromasters/issues/2271

#### What's this PR do?
- Check past runs of course i.e if we have passed run in past it will count course as passed.

@pdpinch 