### PR TITLE
Revert Geosuggest UI in PersonalForm

### DIFF
--- a/app.json
+++ b/app.json
@@ -74,7 +74,7 @@
     },
     "GOOGLE_API_KEY": {
       "description": "API key for accessing Google services",
-      "required": true
+      "required": false
     },
     "MAILGUN_KEY": {
       "description": "The token for authenticating against the Mailgun API"

--- a/static/js/components/PersonalForm.js
+++ b/static/js/components/PersonalForm.js
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import LANGUAGE_CODES from '../data/language_codes';
 import SelectField from './inputs/SelectField';
 import CountrySelectField from './inputs/CountrySelectField';
+import StateSelectField from './inputs/StateSelectField';
 import ProfileFormFields from '../util/ProfileFormFields';
 import { shouldRenderRomanizedFields } from '../util/profile_edit';
 import type {
@@ -63,12 +64,6 @@ export default class PersonalForm extends ProfileFormFields {
     const whyWeAskThis = 'Some program sponsors and employers offer benefits or scholarships ' +
       'to learners with specific backgrounds.';
 
-    const addressMapping = {
-      locality: ["city"],
-      administrative_area_level_1: ["state_or_territory"],
-      country: ["country"],
-    };
-
     return (
       <section>
         <h2 className="sr-only">Personal Information</h2>
@@ -101,15 +96,33 @@ export default class PersonalForm extends ProfileFormFields {
               {...this.defaultInputComponentProps()}
             />
           </Cell>
-          <Cell col={12}>
-            {this.boundGeosuggest(addressMapping, "current-home", "Current address",
-              {
-                placeholder: "Example: 100 Main Street, Anytown, 01234, United States",
-                types: ["address"]
-              }
-            )}
-          </Cell>
         </Grid>
+        <section>
+          <h3>Where are you currently living?</h3>
+          <Grid className="profile-form-grid">
+            <Cell col={4}>
+              <CountrySelectField
+                stateKeySet={['state_or_territory']}
+                countryKeySet={['country']}
+                topMenu={true}
+                label='Country'
+                {...this.defaultInputComponentProps()}
+              />
+            </Cell>
+            <Cell col={4}>
+              <StateSelectField
+                stateKeySet={['state_or_territory']}
+                countryKeySet={['country']}
+                topMenu={true}
+                label='State or Territory'
+                {...this.defaultInputComponentProps()}
+              />
+            </Cell>
+            <Cell col={4}>
+              {this.boundTextField(['city'], 'City')}
+            </Cell>
+          </Grid>
+        </section>
         <section>
           <h3>Where are you from?</h3>
           <span className="tooltip-link"

--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -89,13 +89,6 @@ export const personalValidation = (profile: Profile) => {
       errors.romanized_last_name = "Latin last name is required";
     }
   }
-  if (
-    isNilOrEmptyString(profile.city) ||
-    isNilOrEmptyString(profile.state_or_territory) ||
-    isNilOrEmptyString(profile.country)
-  ) {
-    errors["current-home"] = "Please enter a valid address";
-  }
   return errors;
 };
 

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -329,7 +329,6 @@ describe('Profile validation functions', () => {
         'birth_country': "Country",
       }).map(([k,v]) => ({[k]: `${v} is required`})));
       errors.date_of_birth = "Please enter a valid date of birth";
-      errors["current-home"] = "Please enter a valid address";
       const expectation = [false, PERSONAL_STEP, errors];
       assert.deepEqual(validateProfileComplete(profile), expectation);
     });

--- a/ui/views.py
+++ b/ui/views.py
@@ -67,7 +67,7 @@ class ReactView(View):  # pylint: disable=unused-argument
             context={
                 "has_zendesk_widget": True,
                 "is_public": False,
-                "google_maps_api": True,
+                "google_maps_api": False,
                 "js_settings_json": json.dumps(js_settings),
                 "ga_tracking_id": "",
             }


### PR DESCRIPTION
For the time being, we want to go back to using text inputs for the user's address in the profile form. However, we will be using the Geosuggest component in the future. This is a partial revert of #2167.