### PR TITLE
Allow users to pay after end of the course.

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -271,6 +271,17 @@ class CourseRun(models.Model):
             raise ImproperlyConfigured('Missing freeze_grade_date')
         return datetime.now(pytz.utc) > self.freeze_grade_date
 
+    @property
+    def has_frozen_grades(self):
+        """
+        Checks if the grades for the course have been frozen
+        """
+        try:
+            freeze_status = self.courserungradingstatus
+        except self._meta.model.courserungradingstatus.RelatedObjectDoesNotExist:
+            return False
+        return freeze_status.status == FinalGradeStatus.COMPLETE
+
     @classmethod
     def get_freezable(cls):
         """


### PR DESCRIPTION
#### What are the relevant tickets?
closes #2253 

#### What's this PR do?
Removes the restriction about the fact that the payment must be done by the end of the course. Now the only limit is the `upgrade_deadline`, if present.

#### Where should the reviewer start?
`dashboard/api.py`

#### How should this be manually tested?
Set the course to `past` and with `upgrade_deadline` in the future and verify that you can still see the pay button.
See the code for special cases with the dates and final grades existence.


