### PR TITLE
Fixed seed_db commands to work with indexing/grade changes

### DIFF
--- a/seed_data/lib_test.py
+++ b/seed_data/lib_test.py
@@ -1,0 +1,76 @@
+"""
+Tests for library functions used by seed_db and alter_data commands
+"""
+
+from django.test import TestCase
+from micromasters.factories import UserFactory
+from courses.factories import ProgramFactory, CourseFactory, CourseRunFactory
+from seed_data.lib import (
+    CourseFinder,
+    CourseRunFinder,
+    UserFinder,
+)
+
+
+class UserFinderTests(TestCase):
+    """Test cases for UserFinder"""
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory.create(username='username1', email='email1@example.com')
+        UserFactory.create(username='username2', email='email2@example.com')
+
+    def test_user_finder_success(self):
+        """Tests that UserFinder will return a desired user"""
+        found_users = [
+            UserFinder.find(username='username1'),
+            UserFinder.find(username='name1'),
+            UserFinder.find(email='email1@example.com'),
+            UserFinder.find(email='email1'),
+        ]
+        assert all([self.user == found_user for found_user in found_users])
+
+    def test_user_finder_failure(self):
+        """Tests that UserFinder will fail with unspecific/incorrect parameters"""
+        failing_search_param_sets = [
+            dict(username='username'),
+            dict(email='email'),
+            dict(username='nonexistent_user'),
+            dict(nonsense_param='value'),
+        ]
+        for param_set in failing_search_param_sets:
+            with self.assertRaises(Exception):
+                UserFinder.find(**param_set)
+
+
+class CourseFinderTests(TestCase):
+    """Test cases for CourseFinder"""
+    def test_course_finder_success(self):  # pylint: disable=no-self-use
+        """Tests that CourseFinder will return a desired course"""
+        program = ProgramFactory.create(title='program1')
+        course = CourseFactory.create(title='Course Lvl 100', program=program)
+        CourseFactory.create(title='Course Lvl 200', program=program)
+        CourseFactory.create(title='Course Lvl 300', program=program)
+        CourseFactory.create(title='Other Course 100', program__title='program2')
+
+        found_courses = [
+            CourseFinder.find(course_title='Course Lvl 100'),
+            CourseFinder.find(course_title='Lvl 100'),
+            CourseFinder.find(program_title='program1', course_level='100')
+        ]
+        assert all([course == found_course for found_course in found_courses])
+
+
+class CourseRunFinderTests(TestCase):
+    """Test cases for CourseRunFinder"""
+    def test_course_run_finder_success(self):  # pylint: disable=no-self-use
+        """Tests that CourseRunFinder will return a desired course run"""
+        course_run = CourseRunFactory.create(title='courserun1', edx_course_key='coursekey1')
+        CourseRunFactory.create(title='courserun2', edx_course_key='coursekey2')
+
+        found_course_runs = [
+            CourseRunFinder.find(course_run_title='courserun1'),
+            CourseRunFinder.find(course_run_title='run1'),
+            CourseRunFinder.find(course_run_key='coursekey1'),
+            CourseRunFinder.find(course_run_key='key1')
+        ]
+        assert all([course_run == found_course_run for found_course_run in found_course_runs])

