### PR TITLE
Display toast notification for API failure when skipping financial aid

### DIFF
--- a/static/js/actions/financial_aid.js
+++ b/static/js/actions/financial_aid.js
@@ -71,6 +71,7 @@ export const skipFinancialAid = (programId: number): Dispatcher<*> => {
       },
       () => {
         dispatch(receiveSkipFinancialAidFailure());
+        return Promise.reject();
       });
   };
 };

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -306,6 +306,12 @@ class DashboardPage extends React.Component {
     const { dispatch } = this.props;
     dispatch(skipFinancialAid(programId)).then(() => {
       this.setConfirmSkipDialogVisibility(false);
+    }).catch(() => {
+      this.setConfirmSkipDialogVisibility(false);
+      dispatch(setToastMessage({
+        message: "Failed to skip financial aid.",
+        icon: TOAST_FAILURE,
+      }));
     });
   };
 


### PR DESCRIPTION
Related to #2429. If the user receives an API failure when trying to skip financial aid, show a toast notification with an error message.

I'm not sure the best way to write tests for this change. It doesn't seem like the `skipFinancialAid` is tested at all.
![screen shot 2017-01-24 at 2 41 05 pm](https://cloud.githubusercontent.com/assets/132355/22263656/2bdf67ca-e243-11e6-9a35-209ad812977a.png)
