### PR TITLE
Release 0.39.0

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,17 @@
 Release Notes
 =============
 
+Version 0.39.0
+--------------
+
+- Use factory.Faker() (#2306)
+- Test learner search against null/undefined props
+- Add --reuse-db flag to speed up running tests locally (#2309)
+- Change status for enrollment to audit, since it&#39;s used in FA programs (#2290)
+- Fixed learner search for DEDP fails issues (#2287)
+- Don&#39;t need to make pylint disable missing-docstring for serializer Meta (#2300)
+- remove extraneous about_me serializer fields (#2296)
+
 Version 0.38.0
 --------------
 

--- a/cms/factories.py
+++ b/cms/factories.py
@@ -6,7 +6,6 @@ import tempfile
 
 import factory
 from factory.django import DjangoModelFactory
-import faker
 from wagtail.wagtailimages.models import Image
 from willow.image import Image as WillowImage
 
@@ -14,18 +13,15 @@ from cms.models import ProgramPage, ProgramFaculty
 from courses.factories import ProgramFactory
 
 
-FAKE = faker.Factory.create()
-
-
 class ImageFactory(DjangoModelFactory):
     """Factory for Wagtail images"""
     class Meta:  # pylint: disable=missing-docstring
         model = Image
 
-    file = factory.LazyFunction(FAKE.uri_path)
-    title = factory.LazyFunction(lambda: FAKE.file_name(extension="jpg"))
-    width = factory.LazyFunction(FAKE.pyint)
-    height = factory.LazyFunction(FAKE.pyint)
+    file = factory.Faker('uri_path')
+    title = factory.Faker('file_name', extension="jpg")
+    width = factory.Faker('pyint')
+    height = factory.Faker('pyint')
 
     @factory.post_generation
     def fake_willow_image(self, create, extracted, **kwargs):  # pylint: disable=unused-argument
@@ -55,7 +51,7 @@ class ProgramPageFactory(DjangoModelFactory):
 
     path = '/'
     depth = 1
-    title = factory.LazyFunction(lambda: FAKE.sentence(nb_words=4))
+    title = factory.Faker('sentence', nb_words=4)
 
     program = factory.SubFactory(ProgramFactory)
 
@@ -65,9 +61,9 @@ class FacultyFactory(DjangoModelFactory):
     class Meta:  # pylint: disable=missing-docstring
         model = ProgramFaculty
 
-    name = factory.LazyFunction(FAKE.name)
+    name = factory.Faker('name')
     title = "Ph.D"
-    short_bio = factory.LazyFunction(FAKE.text)
+    short_bio = factory.Faker('text')
 
     program_page = factory.SubFactory(ProgramPageFactory)
     image = factory.SubFactory(ImageFactory)

--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -26,7 +26,7 @@ class FacultyImageSerializer(serializers.ModelSerializer):
         rendition = image.get_rendition('fill-500x385')
         return RenditionSerializer(rendition).data
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = Image
         fields = ('alt', 'rendition',)
 
@@ -35,7 +35,7 @@ class FacultySerializer(serializers.ModelSerializer):
     """Serializer for ProgramFaculty objects."""
     image = FacultyImageSerializer(read_only=True)
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = ProgramFaculty
         fields = ('name', 'title', 'short_bio', 'image')
 
@@ -61,6 +61,6 @@ class ProgramPageSerializer(serializers.ModelSerializer):
             return None
         return slugify(programpage.program.title)
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = ProgramPage
         fields = ('id', 'title', 'slug', 'faculty', 'courses')

--- a/courses/factories.py
+++ b/courses/factories.py
@@ -15,9 +15,9 @@ FAKE = faker.Factory.create()
 class ProgramFactory(DjangoModelFactory):
     """Factory for Programs"""
     title = fuzzy.FuzzyText(prefix="Program ")
-    live = factory.LazyFunction(FAKE.boolean)
+    live = factory.Faker('boolean')
     description = fuzzy.FuzzyText()
-    exam_series_code = factory.LazyFunction(lambda: FAKE.lexify("????_MicroMasters"))
+    exam_series_code = factory.Faker('lexify', text="????_MicroMasters")
 
     class Meta:  # pylint: disable=missing-docstring
         model = Program
@@ -57,7 +57,7 @@ class CourseFactory(DjangoModelFactory):
 
     description = fuzzy.FuzzyText()
     prerequisites = fuzzy.FuzzyText(prefix="Course requires ")
-    exam_module = factory.LazyFunction(lambda: FAKE.numerify("##.##x"))
+    exam_module = factory.Faker('numerify', text="##.##x")
 
     class Meta:  # pylint: disable=missing-docstring
         model = Course
@@ -80,20 +80,20 @@ class CourseRunFactory(DjangoModelFactory):
     edx_course_key = factory.LazyAttribute(
         lambda x: "course:/v{}/{}".format(randint(1, 100), FAKE.slug())
     )
-    enrollment_start = factory.LazyAttribute(
-        lambda x: FAKE.date_time_this_month(before_now=True, after_now=False, tzinfo=pytz.utc)
+    enrollment_start = factory.Faker(
+        'date_time_this_month', before_now=True, after_now=False, tzinfo=pytz.utc
     )
-    start_date = factory.LazyAttribute(
-        lambda x: FAKE.date_time_this_month(before_now=True, after_now=False, tzinfo=pytz.utc)
+    start_date = factory.Faker(
+        'date_time_this_month', before_now=True, after_now=False, tzinfo=pytz.utc
     )
-    enrollment_end = factory.LazyAttribute(
-        lambda x: FAKE.date_time_this_month(before_now=False, after_now=True, tzinfo=pytz.utc)
+    enrollment_end = factory.Faker(
+        'date_time_this_month', before_now=False, after_now=True, tzinfo=pytz.utc
     )
-    end_date = factory.LazyAttribute(
-        lambda x: FAKE.date_time_this_year(before_now=False, after_now=True, tzinfo=pytz.utc)
+    end_date = factory.Faker(
+        'date_time_this_year', before_now=False, after_now=True, tzinfo=pytz.utc
     )
-    freeze_grade_date = factory.LazyAttribute(
-        lambda x: FAKE.date_time_this_year(before_now=False, after_now=True, tzinfo=pytz.utc)
+    freeze_grade_date = factory.Faker(
+        'date_time_this_year', before_now=False, after_now=True, tzinfo=pytz.utc
     )
     fuzzy_start_date = factory.LazyAttribute(
         lambda x: "Starting {}".format(FAKE.sentence())
@@ -101,12 +101,8 @@ class CourseRunFactory(DjangoModelFactory):
     fuzzy_enrollment_start_date = factory.LazyAttribute(
         lambda x: "Enrollment starting {}".format(FAKE.sentence())
     )
-    enrollment_url = factory.LazyAttribute(
-        lambda x: FAKE.url()
-    )
-    prerequisites = factory.LazyAttribute(
-        lambda x: FAKE.paragraph()
-    )
+    enrollment_url = factory.Faker('url')
+    prerequisites = factory.Faker('paragraph')
 
     class Meta:  # pylint: disable=missing-docstring
         model = CourseRun

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -39,7 +39,7 @@ class ProgramSerializer(serializers.ModelSerializer):
         user = self.context['request'].user
         return ProgramEnrollment.objects.filter(user=user, program=program).exists()
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = Program
         fields = (
             'id',
@@ -51,7 +51,7 @@ class ProgramSerializer(serializers.ModelSerializer):
 
 class CourseSerializer(serializers.ModelSerializer):
     """Serializer for Course objects"""
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = Course
         fields = (
             'id',

--- a/dashboard/fixtures/user_enrollments.json
+++ b/dashboard/fixtures/user_enrollments.json
@@ -75,7 +75,7 @@
         },
         "created": "2016-01-27T18:10:35Z",
         "is_active": true,
-        "mode": "verified",
+        "mode": "audit",
         "user": "staff"
     }
 ]

--- a/ecommerce/factories.py
+++ b/ecommerce/factories.py
@@ -2,11 +2,11 @@
 Factories for ecommerce models
 """
 from factory import (
-    LazyFunction,
     LazyAttribute,
     SelfAttribute,
     SubFactory,
     Trait,
+    Faker,
 )
 from factory.django import DjangoModelFactory
 from factory.fuzzy import (
@@ -89,7 +89,7 @@ class ReceiptFactory(DjangoModelFactory):
 class CoursePriceFactory(DjangoModelFactory):
     """Factory for CoursePrice"""
     course_run = SubFactory(CourseRunFactory)
-    is_valid = LazyFunction(FAKE.boolean)
+    is_valid = Faker('boolean')
     price = FuzzyDecimal(low=0, high=12345)
 
     class Meta:  # pylint: disable=missing-docstring,no-init,too-few-public-methods,old-style-class

--- a/financialaid/factories.py
+++ b/financialaid/factories.py
@@ -3,8 +3,7 @@ Factories for financialaid tests
 """
 import datetime
 from django.db.models.signals import post_save
-from factory import SubFactory
-from factory.declarations import LazyFunction
+from factory import SubFactory, Faker
 from factory.django import DjangoModelFactory, mute_signals
 from factory.fuzzy import (
     FuzzyChoice,
@@ -14,7 +13,6 @@ from factory.fuzzy import (
     FuzzyInteger,
     FuzzyText
 )
-import faker
 from pytz import UTC
 
 from courses.factories import ProgramFactory
@@ -26,8 +24,6 @@ from financialaid.models import (
     TierProgram
 )
 from profiles.factories import ProfileFactory
-
-FAKE = faker.Factory.create()
 
 
 class TierFactory(DjangoModelFactory):
@@ -48,7 +44,7 @@ class TierProgramFactory(DjangoModelFactory):
     program = SubFactory(ProgramFactory)
     tier = SubFactory(TierFactory)
     discount_amount = FuzzyInteger(low=1, high=12345)
-    current = LazyFunction(FAKE.boolean)
+    current = Faker('boolean')
     income_threshold = FuzzyInteger(low=1, high=10000)
 
     class Meta:  # pylint: disable=missing-docstring
@@ -67,9 +63,9 @@ class FinancialAidFactory(DjangoModelFactory):
     )
     income_usd = FuzzyFloat(low=0, high=12345)
     original_income = FuzzyFloat(low=0, high=12345)
-    original_currency = LazyFunction(FAKE.currency_code)
-    country_of_income = LazyFunction(FAKE.country_code)
-    country_of_residence = LazyFunction(FAKE.country_code)
+    original_currency = Faker('currency_code')
+    country_of_income = Faker('country_code')
+    country_of_residence = Faker('country_code')
     date_exchange_rate = FuzzyDateTime(datetime.datetime(2000, 1, 1, tzinfo=UTC))
     date_documents_sent = FuzzyDate(datetime.date(2000, 1, 1))
 

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -22,7 +22,7 @@ from celery.schedules import crontab
 from django.core.exceptions import ImproperlyConfigured
 
 
-VERSION = "0.38.0"
+VERSION = "0.39.0"
 
 CONFIG_PATHS = [
     os.environ.get('MICROMASTERS_CONFIG', ''),

--- a/profiles/factories.py
+++ b/profiles/factories.py
@@ -1,7 +1,7 @@
 """Factories for making test data"""
 from datetime import date, datetime, timezone
 
-from factory import SubFactory, LazyFunction
+from factory import SubFactory, LazyFunction, Faker
 from factory.django import (
     DjangoModelFactory,
     ImageField
@@ -23,18 +23,18 @@ FAKE = faker.Factory.create()
 class ProfileFactory(DjangoModelFactory):
     """Factory for Profiles"""
     user = SubFactory(UserFactory)
-    filled_out = LazyFunction(FAKE.boolean)
-    agreed_to_terms_of_service = LazyFunction(FAKE.boolean)
+    filled_out = Faker('boolean')
+    agreed_to_terms_of_service = Faker('boolean')
 
-    first_name = LazyFunction(FAKE.first_name)
-    last_name = LazyFunction(FAKE.last_name)
-    preferred_name = LazyFunction(FAKE.name)
+    first_name = Faker('first_name')
+    last_name = Faker('last_name')
+    preferred_name = Faker('name')
 
     account_privacy = FuzzyChoice(
         [choice[0] for choice in Profile.ACCOUNT_PRIVACY_CHOICES]
     )
 
-    email_optin = LazyFunction(FAKE.boolean)
+    email_optin = Faker('boolean')
 
     edx_employer = FuzzyText(suffix=" corp")
     edx_job_title = FuzzyText(suffix=" consultant")
@@ -42,31 +42,31 @@ class ProfileFactory(DjangoModelFactory):
     edx_bio = FuzzyText()
     about_me = FuzzyText()
 
-    romanized_first_name = LazyFunction(FAKE.first_name)
-    romanized_last_name = LazyFunction(FAKE.last_name)
+    romanized_first_name = Faker('first_name')
+    romanized_last_name = Faker('last_name')
 
     address1 = LazyFunction(lambda: '{} {}'.format(FAKE.building_number(), FAKE.street_name()))
-    address2 = LazyFunction(FAKE.secondary_address)
+    address2 = Faker('secondary_address')
     address3 = None
 
-    postal_code = LazyFunction(FAKE.postcode)
-    city = LazyFunction(FAKE.city)
-    country = LazyFunction(FAKE.country_code)
-    state_or_territory = LazyFunction(FAKE.state)
+    postal_code = Faker('postcode')
+    city = Faker('city')
+    country = Faker('country_code')
+    state_or_territory = Faker('state')
 
-    phone_number = LazyFunction(lambda: FAKE.numerify('###-###-####'))
-    phone_country_code = LazyFunction(lambda: FAKE.numerify('###'))
+    phone_number = Faker('numerify', text='###-###-####')
+    phone_country_code = Faker('numerify', text='###')
 
-    birth_country = LazyFunction(FAKE.country_code)
-    nationality = LazyFunction(FAKE.country_code)
+    birth_country = Faker('country_code')
+    nationality = Faker('country_code')
 
-    edx_requires_parental_consent = LazyFunction(FAKE.boolean)
+    edx_requires_parental_consent = Faker('boolean')
     date_of_birth = FuzzyDate(date(1850, 1, 1))
     edx_level_of_education = FuzzyChoice(
         [None] + [choice[0] for choice in Profile.LEVEL_OF_EDUCATION_CHOICES]
     )
     edx_goals = FuzzyText()
-    preferred_language = LazyFunction(FAKE.language_code)
+    preferred_language = Faker('language_code')
     edx_language_proficiencies = LazyFunction(lambda: [FAKE.text() for _ in range(3)])
     gender = FuzzyChoice(
         [choice[0] for choice in Profile.GENDER_CHOICES]
@@ -90,12 +90,12 @@ class EmploymentFactory(DjangoModelFactory):
     A factory for work history
     """
     profile = SubFactory(ProfileFactory)
-    city = LazyFunction(FAKE.city)
-    country = LazyFunction(FAKE.country)
-    state_or_territory = LazyFunction(FAKE.state)
-    company_name = LazyFunction(FAKE.company)
+    city = Faker('city')
+    country = Faker('country')
+    state_or_territory = Faker('state')
+    company_name = Faker('company')
     industry = FuzzyText(suffix=" IT")
-    position = LazyFunction(FAKE.job)
+    position = Faker('job')
     end_date = FuzzyDate(date(1850, 1, 1))
     start_date = FuzzyDate(date(1850, 1, 1))
 
@@ -114,11 +114,11 @@ class EducationFactory(DjangoModelFactory):
     )
     graduation_date = FuzzyDate(date(2000, 1, 1))
     field_of_study = FuzzyText()
-    online_degree = LazyFunction(FAKE.boolean)
+    online_degree = Faker('boolean')
     school_name = FuzzyText()
-    school_city = LazyFunction(FAKE.city)
-    school_state_or_territory = LazyFunction(FAKE.state)
-    school_country = LazyFunction(FAKE.country)
+    school_city = Faker('city')
+    school_state_or_territory = Faker('state')
+    school_country = Faker('country')
 
     class Meta:  # pylint: disable=missing-docstring
         model = Education

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -9,7 +9,6 @@ from rest_framework.serializers import (
     IntegerField,
     ModelSerializer,
     SerializerMethodField,
-    CharField,
 )
 
 from profiles.api import get_social_username
@@ -173,8 +172,6 @@ class ProfileBaseSerializer(ModelSerializer):
 
 class ProfileSerializer(ProfileBaseSerializer):
     """Serializer for Profile objects"""
-    about_me = CharField(allow_null=True, allow_blank=True, required=False)
-
     def update(self, instance, validated_data):
         with transaction.atomic():
             for attr, value in validated_data.items():
@@ -278,7 +275,6 @@ class ProfileFilledOutSerializer(ProfileSerializer):
     """Serializer for Profile objects which require filled_out = True"""
     work_history = EmploymentFilledOutSerializer(many=True)
     education = EducationFilledOutSerializer(many=True)
-    about_me = CharField(allow_null=True, allow_blank=True, required=False)
 
     def __init__(self, *args, **kwargs):
         """

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -196,7 +196,7 @@ class ProfileSerializer(ProfileBaseSerializer):
                 update_education(validated_data['education'], instance.id)
             return instance
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = Profile
         fields = (
             'username',
@@ -241,7 +241,7 @@ class ProfileLimitedSerializer(ProfileBaseSerializer):
     allowed to see if a profile is marked public.
     """
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta:
         model = Profile
         fields = (
             'username',

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --cov . --pep8 --pylint --cov-report term --cov-report html --ds=micromasters.settings
+addopts = --cov . --pep8 --pylint --cov-report term --cov-report html --ds=micromasters.settings --reuse-db
 norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.egg
 pep8ignore =
    */migrations/* ALL

--- a/static/js/components/search/CountryRefinementOption.js
+++ b/static/js/components/search/CountryRefinementOption.js
@@ -1,6 +1,8 @@
 // @flow
 import React from 'react';
-import iso3166 from 'iso-3166-2';
+import R from 'ramda';
+
+import { codeToCountryName } from '../../lib/location';
 
 export default class CountryRefinementOption extends React.Component {
   props: {
@@ -10,17 +12,13 @@ export default class CountryRefinementOption extends React.Component {
     count:    number,
   };
 
-  countryName = (countryCode: string): string => (
-    iso3166.country(countryCode).name
-  );
-
   render () {
     const { active, onClick, count, label } = this.props;
     let activeClass = () => active ? "is-active" : "";
     let option = "sk-item-list-option";
     return (
       <div className={`${option} sk-item-list__item ${activeClass()}`} onClick={onClick}>
-        <input 
+        <input
           type="checkbox"
           data-qa="checkbox"
           checked={active}
@@ -29,7 +27,7 @@ export default class CountryRefinementOption extends React.Component {
         >
         </input>
         <div className={`${option}__text`}>
-          { this.countryName(label) }
+          { R.when(R.equals(""), () => 'N/A', codeToCountryName(label)) }
         </div>
         <div className={`${option}__count`}>
           { count }

--- a/static/js/components/search/CountryRefinementOption_test.js
+++ b/static/js/components/search/CountryRefinementOption_test.js
@@ -2,6 +2,7 @@
 /* global SETTINGS: false */
 import React from 'react';
 import { assert } from 'chai';
+import _ from 'lodash';
 import sinon from 'sinon';
 import TestUtils from 'react-addons-test-utils';
 
@@ -28,6 +29,13 @@ describe('CountryRefinementOption', () => {
   it('should render a country name, given a country code', () => {
     let option = renderCountryOption(props);
     assert.include(option, 'Afghanistan');
+  });
+
+  it('should render a country placeholder, given no country code', () => {
+    let newProps = _.cloneDeep(props);
+    _.set(newProps, "label", null);
+    let option = renderCountryOption(newProps);
+    assert.include(option, 'N/A');
   });
 
   it('should display the result count for the option', () => {

--- a/static/js/components/search/LearnerResult_test.js
+++ b/static/js/components/search/LearnerResult_test.js
@@ -1,5 +1,6 @@
 // @flow
 /* global SETTINGS: false */
+import _ from 'lodash';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { assert } from 'chai';
@@ -19,7 +20,8 @@ import {
 } from '../../util/util';
 import {
   USER_PROFILE_RESPONSE,
-  USER_PROGRAM_RESPONSE
+  USER_PROGRAM_RESPONSE,
+  ELASTICSEARCH_RESPONSE,
 } from '../../constants';
 
 describe('LearnerResult', () => {
@@ -31,20 +33,23 @@ describe('LearnerResult', () => {
     helper.cleanup();
   });
 
-  let renderLearnerResult = (props = {}) => mount(
+  let renderElasticSearchResult = (result, props = {}) => mount(
     <MuiThemeProvider muiTheme={getMuiTheme()}>
       <Provider store={helper.store}>
         <LearnerResult
-          result={{
-            _source: {
-              profile: USER_PROFILE_RESPONSE,
-              program: USER_PROGRAM_RESPONSE,
-            }
-          }}
+          result={result}
           {...props}
         />
       </Provider>
     </MuiThemeProvider>
+  );
+
+  let renderLearnerResult = (props = {}) => renderElasticSearchResult(
+    { _source: {
+      profile: USER_PROFILE_RESPONSE,
+      program: USER_PROGRAM_RESPONSE,
+    }},
+    props
   );
 
   it("should include the user's name", () => {
@@ -119,4 +124,14 @@ describe('LearnerResult', () => {
       assert.equal(state.ui.userChipVisibility, null);
     });
   });
+
+  for (const [index, profile] of ELASTICSEARCH_RESPONSE.hits.hits.entries()) {
+    it(`should render without error with ES profile result at index ${index}`, () => {
+      let esResult = _.cloneDeep(profile);
+      esResult['program'] = USER_PROGRAM_RESPONSE;
+      assert.doesNotThrow(() => {
+        renderElasticSearchResult(esResult);
+      });
+    });
+  }
 });

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -158,6 +158,65 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
           },
           "id": 3
         }
+      },
+      { // worse-case profile with null props
+        "_index": "micromasters",
+        "_type": "user",
+        "_id": "4",
+        "_score": 1,
+        "_source": {
+          "profile": {
+            "username": null,
+            "filled_out": true,
+            "account_privacy": null,
+            "email_optin": true,
+            "first_name": null,
+            "last_name": null,
+            "preferred_name": null,
+            "country": null,
+            "state_or_territory": null,
+            "city": null,
+            "birth_country": null,
+            "nationality": null,
+            "date_of_birth": null,
+            "preferred_language": null,
+            "gender": null,
+            "pretty_printed_student_id": null,
+            "work_history": [
+              {
+                "id": 15,
+                "city": null,
+                "state_or_territory": null,
+                "country": null,
+                "company_name": null,
+                "position": null,
+                "industry": null,
+                "end_date": null,
+                "start_date": null
+              }
+            ],
+            "edx_level_of_education": null,
+            "education": [
+              {
+                "id": 12,
+                "degree_name": null,
+                "graduation_date": null,
+                "field_of_study": null,
+                "online_degree": false,
+                "school_name": null,
+                "school_city": null,
+                "school_state_or_territory": null,
+                "school_country": null
+              }
+            ]
+          },
+          "id": 4
+        }
+      },
+      { // extreme worst-case empty profile
+        '_source': {
+          "profile": {}
+        }
       }
     ]
   },
@@ -191,6 +250,10 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
           "buckets": [
             {
               "key": "AF",
+              "doc_count": 2
+            },
+            {
+              "key": null,
               "doc_count": 2
             }
           ]

--- a/static/js/lib/currency.js
+++ b/static/js/lib/currency.js
@@ -1,8 +1,8 @@
 // @flow
 import cc from 'currency-codes';
 import R from 'ramda';
-import iso3166 from 'iso-3166-2';
 
+import { codeToCountryName } from './location';
 import { labelSort } from '../util/util';
 
 export const excludedCurrencyCodes = [
@@ -36,8 +36,6 @@ const codesToOptions = R.compose(
 );
 
 export const currencyOptions = codesToOptions(cc.codes());
-
-export const codeToCountryName = (code: string) => iso3166.country(code).name || '';
 
 const currencyToCode = currency => (
   currency.length === 0 ? '' : currency[0].code

--- a/static/js/lib/currency_test.js
+++ b/static/js/lib/currency_test.js
@@ -24,6 +24,7 @@ describe('currency', () => {
         ['FR', 'EUR'],
         ['GB', 'GBP'],
         ['IN', 'INR'],
+        [null, ''],
       ].forEach(([country, currency]) => {
         assert.equal(currencyForCountry(country), currency);
       });

--- a/static/js/lib/location.js
+++ b/static/js/lib/location.js
@@ -1,0 +1,6 @@
+import R from 'ramda';
+import iso3166 from 'iso-3166-2';
+
+export const codeToCountryName = (code: string) =>  R.pathOr(
+  "", ['name'], iso3166.country(R.defaultTo("", code))
+);

--- a/static/js/lib/location_test.js
+++ b/static/js/lib/location_test.js
@@ -1,0 +1,16 @@
+import { assert } from 'chai';
+
+import { codeToCountryName } from './location';
+
+describe('location', () => {
+  describe('codeToCountryName', () => {
+    it('should return a valid country name for a code', () => {
+      [
+        ['US', 'United States'],
+        [null, ''],
+      ].forEach(([countryCode, country]) => {
+        assert.equal(codeToCountryName(countryCode), country);
+      });
+    });
+  });
+});

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -4,7 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import striptags from 'striptags';
 import _ from 'lodash';
-import iso3166 from 'iso-3166-2';
+import { codeToCountryName } from '../lib/location';
 import { S } from '../lib/sanctuary';
 const { Maybe, Just, Nothing } = S;
 import R from 'ramda';
@@ -273,15 +273,17 @@ export function getPreferredName(profile: Profile, last: boolean = true): string
 export function getLocation(profile: Profile, showState: boolean = true): string {
   let { country, state_or_territory, city } = profile;
   let subCountryLocation, countryLocation;
+  city = city ? `${city}, ` : "";
+
   if ( country === 'US' ) {
     let state = state_or_territory.replace(/^\D{2}-/, '');
-    subCountryLocation = showState ? `${city}, ${state}` : city;
+    subCountryLocation = showState ? `${city}${state}, ` : city;
     countryLocation = 'US';
   } else {
     subCountryLocation = city;
-    countryLocation = iso3166.country(country).name;
+    countryLocation = codeToCountryName(country);
   }
-  return `${subCountryLocation}, ${countryLocation}`;
+  return `${subCountryLocation}${countryLocation}`;
 }
 
 /**

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -179,6 +179,33 @@ describe('utility functions', () => {
       // assert hide state
       assert.equal(getLocation(us, false), 'Portland, US');
     });
+
+    it('should return `${city}, ` when no country code', () => {
+      let us = {
+        country: null,
+        state_or_territory: 'US-ME',
+        city: 'Portland'
+      };
+      assert.equal(getLocation(us, false), 'Portland, ');
+    });
+
+    it('should return `US` when no city', () => {
+      let us = {
+        country: 'US',
+        state_or_territory: 'US-ME',
+        city: null
+      };
+      assert.equal(getLocation(us, false), 'US');
+    });
+
+    it('should return `-` when no city and no country', () => {
+      let us = {
+        country: null,
+        state_or_territory: 'US-ME',
+        city: null
+      };
+      assert.equal(getLocation(us, false), '');
+    });
   });
 
   describe('getEmployer', () => {


### PR DESCRIPTION
## David Baumgold
  - [x] Use factory.Faker() (#2306) ([e43ab149](../commit/e43ab14916488cf16af62cd85c8fa34ed52fba32))
  - [x] Don&#39;t need to make pylint disable missing-docstring for serializer Meta (#2300) ([c9f67ee4](../commit/c9f67ee46d53532582ff15f0b13de9b3f4bcb0e2))
  - [x] remove extraneous about_me serializer fields (#2296) ([1a8e8117](../commit/1a8e8117723c615ebdbe1ff6fd34275f4940e9fb))

## Nathan Levesque
  - [x] Test learner search against null/undefined props ([cae68b4f](../commit/cae68b4f7da1dcfc096a031ff245eaaefa94019d))

## George Schneeloch
  - [ ] Add --reuse-db flag to speed up running tests locally (#2309) ([4ab2f20a](../commit/4ab2f20ac95b5f3c2ab2d7939ff14f0bf3cb3d2f))
  - [ ] Change status for enrollment to audit, since it&#39;s used in FA programs (#2290) ([aa6954cb](../commit/aa6954cb264bb9ba739ce84854601fa52b3918dc))

## Amir Qayyum Khan
  - [x] Fixed learner search for DEDP fails issues (#2287) ([5337d48c](../commit/5337d48cf7bc5d051ca60e1d0720a747a933395c))