### PR TITLE
Redeem coupon during checkout

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -468,8 +468,8 @@ def calculate_run_price(course_run, user):
     enrollment = get_object_or_404(ProgramEnrollment, program=program, user=user)
     price = get_formatted_course_price(enrollment)['price']
     coupons = [coupon for coupon in pick_coupons(user) if coupon.program == program]
-    coupon = None
-    if len(coupons) > 0:
-        coupon = coupons[0]
-        price = calculate_coupon_price(coupon, price, course_run.edx_course_key)
+    if not coupons:
+        return price, None
+    coupon = coupons[0]
+    price = calculate_coupon_price(coupon, price, course_run.edx_course_key)
     return price, coupon

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -39,6 +39,7 @@ from ecommerce.models import (
     Coupon,
     Line,
     Order,
+    RedeemedCoupon,
 )
 from financialaid.api import get_formatted_course_price
 from financialaid.models import (
@@ -104,27 +105,25 @@ def get_purchasable_course_run(course_key, user):
 
 
 @transaction.atomic
-def create_unfulfilled_order(course_id, user):
+def create_unfulfilled_order(course_key, user):
     """
     Create a new Order which is not fulfilled for a purchasable course run. If course run is not purchasable,
     it raises an Http404
 
     Args:
-        course_id (str):
+        course_key (str):
             A course key
         user (User):
             The purchaser of the course run
     Returns:
         Order: A newly created Order for the CourseRun with the given course_id
     """
-    course_run = get_purchasable_course_run(course_id, user)
-    enrollment = get_object_or_404(ProgramEnrollment, program=course_run.course.program, user=user)
-    price_dict = get_formatted_course_price(enrollment)
-    price = price_dict['price']
+    course_run = get_purchasable_course_run(course_key, user)
+    price, coupon = calculate_run_price(course_run, user)
     if price < 0:
         log.error(
             "Price to be charged for course run %s for user %s is less than zero: %s",
-            course_id,
+            course_key,
             get_social_username(user),
             price,
         )
@@ -137,10 +136,12 @@ def create_unfulfilled_order(course_id, user):
     )
     Line.objects.create(
         order=order,
-        course_key=course_run.edx_course_key,
+        course_key=course_key,
         description='Seat for {}'.format(course_run.title),
         price=price,
     )
+    if coupon is not None:
+        RedeemedCoupon.objects.create(order=order, coupon=coupon)
     order.save_and_log(user)
     return order
 
@@ -397,7 +398,8 @@ def is_coupon_redeemable(coupon, user):
 
 def pick_coupons(user):
     """
-    Choose the coupon which would be used in redemptions by the user.
+    Choose the coupons which would be used in redemptions by the user. There should be at most one coupon
+    per program in the output.
 
     The heuristic is currently:
      - choose attached coupons over automatic coupons
@@ -407,7 +409,7 @@ def pick_coupons(user):
         user (django.contrib.auth.models.User): A user
 
     Returns:
-        Coupon: The coupon which will be used by the user when redeeming runs in a program
+        list of Coupon: The coupons which will be used by the user when redeeming runs in a program
     """
     sorted_attached_coupons = Coupon.user_coupon_qset(user).order_by('-usercoupon__updated_on')
     sorted_automatic_coupons = Coupon.is_automatic_qset().order_by('-updated_on')
@@ -426,3 +428,48 @@ def pick_coupons(user):
             program_ids.add(program_id)
 
     return coupons
+
+
+def calculate_coupon_price(coupon, price, course_key):
+    """
+    Calculate the adjusted price given a coupon
+
+    Args:
+        coupon (Coupon): A coupon
+        price (decimal.Decimal): A price
+        course_key (str): An edX course key
+
+    Returns:
+        decimal.Decimal: An adjusted price
+    """
+    if course_key not in coupon.course_keys:
+        return price
+    if coupon.amount_type == Coupon.PERCENT_DISCOUNT:
+        return price * (1-coupon.amount)
+    elif coupon.amount_type == Coupon.FIXED_DISCOUNT:
+        return price - coupon.amount
+    else:
+        return price
+
+
+def calculate_run_price(course_run, user):
+    """
+    Calculate the price of a course given the coupons and financial aid available to the user.
+
+    Args:
+        course_run (CourseRun): A course run
+        user (django.contrib.auth.models.User): A user
+
+    Returns:
+        (decimal.Decimal, Coupon):
+            The adjusted of the course, and the coupon used if any
+    """
+    program = course_run.course.program
+    enrollment = get_object_or_404(ProgramEnrollment, program=program, user=user)
+    price = get_formatted_course_price(enrollment)['price']
+    coupons = [coupon for coupon in pick_coupons(user) if coupon.program == program]
+    coupon = None
+    if len(coupons) > 0:
+        coupon = coupons[0]
+        price = calculate_coupon_price(coupon, price, course_run.edx_course_key)
+    return price, coupon

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -808,7 +808,7 @@ class PriceTests(MockedESTestCase):
         course_run, _ = create_purchasable_course_run()
         price = Decimal('0.3')
         coupon = CouponFactory.create(content_object=course_run)