--- a/seed_data/management/commands/seed_db_test.py
+++ b/seed_data/management/commands/seed_db_test.py
@@ -1,0 +1,124 @@
+"""
+Tests for library functions used by seed_db and alter_data commands
+"""
+from django.test import TestCase
+from django.db.models.signals import post_save
+from django.contrib.auth.models import User
+from factory.django import mute_signals
+
+from dashboard.models import CachedEnrollment
+from courses.factories import ProgramFactory, CourseRunFactory
+from seed_data.management.commands.seed_db import (
+    MODEL_DEFAULTS,
+    FAKE_USER_USERNAME_PREFIX,
+    compile_model_data,
+    deserialize_model_data,
+    deserialize_user_data,
+    deserialize_course_data,
+)
+
+
+class SeedDBUtilityTests(TestCase):
+    """Tests for utility functions used by the seed_db command"""
+    def test_compile_model_data(self):  # pylint: disable=no-self-use
+        """Tests that compile_model_data creates a dict of model data"""
+        model_data = compile_model_data(User, {'email': 'email1@example.com'})
+        assert model_data['email'] == 'email1@example.com'
+        for k, v in MODEL_DEFAULTS[User].items():
+            assert model_data[k] == v
+
+    def test_compile_model_data_with_added_params(self):  # pylint: disable=no-self-use
+        """Tests that additional params can be set in compile_model_data"""
+        model_data = compile_model_data(User, {'email': 'email1@example.com'}, username='username1')
+        assert model_data['username'] == 'username1'
+
+    def test_deserialize_model_data(self):  # pylint: disable=no-self-use
+        """Tests that deserialize_model_data creates a new model object"""
+        model_obj = deserialize_model_data(User, {'email': 'email1@example.com'}, username='username1')
+        assert model_obj.email == 'email1@example.com'
+        assert model_obj.username == 'username1'
+        assert model_obj.id is not None
+
+
+class SeedDBDeserializationTests(TestCase):
+    """Tests for object deserializers used by the seed_db command"""
+    USER_DATA = {
+        "first_name": "Mario",
+        "last_name": "Medina",
+        "edx_name": "Mario",
+        "state_or_territory": "ES-AS",
+        "gender": "m",
+        "email": "mario.medina@example.com",
+        "nationality": "ES",
+        "city": "M\u00e1laga",
+        "date_of_birth": "1961-04-29",
+        "preferred_name": "Mario",
+        "country": "ES",
+        "birth_country": "ES",
+        "work_history": [
+            {
+                "industry": "Computer Software",
+                "state_or_territory": "ES-AS",
+                "start_date": "2014-11-22",
+                "position": "Software Engineer",
+                "country": "ES",
+                "company_name": "Microsoft",
+                "city": "M\u00e1laga"
+            }
+        ],
+        "education": [
+            {
+                "school_city": "M\u00e1laga",
+                "degree_name": "hs",
+                "field_of_study": "45.0902",
+                "school_state_or_territory": "ES-AS",
+                "school_country": "ES",
+                "graduation_date": "1979-04-29",
+                "school_name": "M\u00e1laga High School"
+            },
+        ],
+        "_enrollments": [{
+            "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015"
+        }],
+        "_grades": [{
+            "grade": "0.87",
+            "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015"
+        }],
+    }
+
+    COURSE_DATA = {
+        "description": "An introductory course to Digital Learning",
+        "course_runs": [
+            {
+                "enrollment_start": "2016-01-15T00:00:00",
+                "edx_course_key": "course-v1:MITx+Digital+Learning+100+Jan_2016",
+                "enrollment_end": "2016-01-29T00:00:00",
+                "title": "Digital Learning 100 - January 2016",
+                "upgrade_deadline": "2016-01-22T00:00:00",
+                "end_date": "2016-05-15T00:00:00",
+                "start_date": "2016-01-15T00:00:00"
+            },
+        ],
+        "title": "Digital Learning 100",
+        "position_in_program": 1
+    }
+
+    def test_deserialize_user_data(self):  # pylint: disable=no-self-use
+        """Test that user data is correctly deserialized"""
+        new_course_run = CourseRunFactory.create(edx_course_key='course-v1:MITx+Analog+Learning+100+Aug_2015')
+        new_program = new_course_run.course.program
+        with mute_signals(post_save):
+            user = deserialize_user_data(self.USER_DATA, [new_program])
+        assert user.username == '{}mario.medina'.format(FAKE_USER_USERNAME_PREFIX)
+        assert user.profile.first_name == 'Mario'
+        assert user.profile.date_of_birth == '1961-04-29'
+        assert CachedEnrollment.objects.filter(user=user, course_run=new_course_run).count() == 1
+
+    def test_deserialize_course_data(self):  # pylint: disable=no-self-use
+        """Test that course data is correctly deserialized"""
+        new_program = ProgramFactory.create()
+        new_course = deserialize_course_data(new_program, self.COURSE_DATA)
+        new_course_runs = new_course.courserun_set.all()
+        assert new_course.title == 'Digital Learning 100'
+        assert len(new_course_runs) == 1
+        assert new_course_runs[0].title == 'Digital Learning 100 - January 2016'

--- a/seed_data/management/commands/unseed_db.py
+++ b/seed_data/management/commands/unseed_db.py
@@ -12,6 +12,7 @@ from django.contrib.auth.models import User
 from courses.models import Program
 from dashboard.models import CachedEnrollment, CachedCertificate, CachedCurrentGrade
 from financialaid.models import FinancialAid, FinancialAidAudit, Tier, TierProgram
