### PR TITLE
Toast role alert

### DIFF
--- a/static/js/components/Toast.js
+++ b/static/js/components/Toast.js
@@ -30,7 +30,7 @@ export default class Toast extends React.Component {
   render() {
     const { children, open } = this.props;
 
-    return <div className={`toast ${open ? 'open' : ''}`}>
+    return <div role="alert" className={`toast ${open ? 'open' : ''}`}>
       {children}
     </div>;
   }


### PR DESCRIPTION
Set `role="alert"` on toast notifications. This will cause screen readers to read them first when the page is loaded. See http://rawgit.com/w3c/aria/master/aria/aria.html#alert for more info.