### PR TITLE
scroll to error when profile page mounts (handle the redirect properly)

### DIFF
--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -129,17 +129,21 @@ class ProfileFormContainer extends React.Component {
         dispatch(clearProfileEdit(username));
       });
     } else {
-      // `setState` is being called here because we want to guarantee that
-      // the callback executes after the `dispatch` call above. A callback
-      // passed to `setState` executes when the component next re-renders.
-      this.setState({}, () => {
-        let invalidField = document.querySelector('.invalid-input');
-        if ( invalidField !== null ) {
-          invalidField.scrollIntoView();
-        }
-      });
+      this.scrollToError();
       return Promise.reject(errors);
     }
+  }
+
+  scrollToError () {
+    // `setState` is being called here because we want to guarantee that
+    // the callback executes on the next re-render. A callback
+    // passed to `setState` executes when the component next re-renders.
+    this.setState({}, () => {
+      let invalidField = document.querySelector('.invalid-input');
+      if ( invalidField !== null ) {
+        invalidField.scrollIntoView();
+      }
+    });
   }
 
   addProgramEnrollment = (programId: number): void => {

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -16,6 +16,10 @@ import {
 } from '../util/util';
 
 class ProfilePage extends ProfileFormContainer {
+  componentDidMount() {
+    this.scrollToError();
+  }
+
   componentDidUpdate() {
     const username = SETTINGS.user.username;
     const {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2376

#### What's this PR do?

Makes sure that we scroll to any existing validation errors when the `ProfilePage` component mounts.

#### How should this be manually tested?

Go into the django shell and delete a field on your profile. Then visit `/dashboard`. You should be redirected to the profile page, and the page should scroll to ensure you can see the error.