### PR TITLE
fix learner redirect

### DIFF
--- a/static/js/dashboard_routes.js
+++ b/static/js/dashboard_routes.js
@@ -87,6 +87,9 @@ export const routes = {
           .then(loadRoute(cb))
           .catch(errorLoading);
       },
+      indexRoute: {
+        onEnter: (nextState, cb) => cb(`/learner/${username}`)
+      },
       childRoutes: [
         {
           path: ':username',


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #2415 

#### What's this PR do?

re-implements the redirect we had before, for redirecting `/learner` to `/learner/:username`.

based on the [react router docs](https://github.com/ReactTraining/react-router/blob/master/docs/guides/IndexRoutes.md).

#### How should this be manually tested?

Go to `/learner` and confirm the redirect works.