### PR TITLE
Mocked indexing functions in most tests

### DIFF
--- a/backends/pipeline_api_test.py
+++ b/backends/pipeline_api_test.py
@@ -15,11 +15,11 @@ from roles.models import (
     Role,
     Staff,
 )
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
 # pylint: disable=no-self-use
-class EdxPipelineApiTest(ESTestCase):
+class EdxPipelineApiTest(MockedESTestCase):
     """
     Test class for APIs run during the Python Social Auth
     authentication pipeline.

--- a/backends/utils_test.py
+++ b/backends/utils_test.py
@@ -13,11 +13,11 @@ from requests.exceptions import HTTPError
 from backends import utils
 from backends.edxorg import EdxOrgOAuth2
 from profiles.factories import UserFactory
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 # pylint: disable=protected-access
 
 
-class RefreshTest(ESTestCase):
+class RefreshTest(MockedESTestCase):
     """Class to test refresh token"""
 
     @classmethod

--- a/cms/serializers_test.py
+++ b/cms/serializers_test.py
@@ -1,7 +1,7 @@
 """
 Tests for CMS serializers
 """
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 from cms.serializers import (
     FacultySerializer,
     RenditionSerializer,
@@ -12,7 +12,7 @@ from courses.factories import ProgramFactory, CourseFactory
 
 
 # pylint: disable=no-self-use
-class WagtailSerializerTests(ESTestCase):
+class WagtailSerializerTests(MockedESTestCase):
     """
     Tests for WagtailSerializer
     """

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -18,13 +18,13 @@ from courses.factories import (
 from courses.models import CourseRun
 from grades.models import CourseRunGradingStatus
 from grades.constants import FinalGradeStatus
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
 BASE_URL = "http://base.url/"
 
 
-class ProgramTests(ESTestCase):
+class ProgramTests(MockedESTestCase):
     """Tests for Program model"""
 
     def test_to_string(self):
@@ -42,7 +42,7 @@ def from_weeks(weeks, now=None):
     return now + timedelta(weeks=weeks)
 
 
-class CourseModelTests(ESTestCase):
+class CourseModelTests(MockedESTestCase):
     """Mixin for Course models"""
 
     @classmethod

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -17,11 +17,11 @@ from courses.serializers import (
 )
 from dashboard.models import ProgramEnrollment
 from profiles.factories import UserFactory
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
 # pylint: disable=no-self-use
-class CourseSerializerTests(ESTestCase):
+class CourseSerializerTests(MockedESTestCase):
     """
     Tests for CourseSerializer
     """
@@ -52,7 +52,7 @@ class CourseSerializerTests(ESTestCase):
         assert data['enrollment_text'] == course.enrollment_text
 
 
-class ProgramSerializerTests(ESTestCase):
+class ProgramSerializerTests(MockedESTestCase):
     """
     Tests for ProgramSerializer
     """

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -12,10 +12,10 @@ from courses.serializers import ProgramSerializer
 from dashboard.factories import ProgramEnrollmentFactory
 from dashboard.models import ProgramEnrollment
 from micromasters.factories import UserFactory
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
-class ProgramTests(ESTestCase):
+class ProgramTests(MockedESTestCase):
     """Tests for the Program API"""
     @classmethod
     def setUpTestData(cls):
@@ -46,7 +46,7 @@ class ProgramTests(ESTestCase):
         assert len(resp.json()) == 0
 
 
-class ProgramEnrollmentTests(ESTestCase, APITestCase):
+class ProgramEnrollmentTests(MockedESTestCase, APITestCase):
     """Tests for the ProgramEnrollment API"""
 
     @classmethod

--- a/dashboard/api_edx_cache_test.py
+++ b/dashboard/api_edx_cache_test.py
@@ -30,13 +30,13 @@ from dashboard.models import (
 )
 from micromasters.factories import UserFactory
 from micromasters.utils import load_json_from_file
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
 # pylint: disable=no-self-use
 
 
-class CachedEdxUserDataTests(ESTestCase):
+class CachedEdxUserDataTests(MockedESTestCase):
     """
     Tests for the CachedEdxUserData class
     """
@@ -101,7 +101,7 @@ class CachedEdxUserDataTests(ESTestCase):
         assert run_data.current_grade.course_id == self.p1_course_run_keys[0]
 
 
-class CachedEdxDataApiTests(ESTestCase):
+class CachedEdxDataApiTests(MockedESTestCase):
     """
     Tests for the CachedEdxDataApi class
     """

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -24,11 +24,11 @@ from grades.constants import FinalGradeStatus
 from grades.models import FinalGrade, CourseRunGradingStatus
 from micromasters.factories import UserFactory
 from micromasters.utils import is_subset_dict
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
 # pylint: disable=too-many-lines
-class StatusTest(ESTestCase):
+class StatusTest(MockedESTestCase):
     """
     Tests for the different status classes
     """
@@ -98,7 +98,7 @@ class StatusTest(ESTestCase):
         assert len(api.CourseFormatConditionalFields.get_assoc_field(api.CourseStatus.OFFERED)) == 2
 
 
-class CourseTests(ESTestCase):
+class CourseTests(MockedESTestCase):
     """Base class for APIs tests"""
 
     @classmethod
@@ -887,7 +887,7 @@ class InfoCourseTest(CourseTests):
         mock_format.assert_called_once_with(run1, api.CourseStatus.OFFERED, None, position=1)
 
 
-class UserProgramInfoIntegrationTest(ESTestCase):
+class UserProgramInfoIntegrationTest(MockedESTestCase):
     """Integration tests for get_user_program_info"""
     @classmethod
     def setUpTestData(cls):
@@ -992,7 +992,7 @@ class UserProgramInfoIntegrationTest(ESTestCase):
         assert all([run['status'] == api.CourseStatus.NOT_PASSED for run in result[0]['courses'][0]['runs']])
 
 
-class InfoProgramTest(ESTestCase):
+class InfoProgramTest(MockedESTestCase):
     """Tests for get_info_for_program"""
     @classmethod
     def setUpTestData(cls):

--- a/dashboard/factories_test.py
+++ b/dashboard/factories_test.py
@@ -2,16 +2,16 @@
 Tests for dashboard factories
 """
 from django.db.models.signals import post_save
