### PR TITLE
Use address type rather than geocode type

### DIFF
--- a/static/js/components/PersonalForm.js
+++ b/static/js/components/PersonalForm.js
@@ -105,7 +105,7 @@ export default class PersonalForm extends ProfileFormFields {
             {this.boundGeosuggest(addressMapping, "current-home", "Current address",
               {
                 placeholder: "Example: 100 Main Street, Anytown, 01234, United States",
-                types: ["geocode"]
+                types: ["address"]
               }
             )}
           </Cell>


### PR DESCRIPTION
`address` requires at least a street address, while `geocode` appears to only require some kind of geographical reference -- even references as broad as "United States" are acceptable. https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete