### PR TITLE
ensure toast component is visible regardless of scroll position

### DIFF
--- a/static/scss/toast.scss
+++ b/static/scss/toast.scss
@@ -2,7 +2,7 @@
   display: none;
   align-items: center;
   flex-direction: row;
-  position: absolute;
+  position: fixed;
   background-color: $black-transparent;
   color: #c5c5c5;
   margin: 0 auto;
@@ -10,7 +10,8 @@
   padding: 20px;
   left: 0;
   right: 0;
-  z-index: 2;
+  top: 0;
+  z-index: 100;
   font-size: 16px;
 
   &.open {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2393 

#### What's this PR do?

This just adjusts the CSS for the toast component a little bit.

#### How should this be manually tested?

Remove the phone number for your profile. Go to `/dashboard`. You should be redirected to `/profile/personal`, scrolled to the phone number field, and there should be a toast message visible at the top of the screen.

![mega_toast](https://cloud.githubusercontent.com/assets/6207644/22124513/1baebfce-de5e-11e6-8de6-74b42dc33e5f.png)