-from django.test import TestCase
 from factory.django import mute_signals
 
-from ecommerce.models import Line, Order
-from micromasters.factories import UserFactory
 from courses.factories import ProgramFactory
 from dashboard.factories import CachedEnrollmentVerifiedFactory
+from ecommerce.models import Line, Order
+from micromasters.factories import UserFactory
+from search.base import MockedESTestCase
 
 
-class DashboardFactoryTests(TestCase):
+class DashboardFactoryTests(MockedESTestCase):
     """
     Tests for dashboard factories
     """

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -6,7 +6,6 @@ from datetime import datetime
 import ddt
 import faker
 import pytz
-from django.test import TestCase
 from django.db.models.signals import post_save
 from factory.django import mute_signals
 
@@ -41,10 +40,11 @@ from profiles.factories import (
 from profiles.models import Profile
 from roles.models import Role
 from roles.roles import Staff
+from search.base import MockedESTestCase
 
 
 @ddt.ddt
-class UserProgramSearchSerializerTests(TestCase):
+class UserProgramSearchSerializerTests(MockedESTestCase):
     """
     Test cases for the UserProgramSearchSerializer
     """
@@ -242,7 +242,7 @@ class UserProgramSearchSerializerTests(TestCase):
             }
 
 
-class UserProgramSearchSerializerEdxTests(TestCase):
+class UserProgramSearchSerializerEdxTests(MockedESTestCase):
     """
     Test cases for the serialization of a user's course enrollments for search results
     """
@@ -398,7 +398,7 @@ class UserProgramSearchSerializerEdxTests(TestCase):
         assert len(serialized_program_user['enrollments']) == serialized_count_before_addition
 
 
-class UserProgramSemesterSerializerEdxTests(TestCase):
+class UserProgramSemesterSerializerEdxTests(MockedESTestCase):
     """
     Test cases for the serialization of a user's semester enrollments for search results
     """

--- a/dashboard/tasks_test.py
+++ b/dashboard/tasks_test.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.test import TestCase
 
 from backends.edxorg import EdxOrgOAuth2
 from backends.utils import InvalidCredentialStored
@@ -16,11 +15,12 @@ from dashboard.tasks import (
     batch_update_user_data_subtasks
 )
 from micromasters.factories import UserFactory
+from search.base import MockedESTestCase
 
 # pylint: disable=no-self-use
 
 
-class TasksTest(TestCase):
+class TasksTest(MockedESTestCase):
     """
     Tests for periodic task which is for updating user data from edx.
     """

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -19,10 +19,10 @@ from financialaid.factories import TierProgramFactory, FinancialAidFactory
 from financialaid.constants import FinancialAidStatus
 from micromasters.factories import UserFactory
 from micromasters.utils import load_json_from_file
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
-class MMTrackTest(ESTestCase):
+class MMTrackTest(MockedESTestCase):
     """
     Tests for the MMTrack class
     """

