### PR TITLE
Add setting to disable webpack loader functionality for tests

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -130,7 +130,6 @@ INSTALLED_APPS = (
     # other third party APPS
     'rolepermissions',
     'raven.contrib.django.raven_compat',
-    'webpack_loader',
 
     # Our INSTALLED_APPS
     'backends',
@@ -148,6 +147,11 @@ INSTALLED_APPS = (
     'ui',
     'seed_data',
 )
+
+DISABLE_WEBPACK_LOADER_STATS = get_var("DISABLE_WEBPACK_LOADER_STATS", False)
+if not DISABLE_WEBPACK_LOADER_STATS:
+    INSTALLED_APPS += ('webpack_loader',)
+
 
 MIDDLEWARE_CLASSES = (
     'raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware',

--- a/tox.ini
+++ b/tox.ini
@@ -20,3 +20,4 @@ setenv =
     DEBUG=False
     CELERY_ALWAYS_EAGER=True
     SENTRY_DSN=
+    DISABLE_WEBPACK_LOADER_STATS=True

--- a/ui/templatetags/render_bundle.py
+++ b/ui/templatetags/render_bundle.py
@@ -32,13 +32,14 @@ def _get_bundle(request, bundle_name):
     """
     Update bundle URLs to handle webpack hot reloading correctly if DEBUG=True
     """
-    for chunk in get_loader('DEFAULT').get_bundle(bundle_name):
-        chunk_copy = dict(chunk)
-        chunk_copy['url'] = "{host_url}/{bundle}".format(
-            host_url=public_path(request).rstrip("/"),
-            bundle=chunk['name']
-        )
-        yield chunk_copy
+    if not settings.DISABLE_WEBPACK_LOADER_STATS:
+        for chunk in get_loader('DEFAULT').get_bundle(bundle_name):
+            chunk_copy = dict(chunk)
+            chunk_copy['url'] = "{host_url}/{bundle}".format(
+                host_url=public_path(request).rstrip("/"),
+                bundle=chunk['name']
+            )
+            yield chunk_copy
 
 
 @register.simple_tag(takes_context=True)

--- a/ui/templatetags/render_bundle_test.py
+++ b/ui/templatetags/render_bundle_test.py
@@ -25,6 +25,7 @@ FAKE_COMMON_BUNDLE = [
 
 
 # pylint: disable=no-self-use
+@override_settings(DISABLE_WEBPACK_LOADER_STATS=False)
 class TestRenderBundle(TestCase):
     """
     Tests for render_bundle


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2368 

#### What's this PR do?
Disables webpack loader from scratch

#### How should this be manually tested?
- You should still be able to see the dashboard
- Make `webpack-stats.json` have a JSON error somewhere, so that it can't be parsed. Run the tests in `ui/views_test.py`. The tests should all pass regardless of the error.
