### PR TITLE
Fix toast message loop

### DIFF
--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -100,31 +100,35 @@ class DashboardPage extends React.Component {
   }
 
   handleOrderSuccess = (course: Course): void => {
-    const { dispatch } = this.props;
+    const { dispatch, ui: { toastMessage } } = this.props;
     let firstRun: CourseRun = course.runs.length > 0 ? course.runs[0] : null;
 
-    if (firstRun && firstRun.status === STATUS_PAID_BUT_NOT_ENROLLED) {
-      dispatch(setToastMessage({
-        title: 'Course Enrollment',
-        message: `Something went wrong. You paid for this course '${course.title}' but are not enrolled.`,
-        icon: TOAST_FAILURE,
-      }));
-    } else {
-      dispatch(setToastMessage({
-        title: 'Order Complete!',
-        message: `You are now enrolled in ${course.title}`,
-        icon: TOAST_SUCCESS,
-      }));
+    if (_.isNil(toastMessage)) {
+      if (firstRun && firstRun.status === STATUS_PAID_BUT_NOT_ENROLLED) {
+        dispatch(setToastMessage({
+          title: 'Course Enrollment',
+          message: `Something went wrong. You paid for this course '${course.title}' but are not enrolled.`,
+          icon: TOAST_FAILURE,
+        }));
+      } else {
+        dispatch(setToastMessage({
+          title: 'Order Complete!',
+          message: `You are now enrolled in ${course.title}`,
+          icon: TOAST_SUCCESS,
+        }));
+      }
     }
     this.context.router.push('/dashboard/');
   };
 
   handleOrderCancellation = (): void => {
-    const { dispatch } = this.props;
-    dispatch(setToastMessage({
-      message: 'Order was cancelled',
-      icon: TOAST_FAILURE,
-    }));
+    const { dispatch, ui: { toastMessage } } = this.props;
+    if (_.isNil(toastMessage)) {
+      dispatch(setToastMessage({
+        message: 'Order was cancelled',
+        icon: TOAST_FAILURE,
+      }));
+    }
     this.context.router.push('/dashboard/');
   };
 

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -17,6 +17,7 @@ import * as actions from '../actions';
 import {
   SET_TOAST_MESSAGE,
   CLEAR_UI,
+  setToastMessage,
 } from '../actions/ui';
 import {
   SET_TIMEOUT_ACTIVE,
@@ -161,6 +162,37 @@ describe('DashboardPage', () => {
           title: "Order Complete!",
           message: `You are now enrolled in ${course.title}`,
           icon: TOAST_SUCCESS
+        });
+      });
+    });
+
+    describe('toast loop', () => {
+      it("doesn't have a toast message loop on success", () => {
+        let course = findCourse(course =>
+          course.runs.length > 0 &&
+          course.runs[0].status === STATUS_CURRENTLY_ENROLLED
+        );
+        let run = course.runs[0];
+        let encodedKey = encodeURIComponent(run.course_id);
+        const customMessage = {
+          "message": "Custom toast message was not replaced"
+        };
+        helper.store.dispatch(setToastMessage(customMessage));
+        return renderComponent(
+          `/dashboard?status=receipt&course_key=${encodedKey}`,
+          DASHBOARD_SUCCESS_ACTIONS
+        ).then(() => {
+          assert.deepEqual(helper.store.getState().ui.toastMessage, customMessage);
+        });
+      });
+
+      it("doesn't have a toast message loop on failure", () => {
+        const customMessage = {
+          "message": "Custom toast message was not replaced"
+        };
+        helper.store.dispatch(setToastMessage(customMessage));
+        return renderComponent('/dashboard?status=cancel', DASHBOARD_SUCCESS_ACTIONS).then(() => {
+          assert.deepEqual(helper.store.getState().ui.toastMessage, customMessage);
         });
       });
     });


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2359 

#### What's this PR do?
Fixes an infinite loop regarding toast messages. If a toast message is already present other messages will be ignored.

#### How should this be manually tested?
Go to the URL with `/dashboard/?status=receipt&course_key=course_key`, where `course_key` is the edX course key, encoded as a query parameter. The course key can refer to any run which is present in the dashboard API. You should see an order success toast message which goes away after 5 seconds. Also go to `/dashboard/?status=cancel` to verify that the cancellation message works too. If you go to these URLs when you're checked out on master you should get the toast loop which causes the browser to become unresponsive.
