### PR TITLE
Don't need to make pylint disable missing-docstring for serializer Meta

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -26,7 +26,7 @@ class FacultyImageSerializer(serializers.ModelSerializer):
         rendition = image.get_rendition('fill-500x385')
         return RenditionSerializer(rendition).data
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = Image
         fields = ('alt', 'rendition',)
 
@@ -35,7 +35,7 @@ class FacultySerializer(serializers.ModelSerializer):
     """Serializer for ProgramFaculty objects."""
     image = FacultyImageSerializer(read_only=True)
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = ProgramFaculty
         fields = ('name', 'title', 'short_bio', 'image')
 
@@ -61,6 +61,6 @@ class ProgramPageSerializer(serializers.ModelSerializer):
             return None
         return slugify(programpage.program.title)
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = ProgramPage
         fields = ('id', 'title', 'slug', 'faculty', 'courses')

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -39,7 +39,7 @@ class ProgramSerializer(serializers.ModelSerializer):
         user = self.context['request'].user
         return ProgramEnrollment.objects.filter(user=user, program=program).exists()
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = Program
         fields = (
             'id',
@@ -51,7 +51,7 @@ class ProgramSerializer(serializers.ModelSerializer):
 
 class CourseSerializer(serializers.ModelSerializer):
     """Serializer for Course objects"""
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = Course
         fields = (
             'id',

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -199,7 +199,7 @@ class ProfileSerializer(ProfileBaseSerializer):
                 update_education(validated_data['education'], instance.id)
             return instance
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = Profile
         fields = (
             'username',
@@ -244,7 +244,7 @@ class ProfileLimitedSerializer(ProfileBaseSerializer):
     allowed to see if a profile is marked public.
     """
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = Profile
         fields = (
             'username',


### PR DESCRIPTION
[pylint-django](https://github.com/landscapeio/pylint-django) takes care of suppressing this
