### PR TITLE
Don't render closed Toast

### DIFF
--- a/static/js/components/Toast.js
+++ b/static/js/components/Toast.js
@@ -19,13 +19,6 @@ export default class Toast extends React.Component {
     }
   }
 
-  componentDidUpdate() {
-    const { onTimeout, timeout } = this.props;
-    if (onTimeout) {
-      setTimeout(onTimeout, timeout);
-    }
-  }
-
   render() {
     const { children } = this.props;
 

--- a/static/js/components/Toast.js
+++ b/static/js/components/Toast.js
@@ -3,7 +3,6 @@ import React from 'react';
 export default class Toast extends React.Component {
   props: {
     children: any,
-    open: boolean,
     timeout: number,
     onTimeout: () => void,
   };
@@ -13,24 +12,24 @@ export default class Toast extends React.Component {
   };
 
   componentDidMount() {
-    const { onTimeout, open, timeout } = this.props;
+    const { onTimeout, timeout } = this.props;
 
-    if (open && onTimeout) {
+    if (onTimeout) {
       setTimeout(onTimeout, timeout);
     }
   }
 
-  componentDidUpdate(prevProps: Object) {
+  componentDidUpdate() {
     const { onTimeout, timeout } = this.props;
-    if (!prevProps.open && this.props.open && onTimeout) {
+    if (onTimeout) {
       setTimeout(onTimeout, timeout);
     }
   }
 
   render() {
-    const { children, open } = this.props;
+    const { children } = this.props;
 
-    return <div className={`toast ${open ? 'open' : ''}`}>
+    return <div role="alert" className="toast">
       {children}
     </div>;
   }

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -88,8 +88,8 @@ export const FA_PENDING_STATUSES = [
 ];
 export const FA_APPROVED_STATUSES = [FA_STATUS_APPROVED, FA_STATUS_AUTO_APPROVED];
 
-export const TOAST_SUCCESS = 'success';
-export const TOAST_FAILURE = 'failure';
+export const TOAST_SUCCESS = 'done';
+export const TOAST_FAILURE = 'error';
 
 export const EDX_LINK_BASE = urljoin(SETTINGS.edx_base_url, 'courses/');
 

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -182,6 +182,30 @@ class App extends React.Component {
     dispatch(setPhotoDialogVisibility(bool));
   };
 
+  renderToast() {
+    const {
+      ui: { toastMessage }
+    } = this.props;
+    if ( !toastMessage ) {
+      return null;
+    }
+
+    const { icon: iconName, title, message } = toastMessage;
+
+    let icon;
+    if (iconName) {
+      icon = <Icon name={iconName} key="icon" />;
+    }
+
+    return <Toast onTimeout={this.clearMessage}>
+      {icon}
+      <div className="body">
+        <span className="title">{title}</span>
+        <span className="message">{message}</span>
+      </div>
+    </Toast>;
+  }
+
   render() {
     const {
       currentProgramEnrollment,
@@ -189,7 +213,6 @@ class App extends React.Component {
       ui: {
         enrollDialogError,
         enrollDialogVisibility,
-        toastMessage,
         enrollSelectedProgram,
         navDrawerOpen,
       },
@@ -205,20 +228,6 @@ class App extends React.Component {
     if (programs.getStatus === FETCH_FAILURE && !LEARNER_REGEX.test(pathname)) {
       children = <ErrorMessage errorInfo={programs.getErrorInfo} />;
       empty = true;
-    }
-
-    let open = false;
-    let message, title, icon;
-    if (toastMessage) {
-      open = true;
-
-      if (toastMessage.icon === TOAST_FAILURE) {
-        icon = <Icon name="error" key="icon "/>;
-      } else if (toastMessage.icon === TOAST_SUCCESS) {
-        icon = <Icon name="done" key="icon" />;
-      }
-      title = toastMessage.title;
-      message = toastMessage.message;
     }
 
     return <div id="app">
@@ -241,13 +250,7 @@ class App extends React.Component {
         profile={profile}
         setPhotoDialogVisibility={this.setPhotoDialogVisibility}
       />
-      <Toast onTimeout={this.clearMessage} open={open}>
-        {icon}
-        <div className="body">
-          <span className="title">{title}</span>
-          <span className="message">{message}</span>
-        </div>
-      </Toast>
+      {this.renderToast()}
       <div className="page-content">
         { children }
       </div>

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -5,10 +5,7 @@ import Icon from 'react-mdl/lib/Icon';
 import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
-import {
-  TOAST_SUCCESS,
-  TOAST_FAILURE,
-} from '../constants';
+import { TOAST_FAILURE } from '../constants';
 import ErrorMessage from '../components/ErrorMessage';
 import Navbar from '../components/Navbar';
 import Toast from '../components/Toast';

--- a/static/scss/toast.scss
+++ b/static/scss/toast.scss
@@ -1,5 +1,5 @@
 .toast {
-  display: none;
+  display: flex;
   align-items: center;
   flex-direction: row;
   position: fixed;
@@ -13,10 +13,6 @@
   top: 0;
   z-index: 100;
   font-size: 16px;
-
-  &.open {
-    display: flex;
-  }
 
   .material-icons {
     padding: 10px;


### PR DESCRIPTION
Builds off of #2434. When there isn't a `toastMessage` in the Redux state, don't render the `<Toast>` component at all. This pull request also includes the `role="alert"` change from #2434.

#### How should this be manually tested?
This pull request should have no user-visible impact at all. Make sure that you can still get toast notifications through the app.
