### PR TITLE
Filter filled_out fields

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -79,6 +79,13 @@ def create_search_obj(user, search_param_dict=None, filter_on_email_optin=False)
         user,
         filter_on_email_optin=filter_on_email_optin
     ))
+    # Filter so that only filled_out profiles are seen
+    search_obj = search_obj.filter(Q(
+        'bool',
+        must=[
+            Q('term', **{'profile.filled_out': True})
+        ]
+    ))
     if search_param_dict is not None:
         search_param_dict['size'] = settings.ELASTICSEARCH_DEFAULT_PAGE_SIZE
     else:

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -2,7 +2,7 @@
 Tests for search API functionality
 """
 import math
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 from elasticsearch_dsl import Search, Q
 from factory.django import mute_signals
 from django.test import (
@@ -106,11 +106,20 @@ class SearchAPITests(TestCase):  # pylint: disable=missing-docstring
                 Q('term', **{'program.is_learner': True})
             ]
         )
+        expected_filled_out_query = Q(
+            'bool',
+            must=[
+                Q('term', **{'profile.filled_out': True})
+            ]
+        )
         assert 'query' in search_query_dict
         assert 'bool' in search_query_dict['query']
         assert 'filter' in search_query_dict['query']['bool']
         assert len(search_query_dict['query']['bool']['filter']) == 2
-        assert search_query_dict['query']['bool']['filter'][0] == expected_program_query.to_dict()
+        assert search_query_dict['query']['bool']['filter'] == [
+            expected_program_query.to_dict(),
+            expected_filled_out_query.to_dict(),
+        ]
 
     @override_settings(ELASTICSEARCH_DEFAULT_PAGE_SIZE=5)
     def test_size_param_in_query(self):
@@ -129,8 +138,8 @@ class SearchAPITests(TestCase):  # pylint: disable=missing-docstring
         search_param_dict = {'size': 50}
         with patch('search.api.Search.update_from_dict', autospec=True) as mock_update_from_dict:
             search_obj = create_search_obj(self.user, search_param_dict=search_param_dict)
-        assert search_obj._doc_type == list(DOC_TYPES)
-        assert search_obj._index == [settings.ELASTICSEARCH_INDEX]
+        assert search_obj._doc_type == list(DOC_TYPES)  # pylint: disable=protected-access
+        assert search_obj._index == [settings.ELASTICSEARCH_INDEX]  # pylint: disable=protected-access
         mock_update_from_dict.assert_called_with(search_obj, search_param_dict)
 
     def test_user_with_no_program_access(self):

--- a/search/views_test.py
+++ b/search/views_test.py
@@ -203,7 +203,7 @@ class SearchTests(ESTestCase, APITestCase):
         Search results should only include profiles which are filled out
         """
         program = self.program1
-        filled_out_ids = list(ProgramEnrollment.objects.filter(program=program).values_list('id', flat=True))
+        filled_out_ids = list(ProgramEnrollment.objects.filter(program=program).values_list('user_id', flat=True))
         enrollment_not_filled_out = ProgramEnrollmentFactory.create(
             user__profile__filled_out=False,
             program=program,

--- a/search/views_test.py
+++ b/search/views_test.py
@@ -12,6 +12,7 @@ from rest_framework.test import APITestCase
 
 from courses.factories import ProgramFactory
 from dashboard.factories import ProgramEnrollmentFactory
+from dashboard.models import ProgramEnrollment
 from micromasters.factories import UserFactory
 from profiles.factories import ProfileFactory
 from roles.models import Role
@@ -32,7 +33,7 @@ class SearchTests(ESTestCase, APITestCase):
         super(SearchTests, cls).setUpTestData()
         # create some students
         with mute_signals(post_save):
-            cls.students = [(ProfileFactory.create()).user for _ in range(30)]
+            cls.students = [(ProfileFactory.create(filled_out=True)).user for _ in range(30)]
         # create the programs
         cls.program1 = ProgramFactory.create(live=True)
         cls.program2 = ProgramFactory.create(live=True)
@@ -74,6 +75,12 @@ class SearchTests(ESTestCase, APITestCase):
         resp_post = self.client.post(self.search_url, json, format='json')
         assert resp_post.status_code == status_code
         return resp_post
+
+    def get_user_ids_in_hits(self, hits):
+        """
+        Helper function to extract profile ids from elasticsearch hits
+        """
+        return [hit['_source']['user_id'] for hit in hits]
 
     def get_program_ids_in_hits(self, hits):
         """
@@ -189,3 +196,20 @@ class SearchTests(ESTestCase, APITestCase):
             program_ids_in_hits = self.get_program_ids_in_hits(resp.data['hits']['hits'])
             assert len(program_ids_in_hits) == 1
             assert program_ids_in_hits[0] == wanted_program_id
+
+    @override_settings(ELASTICSEARCH_DEFAULT_PAGE_SIZE=1000)
+    def test_filled_out(self):
+        """
+        Search results should only include profiles which are filled out
+        """
+        program = self.program1
+        filled_out_ids = list(ProgramEnrollment.objects.filter(program=program).values_list('id', flat=True))
+        enrollment_not_filled_out = ProgramEnrollmentFactory.create(
+            user__profile__filled_out=False,
+            program=program,
+        )
+
+        resp = self.assert_status_code()
+        user_ids_in_hits = self.get_user_ids_in_hits(resp.data['hits']['hits'])
+        assert sorted(user_ids_in_hits) == sorted(filled_out_ids)
+        assert enrollment_not_filled_out.user.id not in user_ids_in_hits


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2301 

#### What's this PR do?
Adds filtering so that only `filled_out` profiles are seen via the search API.

#### How should this be manually tested?
With one account, create a profile which is partially filled out. Complete the personal step and go to the next step, but do not go any further.

With a staff account, view the learners search. You should not see any learners in the results.

Log back in with the first account and complete your profile. Then log back in as staff and view the learners search. You should see one learner in the results, the one you just created.