--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -21,10 +21,10 @@ from dashboard.factories import UserCacheRefreshTimeFactory
 from dashboard.models import ProgramEnrollment, CachedEnrollment
 from micromasters.exceptions import PossiblyImproperlyConfigured
 from micromasters.factories import UserFactory
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
-class DashboardTest(APITestCase):
+class DashboardTest(MockedESTestCase, APITestCase):
     """
     Tests for dashboard Rest API
     """
@@ -81,7 +81,7 @@ class DashboardTest(APITestCase):
         assert [self.program_1.id, self.program_2.id] == [res_item['id'] for res_item in result.data]
 
 
-class DashboardTokensTest(APITestCase):
+class DashboardTokensTest(MockedESTestCase, APITestCase):
     """
     Tests for access tokens in dashboard Rest API
     """
@@ -171,7 +171,7 @@ class DashboardTokensTest(APITestCase):
         assert res.status_code == status.HTTP_400_BAD_REQUEST
 
 
-class UserCourseEnrollmentTest(ESTestCase, APITestCase):
+class UserCourseEnrollmentTest(MockedESTestCase, APITestCase):
     """
     Tests for the UserCourseEnrollment REST API
     """

--- a/ecommerce/admin_test.py
+++ b/ecommerce/admin_test.py
@@ -3,7 +3,7 @@ Tests for ecommerce admin interface
 """
 from unittest.mock import Mock
 
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 from ecommerce.admin import OrderAdmin
 from ecommerce.factories import OrderFactory
@@ -12,7 +12,7 @@ from profiles.factories import UserFactory
 
 
 # pylint: disable=no-self-use
-class AdminTest(ESTestCase):
+class AdminTest(MockedESTestCase):
     """
     Tests specifically whether new FinancialAidAudit object is created when the financial aid
     admin model is changed.

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -59,7 +59,7 @@ from ecommerce.models import (
 from financialaid.factories import FinancialAidFactory
 from financialaid.models import FinancialAidStatus
 from micromasters.factories import UserFactory
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
 # pylint: disable=no-self-use
@@ -84,7 +84,7 @@ def create_purchasable_course_run():
     return course_run, user
 
 
-class PurchasableTests(ESTestCase):
+class PurchasableTests(MockedESTestCase):
     """
     Tests for get_purchasable_courses and create_unfulfilled_order
     """
@@ -300,7 +300,7 @@ CYBERSOURCE_REFERENCE_PREFIX = 'prefix'
     CYBERSOURCE_PROFILE_ID=CYBERSOURCE_PROFILE_ID,
     CYBERSOURCE_SECURITY_KEY=CYBERSOURCE_SECURITY_KEY,
 )
-class CybersourceTests(ESTestCase):
+class CybersourceTests(MockedESTestCase):
     """
     Tests for generate_cybersource_sa_payload and generate_cybersource_sa_signature
     """
@@ -378,7 +378,7 @@ class CybersourceTests(ESTestCase):
 
 
 @override_settings(CYBERSOURCE_REFERENCE_PREFIX=CYBERSOURCE_REFERENCE_PREFIX)
-class ReferenceNumberTests(ESTestCase):
+class ReferenceNumberTests(MockedESTestCase):
     """
     Tests for get_order_by_reference_number and make_reference_id
     """
@@ -436,7 +436,7 @@ class ReferenceNumberTests(ESTestCase):
             assert ex.exception.args[0] == "Order {} is expected to have status 'created'".format(order.id)
 
 
-class EnrollUserTests(ESTestCase):
+class EnrollUserTests(MockedESTestCase):
     """
     Tests for enroll_user
     """
@@ -519,7 +519,7 @@ class EnrollUserTests(ESTestCase):
         assert enrollment.data == create_audit(self.line2.course_key).json
 
 
-class CouponTests(ESTestCase):
+class CouponTests(MockedESTestCase):
     """
     Tests for coupon-related API functions
     """
@@ -640,7 +640,7 @@ class CouponTests(ESTestCase):
         assert is_coupon_redeemable(coupon, self.user) is False
 
 
-class PickCouponTests(ESTestCase):
+class PickCouponTests(MockedESTestCase):
     """Tests for pick_coupon"""
 
     @classmethod

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -14,7 +14,6 @@ from django.core.exceptions import (
     ValidationError,
 )
 from django.test import (
-    TestCase,
     override_settings,
 )
 import pytz
