### PR TITLE
fix program selection

### DIFF
--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -68,7 +68,15 @@ export default class PersonalTab extends React.Component {
     dispatch(setProfileStep(PERSONAL_STEP));
   }
 
-  onChange = (selection: Option): void => {
+  componentDidUpdate() {
+    const { currentProgramEnrollment, setProgram } = this.props;
+    const selectedProgram = this.getSelectedProgramId();
+    if ( currentProgramEnrollment && !selectedProgram ) {
+      setProgram(currentProgramEnrollment);
+    }
+  }
+
+  onProgramSelect = (selection: Option): void => {
     const {
       programs,
       setProgram,
@@ -91,7 +99,7 @@ export default class PersonalTab extends React.Component {
     return (
       <Select
         value={this.getSelectedProgramId()}
-        onChange={this.onChange}
+        onChange={this.onProgramSelect}
         clearable={false}
         className={`program-selectfield ${validationErrorSelector(errors, ['program'])}`}
         errorText={_.get(errors, "program")}

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -37,7 +37,6 @@ import {
   setNavDrawerOpen,
   clearUI,
   setPhotoDialogVisibility,
-  setProgram,
 } from '../actions/ui';
 import { validateProfileComplete } from '../lib/validation/profile';
 import { currentOrFirstIncompleteStep } from '../util/util';
@@ -108,17 +107,9 @@ class App extends React.Component {
     const {
       programs,
       dispatch,
-      location: { pathname },
-      currentProgramEnrollment,
-      ui: { selectedProgram },
     } = this.props;
     if (programs.getStatus === undefined && SETTINGS.user) {
-      dispatch(fetchProgramEnrollments()).then(({payload}) => {
-        if ( PROFILE_REGEX.test(pathname) && currentProgramEnrollment && !selectedProgram ) {
-          let selected = payload.find(program => program.id === currentProgramEnrollment.id);
-          dispatch(setProgram(selected));
-        }
-      });
+      dispatch(fetchProgramEnrollments());
     }
   }
 


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2347

#### What's this PR do?

This PR fixes a small UI bug with the program selector that we show on `/profile/personal`. 

Basically, if a user returns to `/profile/personal` to change something, and they have already enrolled in a program, we don't want the program selector to be empty. If the program selector is empty, when the user presses 'save' we will show a validation error - if the user is already enrolled in a program this is inappropriate.

I made a change in https://github.com/mitodl/micromasters/commit/72504a58efe6d679e3e3f69f7d76e5a67a83e2f4 that was supposed to address this. My earlier fix made sure that, after we fetch the program enrollments, we check if the user is on `/profile` and, if so, we dispatch the action to pre-set the user's first enrolled program, which would prevent the validation error from showing up.

There is a bug in this fix, though. In the case that the user had a validation error which would cause them to be redirected from `/dashboard` -> `/profile`, the request to fetch enrollment information could come back while the user was still on the dashboard. Then the `pathname` check would fail, and so the user would still see the validation error when they tried to save (yucky). This wasn't an issue if the user visited `/profile/personal` right away, because then the profile regex pathname check would pass.

Anyway, this logic shouldn't really be in `<App />` anyway, so I've moved it into the relevant component (`<PersonalTab />`). This should ensure that any time we render the personal tab we perform the same actions (to dispatch the `setProgram` action and ensure the user doesn't see a needless validation error).

#### How should this be manually tested?

Blank out a field on a user profile which already has program enrollments in the django shell. Then:

1. Visit `/dashboard` and confirm you get redirected to `/profile/personal` and, when you arrive, a program enrollment is already selected.

2. Visit `/profile/personal` directly, and confirm that a program enrollment is already selected.