### PR TITLE
remove extraneous about_me serializer fields

### DIFF
--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -9,7 +9,6 @@ from rest_framework.serializers import (
     IntegerField,
     ModelSerializer,
     SerializerMethodField,
-    CharField,
 )
 
 from profiles.api import get_social_username
@@ -173,8 +172,6 @@ class ProfileBaseSerializer(ModelSerializer):
 
 class ProfileSerializer(ProfileBaseSerializer):
     """Serializer for Profile objects"""
-    about_me = CharField(allow_null=True, allow_blank=True, required=False)
-
     def update(self, instance, validated_data):
         with transaction.atomic():
             for attr, value in validated_data.items():
@@ -278,7 +275,6 @@ class ProfileFilledOutSerializer(ProfileSerializer):
     """Serializer for Profile objects which require filled_out = True"""
     work_history = EmploymentFilledOutSerializer(many=True)
     education = EducationFilledOutSerializer(many=True)
-    about_me = CharField(allow_null=True, allow_blank=True, required=False)
 
     def __init__(self, *args, **kwargs):
         """


### PR DESCRIPTION
These fields were introduced in #1862, but they aren't actually necessary. Because these classes inherit from `ModelSerializer`, they automatically generate these fields, so there's no need to specify them (except in the `Meta.fields` list, where they're already specified).