@@ -36,11 +35,12 @@ from ecommerce.models import (
 from micromasters.utils import serialize_model_object
 from profiles.factories import UserFactory
 from profiles.models import Profile
+from search.base import MockedESTestCase
 
 
 # pylint: disable=no-self-use
 @override_settings(CYBERSOURCE_SECURITY_KEY='fake')
-class OrderTests(TestCase):
+class OrderTests(MockedESTestCase):
     """
     Tests for Order, Line, and Receipt
     """
@@ -81,7 +81,7 @@ class OrderTests(TestCase):
         assert lines_data == [serialize_model_object(line) for line in lines]
 
 
-class CoursePriceTests(TestCase):
+class CoursePriceTests(MockedESTestCase):
     """
     Tests for CoursePrice
     """
@@ -150,7 +150,7 @@ class CoursePriceTests(TestCase):
 
 
 @ddt.ddt
-class CouponTests(TestCase):
+class CouponTests(MockedESTestCase):
     """Tests for Coupon"""
 
     def test_validate_content_object(self):

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -33,7 +33,7 @@ from ecommerce.serializers import CouponSerializer
 from micromasters.factories import UserFactory
 from profiles.api import get_social_username
 from profiles.factories import ProfileFactory
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
 CYBERSOURCE_SECURE_ACCEPTANCE_URL = 'http://fake'
@@ -41,7 +41,7 @@ CYBERSOURCE_REFERENCE_PREFIX = 'fake'
 FAKE = faker.Factory.create()
 
 
-class CheckoutViewTests(ESTestCase):
+class CheckoutViewTests(MockedESTestCase):
     """
     Tests for /api/v0/checkout/
     """
@@ -196,7 +196,7 @@ class CheckoutViewTests(ESTestCase):
     CYBERSOURCE_REFERENCE_PREFIX=CYBERSOURCE_REFERENCE_PREFIX,
     ECOMMERCE_EMAIL='ecommerce@example.com'
 )
-class OrderFulfillmentViewTests(ESTestCase):
+class OrderFulfillmentViewTests(MockedESTestCase):
     """
     Tests for order fulfillment
     """
@@ -337,7 +337,7 @@ class OrderFulfillmentViewTests(ESTestCase):
 
 
 @ddt.ddt
-class CouponTests(ESTestCase):
+class CouponTests(MockedESTestCase):
     """
     Tests for list coupon view
     """

