### PR TITLE
Removed `In Progress` status after course end date past

### DIFF
--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -154,7 +154,11 @@ export default class CourseAction extends React.Component {
       description = this.renderStatusDescription(run.status, 'Failed');
       break;
     case STATUS_CURRENTLY_ENROLLED: {
-      description = this.renderBoxedDescription('In Progress');
+      let endDate = moment(run.course_end_date).startOf('day');
+      let nowDate = moment(now).startOf('day');
+      if (endDate.diff(nowDate, 'days') > 0 ) {
+        description = this.renderBoxedDescription('In Progress');
+      }
       break;
     }
     case STATUS_WILL_ATTEND: {

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -111,17 +111,36 @@ describe('CourseAction', () => {
   });
 
   it('shows a message for a verified course', () => {
-    let course = findCourse(course => (
+    let course = findAndCloneCourse(course => (
       course.runs.length > 0 &&
       course.runs[0].status === STATUS_CURRENTLY_ENROLLED
     ));
-    let firstRun = course.runs[0];
+    let firstRun = alterFirstRun(course, {
+      course_end_date: moment(now).add(10, 'days').toISOString()
+    });
     const wrapper = renderCourseAction({
       courseRun: firstRun
     });
     let elements = getElements(wrapper);
 
     assert.equal(elements.descriptionText, 'In Progress');
+  });
+
+  it('shows a message for a verified course after course end date', () => {
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_CURRENTLY_ENROLLED
+    ));
+    let firstRun = alterFirstRun(course, {
+      course_end_date: moment(now).add(-10, 'days').toISOString()
+    });
+    const wrapper = renderCourseAction({
+      courseRun: firstRun
+    });
+    let elements = getElements(wrapper);
+
+    // asset that ``descriptionText`` element dont exist.
+    assert.isUndefined(elements.descriptionText);
   });
 
   it('shows a message for course user paid but not enrolled', () => {


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/2411

#### What's this PR do?
- Removed `In Progress` status on and after course end date past if status is still ```STATUS_CURRENTLY_ENROLLED```

@pdpinch 

### Questions:
- [ ] Should we considered the end date it self in removing status, currently on the end date i remove status?
- [ ] I am removing this info completely, i mean not showing anything in place of  `In Progress` are you ok with that?