-        # Use manager to get around validation
+        # Use manager to skip validation, which usually prevents setting content_object to an arbitrary object
         Coupon.objects.filter(id=coupon.id).update(amount_type='xyz')
         coupon.refresh_from_db()
         assert calculate_coupon_price(coupon, price, course_run.edx_course_key) == price

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -748,7 +748,8 @@ class PriceTests(MockedESTestCase):
         coupon = CouponFactory.create()
         UserCoupon.objects.create(coupon=coupon, user=user)
         discounted_price = 5
-        fa_price = get_formatted_course_price(course_run.course.program.programenrollment_set.first())['price']
+        program_enrollment = course_run.course.program.programenrollment_set.first()
+        fa_price = get_formatted_course_price(program_enrollment)['price']
         with patch('ecommerce.api.calculate_coupon_price', autospec=True) as _calculate_coupon_price:
             _calculate_coupon_price.return_value = discounted_price
             assert calculate_run_price(course_run, user) == (fa_price, None)
@@ -774,7 +775,8 @@ class PriceTests(MockedESTestCase):
         with patch('ecommerce.api.calculate_coupon_price', autospec=True) as _calculate_coupon_price:
             _calculate_coupon_price.return_value = discounted_price
             assert calculate_run_price(course_run, user) == (discounted_price, coupon)
-        fa_price = get_formatted_course_price(course_run.course.program.programenrollment_set.first())['price']
+        program_enrollment = course_run.course.program.programenrollment_set.first()
+        fa_price = get_formatted_course_price(program_enrollment)['price']
         _calculate_coupon_price.assert_called_with(coupon, fa_price, course_run.edx_course_key)
 
     def test_percent_discount(self):

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -203,10 +203,8 @@ class PurchasableTests(MockedESTestCase):
         """
         course_run, user = create_purchasable_course_run()
         ProgramEnrollment.objects.filter(program=course_run.course.program, user=user).delete()
-        try:
+        with self.assertRaises(Http404):
             create_unfulfilled_order(course_run.edx_course_key, user)
-        except Http404:
-            pass
 
     def test_already_purchased(self):
         """
@@ -762,10 +760,8 @@ class PriceTests(MockedESTestCase):
         """
         course_run, user = create_purchasable_course_run()
         ProgramEnrollment.objects.filter(program=course_run.course.program, user=user).delete()
-        try:
+        with self.assertRaises(Http404):
             calculate_run_price(course_run, user)
-        except Http404:
-            pass
 
     def test_calculate_run_price_coupon(self):
         """

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -736,7 +736,7 @@ class PickCouponTests(MockedESTestCase):
             _is_coupon_redeemable.assert_any_call(coupon, self.user)
 
 
-class PriceTests(ESTestCase):
+class PriceTests(MockedESTestCase):
     """
     Tests for calculating prices
     """

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -815,9 +815,10 @@ class PriceTests(MockedESTestCase):
 
     def test_coupon_allowed(self):
         """
-        Assert that the price is not adjusted if the coupon doesn't affect the course run
+        Assert that the price is not adjusted if the coupon is for a different program
         """
         course_run, _ = create_purchasable_course_run()
         price = Decimal('0.3')
         coupon = CouponFactory.create()