--- a/exams/signals_test.py
+++ b/exams/signals_test.py
@@ -2,7 +2,6 @@
 Tests for exam signals
 """
 from django.contrib.auth.models import User
-from django.test import TestCase
 from django.db.models.signals import post_save
 from factory.django import mute_signals
 
@@ -26,9 +25,10 @@ from grades.models import (
     FinalGradeStatus,
 )
 from profiles.factories import ProfileFactory
+from search.base import MockedESTestCase
 
 
-class ExamSignalsTest(TestCase):
+class ExamSignalsTest(MockedESTestCase):
     """
     Tests for exam signals
     """

--- a/financialaid/api_test.py
+++ b/financialaid/api_test.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 import ddt
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.signals import post_save
-from django.test import TestCase
 from factory.django import mute_signals
 import pytz
 
@@ -34,6 +33,7 @@ from financialaid.models import (
 from profiles.factories import ProfileFactory
 from roles.models import Role
 from roles.roles import Staff, Instructor
+from search.base import MockedESTestCase
 
 
 def create_program(create_tiers=True, past=False):
@@ -108,7 +108,7 @@ def create_enrolled_profile(program, role=None, **profile_kwargs):
     return profile
 
 
-class FinancialAidBaseTestCase(TestCase):
+class FinancialAidBaseTestCase(MockedESTestCase):
     """
     Base test case for financial aid test setup
     """
@@ -352,7 +352,7 @@ class CoursePriceAPITests(FinancialAidBaseTestCase):
         )
 
 
-class ExchangeRateAPITests(TestCase):
+class ExchangeRateAPITests(MockedESTestCase):
     """
     Tests for financial aid exchange rate api backend
     """

--- a/financialaid/models_test.py
+++ b/financialaid/models_test.py
@@ -16,10 +16,10 @@ from financialaid.models import (
 )
 from micromasters.utils import serialize_model_object
 from profiles.factories import ProfileFactory
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
-class FinancialAidModelsTests(ESTestCase):
+class FinancialAidModelsTests(MockedESTestCase):
     """
     Tests for financialaid models
     """

--- a/grades/api_test.py
+++ b/grades/api_test.py
@@ -24,13 +24,13 @@ from financialaid.factories import (
 from grades import api
 from grades.models import FinalGrade, FinalGradeStatus
 from micromasters.factories import UserFactory
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
 # pylint: disable=no-self-use, protected-access
 
 
-class GradeAPITests(ESTestCase):
+class GradeAPITests(MockedESTestCase):
     """
     Tests for final grades api
     """

--- a/grades/models_test.py
+++ b/grades/models_test.py
@@ -11,10 +11,10 @@ from grades.models import (
 )
 from grades.constants import FinalGradeStatus
 from micromasters.factories import UserFactory
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
-class FinalGradeModelTests(ESTestCase):
+class FinalGradeModelTests(MockedESTestCase):
     """
     Tests for final grade model
     """
@@ -52,7 +52,7 @@ class FinalGradeModelTests(ESTestCase):
                 )
 
 
-class CourseRunGradingStatusTests(ESTestCase):
+class CourseRunGradingStatusTests(MockedESTestCase):
     """
     Tests for CourseRunGradingStatus methods
     """

--- a/grades/tasks_test.py
+++ b/grades/tasks_test.py
@@ -16,13 +16,13 @@ from grades.models import (
     FinalGradeStatus,
 )
 from micromasters.factories import UserFactory
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
 # pylint: disable=no-self-use, protected-access
 
 
-class GradeTasksTests(ESTestCase):
+class GradeTasksTests(MockedESTestCase):
     """
     Tests for final grades tasks
     """

--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 from ddt import ddt, data
 from django.conf import settings
 from django.db.models.signals import post_save
-from django.test import TestCase, override_settings
+from django.test import override_settings
 from factory.django import mute_signals
 from requests import Response
 from rest_framework.status import HTTP_200_OK
@@ -20,14 +20,14 @@ from mail.api import MailgunClient
 from mail.models import FinancialAidEmailAudit
 from mail.views_test import mocked_json
 from profiles.factories import ProfileFactory
-
+from search.base import MockedESTestCase
 
 # pylint: disable=no-self-use
 
 
 @ddt
 @patch('requests.post')
-class MailAPITests(TestCase):
+class MailAPITests(MockedESTestCase):
     """
     Tests for the Mailgun client class
     """
@@ -165,7 +165,7 @@ class MailAPITests(TestCase):
 
 
 @patch('requests.post')
-class FinancialAidMailAPITests(TestCase):
+class FinancialAidMailAPITests(MockedESTestCase):
     """
     Tests for the Mailgun client class for financial aid
     """

--- a/mail/utils_test.py
+++ b/mail/utils_test.py
@@ -4,7 +4,6 @@ Tests for mail utils
 
 from unittest.mock import Mock
 from django.core.exceptions import ValidationError, ImproperlyConfigured
-from django.test import TestCase
 from requests import Response
 from rest_framework import status
 
@@ -22,9 +21,10 @@ from financialaid.constants import (
 from financialaid.factories import FinancialAidFactory
 from mail.utils import generate_financial_aid_email, generate_mailgun_response_json
 from mail.views_test import mocked_json
+from search.base import MockedESTestCase
 
 
-class MailUtilsTests(TestCase):
+class MailUtilsTests(MockedESTestCase):
     """
     Tests for mail utils
     """

--- a/micromasters/serializers_test.py
+++ b/micromasters/serializers_test.py
@@ -9,11 +9,11 @@ from factory.django import mute_signals
 from micromasters.serializers import UserSerializer, serialize_maybe_user
 from micromasters.factories import UserFactory
 from profiles.factories import ProfileFactory
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 # pylint: disable=no-self-use, missing-docstring
 
 
-class UserTests(ESTestCase):
+class UserTests(MockedESTestCase):
     """
     Tests for serializing users.
     """

--- a/micromasters/tests/test_settings.py
+++ b/micromasters/tests/test_settings.py
@@ -15,10 +15,10 @@ import semantic_version
 import yaml
 
 from micromasters.settings import load_fallback, get_var
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
-class TestSettings(ESTestCase):
+class TestSettings(MockedESTestCase):
     """Validate that settings work as expected."""
 
     def reload_settings(self):

--- a/micromasters/utils_test.py
+++ b/micromasters/utils_test.py
@@ -11,7 +11,6 @@ from django.template import RequestContext
 from django.test import (
     override_settings,
     RequestFactory,
-    TestCase,
 )
 import pytz
 from rest_framework import status
@@ -35,10 +34,11 @@ from micromasters.utils import (
     is_subset_dict,
     serialize_model_object,
 )
+from search.base import MockedESTestCase
 
 
 @ddt.ddt
-class ExceptionHandlerTest(TestCase):
+class ExceptionHandlerTest(MockedESTestCase):
     """
     Tests for the custom_exception_handler function.\
     This is a Django Rest framework custom exception handler
