### PR TITLE
Attach user to coupon

### DIFF
--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -224,6 +224,7 @@ class UserCouponsView(APIView):
             return Response(
                 status=HTTP_200_OK,
                 data={
-                    'message': 'Attached user to coupon successfully.'
+                    'message': 'Attached user to coupon successfully.',
+                    'coupon': CouponSerializer(coupon).data,
                 }
             )

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -416,7 +416,15 @@ class CouponTests(MockedESTestCase):
         user_coupon = UserCoupon.objects.get(user=self.user, coupon=self.coupon)
         assert user_coupon.updated_on > previous_modified
         assert resp.json() == {
-            'message': 'Attached user to coupon successfully.'
+            'message': 'Attached user to coupon successfully.',
+            'coupon': {
+                'amount': str(self.coupon.amount),
+                'amount_type': self.coupon.amount_type,
+                'content_type': self.coupon.content_type.model,
+                'coupon_code': self.coupon.coupon_code,
+                'object_id': self.coupon.object_id,
+                'program_id': self.coupon.program.id,
+            }
         }
 
     def test_empty_dict(self):

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "codecov": "^1.0.1",
     "css-loader": "^0.26.1",
     "currency-codes": "^1.1.2",
+    "decimal.js-light": "^2.2.0",
     "deep-freeze": "0.0.1",
     "detect-browser": "^1.5.0",
     "enzyme": "^2.4.1",

--- a/static/js/actions/coupons.js
+++ b/static/js/actions/coupons.js
@@ -3,7 +3,7 @@ import type { Dispatch } from 'redux';
 import { createAction } from 'redux-actions';
 
 import type { Dispatcher } from '../flow/reduxTypes';
-import type { Coupons } from '../flow/couponTypes';
+import type { Coupons, AttachCouponResponse } from '../flow/couponTypes';
 import * as api from '../lib/api';
 
 export const REQUEST_ATTACH_COUPON = 'REQUEST_ATTACH_COUPON';