+        assert coupon.content_object != course_run
         assert calculate_coupon_price(coupon, price, course_run.edx_course_key) == price

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -3,6 +3,7 @@ Test for ecommerce functions
 """
 from base64 import b64encode
 from datetime import datetime
+from decimal import Decimal
 import hashlib
 import hmac
 from unittest.mock import (
@@ -12,6 +13,7 @@ from unittest.mock import (
 )
 from urllib.parse import quote_plus
 
+import ddt
 from django.core.exceptions import ImproperlyConfigured
 from django.http.response import Http404
 from django.test import override_settings
@@ -27,6 +29,8 @@ from dashboard.models import (
     ProgramEnrollment,
 )
 from ecommerce.api import (
+    calculate_coupon_price,
+    calculate_run_price,
     create_unfulfilled_order,
     enroll_user_on_success,
     generate_cybersource_sa_payload,
@@ -54,8 +58,10 @@ from ecommerce.models import (
     Coupon,
     Order,
     OrderAudit,
+    RedeemedCoupon,
     UserCoupon,
 )
+from financialaid.api import get_formatted_course_price
 from financialaid.factories import FinancialAidFactory
 from financialaid.models import FinancialAidStatus
 from micromasters.factories import UserFactory
@@ -84,6 +90,7 @@ def create_purchasable_course_run():
     return course_run, user
 
 
+@ddt.ddt
 class PurchasableTests(MockedESTestCase):
     """
     Tests for get_purchasable_courses and create_unfulfilled_order
@@ -238,32 +245,32 @@ class PurchasableTests(MockedESTestCase):
 
             assert Order.objects.count() == 0
 
-    def test_create_order(self):
+    @ddt.data(True, False)
+    def test_create_order(self, has_coupon):
         """
         Create Order from a purchasable course
         """
         course_run, user = create_purchasable_course_run()
         discounted_price = round(course_run.courseprice_set.get(is_valid=True).price/2, 2)
-        price_dict = {
-            "price": discounted_price
-        }
+        coupon = None
+        if has_coupon:
+            coupon = CouponFactory.create(content_object=course_run)
+        price_tuple = (discounted_price, coupon)
 
         with patch(
             'ecommerce.api.get_purchasable_course_run',
             autospec=True,
             return_value=course_run,
         ) as get_purchasable, patch(
-            'ecommerce.api.get_formatted_course_price',
+            'ecommerce.api.calculate_run_price',
             autospec=True,
-            return_value=price_dict,
-        ) as get_price:
+            return_value=price_tuple,
+        ) as _calculate_run_price:
             order = create_unfulfilled_order(course_run.edx_course_key, user)
         assert get_purchasable.call_count == 1
         assert get_purchasable.call_args[0] == (course_run.edx_course_key, user)
-        assert get_price.call_count == 1
-        assert get_price.call_args[0] == (
-            ProgramEnrollment.objects.get(user=user, program=course_run.course.program),
-        )
+        assert _calculate_run_price.call_count == 1
+        assert _calculate_run_price.call_args[0] == (course_run, user)
 
         assert Order.objects.count() == 1
         assert order.status == Order.CREATED
@@ -288,6 +295,14 @@ class PurchasableTests(MockedESTestCase):
         del data_before['modified_at']
         del dict_before['modified_at']
         assert data_before == dict_before
+
+        if has_coupon:
+            assert RedeemedCoupon.objects.count() == 1
+            redeemed_coupon = RedeemedCoupon.objects.first()
+            assert redeemed_coupon.order == order
+            assert redeemed_coupon.coupon == coupon
+        else:
+            assert RedeemedCoupon.objects.count() == 0
 
 CYBERSOURCE_ACCESS_KEY = 'access'
 CYBERSOURCE_PROFILE_ID = 'profile'
@@ -719,3 +734,92 @@ class PickCouponTests(MockedESTestCase):
             assert pick_coupons(self.user) == []
         for coupon in Coupon.objects.all().exclude(id=self.not_auto_or_attached_coupon.id):
             _is_coupon_redeemable.assert_any_call(coupon, self.user)
