### PR TITLE
Past enrolled courses need to be under feature flag

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -4,6 +4,7 @@ Apis for the dashboard
 import datetime
 import logging
 
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 import pytz
@@ -300,7 +301,11 @@ def get_status_for_courserun(course_run, mmtrack):
             status = CourseRunStatus.CHECK_IF_PASSED
         # this last check needs to be done as last one
         elif course_run.is_past:
-            status = CourseRunStatus.CURRENTLY_ENROLLED
+            version = settings.FEATURES.get("FINAL_GRADE_ALGO", "v0")
+            if version == "v1":
+                status = CourseRunStatus.CURRENTLY_ENROLLED
+            else:
+                status = CourseRunStatus.CHECK_IF_PASSED
         else:
             raise ImproperlyConfigured(
                 'The course {0} results are not either current, past, or future at the same time'.format(

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, MagicMock, PropertyMock
 import ddt
 import pytz
 from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
 
 from courses.factories import (
     CourseFactory,
@@ -278,11 +279,13 @@ class CourseRunTest(CourseTests):
         assert run_status.course_run == crun
 
     @ddt.data(
-        (True, api.CourseRunStatus.CHECK_IF_PASSED),
-        (False, api.CourseRunStatus.CURRENTLY_ENROLLED)
+        (True, api.CourseRunStatus.CHECK_IF_PASSED, 'v1'),
+        (False, api.CourseRunStatus.CURRENTLY_ENROLLED, 'v1'),
+        (True, api.CourseRunStatus.CHECK_IF_PASSED, 'v0'),
+        (False, api.CourseRunStatus.CHECK_IF_PASSED, 'v0')
     )
     @ddt.unpack
-    def test_check_if_passed(self, has_frozen_grades, expected_status):
+    def test_check_if_passed(self, has_frozen_grades, expected_status, grade_algo):
         """test for get_status_for_courserun for a finished course if enrolled"""
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
@@ -297,7 +300,10 @@ class CourseRunTest(CourseTests):
             enr_end=self.now-timedelta(weeks=53),
             edx_key="course-v1:edX+DemoX+Demo_Course"
         )
-        with patch('courses.models.CourseRun.has_frozen_grades', new_callable=PropertyMock) as frozen_mock:
+        with patch(
+            'courses.models.CourseRun.has_frozen_grades',
+            new_callable=PropertyMock
+        ) as frozen_mock, override_settings(FEATURES={"FINAL_GRADE_ALGO": grade_algo}):
             frozen_mock.return_value = has_frozen_grades
             run_status = api.get_status_for_courserun(crun, self.mmtrack)
         assert run_status.status == expected_status

--- a/dashboard/signals_test.py
+++ b/dashboard/signals_test.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 from django.db.models.signals import post_save
 from django.test import (
     override_settings,
-    TestCase,
 )
 from factory.django import mute_signals
 
@@ -15,12 +14,13 @@ from courses.factories import ProgramFactory, CourseFactory
 
 from dashboard.models import ProgramEnrollment
 from profiles.factories import ProfileFactory
+from search.base import MockedESTestCase
 
 
 # pylint: disable=no-self-use
 # Make sure that any unmocked ES activity results in an error
 @override_settings(ELASTICSEARCH_URL="fake")
-class IndexingTests(TestCase):
+class IndexingTests(MockedESTestCase):
     """
     Test class for signals that index certain objects in Elasticsearch
     """


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #2412 

#### What's this PR do?
Adds a feature flag to have different statuses for past course runs. 
in `v0` they need to be checked if the user passed it, in `v1` if the code reaches that place, there is a weird situation with the final grades. 

#### Where should the reviewer start?
`dashboard/api.py`

#### How should this be manually tested?
For a Non Financial aid course run already ended, add a `CachedEnrollment`, `CachedCurrentGrade` and `CachedCertificate` to fake the user has passed the course.
In this branch the course should appear as "Passed" while on master it should appear as "In Progress"


**NOTE**: the changes to `dashboard/signals_test.py` are irrelevant to this PR