+from grades.models import FinalGrade
 from mail.models import FinancialAidEmailAudit
 from search.indexing_api import recreate_index
 from seed_data.management.commands import (  # pylint: disable=import-error
@@ -39,6 +40,48 @@ def remove_delete_protection(*models):
                 cursor.execute("CREATE RULE delete_protect AS ON DELETE TO {} DO INSTEAD NOTHING".format(table_name))
 
 
+def unseed_db():
+    """
+    Deletes all seed data from the database
+    """
+    fake_program_ids = (
+        Program.objects
+        .filter(description__startswith=FAKE_PROGRAM_DESC_PREFIX)
+        .values_list('id', flat=True)
+    )
+    fake_user_ids = (
+        User.objects
+        .filter(username__startswith=FAKE_USER_USERNAME_PREFIX)
+        .values_list('id', flat=True)
+    )
+    fake_tier_ids = (
+        TierProgram.objects
+        .filter(program__id__in=fake_program_ids)
+        .values_list('tier__id', flat=True)
+    )
+    fake_final_grade_ids = (
+        FinalGrade.objects
+        .filter(course_run__course__program__id__in=fake_program_ids)
+        .values_list('id', flat=True)
+    )
+    financial_aid_ids = (
+        FinancialAid.objects
+        .filter(Q(user_id__in=fake_user_ids) | Q(tier_program__program__id__in=fake_program_ids))
+        .values_list('id', flat=True)
+    )
+    fin_aid_audit_models = [FinancialAidAudit, FinancialAidEmailAudit]
+    with mute_signals(post_delete):
+        with remove_delete_protection(*fin_aid_audit_models):
+            for audit_model in fin_aid_audit_models:
+                audit_model.objects.filter(financial_aid__id__in=financial_aid_ids).delete()
+        for model_cls in [CachedEnrollment, CachedCertificate, CachedCurrentGrade]:
+            model_cls.objects.filter(course_run__course__program__id__in=fake_program_ids).delete()
+        Tier.objects.filter(id__in=fake_tier_ids).delete()
+        FinalGrade.objects.filter(id__in=fake_final_grade_ids).delete()
+        Program.objects.filter(id__in=fake_program_ids).delete()
+        User.objects.filter(id__in=fake_user_ids).delete()
+
+
 class Command(BaseCommand):
     """
     Delete seeded data from the database, for development purposes.
@@ -46,36 +89,5 @@ class Command(BaseCommand):
     help = "Delete seeded data from the database, for development purposes."
 
     def handle(self, *args, **options):
-        # pylint: disable=bad-continuation
-        fake_program_ids = (
-            Program.objects
-            .filter(description__startswith=FAKE_PROGRAM_DESC_PREFIX)
-            .values_list('id', flat=True)
-        )
-        fake_user_ids = (
-            User.objects
-            .filter(username__startswith=FAKE_USER_USERNAME_PREFIX)
-            .values_list('id', flat=True)
-        )
-        fake_tier_ids = (
-            TierProgram.objects
-            .filter(program__id__in=fake_program_ids)
-            .values_list('tier__id', flat=True)
-        )
-        financial_aid_ids = (
-            FinancialAid.objects
-            .filter(Q(user_id__in=fake_user_ids) | Q(tier_program__program__id__in=fake_program_ids))
-            .values_list('id', flat=True)
-        )
-        audit_models_to_clear = [FinancialAidAudit, FinancialAidEmailAudit]
-
-        with mute_signals(post_delete):
-            with remove_delete_protection(*audit_models_to_clear):
-                for audit_model in audit_models_to_clear:
-                    audit_model.objects.filter(financial_aid__id__in=financial_aid_ids).delete()
-            for model_cls in [CachedEnrollment, CachedCertificate, CachedCurrentGrade]:
-                model_cls.objects.filter(course_run__course__program__id__in=fake_program_ids).delete()
-            Tier.objects.filter(id__in=fake_tier_ids).delete()
-            Program.objects.filter(id__in=fake_program_ids).delete()
-            User.objects.filter(id__in=fake_user_ids).delete()
+        unseed_db()
         recreate_index()

--- a/seed_data/management/commands/unseed_db_test.py
+++ b/seed_data/management/commands/unseed_db_test.py
@@ -1,0 +1,29 @@
+"""
+Tests for the unseed_db command
+"""
+from django.test import TestCase
+from django.contrib.auth.models import User
+from micromasters.factories import UserFactory
+from courses.factories import ProgramFactory
+from courses.models import Program
+from seed_data.management.commands.unseed_db import unseed_db
+from seed_data.management.commands import (
+    FAKE_USER_USERNAME_PREFIX,
+    FAKE_PROGRAM_DESC_PREFIX,
+)
+
+
+class UnseedDBTests(TestCase):
+    """Tests for the unseed_db_commond"""
+    def test_unseed_db(self):  # pylint: disable=no-self-use
+        """Test that unseed_db deletes seed data"""
+        for i in range(2):
+            ProgramFactory.create(description='{} test program {}'.format(FAKE_PROGRAM_DESC_PREFIX, i))
+            UserFactory.create(username='{}.test.user.{}'.format(FAKE_USER_USERNAME_PREFIX, i))
+        fake_program_qset = Program.objects.filter(description__startswith=FAKE_PROGRAM_DESC_PREFIX)
+        fake_user_qset = User.objects.filter(username__startswith=FAKE_USER_USERNAME_PREFIX)
+        assert fake_program_qset.count() == 2
+        assert fake_user_qset.count() == 2
+        unseed_db()
+        assert fake_program_qset.count() == 0
+        assert fake_user_qset.count() == 0


### PR DESCRIPTION
#### What are the relevant tickets?

No ticket

#### What's this PR do?

2 recent changes caused some problems for the `seed_db` command:

1. Omitting users with `filled_out=False` from search results (this exposed a minor bug in the script)
1. Final grade freezing

#### How should this be manually tested?

Unseed and re-seed the db with your user as the `staff-user` parameter (`seed_db --staff-user=YOUR_USERNAME`), and check out the /learners search results. All of the seed data should be there

#### Any background context you want to provide?

Details about the bugs being fixed:

- `Profile` deserialization wasn't properly setting `filled_out=True` for all of the test users
- The `FinalGrade` table needed to be cleared of fake course runs before the fake programs could be deleted