### PR TITLE
hide financial aid card if 100% coupon is present

### DIFF
--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -246,7 +246,7 @@ export default class FinancialAidCard extends React.Component {
       contents = this.renderAidApplicationStatus();
     }
 
-    return <Card shadow={0}>
+    return <Card shadow={0} className="financial-aid-card">
       <SkipFinancialAidDialog
         open={skipDialogVisibility}
         cancel={() => setConfirmSkipDialogVisibility(false)}

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -63,6 +63,10 @@ export default class IntegrationTestHelper {
     this.programsGetStub.returns(Promise.resolve(PROGRAMS));
     this.attachCouponStub = this.sandbox.stub(api, 'attachCoupon');
     this.attachCouponStub.returns(Promise.resolve(ATTACH_COUPON_RESPONSE));
+    this.skipFinancialAidStub = this.sandbox.stub(api, 'skipFinancialAid');
+    this.skipFinancialAidStub.returns(Promise.resolve());
+    this.addFinancialAidStub = this.sandbox.stub(api, 'addFinancialAid');
+    this.addFinancialAidStub.returns(Promise.resolve());
     this.scrollIntoViewStub = this.sandbox.stub();
     window.HTMLDivElement.prototype.scrollIntoView = this.scrollIntoViewStub;
     window.HTMLFieldSetElement.prototype.scrollIntoView = this.scrollIntoViewStub;


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #2334 

#### What's this PR do?

This checks to see if a user has a 100% off coupon before we show the financial aid card. If they do, we dont show it, and we automatically submit a request to 'skip' financial aid (provided they do not already have a financial aid object).

#### How should this be manually tested?

I think you want to:

1. confirm that without adding a coupon the financial aid card still appears.

2. add a 100% discount coupon to your user and ensure that your user does not currently have a financial aid.

3. visit `/dashboard`.

4. confirm that a request to skip financial aid was issued, and that the financial aid card UI does not show up.

I think that's it!