### PR TITLE
Change status for enrollment to audit, since it's used in FA programs

### DIFF
--- a/dashboard/fixtures/user_enrollments.json
+++ b/dashboard/fixtures/user_enrollments.json
@@ -75,7 +75,7 @@
         },
         "created": "2016-01-27T18:10:35Z",
         "is_active": true,
-        "mode": "verified",
+        "mode": "audit",
         "user": "staff"
     }
 ]


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Changes the enrollment status in test data from `verified` to `audit` for test data, since this course run is used in FA programs and users are always `audit` on edX for FA programs
