### PR TITLE
Test learner search against null/undefined props

### DIFF
--- a/static/js/components/search/LearnerResult_test.js
+++ b/static/js/components/search/LearnerResult_test.js
@@ -1,5 +1,6 @@
 // @flow
 /* global SETTINGS: false */
+import _ from 'lodash';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { assert } from 'chai';
@@ -19,7 +20,8 @@ import {
 } from '../../util/util';
 import {
   USER_PROFILE_RESPONSE,
-  USER_PROGRAM_RESPONSE
+  USER_PROGRAM_RESPONSE,
+  ELASTICSEARCH_RESPONSE,
 } from '../../constants';
 
 describe('LearnerResult', () => {
@@ -31,20 +33,23 @@ describe('LearnerResult', () => {
     helper.cleanup();
   });
 
-  let renderLearnerResult = (props = {}) => mount(
+  let renderElasticSearchResult = (result, props = {}) => mount(
     <MuiThemeProvider muiTheme={getMuiTheme()}>
       <Provider store={helper.store}>
         <LearnerResult
-          result={{
-            _source: {
-              profile: USER_PROFILE_RESPONSE,
-              program: USER_PROGRAM_RESPONSE,
-            }
-          }}
+          result={result}
           {...props}
         />
       </Provider>
     </MuiThemeProvider>
+  );
+
+  let renderLearnerResult = (props = {}) => renderElasticSearchResult(
+    { _source: {
+      profile: USER_PROFILE_RESPONSE,
+      program: USER_PROGRAM_RESPONSE,
+    }},
+    props
   );
 
   it("should include the user's name", () => {
@@ -119,4 +124,14 @@ describe('LearnerResult', () => {
       assert.equal(state.ui.userChipVisibility, null);
     });
   });
+
+  for (const [index, profile] of ELASTICSEARCH_RESPONSE.hits.hits.entries()) {
+    it(`should render without error with ES profile result at index ${index}`, () => {
+      let esResult = _.cloneDeep(profile);
+      esResult['program'] = USER_PROGRAM_RESPONSE;
+      assert.doesNotThrow(() => {
+        renderElasticSearchResult(esResult);
+      });
+    });
+  }
 });

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -158,6 +158,65 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
           },
           "id": 3
         }
+      },
+      { // worse-case profile with null props
+        "_index": "micromasters",
+        "_type": "user",
+        "_id": "4",
+        "_score": 1,
+        "_source": {
+          "profile": {
+            "username": null,
+            "filled_out": true,
+            "account_privacy": null,
+            "email_optin": true,
+            "first_name": null,
+            "last_name": null,
+            "preferred_name": null,
+            "country": null,
+            "state_or_territory": null,
+            "city": null,
+            "birth_country": null,
+            "nationality": null,
+            "date_of_birth": null,
+            "preferred_language": null,
+            "gender": null,
+            "pretty_printed_student_id": null,
+            "work_history": [
+              {
+                "id": 15,
+                "city": null,
+                "state_or_territory": null,
+                "country": null,
+                "company_name": null,
+                "position": null,
+                "industry": null,
+                "end_date": null,
+                "start_date": null
+              }
+            ],
+            "edx_level_of_education": null,
+            "education": [
+              {
+                "id": 12,
+                "degree_name": null,
+                "graduation_date": null,
+                "field_of_study": null,
+                "online_degree": false,
+                "school_name": null,
+                "school_city": null,
+                "school_state_or_territory": null,
+                "school_country": null
+              }
+            ]
+          },
+          "id": 4
+        }
+      },
+      { // extreme worst-case empty profile
+        '_source': {
+          "profile": {}
+        }
       }
     ]
   },
@@ -191,6 +250,10 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
           "buckets": [
             {
               "key": "AF",
+              "doc_count": 2
+            },
+            {
+              "key": null,
               "doc_count": 2
             }
           ]


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #2303 

#### What's this PR do?

It adds tests around `<LearnerResult/>` to ensure it doesn't raise an error and cause the whole page to fail to render if profile properties are null or undefined. This should be sufficient to catch errors in the code for existing properties, although there's always a possibility that someone adds code for a new property that isn't null-safe and forgets to add it to the test data here. I don't think there's a good way to test against that.

#### How should this be manually tested?

This is a test-only PR so we want those to pass.

#### What GIF best describes this PR or how it makes you feel?

![giphy](https://cloud.githubusercontent.com/assets/28598/21826542/e8f97a10-d755-11e6-99ec-9fc818837a21.gif)