### PR TITLE
Remove jsonfield dependency

### DIFF
--- a/dashboard/migrations/0001_initial.py
+++ b/dashboard/migrations/0001_initial.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
-import jsonfield.fields
+from django.contrib.postgres.fields import JSONField
 
 
 class Migration(migrations.Migration):
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
             name='CachedCertificate',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('data', jsonfield.fields.JSONField(null=True)),
+                ('data', JSONField(null=True)),
                 ('last_request', models.DateTimeField()),
                 ('course_run', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='courses.CourseRun')),
                 ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
             name='CachedEnrollment',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('data', jsonfield.fields.JSONField(null=True)),
+                ('data', JSONField(null=True)),
                 ('last_request', models.DateTimeField()),
                 ('course_run', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='courses.CourseRun')),
                 ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),

--- a/dashboard/migrations/0003_current_grade.py
+++ b/dashboard/migrations/0003_current_grade.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
-import jsonfield.fields
+from django.contrib.postgres.fields import JSONField
 
 
 class Migration(migrations.Migration):
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
             name='CachedCurrentGrade',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('data', jsonfield.fields.JSONField(null=True)),
+                ('data', JSONField(null=True)),
                 ('last_request', models.DateTimeField()),
                 ('course_run', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='courses.CourseRun')),
                 ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),

--- a/ecommerce/migrations/0004_create_receipt.py
+++ b/ecommerce/migrations/0004_create_receipt.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.db.models.deletion
-import jsonfield.fields
+from django.contrib.postgres.fields import JSONField
 
 
 class Migration(migrations.Migration):
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
             name='Receipt',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('data', jsonfield.fields.JSONField()),
+                ('data', JSONField()),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
             ],

--- a/financialaid/migrations/0001_initial.py
+++ b/financialaid/migrations/0001_initial.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
-import jsonfield.fields
+from django.contrib.postgres.fields import JSONField
 
 
 class Migration(migrations.Migration):
@@ -55,8 +55,8 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('table_changed', models.CharField(max_length=50)),
-                ('data_before', jsonfield.fields.JSONField(blank=True)),
-                ('data_after', jsonfield.fields.JSONField(blank=True)),
+                ('data_before', JSONField(blank=True)),
+                ('data_after', JSONField(blank=True)),
                 ('date', models.DateTimeField()),
                 ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],

--- a/profiles/migrations/0001_initial.py
+++ b/profiles/migrations/0001_initial.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
-import jsonfield.fields
+from django.contrib.postgres.fields import JSONField
 
 
 class Migration(migrations.Migration):
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
                 ('year_of_birth', models.IntegerField(blank=True, null=True)),
                 ('level_of_education', models.TextField(blank=True, choices=[('p', 'Doctorate'), ('m', "Master's or professional degree"), ('b', "Bachelor's degree"), ('a', 'Associate degree'), ('hs', 'High school'), ('jhs', 'Junior high school'), ('el', 'Elementary school'), ('none', 'No formal education'), ('other', 'Other education')], max_length=6, null=True)),
                 ('goals', models.TextField(blank=True, null=True)),
-                ('language_proficiencies', jsonfield.fields.JSONField(blank=True, null=True)),
+                ('language_proficiencies', JSONField(blank=True, null=True)),
                 ('gender', models.CharField(blank=True, choices=[('m', 'Male'), ('f', 'Female'), ('o', 'Other/Prefer Not to Say')], max_length=6, null=True)),
                 ('mailing_address', models.TextField(blank=True, null=True)),
                 ('date_joined', models.DateTimeField(blank=True, null=True)),

--- a/profiles/migrations/0004_profile_linkedin.py
+++ b/profiles/migrations/0004_profile_linkedin.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
-import jsonfield.fields
+from django.contrib.postgres.fields import JSONField
 
 
 class Migration(migrations.Migration):
@@ -16,6 +16,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='profile',
             name='linkedin',
-            field=jsonfield.fields.JSONField(blank=True, null=True),
+            field=JSONField(blank=True, null=True),
         ),
     ]

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,6 @@ elasticsearch==2.3.0
 factory_boy
 faker
 html5lib==0.999999
-jsonfield==1.0.3
 newrelic
 psycopg2==2.6
 pycountry==16.11.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,6 @@ factory-boy==2.8.1
 faker==0.7.3
 html5lib==0.999999
 idna==2.1                 # via cryptography
-jsonfield==1.0.3
 kombu==3.0.37             # via celery, django-server-status
 newrelic==2.72.1.53
 oauthlib==2.0.0           # via python-social-auth, requests-oauthlib


### PR DESCRIPTION
Now that Django has a built-in [JSONField type](https://docs.djangoproject.com/en/1.10/ref/contrib/postgres/fields/#jsonfield), we don't need to depend on the [jsonfield](https://pypi.python.org/pypi/jsonfield) library. This pull request removes that dependency.

To test this pull request, I suggest dumping your database and re-running all the database migrations to be sure they work successfully. I did that on my computer, and had no problems.