### PR TITLE
set the toast!

### DIFF
--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -133,6 +133,11 @@ class App extends React.Component {
       dispatch(startProfileEdit(SETTINGS.user.username));
       dispatch(updateValidationVisibility(username, ALL_ERRORS_VISIBLE));
       dispatch(updateProfileValidation(username, errors));
+      dispatch(setToastMessage({
+        title: "Profile",
+        message: "We need to know a little bit more about you. Please complete your profile.",
+        icon: TOAST_FAILURE
+      }));
       this.context.router.push(`/profile/${idealStep}`);
     }
   }

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -32,6 +32,7 @@ import {
   setNavDrawerOpen,
   SET_NAV_DRAWER_OPEN,
   SET_PHOTO_DIALOG_VISIBILITY,
+  SET_TOAST_MESSAGE,
 } from '../actions/ui';
 import * as uiActions from '../actions/ui';
 import { USER_PROFILE_RESPONSE } from '../test_constants';
@@ -49,6 +50,7 @@ const REDIRECT_ACTIONS = SUCCESS_ACTIONS.concat([
   UPDATE_PROFILE_VALIDATION,
   UPDATE_VALIDATION_VISIBILITY,
   SET_PROFILE_STEP,
+  SET_TOAST_MESSAGE,
 ]);
 
 describe('App', function() {


### PR DESCRIPTION
#### What are the relevant tickets?

#2379 

#### What's this PR do?

This displays a toast message when we're going to redirect the user to fill out a missing profile field.

#### How should this be manually tested?

Use the django shell to null out a profile field, and then visit `/dashboard`. You should see a message at the top of the page that describes what's going on.

#### Screenshots (if appropriate)

![toast](https://cloud.githubusercontent.com/assets/6207644/22082678/af145c42-dd96-11e6-8589-157c360c5c1c.png)
