### PR TITLE
Add --reuse-db flag to speed up running Python tests locally

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --cov . --pep8 --pylint --cov-report term --cov-report html --ds=micromasters.settings
+addopts = --cov . --pep8 --pylint --cov-report term --cov-report html --ds=micromasters.settings --reuse-db
 norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.egg
 pep8ignore =
    */migrations/* ALL


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2307 

#### What's this PR do?
Adds --reuse-db flag to speed up running Python tests locally.

#### How should this be manually tested?
Run the Python tests twice, maybe on a single file. The second run should be notably faster than the first. No tests should fail.
