### PR TITLE
Added SFTP env vars to app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,6 +20,10 @@
   ],
   "description": "Web Portal for MicroMasters",
   "env": {
+    "ADWORDS_CONVERSION_ID": {
+      "description": "Id for adwords conversion.",
+      "required": false
+    },
     "ALLOWED_HOSTS": {
       "default": "['*']",
       "description": "Array of allowed hostnames"
@@ -71,6 +75,26 @@
     },
     "ELASTICSEARCH_URL": {
       "description": "URL for connecting to Elasticsearch cluster"
+    },
+    "EXAMS_SFTP_HOST": {
+      "description": "Hostname for Pearson SFTP server",
+      "required": false
+    },
+    "EXAMS_SFTP_PORT": {
+      "description": "Port for Pearson SFTP server",
+      "required": false
+    },
+    "EXAMS_SFTP_USERNAME": {
+      "description": "Username for Pearson SFTP server authentication",
+      "required": false
+    },
+    "EXAMS_SFTP_PASSWORD": {
+      "description": "Password for Pearson SFTP server authentication",
+      "required": false
+    },
+    "EXAMS_SFTP_UPLOAD_DIR": {
+      "description": "Upload directory for files we send to Pearson",
+      "required": false
     },
     "GOOGLE_API_KEY": {
       "description": "API key for accessing Google services",
@@ -158,10 +182,6 @@
     "STATUS_TOKEN": {
       "description": "Token to access the status API.",
       "required": true
-    },
-    "ADWORDS_CONVERSION_ID": {
-      "description": "Id for adwords conversion.",
-      "required": false
     }
   },
   "keywords": [


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #2394 

#### What's this PR do?

Adds missing env variables to app.json. I also moved `ADWORDS_CONVERSION_ID` to the correct lexicographical position.

#### Where should the reviewer start?

app.json

#### How should this be manually tested?

I set the 5 `EXAMS*` vars in Heroku for the PR build. Connect to the dyno and verify the environment variables are present (`env | grep EXAMS`). 
