### PR TITLE
Added base reader class for Pearson TSV responses

### DIFF
--- a/exams/pearson/constants.py
+++ b/exams/pearson/constants.py
@@ -1,10 +1,6 @@
-"""
-Pearson-related constants
-"""
+"""Pearson-related constants"""
 
 # Pearson TSV constants
-PEARSON_CSV_DIALECT = 'pearsontsv'
-
 PEARSON_DATE_FORMAT = "%Y/%m/%d"
 PEARSON_DATETIME_FORMAT = "%Y/%m/%d %H:%M:%S"
 
@@ -16,3 +12,8 @@ PEARSON_UPLOAD_REQUIRED_SETTINGS = [
     "EXAMS_SFTP_PASSWORD",
     "EXAMS_SFTP_UPLOAD_DIR",
 ]
+
+# Common options for Pearson TSV readers/writers
+PEARSON_DIALECT_OPTIONS = {
+    'delimiter': '\t',
+}

--- a/exams/pearson/readers.py
+++ b/exams/pearson/readers.py
@@ -1,0 +1,110 @@
+"""
+Readers for data Pearson exports
+"""
+import csv
+from datetime import datetime
+
+import pytz
+
+from exams.pearson.constants import (
+    PEARSON_DATETIME_FORMAT,
+    PEARSON_DIALECT_OPTIONS,
+)
+from exams.pearson.exceptions import InvalidTsvRowException
+
+
+class BaseTSVReader(object):
+    """
+    Base class for TSV file readers
+
+    It handles the high-level mapping and reading of the data.
+    Subclasses specify how the fields map.
+    """
+    def __init__(self, field_mappers, read_as_cls):
+        """
+        Initializes a new TSV writer
+
+        The first value of each fields tuple is the destination field name.
+        The second value is a str property path (e.g. "one.two.three") or
+        a callable that when passed a row returns a computed field value
+
+        Usage:
+
+            # maps column 'ABC' to field 'abc' and casts it to an int
+            # maps column 'DEF' to field 'def' and leaves it as a str
+            # Initializes each row into the namedtuple
+            Record = namedtuple('Record', ['abc', 'def'])
+
+            BaseTSVReader([
+                ('ABC', 'abc', int),
+                ('DEF', 'def'),
+            ], Record)
+
+        Arguments:
+            field_mappers (list(tuple)): list of tuple field mappers
+            read_as_cld (cls): class to instantiate row data
+        """
+        self.read_as_cls = read_as_cls
+        self.field_mappers = field_mappers
+
+    @classmethod
+    def parse_datetime(cls, dt):
+        """
+        Parses a datetime from Pearson's format
+        """
+        return datetime.strptime(dt, PEARSON_DATETIME_FORMAT).replace(tzinfo=pytz.UTC)
+
+    @classmethod
+    def map_cell(cls, row, source, target, transformer=None):
+        """
+        Maps an individual cell of a row
+
+        Args:
+            row (dict): row data to map
+            source (str): source key to pull data from row
+            target (str): target property to put data into
+            transformer (callable): optional transformer callable, used to parse values
+        """
+        if source not in row:
+            raise InvalidTsvRowException("Column '{}' missing from row".format(source))
+
+        value = row[source]
+
+        if transformer is not None and callable(transformer):
+            value = transformer(value)
+
+        return (target, value)
+
+    def map_row(self, row):
+        """
+        Maps a row object to a row dict
+
+        Args:
+            row: the row to map to a dict
+
+        Returns:
+            object:
+                row mapped to an object using the field mappers and read_as_cls
+        """
+
+        kwargs = dict(self.map_cell(row, *mapper) for mapper in self.field_mappers)
+
+        return self.read_as_cls(**kwargs)
+
+    def read(self, tsv_file):
+        """
+        Reads the rows from the designated file using the configured fields.
+
+        Arguments:
+            tsv_file: a file-like object to read the data from
+
+        Returns:
+            records(list):
+                a list of the records cat to read_as_cls
+        """
+        file_reader = csv.DictReader(
+            tsv_file,
+            **PEARSON_DIALECT_OPTIONS
+        )
+
+        return [self.map_row(row) for row in file_reader]