@@ -95,7 +95,7 @@ def format_as_iso8601(time):
 
 
 # pylint: disable=no-self-use
-class SerializerTests(TestCase):
+class SerializerTests(MockedESTestCase):
     """
     Tests for serialize_model
     """

--- a/profiles/api_test.py
+++ b/profiles/api_test.py
@@ -11,10 +11,10 @@ from testfixtures import LogCapture
 from backends.edxorg import EdxOrgOAuth2
 from profiles.api import get_social_username
 from profiles.factories import ProfileFactory
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
-class SocialTests(ESTestCase):
+class SocialTests(MockedESTestCase):
     """
     Tests for profile functions
     """

--- a/profiles/models_test.py
+++ b/profiles/models_test.py
@@ -16,10 +16,10 @@ from profiles.util import (
     profile_image_upload_uri_small,
     profile_image_upload_uri_medium,
 )
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
-class StudentIdTests(ESTestCase):
+class StudentIdTests(MockedESTestCase):
     """tests that student_id is updated properly"""
 
     def test_on_save(self):
@@ -62,7 +62,7 @@ class StudentIdTests(ESTestCase):
         assert profile.pretty_printed_student_id is ''
 
 
-class ImageTests(ESTestCase):
+class ImageTests(MockedESTestCase):
     """
     Tests for image fields
     """
@@ -85,7 +85,7 @@ class ImageTests(ESTestCase):
             )
 
 
-class ProfileAddressTests(ESTestCase):
+class ProfileAddressTests(MockedESTestCase):
     """
     Tests for splitting a user's address field
     """

--- a/profiles/permissions_test.py
+++ b/profiles/permissions_test.py
@@ -21,11 +21,11 @@ from roles.roles import (
     Instructor,
     Staff,
 )
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
 # pylint: disable=no-self-use
-class CanEditIfOwnerTests(ESTestCase):
+class CanEditIfOwnerTests(MockedESTestCase):
     """
     Tests for CanEditIfOwner permissions
     """
@@ -67,7 +67,7 @@ class CanEditIfOwnerTests(ESTestCase):
 
 
 # pylint: disable=no-self-use
-class CanSeeIfNotPrivateTests(ESTestCase):
+class CanSeeIfNotPrivateTests(MockedESTestCase):
     """
     Tests for CanSeeIfNotPrivate permissions
     """

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -36,11 +36,11 @@ from profiles.serializers import (
     ProfileSerializer,
     ProfileFilledOutSerializer,
 )
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
 # pylint: disable=no-self-use
-class ProfileTests(ESTestCase):
+class ProfileTests(MockedESTestCase):
     """
     Tests for profile serializers
     """
@@ -314,7 +314,7 @@ class ProfileTests(ESTestCase):
         assert employment3.profile.work_history.count() == 1
 
 
-class ProfileFilledOutTests(ESTestCase):
+class ProfileFilledOutTests(MockedESTestCase):
     """Tests for validating filled out profiles"""
 
     @classmethod
@@ -338,6 +338,7 @@ class ProfileFilledOutTests(ESTestCase):
         """
         Create a profile and social auth
         """
+        super().setUp()
         serializer = ProfileFilledOutSerializer(self.profile)
         self.data = serializer.data
         self.profile.refresh_from_db()

--- a/profiles/signals_test.py
+++ b/profiles/signals_test.py
@@ -5,11 +5,11 @@ Tests for signals
 from django.contrib.auth.models import User
 
 from profiles.models import Profile
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
 # pylint: disable=no-self-use
-class SignalProfilesTest(ESTestCase):
+class SignalProfilesTest(MockedESTestCase):
     """
     Test class for signals that creates a profile whenever a user is created
     """

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -51,7 +51,7 @@ from roles.roles import (
     Instructor,
     Staff,
 )
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
 def format_image_expectation(profile):
@@ -63,7 +63,7 @@ def format_image_expectation(profile):
     return profile
 
 
-class ProfileBaseTests(ESTestCase):
+class ProfileBaseTests(MockedESTestCase):
     """
     Tests for profile views
     """

--- a/roles/api_test.py
+++ b/roles/api_test.py
@@ -7,10 +7,10 @@ from micromasters.factories import UserFactory
 from roles.api import get_advance_searchable_programs
 from roles.models import Role
 from roles.roles import Staff
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
-class APITests(ESTestCase):
+class APITests(MockedESTestCase):
     """Tests for the roles apis"""
 
     @classmethod