+
+
+class PriceTests(ESTestCase):
+    """
+    Tests for calculating prices
+    """
+
+    def test_calculate_run_price_no_coupons(self):
+        """
+        If there are no coupons for this program the price should be what get_formatted_course_price returned
+        """
+        course_run, user = create_purchasable_course_run()
+        # This coupon is for a different program
+        coupon = CouponFactory.create()
+        UserCoupon.objects.create(coupon=coupon, user=user)
+        discounted_price = 5
+        fa_price = get_formatted_course_price(course_run.course.program.programenrollment_set.first())['price']
+        with patch('ecommerce.api.calculate_coupon_price', autospec=True) as _calculate_coupon_price:
+            _calculate_coupon_price.return_value = discounted_price
+            assert calculate_run_price(course_run, user) == (fa_price, None)
+        assert _calculate_coupon_price.called is False
+
+    def test_no_program_enrollment(self):
+        """
+        If a user is not enrolled a 404 should be raised when getting the price
+        """
+        course_run, user = create_purchasable_course_run()
+        ProgramEnrollment.objects.filter(program=course_run.course.program, user=user).delete()
+        try:
+            calculate_run_price(course_run, user)
+        except Http404:
+            pass
+
+    def test_calculate_run_price_coupon(self):
+        """
+        If there is a coupon calculate_run_price should use calculate_coupon_price to get the discounted price
+        """
+        course_run, user = create_purchasable_course_run()
+        coupon = CouponFactory.create(content_object=course_run)
+        UserCoupon.objects.create(coupon=coupon, user=user)
+        discounted_price = 5
+        with patch('ecommerce.api.calculate_coupon_price', autospec=True) as _calculate_coupon_price:
+            _calculate_coupon_price.return_value = discounted_price
+            assert calculate_run_price(course_run, user) == (discounted_price, coupon)
+        fa_price = get_formatted_course_price(course_run.course.program.programenrollment_set.first())['price']
+        _calculate_coupon_price.assert_called_with(coupon, fa_price, course_run.edx_course_key)
+
+    def test_percent_discount(self):
+        """
+        Assert the price with a percent discount
+        """
+        course_run, _ = create_purchasable_course_run()
+        price = Decimal(5)
+        coupon = CouponFactory.create(
+            content_object=course_run, amount_type=Coupon.PERCENT_DISCOUNT, amount=Decimal("0.3")
+        )
+        assert calculate_coupon_price(coupon, price, course_run.edx_course_key) == price * (1 - coupon.amount)
+
+    def test_fixed_discount(self):
+        """
+        Assert the price with a fixed discount
+        """
+        course_run, _ = create_purchasable_course_run()
+        price = Decimal(5)
+        coupon = CouponFactory.create(
+            content_object=course_run, amount_type=Coupon.FIXED_DISCOUNT, amount=Decimal("1.5")
+        )
+        assert calculate_coupon_price(coupon, price, course_run.edx_course_key) == price - coupon.amount
+
+    def test_calculate_coupon_price(self):
+        """
+        Assert that the price is not adjusted if the amount type is unknown
+        """
+        course_run, _ = create_purchasable_course_run()
+        price = Decimal('0.3')
+        coupon = CouponFactory.create(content_object=course_run)
+        # Use manager to get around validation
+        Coupon.objects.filter(id=coupon.id).update(amount_type='xyz')
+        coupon.refresh_from_db()
+        assert calculate_coupon_price(coupon, price, course_run.edx_course_key) == price
+
+    def test_coupon_allowed(self):
+        """
+        Assert that the price is not adjusted if the coupon doesn't affect the course run
+        """
+        course_run, _ = create_purchasable_course_run()
+        price = Decimal('0.3')
+        coupon = CouponFactory.create()
+        assert calculate_coupon_price(coupon, price, course_run.edx_course_key) == price


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2325 

#### What's this PR do?
- Adds a `RedeemedCoupon` between an order and coupon when the order is created
- Lowers the price in the backend when order is fulfilled

The `RedeemedCoupon` should only prevent other users from purchasing when the order is fullfiled

#### How should this be manually tested?
 - Create a coupon locally in the Django shell using `CouponFactory`. Set `content_object` to a relevant run, course, or program which is available for purchase. Make sure that the discount will make the final price $0, to make it easier to test.
 - Attach your user to the coupon using the API. POST `/api/v0/coupons/<coupon.coupon_code>/users/` with `{username: 'your_edx_username'}` to do this, or just create `UserCoupon` in the Django shell
 - Purchase the course. The price will show up as the regular price of the course (inc financial aid), the coupon is not accounted for in the front end yet. The coupon should take effect when you actually make the purchase though. Because the coupon is for the full remaining price you should immediately be redirected to the dashboard with an order success message. 