--- a/exams/pearson/readers_test.py
+++ b/exams/pearson/readers_test.py
@@ -1,0 +1,106 @@
+
+"""
+Tests for TSV readers
+"""
+import io
+from collections import namedtuple
+from datetime import datetime
+from unittest import TestCase as UnitTestCase
+
+import pytz
+
+from exams.pearson.readers import (
+    BaseTSVReader,
+)
+from exams.pearson.exceptions import InvalidTsvRowException
+
+FIXED_DATETIME = datetime(2016, 5, 15, 15, 2, 55, tzinfo=pytz.UTC)
+
+
+class BaseTSVReaderTest(UnitTestCase):
+    """
+    Tests for Pearson reader code
+    """
+
+    def test_parse_datetime(self):  # pylint: disable=no-self-use
+        """
+        Tests that datetimes format correctly according to Pearson spec
+        """
+        assert BaseTSVReader.parse_datetime('2016/05/15 15:02:55') == FIXED_DATETIME
+
+    def test_reader_init(self):  # pylint: disable=no-self-use
+        """
+        Tests that the reader initializes correctly
+        """
+
+        PropTuple = namedtuple('PropTuple', ['prop2'])
+        fields = {
+            ('prop2', 'Prop2', int),
+        }
+
+        reader = BaseTSVReader(fields, PropTuple)
+
+        assert reader.field_mappers == fields
+        assert reader.read_as_cls == PropTuple
+
+    def test_map_row(self):  # pylint: disable=no-self-use
+        """
+        Tests map_row with a prefix set
+        """
+        PropTuple = namedtuple('PropTuple', ['prop2'])
+        reader = BaseTSVReader({
+            ('Prop2', 'prop2'),
+        }, PropTuple)
+
+        row = {
+            'Prop1': '12',
+            'Prop2': '145',
+        }
+
+        result = reader.map_row(row)
+        assert result == PropTuple(
+            prop2='145',
+        )
+        assert isinstance(result.prop2, str)
+
+        reader = BaseTSVReader({
+            ('Prop2', 'prop2', int),
+        }, PropTuple)
+
+        row = {
+            'Prop1': 12,
+            'Prop2': 145,
+        }
+
+        result = reader.map_row(row)
+        assert result == PropTuple(
+            prop2=145,
+        )
+        assert isinstance(result.prop2, int)
+
+        with self.assertRaises(InvalidTsvRowException):
+            reader.map_row({})
+
+    def test_read(self):  # pylint: disable=no-self-use
+        """
+        Tests the read method outputs correctly
+        """
+
+        PropTuple = namedtuple('PropTuple', ['prop1', 'prop2'])
+        tsv_file = io.StringIO(
+            "Prop1\tProp2\r\n"
+            "137\t145\r\n"
+        )
+        reader = BaseTSVReader([
+            ('Prop1', 'prop1'),
+            ('Prop2', 'prop2', int),
+        ], PropTuple)
+
+        row = PropTuple(
+            prop1='137',
+            prop2=145,
+        )
+
+        rows = reader.read(tsv_file)
+
+        assert rows == [row]

--- a/exams/pearson/writers.py
+++ b/exams/pearson/writers.py
@@ -10,19 +10,13 @@ import re
 import pycountry
 
 from exams.pearson.constants import (
-    PEARSON_CSV_DIALECT,
     PEARSON_DATE_FORMAT,
     PEARSON_DATETIME_FORMAT,
+    PEARSON_DIALECT_OPTIONS,
 )
 from exams.pearson.exceptions import (
     InvalidProfileDataException,
     InvalidTsvRowException,
-)
-
-# custom csv dialect for Pearson
-csv.register_dialect(
-    PEARSON_CSV_DIALECT,
-    delimiter='\t',
 )
 
 log = logging.getLogger(__name__)
@@ -110,8 +104,8 @@ class BaseTSVWriter(object):
         file_writer = csv.DictWriter(
             tsv_file,
             self.columns,
-            dialect=PEARSON_CSV_DIALECT,
             restval='',  # ensure we don't print 'None' into the file for optional fields
+            **PEARSON_DIALECT_OPTIONS
         )
 
         file_writer.writeheader()

--- a/exams/pearson/writers_test.py
+++ b/exams/pearson/writers_test.py
@@ -3,6 +3,7 @@ Tests for TSV writers
 """
 import io
 from datetime import date, datetime
+from unittest import TestCase as UnitTestCase
 from unittest.mock import (
     Mock,
     NonCallableMock,
@@ -28,12 +29,13 @@ from exams.pearson.writers import (
     BaseTSVWriter,
 )
 from profiles.factories import ProfileFactory
+from profiles.models import Profile
 
 FIXED_DATETIME = datetime(2016, 5, 15, 15, 2, 55, tzinfo=pytz.UTC)
 FIXED_DATE = date(2016, 5, 15)
 
 
-class TSVWriterTestCase(TestCase):
+class TSVWriterTestCase(UnitTestCase):
     """
     Base class for tests around TSVWriter implementations
     """
@@ -70,13 +72,12 @@ class BaseTSVWriterTest(TSVWriterTestCase):
         """
         Tests that _get_field_mapper handles input correctly
         """
-        with mute_signals(post_save):
-            profile = ProfileFactory.create()
+        profile = Profile(address='1 Main St')
 
-        assert BaseTSVWriter.get_field_mapper('address1')(profile) == profile.address1
+        assert BaseTSVWriter.get_field_mapper('address')(profile) == profile.address
 
         def get_addr1(profile):  # pylint: disable=missing-docstring
-            return profile.address1
+            return profile.address
 
         addr1_field_mapper = BaseTSVWriter.get_field_mapper(get_addr1)
 
@@ -186,7 +187,7 @@ class BaseTSVWriterTest(TSVWriterTestCase):
 
 
 @ddt.ddt
-class CDDWriterTest(TSVWriterTestCase):
+class CDDWriterTest(TSVWriterTestCase, TestCase):
     """
     Tests for CDDWriter
     """
@@ -276,7 +277,7 @@ class CDDWriterTest(TSVWriterTestCase):
         )
 
 
-class EADWriterTest(TSVWriterTestCase):
+class EADWriterTest(TSVWriterTestCase, TestCase):
     """
     Tests for EADWriter
     """


### PR DESCRIPTION
#### What are the relevant tickets?

None - this PR is for common work needed in #1797 and #2080.

#### What's this PR do?

This PR implements a base TSV file reader in the style of the writers implemented in `exams/pearson/writers.py`.

#### Where should the reviewer start?

exams/pearson/readers.py

#### How should this be manually tested?

There is no user-facing code for this yet, so passing tests are all we need here.

#### What GIF best describes this PR or how it makes you feel?
![Base Class](http://www.allyourbasearebelongtous.com/gif/allyourbase.gif)