--- a/roles/models_test.py
+++ b/roles/models_test.py
@@ -7,12 +7,12 @@ from courses.factories import ProgramFactory
 from micromasters.factories import UserFactory
 from roles import roles
 from roles.models import Role
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 # pylint: disable=no-self-use
 
 
-class MicroMastersRoleTest(ESTestCase):
+class MicroMastersRoleTest(MockedESTestCase):
     """
     Tests for the MicroMastersRole model
     """

--- a/roles/signals_test.py
+++ b/roles/signals_test.py
@@ -2,7 +2,6 @@
 Tests for signals
 """
 from django.db.models.signals import post_save
-from django.test import TestCase
 from factory.django import mute_signals
 from rolepermissions.verifications import (
     has_role,
@@ -13,11 +12,12 @@ from rolepermissions.verifications import (
 from courses.factories import ProgramFactory
 from roles.models import Role
 from micromasters.factories import UserFactory
-
+from search.base import MockedESTestCase
 
 # pylint: disable=no-self-use
 
-class SignalsTest(TestCase):
+
+class SignalsTest(MockedESTestCase):
     """
     Tests for signals triggered by the role assignment
     """

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -7,7 +7,6 @@ from elasticsearch_dsl import Search, Q
 from factory.django import mute_signals
 from django.test import (
     override_settings,
-    TestCase
 )
 from django.db.models.signals import post_save
 from django.conf import settings
@@ -23,6 +22,7 @@ from search.api import (
     prepare_and_execute_search,
     get_all_query_matching_emails,
 )
+from search.base import ESTestCase
 from search.indexing_api import (
     DOC_TYPES,
 )
@@ -52,7 +52,7 @@ def create_fake_search_result(hits_cls):
     return Mock(hits=hits_cls())
 
 
-class SearchAPITests(TestCase):  # pylint: disable=missing-docstring
+class SearchAPITests(ESTestCase):  # pylint: disable=missing-docstring
     @classmethod
     def setUpTestData(cls):
         with mute_signals(post_save):

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -317,6 +317,16 @@ def clear_index():
     create_mappings()
 
 
+def delete_index():
+    """
+    Drop the index without re-creating it
+    """
+    conn = get_conn(verify=False)
+    index_name = settings.ELASTICSEARCH_INDEX
+    if conn.indices.exists(index_name):
+        conn.indices.delete(index_name)
+
+
 def recreate_index():
     """
     Wipe and recreate index and mapping, and index all items.

--- a/search/signals.py
+++ b/search/signals.py
@@ -16,7 +16,6 @@ from search.tasks import index_users, remove_user
 
 log = logging.getLogger(__name__)
 
-
 # all the following signal handlers do basically the same.
 # The reason why there is one function per sender is
 # because each signal handler needs to be hooked to a single sender

