### PR TITLE
Freeze grade sync in case the course run has already frozen grades.

### DIFF
--- a/grades/exceptions.py
+++ b/grades/exceptions.py
@@ -1,0 +1,7 @@
+"""Exceptions for the grades app"""
+
+
+class FreezeGradeFailedException(Exception):
+    """
+    Custom Exception in case the grade freezing fails for an user.
+    """


### PR DESCRIPTION
#### What are the relevant tickets?
closes #2391 

#### What's this PR do?
If the course run has already final grades and the user does not have one for the course run, a final grade freeze is performed synchronously for the user in the course run.

#### Where should the reviewer start?
`dashboard/api.py`

#### How should this be manually tested?
The manual test is pretty complicated. 

Set in your `.env` the variable `FEATURE_FINAL_GRADE_ALGORITHM=v1` 

To really test this, you should create 2 real courses on the edX instance with a real enrollment for your user and connect one to a course on a Financial Aid program and the other to a non Financial Aid program. 
Remember to create a verified enrollment for the non Financial Aid Program.

The reason why you need to create a real course is because the freezing of a grade will trigger a refresh of the cache even if the cache is fresh, so there is no way to avoid the request to edX.

Once this is set, there are 2 parts to test.

For the first part, use the Financial Aid Program. 
Set the course run to be past, but with the upgrade deadline in the future.
Then create an entry in `grades.models.CourseRunGradingStatus` with `course_run=<your_course_run>` and `status='complete'` to simulate the status of the grades already frozen.
Then refresh the dashboard. The status for the course run should be "Failed" (unless the current grade on edX is `>>0`), but now you should have an entry in `grades.models.FinalGrade` for your user in the course_run.

For the second part, use the non Financial Aid Program. 
Set the course run to be past. The upgrade deadline is not important because the enrollment is already verified on edX (so the user paid).
Then create an entry in `grades.models.CourseRunGradingStatus` with `course_run=<your_course_run>` and `status='complete'` to simulate the status of the grades already frozen.
Then refresh the dashboard. The status for the course run should be "Failed" (the user does not have a certificate), but now you should have an entry in `grades.models.FinalGrade` for your user in the course_run.

**NOTE**: there is a way to avoid creating courses on edX and it is commenting [this line](https://github.com/mitodl/micromasters/blob/caa9081f18d73fd5a09f122c29adcf2bdef9dc1e/grades/api.py#L147) and put a dumb statement: it is where the refresh of the cache is called. 
If you do this then you can set everything locally on MM.

#### What GIF best describes this PR or how it makes you feel?
![](https://i.makeagif.com/media/7-30-2015/9wo-gS.gif)