@@ -19,13 +19,13 @@ export const attachCoupon = (code: string): Dispatcher<*> => {
   return (dispatch: Dispatch) => {
     dispatch(requestAttachCoupon());
     return api.attachCoupon(code).then(
-      () => {
-        dispatch(receiveAttachCouponSuccess());
-        return Promise.resolve();
+      (response: AttachCouponResponse) => {
+        dispatch(receiveAttachCouponSuccess(response));
+        return Promise.resolve(response);
       },
-      () => {
-        dispatch(receiveAttachCouponFailure());
-        return Promise.reject();
+      (response) => {
+        dispatch(receiveAttachCouponFailure(response));
+        return Promise.reject(response);
       });
   };
 };
@@ -56,3 +56,6 @@ export const fetchCoupons = (): Dispatcher<*> => {
 
 export const CLEAR_COUPONS = 'CLEAR_COUPONS';
 export const clearCoupons = createAction(CLEAR_COUPONS);
+
+export const SET_RECENTLY_ATTACHED_COUPON = 'SET_RECENTLY_ATTACHED_COUPON';
+export const setRecentlyAttachedCoupon = createAction(SET_RECENTLY_ATTACHED_COUPON);

--- a/static/js/actions/coupons_test.js
+++ b/static/js/actions/coupons_test.js
@@ -14,6 +14,8 @@ import {
   receiveFetchCouponsFailure,
   CLEAR_COUPONS,
   clearCoupons,
+  SET_RECENTLY_ATTACHED_COUPON,
+  setRecentlyAttachedCoupon,
 } from './coupons';
 import { assertCreatedActionHelper } from './util';
 
@@ -27,6 +29,7 @@ describe('coupons actions', () => {
       [receiveFetchCouponsSuccess, RECEIVE_FETCH_COUPONS_SUCCESS],
       [receiveFetchCouponsFailure, RECEIVE_FETCH_COUPONS_FAILURE],
       [clearCoupons, CLEAR_COUPONS],
+      [setRecentlyAttachedCoupon, SET_RECENTLY_ATTACHED_COUPON],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -105,6 +105,9 @@ export const setConfirmSkipDialogVisibility = createAction(SET_CONFIRM_SKIP_DIAL
 export const SET_DOCS_INSTRUCTIONS_VISIBILITY = 'SET_DOCS_INSTRUCTIONS_VISIBILITY';
 export const setDocsInstructionsVisibility = createAction(SET_DOCS_INSTRUCTIONS_VISIBILITY);
 
+export const SET_COUPON_NOTIFICATION_VISIBILITY = 'SET_COUPON_NOTIFICATION_VISIBILITY';
+export const setCouponNotificationVisibility = createAction(SET_COUPON_NOTIFICATION_VISIBILITY);
+
 export const SET_NAV_DRAWER_OPEN = 'SET_NAV_DRAWER_OPEN';
 export const setNavDrawerOpen = createAction(SET_NAV_DRAWER_OPEN);
 

--- a/static/js/actions/ui_test.js
+++ b/static/js/actions/ui_test.js
@@ -27,6 +27,7 @@ import {
   SET_PROGRAM,
   SET_CONFIRM_SKIP_DIALOG_VISIBILITY,
   SET_DOCS_INSTRUCTIONS_VISIBILITY,
+  SET_COUPON_NOTIFICATION_VISIBILITY,
   SET_NAV_DRAWER_OPEN,
   SET_USER_CHIP_VISIBILITY,
 
@@ -58,6 +59,7 @@ import {
   setProgram,
   setConfirmSkipDialogVisibility,
   setDocsInstructionsVisibility,
+  setCouponNotificationVisibility,
   setNavDrawerOpen,
   setUserChipVisibility,
 } from '../actions/ui';
@@ -93,6 +95,7 @@ describe('generated UI action helpers', () => {
       [setProgram, SET_PROGRAM],
       [setConfirmSkipDialogVisibility, SET_CONFIRM_SKIP_DIALOG_VISIBILITY],
       [setDocsInstructionsVisibility, SET_DOCS_INSTRUCTIONS_VISIBILITY],
+      [setCouponNotificationVisibility, SET_COUPON_NOTIFICATION_VISIBILITY],
       [setWorkHistoryAnswer, SET_WORK_HISTORY_ANSWER],
       [setNavDrawerOpen, SET_NAV_DRAWER_OPEN],
       [setUserChipVisibility, SET_USER_CHIP_VISIBILITY],

--- a/static/js/components/CouponNotificationDialog.js
+++ b/static/js/components/CouponNotificationDialog.js
@@ -1,0 +1,102 @@
+// @flow
+import React from 'react';
+import Dialog from 'material-ui/Dialog';
+import Button from 'react-mdl/lib/Button';
+import {
+  COUPON_CONTENT_TYPE_PROGRAM,
+  COUPON_AMOUNT_TYPE_FIXED_DISCOUNT,
+  COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT,
+} from '../constants';
+import type { Coupon } from '../flow/couponTypes';
+import type { AvailableProgram } from '../flow/enrollmentTypes';
+import type { Course } from '../flow/programTypes';
+
+type CouponNotification = {
+  coupon:               Coupon,
+  couponProgram:        ?AvailableProgram,
+  couponCourse:         ?Course,
+  open:                 boolean,
+  setDialogVisibility:  (v: boolean) => void,
+};
+
+const CouponNotificationDialog = (
+  { coupon, couponProgram, couponCourse, open, setDialogVisibility }: CouponNotification
+) => {
+  const {
+    amount,
+    amount_type: amountType,
+    content_type: contentType,
+    program_id: programId,
+    object_id: objectId,
+  } = coupon;
+  let programName;
+  if ( couponProgram ) {
+    programName = `the ${couponProgram.title} MicroMasters program`;
+  } else {
+    programName = `program ID ${programId}`;
+  }
+
+  let title, message;
+  if ( contentType === COUPON_CONTENT_TYPE_PROGRAM ) {
+    if ( amountType === COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT ) {
+      title = `Coupon applied: ${amount.times(100)}% off each course!`;
+      message = <p>
+        This coupon gives <strong>a discount
+        of { amount.times(100).toString() }% off</strong> the price
+        of <strong>each</strong> course in { programName }.
+      </p>;
+    } else if ( amountType === COUPON_AMOUNT_TYPE_FIXED_DISCOUNT ) {
+      title = `Coupon applied: $${amount} off each course!`;
+      message = <p>
+        This coupon gives <strong>a discount
+        of ${ amount.toString() } off</strong> the price
+        of <strong>each</strong> course in { programName }.
+      </p>;
+    }
+  } else {
+    let courseName;
+    if ( couponCourse ) {
+      courseName = `${couponCourse.title} in ${programName}`;
+    } else {
+      courseName = `course ID ${objectId} in ${programName}`;
+    }
+    if ( amountType === COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT ) {
+      title = `Coupon applied: ${amount.times(100)}% off!`;
+      message = <p>
+        This coupon gives <strong>a discount
+        of { amount.times(100).toString() }% off</strong> the price
+        of { courseName }.
+      </p>;
+    } else if ( amountType === COUPON_AMOUNT_TYPE_FIXED_DISCOUNT ) {
+      title = `Coupon applied: $${amount} off!`;
+      message = <p>
+        This coupon gives <strong>a discount
+        of ${ amount.toString() } off</strong> the price
+        of { courseName }.
+      </p>;
+    }
+  }
+
+  const okButton = <Button
+    type='ok'
+    key='ok'
+    className="primary-button ok-button"
+    onClick={() => setDialogVisibility(false)}>
+    OK
+  </Button>;
+
+  return <Dialog
+    title={title}
+    titleClassName="dialog-title"
+    contentClassName="dialog coupon-notification-dialog"
+    className="coupon-notification-dialog-wrapper"
+    actions={okButton}
+    open={open}
+    onRequestClose={() => setDialogVisibility(false)}
+  >
+    {message}
+    <p>The discount will be automatically applied when you enroll.</p>
+  </Dialog>;
+};
+
+export default CouponNotificationDialog;

--- a/static/js/components/CouponNotificationDialog.js
+++ b/static/js/components/CouponNotificationDialog.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import Button from 'react-mdl/lib/Button';
+
+import { formatPrice, formatPercent } from '../util/util';
 import {
   COUPON_CONTENT_TYPE_PROGRAM,
   COUPON_AMOUNT_TYPE_FIXED_DISCOUNT,
@@ -39,10 +41,10 @@ const CouponNotificationDialog = (
   let title, message;
   if ( contentType === COUPON_CONTENT_TYPE_PROGRAM ) {
     if ( amountType === COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT ) {
-      title = `Coupon applied: ${amount.times(100)}% off each course!`;
+      title = `Coupon applied: ${amount.times(100).toDecimalPlaces(0).toString()}% off each course!`;
       message = <p>
         This coupon gives <strong>a discount
-        of { amount.times(100).toString() }% off</strong> the price
+        of { amount.times(100).toDecimalPlaces(0).toString() }% off</strong> the price
         of <strong>each</strong> course in { programName }.
       </p>;
     } else if ( amountType === COUPON_AMOUNT_TYPE_FIXED_DISCOUNT ) {

--- a/static/js/components/CouponNotificationDialog.js
+++ b/static/js/components/CouponNotificationDialog.js
@@ -3,7 +3,6 @@ import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import Button from 'react-mdl/lib/Button';
 
-import { formatPrice, formatPercent } from '../util/util';
 import {
   COUPON_CONTENT_TYPE_PROGRAM,
   COUPON_AMOUNT_TYPE_FIXED_DISCOUNT,

--- a/static/js/components/CouponNotificationDialog.js
+++ b/static/js/components/CouponNotificationDialog.js
@@ -5,6 +5,7 @@ import Button from 'react-mdl/lib/Button';
 
 import {
   COUPON_CONTENT_TYPE_PROGRAM,
+  COUPON_CONTENT_TYPE_COURSE,
   COUPON_AMOUNT_TYPE_FIXED_DISCOUNT,
   COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT,
 } from '../constants';
@@ -54,7 +55,7 @@ const CouponNotificationDialog = (
         of <strong>each</strong> course in { programName }.
       </p>;
     }
-  } else {
+  } else if (contentType === COUPON_CONTENT_TYPE_COURSE) {
     let courseName;
     if ( couponCourse ) {
       courseName = `${couponCourse.title} in ${programName}`;

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -148,11 +148,11 @@ describe("CouponNotificationDialog", () => {
   });
 
   it('has an OK button', () => {
-    const callback = sandbox.spy();
+    const callback = sandbox.stub();
     const div = renderDialog(COUPON_PERCENT, PROGRAM, null, true, callback);
     const buttonEl = div.querySelector("button.primary-button");
     assert.equal(buttonEl.textContent, "OK");
     TestUtils.Simulate.click(buttonEl);
-    assert(callback.called);
+    assert.isTrue(callback.calledWith(false));
   });
 });

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -32,7 +32,7 @@ const COUPON_PERCENT: Coupon = {
   coupon_code: "percent",
   content_type: COUPON_CONTENT_TYPE_PROGRAM,
   amount_type: COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT,
-  amount: new Decimal('0.55'),
+  amount: new Decimal('0.5543'),
   program_id: 1,
   object_id: 1,
 };

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -62,12 +62,21 @@ const PROGRAM: AvailableProgram = {
 
 
 describe("CouponNotificationDialog", () => {
+  let sandbox;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   const renderDialog = (
     coupon: Coupon,
     couponProgram: ?AvailableProgram = null,
     couponCourse: ?Course = null,
     open = true,
-    setDialogVisibility = (v) => {}, // eslint-disable-line no-unused-vars
+    setDialogVisibility = () => {},
   ) => {
     mount(
       <MuiThemeProvider muiTheme={getMuiTheme()}>
@@ -84,10 +93,10 @@ describe("CouponNotificationDialog", () => {
   };
 
   it('renders with a fixed coupon', () => {
-    const wrapper = renderDialog(COUPON_FIXED, PROGRAM);
-    const titleEl = wrapper.querySelector(".dialog-title");
+    const div = renderDialog(COUPON_FIXED, PROGRAM);
+    const titleEl = div.querySelector(".dialog-title");
     assert.equal(titleEl.textContent, "Coupon applied: $123.45 off each course!");
-    const messageEl = wrapper.querySelector("p:first-child");
+    const messageEl = div.querySelector("p:first-child");
     assert.equal(
       messageEl.textContent,
       "This coupon gives a discount of $123.45 off the price of each course in the Awesomesauce MicroMasters program."
@@ -95,10 +104,10 @@ describe("CouponNotificationDialog", () => {
   });
 
   it('renders with a percentage coupon', () => {
-    const wrapper = renderDialog(COUPON_PERCENT, PROGRAM);
-    const titleEl = wrapper.querySelector(".dialog-title");
+    const div = renderDialog(COUPON_PERCENT, PROGRAM);
+    const titleEl = div.querySelector(".dialog-title");
     assert.equal(titleEl.textContent, "Coupon applied: 55% off each course!");
-    const messageEl = wrapper.querySelector("p:first-child");
+    const messageEl = div.querySelector("p:first-child");
     assert.equal(
       messageEl.textContent,
       "This coupon gives a discount of 55% off the price of each course in the Awesomesauce MicroMasters program."
@@ -106,10 +115,10 @@ describe("CouponNotificationDialog", () => {
   });
 
   it('falls back on program ID when program is not present', () => {
-    const wrapper = renderDialog(COUPON_PERCENT);
-    const titleEl = wrapper.querySelector(".dialog-title");
+    const div = renderDialog(COUPON_PERCENT);
+    const titleEl = div.querySelector(".dialog-title");
     assert.equal(titleEl.textContent, "Coupon applied: 55% off each course!");
-    const messageEl = wrapper.querySelector("p:first-child");
+    const messageEl = div.querySelector("p:first-child");
     assert.equal(
       messageEl.textContent,
       "This coupon gives a discount of 55% off the price of each course in program ID 1."
@@ -117,10 +126,10 @@ describe("CouponNotificationDialog", () => {
   });
 
   it('renders with a course coupon', () => {
-    const wrapper = renderDialog(COUPON_COURSE, PROGRAM, COURSE);
-    const titleEl = wrapper.querySelector(".dialog-title");
+    const div = renderDialog(COUPON_COURSE, PROGRAM, COURSE);
+    const titleEl = div.querySelector(".dialog-title");
     assert.equal(titleEl.textContent, "Coupon applied: 100% off!");
-    const messageEl = wrapper.querySelector("p:first-child");
+    const messageEl = div.querySelector("p:first-child");
     assert.equal(
       messageEl.textContent,
       "This coupon gives a discount of 100% off the price of Horse in the Awesomesauce MicroMasters program."
@@ -128,10 +137,10 @@ describe("CouponNotificationDialog", () => {
   });
 
   it('falls back on the course ID when course is not present', () => {
-    const wrapper = renderDialog(COUPON_COURSE, PROGRAM);
-    const titleEl = wrapper.querySelector(".dialog-title");
+    const div = renderDialog(COUPON_COURSE, PROGRAM);
+    const titleEl = div.querySelector(".dialog-title");
     assert.equal(titleEl.textContent, "Coupon applied: 100% off!");
-    const messageEl = wrapper.querySelector("p:first-child");
+    const messageEl = div.querySelector("p:first-child");
     assert.equal(
       messageEl.textContent,
       "This coupon gives a discount of 100% off the price of course ID 2 in the Awesomesauce MicroMasters program."
@@ -139,9 +148,9 @@ describe("CouponNotificationDialog", () => {
   });
 
   it('has an OK button', () => {
-    const callback = sinon.spy();
-    const wrapper = renderDialog(COUPON_PERCENT, PROGRAM, null, true, callback);
-    const buttonEl = wrapper.querySelector("button.primary-button");
+    const callback = sandbox.spy();
+    const div = renderDialog(COUPON_PERCENT, PROGRAM, null, true, callback);
+    const buttonEl = div.querySelector("button.primary-button");
     assert.equal(buttonEl.textContent, "OK");
     TestUtils.Simulate.click(buttonEl);
     assert(callback.called);

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -1,0 +1,149 @@
+// @flow
+import React from 'react';
+import Decimal from 'decimal.js-light';
+import { mount } from 'enzyme';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import TestUtils from 'react-addons-test-utils';
+
+import {
+  COUPON_CONTENT_TYPE_COURSE,
+  COUPON_CONTENT_TYPE_PROGRAM,
+  COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT,
+  COUPON_AMOUNT_TYPE_FIXED_DISCOUNT,
+} from '../constants';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import CouponNotificationDialog from './CouponNotificationDialog';
+import type { Coupon } from '../flow/couponTypes';
+import type { AvailableProgram } from '../flow/enrollmentTypes';
+import type { Course } from '../flow/programTypes';
+
+const COUPON_FIXED: Coupon = {
+  coupon_code: "fixed",
+  content_type: COUPON_CONTENT_TYPE_PROGRAM,
+  amount_type: COUPON_AMOUNT_TYPE_FIXED_DISCOUNT,
+  amount: new Decimal('123.45'),
+  program_id: 1,
+  object_id: 1,
+};
+
+const COUPON_PERCENT: Coupon = {
+  coupon_code: "percent",
+  content_type: COUPON_CONTENT_TYPE_PROGRAM,
+  amount_type: COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT,
+  amount: new Decimal('0.55'),
+  program_id: 1,
+  object_id: 1,
+};
+
+const COUPON_COURSE: Coupon = {
+  coupon_code: "course",
+  content_type: COUPON_CONTENT_TYPE_COURSE,
+  amount_type: COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT,
+  amount: new Decimal('1'),
+  program_id: 1,
+  object_id: 2,
+};
+
+const COURSE: Course = {
+  id: 2,
+  title: "Horse",
+  position_in_program: 1,
+  runs: []
+};
+
+const PROGRAM: AvailableProgram = {
+  id: 1,
+  title: "Awesomesauce",
+  enrolled: true,
+  programpage_url: null,
+};
+
+
+describe("CouponNotificationDialog", () => {
+  const renderDialog = (
+    coupon: Coupon,
+    couponProgram: ?AvailableProgram = null,
+    couponCourse: ?Course = null,
+    open = true,
+    setDialogVisibility = (v) => {}, // eslint-disable-line no-unused-vars
+  ) => {
+    mount(
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <CouponNotificationDialog
+          coupon={coupon}
+          couponProgram={couponProgram}
+          couponCourse={couponCourse}
+          open={open}
+          setDialogVisibility={setDialogVisibility}
+        />
+      </MuiThemeProvider>
+    );
+    return document.querySelector('.coupon-notification-dialog');
+  };
+
+  it('renders with a fixed coupon', () => {
+    const wrapper = renderDialog(COUPON_FIXED, PROGRAM);
+    const titleEl = wrapper.querySelector(".dialog-title");
+    assert.equal(titleEl.textContent, "Coupon applied: $123.45 off each course!");
+    const messageEl = wrapper.querySelector("p:first-child");
+    assert.equal(
+      messageEl.textContent,
+      "This coupon gives a discount of $123.45 off the price of each course in the Awesomesauce MicroMasters program."
+    );
+  });
+
+  it('renders with a percentage coupon', () => {
+    const wrapper = renderDialog(COUPON_PERCENT, PROGRAM);
+    const titleEl = wrapper.querySelector(".dialog-title");
+    assert.equal(titleEl.textContent, "Coupon applied: 55% off each course!");
+    const messageEl = wrapper.querySelector("p:first-child");
+    assert.equal(
+      messageEl.textContent,
+      "This coupon gives a discount of 55% off the price of each course in the Awesomesauce MicroMasters program."
+    );
+  });
+
+  it('falls back on program ID when program is not present', () => {
+    const wrapper = renderDialog(COUPON_PERCENT);
+    const titleEl = wrapper.querySelector(".dialog-title");
+    assert.equal(titleEl.textContent, "Coupon applied: 55% off each course!");
+    const messageEl = wrapper.querySelector("p:first-child");
+    assert.equal(
+      messageEl.textContent,
+      "This coupon gives a discount of 55% off the price of each course in program ID 1."
+    );
+  });
+
+  it('renders with a course coupon', () => {
+    const wrapper = renderDialog(COUPON_COURSE, PROGRAM, COURSE);
+    const titleEl = wrapper.querySelector(".dialog-title");
+    assert.equal(titleEl.textContent, "Coupon applied: 100% off!");
+    const messageEl = wrapper.querySelector("p:first-child");
+    assert.equal(
+      messageEl.textContent,
+      "This coupon gives a discount of 100% off the price of Horse in the Awesomesauce MicroMasters program."
+    );
+  });
+
+  it('falls back on the course ID when course is not present', () => {
+    const wrapper = renderDialog(COUPON_COURSE, PROGRAM);
+    const titleEl = wrapper.querySelector(".dialog-title");
+    assert.equal(titleEl.textContent, "Coupon applied: 100% off!");
+    const messageEl = wrapper.querySelector("p:first-child");
+    assert.equal(
+      messageEl.textContent,
+      "This coupon gives a discount of 100% off the price of course ID 2 in the Awesomesauce MicroMasters program."
+    );
+  });
+
+  it('has an OK button', () => {
+    const callback = sinon.spy();
+    const wrapper = renderDialog(COUPON_PERCENT, PROGRAM, null, true, callback);
+    const buttonEl = wrapper.querySelector("button.primary-button");
+    assert.equal(buttonEl.textContent, "OK");
+    TestUtils.Simulate.click(buttonEl);
+    assert(callback.called);
+  });
+});

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -240,14 +240,33 @@ class DashboardPage extends React.Component {
   handleCoupon = () => {
     const { coupons, dispatch, location: { query } } = this.props;
 
-    if (!query.coupon) {
+    if ( !query.coupon ) {
       // If there's no coupon code in the URL query parameters,
       // there's nothing to do.
       return;
     }
 
     if ( coupons.fetchPostStatus !== undefined ) {
-      // If we've already launched a coupon fetch, don't launch another one
+      // If we've already launched a POST request to attach this coupon
+      // to this user. Don't launch another one.
+      return;
+    }
+
+    if ( coupons.fetchGetStatus === FETCH_PROCESSING ) {
+      /*
+      Abort to avoid the following race condition:
+
+        1. launch first fetchCoupons() API request
+        2. launch attachCoupon() API request
+        3. attachCoupon() returns, launch second fetchCoupons() API request
+        4. second fetchCoupons() returns, updates Redux store with accurate information
+        5. first fetchCoupons() finally returns, updates Redux store with stale information
+
+      Ideally, it would be nice to abort the first fetchCoupons() API request
+      in this case, but fetches can't be aborted. Instead, we will abort
+      this function (by returning early), and rely on being called again in the
+      future.
+      */
       return;
     }
 

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -19,6 +19,7 @@ import {
   clearCoursePrices,
 } from '../actions';
 import {
+  COUPON_CONTENT_TYPE_COURSE,
   TOAST_SUCCESS,
   TOAST_FAILURE,
   STATUS_OFFERED,
@@ -34,6 +35,7 @@ import {
   setToastMessage,
   setConfirmSkipDialogVisibility,
   setDocsInstructionsVisibility,
+  setCouponNotificationVisibility,
 } from '../actions/ui';
 import { createForm, findCourseRun } from '../util/util';
 import CourseListCard from '../components/dashboard/CourseListCard';
@@ -55,13 +57,16 @@ import {
   updateCalculatorEdit,
 } from '../actions/financial_aid';
 import { setTimeoutActive } from '../actions/order_receipt';
+import { attachCoupon, setRecentlyAttachedCoupon } from '../actions/coupons';
 import type { UIState } from '../reducers/ui';
 import type { OrderReceiptState } from '../reducers/order_receipt';
 import type {
   DocumentsState,
 } from '../reducers/documents';
 import type { CoursePricesState, DashboardState } from '../flow/dashboardTypes';
-import type { AvailableProgram, CourseEnrollmentsState } from '../flow/enrollmentTypes';
+import type {
+  AvailableProgram, AvailableProgramsState, CourseEnrollmentsState
+} from '../flow/enrollmentTypes';
 import type { FinancialAidState } from '../reducers/financial_aid';
 import type { CouponsState } from '../reducers/coupons';
 import type { ProfileGetResult } from '../flow/profileTypes';
@@ -70,6 +75,7 @@ import type { CheckoutState } from '../reducers';
 import { skipFinancialAid } from '../actions/financial_aid';
 import { currencyForCountry } from '../lib/currency';
 import DocsInstructionsDialog from '../components/DocsInstructionsDialog';
+import CouponNotificationDialog from '../components/CouponNotificationDialog';
 
 class DashboardPage extends React.Component {
   static contextTypes = {
@@ -80,6 +86,7 @@ class DashboardPage extends React.Component {
     coupons:                  CouponsState,
     profile:                  ProfileGetResult,
     currentProgramEnrollment: AvailableProgram,
+    programs:                 AvailableProgramsState,
     dashboard:                DashboardState,
     prices:                   CoursePricesState,
     dispatch:                 Dispatch,
@@ -168,6 +175,7 @@ class DashboardPage extends React.Component {
   updateRequirements = () => {
     this.fetchDashboard();
     this.fetchCoursePrices();
+    this.handleCoupon();
     this.fetchCoupons();
     this.handleOrderStatus();
   };
@@ -227,6 +235,36 @@ class DashboardPage extends React.Component {
     } else if (query.status === 'cancel') {
       this.handleOrderCancellation();
     }
+  };
+
+  handleCoupon = () => {
+    const { coupons, dispatch, location: { query } } = this.props;
+
+    if (!query.coupon) {
+      // If there's no coupon code in the URL query parameters,
+      // there's nothing to do.
+      return;
+    }
+
+    if ( coupons.fetchPostStatus !== undefined ) {
+      // If we've already launched a coupon fetch, don't launch another one
+      return;
+    }
+
+    dispatch(attachCoupon(query.coupon)).then(result => {
+      this.setRecentlyAttachedCoupon(result.coupon);
+      this.setCouponNotificationVisibility(true);
+      this.context.router.push('/dashboard/');
+      // update coupon state in Redux
+      return dispatch(fetchCoupons());
+    }).catch(() => {
+      dispatch(setToastMessage({
+        title: "Coupon failed",
+        message: "This coupon code is invalid or does not exist.",
+        icon: TOAST_FAILURE
+      }));
+      this.context.router.push('/dashboard/');
+    });
   };
 
   dispatchCheckout = (courseId: string) => {
@@ -292,6 +330,48 @@ class DashboardPage extends React.Component {
     dispatch(setDocsInstructionsVisibility(bool));
   };
 
+  setCouponNotificationVisibility = bool => {
+    const { dispatch } = this.props;
+    dispatch(setCouponNotificationVisibility(bool));
+  };
+
+  setRecentlyAttachedCoupon = coupon => {
+    const { dispatch } = this.props;
+    dispatch(setRecentlyAttachedCoupon(coupon));
+  };
+
+  renderCouponDialog() {
+    const {
+      programs,
+      ui,
+      coupons,
+      dashboard,
+    } = this.props;
+    const coupon = coupons.recentlyAttachedCoupon;
+    if ( !coupon ) {
+      return null;
+    }
+    const couponProgram = programs.availablePrograms.find(
+      program => program.id === coupon.program_id
+    );
+    let couponCourse = null;
+    if ( coupon.content_type === COUPON_CONTENT_TYPE_COURSE ) {
+      const dashboardCouponProgram = dashboard.programs.find(
+        program => program.id === coupon.program_id
+      );
+      couponCourse = dashboardCouponProgram.courses.find(
+        course => course.id === coupon.object_id
+      );
+    }
+    return <CouponNotificationDialog
+      coupon={coupon}
+      couponProgram={couponProgram}
+      couponCourse={couponCourse}
+      open={ui.couponNotificationVisibility}
+      setDialogVisibility={this.setCouponNotificationVisibility}
+    />;
+  }
+
   render() {
     const {
       dashboard,
@@ -349,6 +429,7 @@ class DashboardPage extends React.Component {
             open={ui.docsInstructionsVisibility}
             setDialogVisibility={this.setDocsInstructionsVisibility}
           />
+          {this.renderCouponDialog()}
           <div className="first-column">
             <DashboardUserCard profile={profile} program={program}/>
             {financialAidCard}
@@ -392,6 +473,7 @@ const mapStateToProps = (state) => {
     profile: profile,
     dashboard: state.dashboard,
     prices: state.prices,
+    programs: state.programs,
     currentProgramEnrollment: state.currentProgramEnrollment,
     ui: state.ui,
     documents: state.documents,

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -252,7 +252,7 @@ class DashboardPage extends React.Component {
       return;
     }
 
-    if ( coupons.fetchGetStatus === FETCH_PROCESSING ) {
+    if ( coupons.fetchGetStatus === FETCH_PROCESSING || coupons.fetchGetStatus === undefined ) {
       /*
       Abort to avoid the following race condition:
 

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -248,7 +248,7 @@ class DashboardPage extends React.Component {
 
     if ( coupons.fetchPostStatus !== undefined ) {
       // If we've already launched a POST request to attach this coupon
-      // to this user. Don't launch another one.
+      // to this user, don't launch another one.
       return;
     }
 

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -275,7 +275,7 @@ class DashboardPage extends React.Component {
       this.setCouponNotificationVisibility(true);
       this.context.router.push('/dashboard/');
       // update coupon state in Redux
-      return dispatch(fetchCoupons());
+      dispatch(fetchCoupons());
     }).catch(() => {
       dispatch(setToastMessage({
         title: "Coupon failed",

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -392,37 +392,30 @@ describe('DashboardPage', () => {
       });
     });
 
-    it.only('without a race condition', () => {  // eslint-disable-line mocha/no-skipped-tests
+    it('without a race condition', () => {  // eslint-disable-line mocha/no-skipped-tests
       let program = DASHBOARD_RESPONSE[1];
       let coupon1 = makeCoupon(program);
       let coupon2 = makeCoupon(program);
-      coupon2.coupon_code = 'coupon_2';
+      coupon2.coupon_code = 'second-coupon';
       const slowPromise = new Promise(resolve => {
-        console.log("start");
         setTimeout(() => {
-          console.log("resolved");
           resolve([coupon1]);
         }, 200);
       });
 
       // Make sure we wait for the first call to complete before resolving the second promise
       helper.couponsStub.onCall(0).returns(slowPromise);
-      helper.couponsStub.onCall(1).returns(new Promise(resolve => {
-        console.log("call2");
-        resolve([coupon2]);
-      }));
+      helper.couponsStub.onCall(1).returns(Promise.resolve([coupon2]));
 
       return renderComponent(
         '/dashboard?coupon=success-coupon',
         COUPON_SUCCESS_ACTIONS
       ).then(() => {
-        console.log(COUPON_SUCCESS_ACTIONS);
         const state = helper.store.getState();
         assert.deepEqual(state.coupons.recentlyAttachedCoupon, COUPON);
         // must be the second call result
         assert.deepEqual(state.coupons.coupons, [coupon2]);
-        assert.isFalse(state.ui.couponNotificationVisibility);
-        assert.isUndefined(state.ui.toastMessage);
+        assert.isTrue(state.ui.couponNotificationVisibility);
         assert.equal(helper.couponsStub.callCount, 2);
       });
     });

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -10,9 +10,6 @@ import { makeCoupon } from '../factories/dashboard';
 import IntegrationTestHelper from '../util/integration_test_helper';
 import {
   REQUEST_DASHBOARD,
-  RECEIVE_DASHBOARD_SUCCESS,
-  REQUEST_COURSE_PRICES,
-  RECEIVE_COURSE_PRICES_SUCCESS,
   UPDATE_COURSE_STATUS,
   CLEAR_COURSE_PRICES,
   CLEAR_DASHBOARD,
@@ -67,10 +64,7 @@ import {
   STATUS_PAID_BUT_NOT_ENROLLED,
 } from '../constants';
 import { findCourse } from '../util/test_utils';
-import {
-  SUCCESS_ACTIONS,
-  DASHBOARD_SUCCESS_ACTIONS,
-} from './test_util';
+import { DASHBOARD_SUCCESS_ACTIONS } from './test_util';
 
 describe('DashboardPage', () => {
   let renderComponent, helper;

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -1,5 +1,6 @@
 // @flow
 import R from 'ramda';
+import Decimal from 'decimal.js-light';
 
 import {
   STATUS_OFFERED,
@@ -96,7 +97,7 @@ export const makeCoupon = (program: Program): Coupon => ({
   coupon_code: `coupon_for_${program.id}`,
   content_type: 'program',
   amount_type: 'fixed-discount',
-  amount: '50',
+  amount: Decimal('50'),
   program_id: program.id,
   object_id: program.id,
 });

--- a/static/js/flow/couponTypes.js
+++ b/static/js/flow/couponTypes.js
@@ -1,4 +1,5 @@
 // @flow
+import Decimal from 'decimal.js-light';
 import {
   COUPON_CONTENT_TYPE_PROGRAM,
   COUPON_CONTENT_TYPE_COURSE,
@@ -11,11 +12,16 @@ export type Coupon = {
   coupon_code: string,
   content_type: COUPON_CONTENT_TYPE_COURSERUN | COUPON_CONTENT_TYPE_COURSE | COUPON_CONTENT_TYPE_PROGRAM,
   amount_type: COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT | COUPON_AMOUNT_TYPE_FIXED_DISCOUNT,
-  amount: string,  // Python decimal type exposes floats as strings so we need to parse here
+  amount: Decimal,
   program_id: number,
   object_id: number,  // either program id, course id, or run id (different than the course key)
 };
 
 export type Coupons = Array<Coupon>;
+
+export type AttachCouponResponse = {
+  message: string,
+  coupon: Coupon,
+};
 
 export type CalculatedPrices = Map<number, number>;

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -245,9 +245,6 @@ export function addCourseEnrollment(courseId: string) {
 
 export function getCoupons(): Promise<Coupons> {
   return fetchJSONWithCSRF('/api/v0/coupons/').then(coupons => {
-    if ( !coupons ) {
-      return coupons;
-    }
     // turn `amount` from string into decimal
     return R.map(R.evolve({amount: Decimal}), coupons);
   });

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -244,9 +244,9 @@ export function addCourseEnrollment(courseId: string) {
 }
 
 export function getCoupons(): Promise<Coupons> {
-  return fetchJSONWithCSRF('/api/v0/coupons/').then(coupon => (
+  return fetchJSONWithCSRF('/api/v0/coupons/').then(coupons => (
     // turn `amount` from string into decimal
-    R.evolve({amount: Decimal}, coupon)
+    R.map(R.evolve({amount: Decimal}), coupons)
   ));
 }
 
@@ -257,7 +257,7 @@ export function attachCoupon(couponCode: string): Promise<AttachCouponResponse> 
     body: JSON.stringify({
       username: SETTINGS.user.username
     })
-  }).then(obj => (
-    R.evolve({coupon: {amount: Decimal}}, obj)
+  }).then(response => (
+    R.evolve({coupon: {amount: Decimal}}, response)
   ));
 }

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -244,10 +244,13 @@ export function addCourseEnrollment(courseId: string) {
 }
 
 export function getCoupons(): Promise<Coupons> {
-  return fetchJSONWithCSRF('/api/v0/coupons/').then(coupons => (
+  return fetchJSONWithCSRF('/api/v0/coupons/').then(coupons => {
+    if ( !coupons ) {
+      return coupons;
+    }
     // turn `amount` from string into decimal
-    R.map(R.evolve({amount: Decimal}), coupons)
-  ));
+    return R.map(R.evolve({amount: Decimal}), coupons);
+  });
 }
 
 export function attachCoupon(couponCode: string): Promise<AttachCouponResponse> {

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -3,10 +3,11 @@
 // For mocking purposes we need to use 'fetch' defined as a global instead of importing as a local.
 import 'isomorphic-fetch';
 import R from 'ramda';
+import Decimal from 'decimal.js-light';
 
 import type { Profile, ProfileGetResult, ProfilePatchResult } from '../flow/profileTypes';
 import type { CheckoutResponse } from '../flow/checkoutTypes';
-import type { Coupons } from '../flow/couponTypes';
+import type { Coupons, AttachCouponResponse } from '../flow/couponTypes';
 import type { Dashboard } from '../flow/dashboardTypes';
 import type { AvailableProgram, AvailablePrograms } from '../flow/enrollmentTypes';
 import type { EmailSendResponse } from '../flow/emailTypes';
@@ -243,15 +244,20 @@ export function addCourseEnrollment(courseId: string) {
 }
 
 export function getCoupons(): Promise<Coupons> {
-  return fetchJSONWithCSRF('/api/v0/coupons/');
+  return fetchJSONWithCSRF('/api/v0/coupons/').then(coupon => (
+    // turn `amount` from string into decimal
+    R.evolve({amount: Decimal}, coupon)
+  ));
 }
 
-export function attachCoupon(couponCode: string): Promise<*> {
+export function attachCoupon(couponCode: string): Promise<AttachCouponResponse> {
   let code = encodeURI(couponCode);
   return fetchJSONWithCSRF(`/api/v0/coupons/${code}/users/`, {
     method: 'POST',
     body: JSON.stringify({
       username: SETTINGS.user.username
     })
-  });
+  }).then(obj => (
+    R.evolve({coupon: {amount: Decimal}}, obj)
+  ));
 }

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -36,9 +36,7 @@ import {
   DASHBOARD_RESPONSE,
   COURSE_PRICES_RESPONSE,
   USER_PROFILE_RESPONSE,
-  ATTACH_COUPON_RESPONSE,
   PROGRAMS,
-  COUPON,
 } from '../test_constants';
 
 describe('api', function() {
@@ -386,7 +384,7 @@ describe('api', function() {
           coupon_code: "success-coupon",
           object_id: 3,
           program_id: 3,
-        }
+        };
         fetchJSONStub.returns(Promise.resolve([apiCoupon]));
 
         return getCoupons().then(coupons => {
@@ -435,7 +433,7 @@ describe('api', function() {
             object_id: 3,
             program_id: 3,
           }
-        }
+        };
         fetchJSONStub.returns(Promise.resolve(apiResponse));
 
         return attachCoupon('success-coupon').then(resp => {

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -2,6 +2,8 @@
 import { assert } from 'chai';
 import fetchMock from 'fetch-mock/src/server';
 import sinon from 'sinon';
+import Decimal from 'decimal.js-light';
+import R from 'ramda';
 
 import {
   getUserProfile,
@@ -26,11 +28,17 @@ import {
 } from './api';
 import * as api from './api';
 import {
+  COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT,
+  COUPON_CONTENT_TYPE_PROGRAM,
+} from '../constants';
+import {
   CYBERSOURCE_CHECKOUT_RESPONSE,
   DASHBOARD_RESPONSE,
   COURSE_PRICES_RESPONSE,
   USER_PROFILE_RESPONSE,
+  ATTACH_COUPON_RESPONSE,
   PROGRAMS,
+  COUPON,
 } from '../test_constants';
 
 describe('api', function() {
@@ -370,6 +378,28 @@ describe('api', function() {
         });
       });
 
+      it('parses response correctly', () => {
+        const apiCoupon = {
+          amount: "0.55",
+          amount_type: COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT,
+          content_type: COUPON_CONTENT_TYPE_PROGRAM,
+          coupon_code: "success-coupon",
+          object_id: 3,
+          program_id: 3,
+        }
+        fetchJSONStub.returns(Promise.resolve([apiCoupon]));
+
+        return getCoupons().then(coupons => {
+          const coupon = coupons[0];
+          assert.instanceOf(coupon.amount, Decimal);
+          assert.equal(coupon.amount.toString(), apiCoupon.amount);
+          // everything else aside from `amount` should be identical
+          const couponProps = R.omit(['amount'], coupon);
+          const apiCouponProps = R.omit(['amount'], apiCoupon);
+          assert.deepEqual(couponProps, apiCouponProps);
+        });
+      });
+
       it('fails to fetch coupons', () => {
         fetchJSONStub.returns(Promise.reject());
 
@@ -391,6 +421,32 @@ describe('api', function() {
               username: SETTINGS.user.username
             })
           }));
+        });
+      });
+
+      it('parses response correctly', () => {
+        const apiResponse = {
+          message: "Attached user to coupon successfully.",
+          coupon: {
+            amount: "0.55",
+            amount_type: COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT,
+            content_type: COUPON_CONTENT_TYPE_PROGRAM,
+            coupon_code: "success-coupon",
+            object_id: 3,
+            program_id: 3,
+          }
+        }
+        fetchJSONStub.returns(Promise.resolve(apiResponse));
+
+        return attachCoupon('success-coupon').then(resp => {
+          assert.equal(apiResponse.message, resp.message);
+          const coupon = resp.coupon, apiCoupon = apiResponse.coupon;
+          assert.instanceOf(coupon.amount, Decimal);
+          assert.equal(coupon.amount.toString(), apiCoupon.amount);
+          // everything else aside from `amount` should be identical
+          const couponProps = R.omit(['amount'], coupon);
+          const apiCouponProps = R.omit(['amount'], apiCoupon);
+          assert.deepEqual(couponProps, apiCouponProps);
         });
       });
 

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -32,6 +32,7 @@ import {
   COUPON_CONTENT_TYPE_PROGRAM,
 } from '../constants';
 import {
+  COUPON,
   CYBERSOURCE_CHECKOUT_RESPONSE,
   DASHBOARD_RESPONSE,
   COURSE_PRICES_RESPONSE,
@@ -369,10 +370,11 @@ describe('api', function() {
 
     describe("fetching a coupon", () => {
       it('fetches coupons', () => {
-        fetchJSONStub.returns(Promise.resolve());
+        fetchJSONStub.returns(Promise.resolve([COUPON]));
 
-        return getCoupons().then(() => {
+        return getCoupons().then(coupons => {
           assert.ok(fetchJSONStub.calledWith('/api/v0/coupons/'));
+          assert.deepEqual(coupons, [COUPON]);
         });
       });
 

--- a/static/js/reducers/coupons.js
+++ b/static/js/reducers/coupons.js
@@ -7,6 +7,7 @@ import {
   RECEIVE_FETCH_COUPONS_SUCCESS,
   RECEIVE_FETCH_COUPONS_FAILURE,
   CLEAR_COUPONS,
+  SET_RECENTLY_ATTACHED_COUPON,
 } from '../actions/coupons';
 import {
   FETCH_FAILURE,
@@ -14,16 +15,18 @@ import {
   FETCH_SUCCESS,
 } from '../actions';
 import type { Action } from '../flow/reduxTypes';
-import type { Coupons } from '../flow/couponTypes';
+import type { Coupon, Coupons } from '../flow/couponTypes';
 
 export type CouponsState = {
-  fetchPostStatus?:  string,
-  fetchGetStatus?: string,
-  coupons: Coupons,
+  fetchPostStatus?:        string,
+  fetchGetStatus?:         string,
+  coupons:                 Coupons,
+  recentlyAttachedCoupon:  ?Coupon,
 };
 
 export const INITIAL_COUPONS_STATE: CouponsState = {
   coupons: [],
+  recentlyAttachedCoupon: null,
 };
 
 export const coupons = (state: CouponsState = INITIAL_COUPONS_STATE, action: Action) => {
@@ -46,6 +49,8 @@ export const coupons = (state: CouponsState = INITIAL_COUPONS_STATE, action: Act
     return { ...state, fetchGetStatus: FETCH_FAILURE };
   case CLEAR_COUPONS:
     return INITIAL_COUPONS_STATE;
+  case SET_RECENTLY_ATTACHED_COUPON:
+    return { ...state, recentlyAttachedCoupon: action.payload };
   default:
     return state;
   }

--- a/static/js/reducers/coupons_test.js
+++ b/static/js/reducers/coupons_test.js
@@ -14,6 +14,7 @@ import {
   RECEIVE_FETCH_COUPONS_FAILURE,
   fetchCoupons,
   clearCoupons,
+  setRecentlyAttachedCoupon,
 } from '../actions/coupons';
 import { INITIAL_COUPONS_STATE } from '../reducers/coupons';
 import {
@@ -23,15 +24,19 @@ import {
 } from '../actions';
 import rootReducer from '../reducers';
 import * as api from '../lib/api';
+import type { CouponsState } from '../reducers/coupons';
+import type { AssertReducerResultState } from '../flow/reduxTypes';
+import { createAssertReducerResultState } from '../util/test_utils';
 
-describe('financial aid reducers', () => {
-  let sandbox, store, dispatchThen;
+describe('coupon reducers', () => {
+  let sandbox, store, dispatchThen, assertReducerResultState: AssertReducerResultState<CouponsState>;
   let attachCouponStub, getCouponsStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     store = configureTestStore(rootReducer);
     dispatchThen = store.createDispatchThen(state => state.coupons);
+    assertReducerResultState = createAssertReducerResultState(store, state => state.coupons);
     getCouponsStub = sandbox.stub(api, 'getCoupons');
     attachCouponStub = sandbox.stub(api, 'attachCoupon');
   });
@@ -58,6 +63,7 @@ describe('financial aid reducers', () => {
       let expectation = {
         fetchPostStatus: FETCH_SUCCESS,
         coupons: [],
+        recentlyAttachedCoupon: null,
       };
       assert.deepEqual(state, expectation);
       assert.isTrue(attachCouponStub.calledWith(code));
@@ -74,6 +80,7 @@ describe('financial aid reducers', () => {
       let expectation = {
         fetchPostStatus: FETCH_FAILURE,
         coupons: [],
+        recentlyAttachedCoupon: null,
       };
       assert.deepEqual(state, expectation);
       assert.isTrue(attachCouponStub.calledWith(code));
@@ -90,6 +97,7 @@ describe('financial aid reducers', () => {
       assert.deepEqual(state, {
         fetchGetStatus: FETCH_SUCCESS,
         coupons: coupons,
+        recentlyAttachedCoupon: null,
       });
       assert.isTrue(getCouponsStub.calledWith());
 
@@ -105,10 +113,19 @@ describe('financial aid reducers', () => {
       RECEIVE_FETCH_COUPONS_FAILURE
     ]).then(state => {
       assert.deepEqual(state, {
-        coupons: [],
         fetchGetStatus: FETCH_FAILURE,
+        coupons: [],
+        recentlyAttachedCoupon: null,
       });
       assert.isTrue(getCouponsStub.calledWith());
     });
+  });
+
+  it('should let you set a recently attached coupon', () => {
+    assertReducerResultState(
+      setRecentlyAttachedCoupon,
+      coupons => coupons.recentlyAttachedCoupon,
+      null
+    );
   });
 });

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -38,6 +38,7 @@ import {
   SET_CALCULATOR_DIALOG_VISIBILITY,
   SET_CONFIRM_SKIP_DIALOG_VISIBILITY,
   SET_DOCS_INSTRUCTIONS_VISIBILITY,
+  SET_COUPON_NOTIFICATION_VISIBILITY,
   SET_NAV_DRAWER_OPEN,
   SET_PROGRAM,
   SET_USER_CHIP_VISIBILITY,
@@ -82,6 +83,7 @@ export type UIState = {
   selectedProgram:                  ?AvailableProgram,
   skipDialogVisibility:             boolean,
   docsInstructionsVisibility:       boolean,
+  couponNotificationVisibility:     boolean,
   navDrawerOpen:                    boolean,
   userChipVisibility:               ?string,
 };
@@ -116,6 +118,7 @@ export const INITIAL_UI_STATE: UIState = {
   selectedProgram: null,
   skipDialogVisibility: false,
   docsInstructionsVisibility: false,
+  couponNotificationVisibility: false,
   navDrawerOpen: false,
   userChipVisibility: null,
 };
@@ -279,6 +282,8 @@ export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
     return { ...state, skipDialogVisibility: action.payload };
   case SET_DOCS_INSTRUCTIONS_VISIBILITY:
     return { ...state, docsInstructionsVisibility: action.payload };
+  case SET_COUPON_NOTIFICATION_VISIBILITY:
+    return { ...state, couponNotificationVisibility: action.payload };
   case SET_NAV_DRAWER_OPEN:
     return { ...state, navDrawerOpen: action.payload };
   case SET_USER_CHIP_VISIBILITY:

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -1,6 +1,7 @@
 /* global SETTINGS: false */
 // @flow
 import deepFreeze from 'deep-freeze';
+import Decimal from 'decimal.js-light';
 
 import type {
   CoursePrices,
@@ -20,6 +21,8 @@ import {
   STATUS_OFFERED,
   STATUS_PAID_BUT_NOT_ENROLLED,
   STATUS_PENDING_ENROLLMENT,
+  COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT,
+  COUPON_CONTENT_TYPE_PROGRAM,
 } from './constants';
 
 export const ELASTICSEARCH_RESPONSE = deepFreeze({
@@ -706,10 +709,24 @@ export const COURSE_PRICES_RESPONSE: CoursePrices = deepFreeze(DASHBOARD_RESPONS
 })));
 
 export const ERROR_RESPONSE = deepFreeze({
-  "errorStatusCode": 500,
-  "error_code": "AB123",
-  "user_message": "custom error message for the user."
+  errorStatusCode: 500,
+  error_code: "AB123",
+  user_message: "custom error message for the user."
 });
+
+export const ATTACH_COUPON_RESPONSE = deepFreeze({
+  message: "Attached user to coupon successfully.",
+  coupon: {
+    amount: Decimal("0.55"),
+    amount_type: COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT,
+    content_type: COUPON_CONTENT_TYPE_PROGRAM,
+    coupon_code: "success-coupon",
+    object_id: 3,
+    program_id: 3,
+  }
+});
+
+export const COUPON = deepFreeze(ATTACH_COUPON_RESPONSE.coupon);
 
 /* eslint-disable max-len */
 export const CYBERSOURCE_CHECKOUT_RESPONSE = deepFreeze({

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -12,6 +12,7 @@ import {
   COURSE_PRICES_RESPONSE,
   PROGRAMS,
   USER_PROFILE_RESPONSE,
+  ATTACH_COUPON_RESPONSE,
 } from '../test_constants';
 import {
   REQUEST_GET_USER_PROFILE,
@@ -60,6 +61,8 @@ export default class IntegrationTestHelper {
     this.profileGetStub.withArgs(SETTINGS.user.username).returns(Promise.resolve(USER_PROFILE_RESPONSE));
     this.programsGetStub = this.sandbox.stub(api, 'getPrograms');
     this.programsGetStub.returns(Promise.resolve(PROGRAMS));
+    this.attachCouponStub = this.sandbox.stub(api, 'attachCoupon');
+    this.attachCouponStub.returns(Promise.resolve(ATTACH_COUPON_RESPONSE));
     this.scrollIntoViewStub = this.sandbox.stub();
     window.HTMLDivElement.prototype.scrollIntoView = this.scrollIntoViewStub;
     window.HTMLFieldSetElement.prototype.scrollIntoView = this.scrollIntoViewStub;

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -337,3 +337,9 @@
     }
   }
 }
+
+.dialog {
+  p:last-child {
+    margin-bottom: 0;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1737,6 +1737,10 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decimal.js-light@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.2.0.tgz#0639351eeb5e09dd3115634139e63954d589f7a1"
+
 decompress-tar@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/decompress-tar/-/decompress-tar-3.1.0.tgz#217c789f9b94450efaadc5c5e537978fc333c466"


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2323.

#### What's this PR do?
When the user visits the dashboard with a `coupon` query parameter in the URL, that query parameter is assumed to be a coupon code. This PR detects that query parameter, and tries to attach the currently logged-in user to that coupon. If the coupon is invalid or doesn't exist, we pop a toast notification that it didn't work. If the coupon exists and is valid for the user, we pop a notification to confirm that they have successfully applied the coupon.

#### How should this be manually tested?
* Try applying a coupon code for a coupon that doesn't exist, and confirm that you get a notification.
* Then make a coupon that is invalid, and confirm you get the same notification when you try to apply it.
* Make a percentage discount coupon that can be successfully applied, and apply it. You should get a confirmation notification, with information about the coupon you just applied.
* Try again with a fixed discount coupon that can be successfully applied. Make sure that the information in the confirmation notification is accurate.

#### Screenshots (if appropriate)

![fixed discount notification](https://cloud.githubusercontent.com/assets/132355/22153480/7da7c0e4-def5-11e6-88b4-c8b87a196ec4.png)
![percent discount notification](https://cloud.githubusercontent.com/assets/132355/22153481/7dad7c50-def5-11e6-9333-70e799ed9313.png)
![coupon failure notification](https://cloud.githubusercontent.com/assets/132355/22153479/7da7396c-def5-11e6-83b8-86a1d7ff53de.png)