--- a/seed_data/lib_test.py
+++ b/seed_data/lib_test.py
@@ -2,7 +2,6 @@
 Tests for library functions used by seed_db and alter_data commands
 """
 
-from django.test import TestCase
 from micromasters.factories import UserFactory
 from courses.factories import ProgramFactory, CourseFactory, CourseRunFactory
 from seed_data.lib import (
@@ -10,9 +9,10 @@ from seed_data.lib import (
     CourseRunFinder,
     UserFinder,
 )
+from search.base import MockedESTestCase
 
 
-class UserFinderTests(TestCase):
+class UserFinderTests(MockedESTestCase):
     """Test cases for UserFinder"""
     @classmethod
     def setUpTestData(cls):
@@ -42,7 +42,7 @@ class UserFinderTests(TestCase):
                 UserFinder.find(**param_set)
 
 
-class CourseFinderTests(TestCase):
+class CourseFinderTests(MockedESTestCase):
     """Test cases for CourseFinder"""
     def test_course_finder_success(self):  # pylint: disable=no-self-use
         """Tests that CourseFinder will return a desired course"""
@@ -60,7 +60,7 @@ class CourseFinderTests(TestCase):
         assert all([course == found_course for found_course in found_courses])
 
 
-class CourseRunFinderTests(TestCase):
+class CourseRunFinderTests(MockedESTestCase):
     """Test cases for CourseRunFinder"""
     def test_course_run_finder_success(self):  # pylint: disable=no-self-use
         """Tests that CourseRunFinder will return a desired course run"""

--- a/seed_data/management/commands/create_tiers_test.py
+++ b/seed_data/management/commands/create_tiers_test.py
@@ -5,10 +5,10 @@ from courses.factories import ProgramFactory
 from financialaid.factories import TierProgramFactory
 from financialaid.models import Tier, TierProgram
 from seed_data.management.commands import create_tiers
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 
 
-class CreateTiersTest(ESTestCase):
+class CreateTiersTest(MockedESTestCase):
     """
     Tests for create_tier management command
     """

--- a/seed_data/management/commands/seed_db_test.py
+++ b/seed_data/management/commands/seed_db_test.py
@@ -1,7 +1,6 @@
 """
 Tests for library functions used by seed_db and alter_data commands
 """
-from django.test import TestCase
 from django.db.models.signals import post_save
 from django.contrib.auth.models import User
 from factory.django import mute_signals
@@ -16,9 +15,10 @@ from seed_data.management.commands.seed_db import (
     deserialize_user_data,
     deserialize_course_data,
 )
+from search.base import MockedESTestCase
 
 
-class SeedDBUtilityTests(TestCase):
+class SeedDBUtilityTests(MockedESTestCase):
     """Tests for utility functions used by the seed_db command"""
     def test_compile_model_data(self):  # pylint: disable=no-self-use
         """Tests that compile_model_data creates a dict of model data"""
@@ -40,7 +40,7 @@ class SeedDBUtilityTests(TestCase):
         assert model_obj.id is not None
 
 
-class SeedDBDeserializationTests(TestCase):
+class SeedDBDeserializationTests(MockedESTestCase):
     """Tests for object deserializers used by the seed_db command"""
     USER_DATA = {
         "first_name": "Mario",

--- a/seed_data/management/commands/unseed_db_test.py
+++ b/seed_data/management/commands/unseed_db_test.py
@@ -1,7 +1,6 @@
 """
 Tests for the unseed_db command
 """
-from django.test import TestCase
 from django.contrib.auth.models import User
 from micromasters.factories import UserFactory
 from courses.factories import ProgramFactory
@@ -11,9 +10,10 @@ from seed_data.management.commands import (
     FAKE_USER_USERNAME_PREFIX,
     FAKE_PROGRAM_DESC_PREFIX,
 )
+from search.base import MockedESTestCase
 
 
-class UnseedDBTests(TestCase):
+class UnseedDBTests(MockedESTestCase):
     """Tests for the unseed_db_commond"""
     def test_unseed_db(self):  # pylint: disable=no-self-use
         """Test that unseed_db deletes seed data"""

--- a/ui/decorators_test.py
+++ b/ui/decorators_test.py
@@ -7,14 +7,14 @@ from factory.django import mute_signals
 
 from backends.edxorg import EdxOrgOAuth2
 from profiles.factories import ProfileFactory
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 from ui.url_utils import (
     DASHBOARD_URL,
     PROFILE_URL,
 )
 
 
-class DecoratorTests(ESTestCase):
+class DecoratorTests(MockedESTestCase):
     """
     Decorator tests for UI views
     """

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -22,11 +22,11 @@ from backends.edxorg import EdxOrgOAuth2
 from profiles.api import get_social_username
 from profiles.factories import ProfileFactory
 from roles.models import Role
-from search.base import ESTestCase
+from search.base import MockedESTestCase
 from ui.url_utils import DASHBOARD_URL, TERMS_OF_SERVICE_URL
 
 
-class ViewsTests(ESTestCase):
+class ViewsTests(MockedESTestCase):
     """
     Test that the views work as expected.
     """


### PR DESCRIPTION
#### What are the relevant tickets?
closes #2254 
#### What's this PR do?
This PR introduces a new version of `ESTestCase` where the indexing functions are mocked and renames the old `ESTestCase` to `ESTestCaseWithIndex`. 
`ESTestCaseWithIndex` now drops the index after every single Test Class, to avoid the side effect of having some test classes inheriting from `django.test.TestCase` and still working because the index was created by a previous test.
The only tests that use `ESTestCaseWithIndex` are the ones in the `search` app.

#### Where should the reviewer start?
`search.base`

#### How should this be manually tested?
Start your docker environment with a `docker-compose up` so you can monitor the logs.
In another shell you should run first 
`docker-compose run web tox -- -k 'not search'`
that will run all the tests but the ones in the `search` directory. You should not see any activity in the elasticsearch logs.

Then run `docker-compose run web tox -- search/*` to run the `search` tests and you should see activity in the elasticsearch logs.

Then run `docker-compose run web tox ` to run all the tests to see that everything works.

Finally, after running the tests before, you should modify a test class that uses `ESTestCase` to use `django.test.TestCase`. The tests should fail with an error related to the lack of the index.

#### What GIF best describes this PR or how it makes you feel?
![](http://24.media.tumblr.com/tumblr_ljpce0KKdD1qj3i5lo1_400.gif)