### PR TITLE
Fixed missing pagination in learner's search

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -36,6 +36,8 @@ import type { Email } from '../flow/emailTypes';
 import type { AvailableProgram } from '../flow/enrollmentTypes';
 import { EDUCATION_LEVELS } from '../constants';
 
+import PatchedPagination from './search/PatchedPagination';
+
 const makeCountryNameTranslations: () => Object = () => {
   let translations = {};
   for (let code of Object.keys(iso3166.data)) {
@@ -162,7 +164,7 @@ export default class LearnerSearch extends SearchkitComponent {
         <Cell col={2} />
         <Cell col={4} className="pagination-sort">
           <SortingSelector options={sortOptions} listComponent={CustomSortingSelect} />
-          <Pagination showText={false} listComponent={CustomPaginationDisplay} />
+          <PatchedPagination showText={false} listComponent={CustomPaginationDisplay} />
         </Cell>
         <Cell col={12} className="mm-filters">
           <SelectedFilters />

--- a/static/js/components/search/PatchedPagination.js
+++ b/static/js/components/search/PatchedPagination.js
@@ -1,0 +1,18 @@
+// @flow
+import _ from 'lodash';
+import { Pagination } from 'searchkit';
+
+// NOTE:
+// This is a hack to fix a bug we experienced with searchkit. The pagination control did
+// not appear for result sets that had multiple pages.
+// Issue: https://github.com/mitodl/micromasters/issues/2336
+// Source in searchkit: /src/components/search/pagination/src/Pagination.tsx#L79
+
+export default class PatchedPagination extends Pagination {
+  getTotalPages() {
+    return Math.ceil(
+      _.get(this.getResults(), "hits.total", 1) /
+      _.get(this.getQuery(), "query.size", 10)
+    );
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #2336 

#### What's this PR do?

Fixes missing pagination control. Details in warroom

#### Screenshots (if appropriate)

![ss 2017-01-12 at 12 48 05](https://cloud.githubusercontent.com/assets/14932219/21901576/50d1f394-d8c6-11e6-982e-e20dec83de82.png)

