### PR TITLE
don't set 'use-credentials'

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -19,7 +19,7 @@ module.exports = Object.assign(prodConfig, {
     path: path.resolve('./static/bundles/'),
     filename: "[name]-[chunkhash].js",
     chunkFilename: "[id]-[chunkhash].js",
-    crossOriginLoading: "use-credentials",
+    crossOriginLoading: "anonymous",
   },
 
   plugins: [


### PR DESCRIPTION
This option was set during development / testing and snuck into the merged PR