### PR TITLE
Changed front-end handling of emails

### DIFF
--- a/static/js/actions/email.js
+++ b/static/js/actions/email.js
@@ -3,7 +3,12 @@ import type { Dispatch } from 'redux';
 import { createAction } from 'redux-actions';
 
 import type { Dispatcher } from '../flow/reduxTypes';
-import type { EmailSendResponse } from '../flow/emailTypes';
+import type {
+  EmailSendResponse,
+} from '../flow/emailTypes';
+import {
+  SEARCH_EMAIL_TYPE,
+} from '../components/email/constants';
 import * as api from '../lib/api';
 
 export const START_EMAIL_EDIT = 'START_EMAIL_EDIT';
@@ -33,13 +38,13 @@ export function sendSearchResultMail(
   searchRequest: Object
 ): Dispatcher<EmailSendResponse> {
   return (dispatch: Dispatch) => {
-    dispatch(initiateSendEmail());
+    dispatch(initiateSendEmail(SEARCH_EMAIL_TYPE));
     return api.sendSearchResultMail(subject, body, searchRequest).
       then(response => {
-        dispatch(sendEmailSuccess());
+        dispatch(sendEmailSuccess(SEARCH_EMAIL_TYPE));
         return Promise.resolve(response);
       }).catch(error => {
-        dispatch(sendEmailFailure(error));
+        dispatch(sendEmailFailure({type: SEARCH_EMAIL_TYPE, error: error}));
       });
   };
 }

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -30,9 +30,9 @@ import CustomSortingSelect from './search/CustomSortingSelect';
 import FilterVisibilityToggle from './search/FilterVisibilityToggle';
 import HitsCount from './search/HitsCount';
 import CustomNoHits from './search/CustomNoHits';
-import EmailCompositionDialog from './EmailCompositionDialog';
+import EmailCompositionDialog from './email/EmailCompositionDialog';
 import type { Option } from '../flow/generalTypes';
-import type { Email } from '../flow/emailTypes';
+import type { EmailState } from '../flow/emailTypes';
 import type { AvailableProgram } from '../flow/enrollmentTypes';
 import { EDUCATION_LEVELS } from '../constants';
 
@@ -115,11 +115,11 @@ export default class LearnerSearch extends SearchkitComponent {
     checkFilterVisibility:    (s: string) => boolean,
     setFilterVisibility:      (s: string, v: boolean) => void,
     openEmailComposer:        () => void,
-    emailDialogVisibility:    boolean,
     closeEmailDialog:         () => void,
     updateEmailEdit:          (o: Object) => void,
     sendEmail:                () => void,
-    email:                    Email,
+    emailDialogVisibility:    boolean,
+    email:                    EmailState,
     children:                 React$Element<*>[],
     currentProgramEnrollment: AvailableProgram,
   };
@@ -142,9 +142,11 @@ export default class LearnerSearch extends SearchkitComponent {
        results.hits && results.hits.hits && results.hits.hits.length > 0 ? results.hits.hits[0] : null
     );
     return hit !== null ? hit._source.program.total_courses : 0;
-  }
+  };
 
-  renderSearchHeader: Function = (openEmailComposer: Function): React$Element<*>|null => {
+  renderSearchHeader: Function = (): React$Element<*>|null => {
+    const { openEmailComposer } = this.props;
+
     if (_.isNull(this.getResults())) {
       return null;
     }
@@ -155,7 +157,7 @@ export default class LearnerSearch extends SearchkitComponent {
           <button
             id="email-selected"
             className="mdl-button minor-action"
-            onClick={() => openEmailComposer(this.searchkit)}
+            onClick={openEmailComposer}
           >
             Email These Learners
           </button>
@@ -288,7 +290,6 @@ export default class LearnerSearch extends SearchkitComponent {
       updateEmailEdit,
       sendEmail,
       email,
-      openEmailComposer,
       currentProgramEnrollment,
     } = this.props;
 
@@ -311,7 +312,7 @@ export default class LearnerSearch extends SearchkitComponent {
           </Cell>
           <Cell col={9}>
             <Card className="fullwidth results-padding" shadow={1}>
-              { this.renderSearchHeader(openEmailComposer) }
+              { this.renderSearchHeader() }
               <Hits
                 className="learner-results"
                 hitsPerPage={SETTINGS.es_page_size}

--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -3,12 +3,12 @@ import React from 'react';
 import Dialog from 'material-ui/Dialog';
 import R from 'ramda';
 
-import { FETCH_PROCESSING } from '../actions';
-import { dialogActions } from './inputs/util';
+import { FETCH_PROCESSING } from '../../actions';
+import { dialogActions } from '../inputs/util';
 import type {
-  Email,
+  EmailState,
   EmailValidationErrors
-} from '../flow/emailTypes';
+} from '../../flow/emailTypes';
 
 const showValidationError = R.curry((getter, object: EmailValidationErrors) => {
   let val = getter(object);
@@ -27,7 +27,7 @@ type EmailDialogProps = {
   closeEmailDialog: () => void,
   updateEmailEdit:  Function,
   open:             boolean,
-  email:            Email,
+  email:            EmailState,
   searchkit:        Object,
   sendEmail:        () => void,
 };
@@ -37,7 +37,7 @@ const EmailCompositionDialog = (props: EmailDialogProps) => {
     closeEmailDialog,
     updateEmailEdit,
     open,
-    email: { email, validationErrors, fetchStatus },
+    email: { inputs, validationErrors, fetchStatus },
     searchkit,
     sendEmail,
   } = props;
@@ -59,7 +59,7 @@ const EmailCompositionDialog = (props: EmailDialogProps) => {
         rows="1"
         className="email-subject"
         placeholder="Subject"
-        value={email.subject || ""}
+        value={inputs.subject || ""}
         onChange={updateEmailEdit('subject')}
       />
       { showSubjectError(validationErrors) }
@@ -67,7 +67,7 @@ const EmailCompositionDialog = (props: EmailDialogProps) => {
         rows="7"
         className="email-body"
         placeholder="Type a message"
-        value={email.body || ""}
+        value={inputs.body || ""}
         onChange={updateEmailEdit('body')}
       />
       { showBodyError(validationErrors) }

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -6,10 +6,12 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import TestUtils from 'react-addons-test-utils';
 
-import * as inputUtil from '../components/inputs/util';
-import { FETCH_PROCESSING } from '../actions';
-import { INITIAL_EMAIL_STATE, NEW_EMAIL_EDIT } from '../reducers/email';
-import { modifyTextField } from '../util/test_utils';
+import * as inputUtil from '../inputs/util';
+import { FETCH_PROCESSING } from '../../actions';
+import {
+  INITIAL_EMAIL_STATE
+} from '../../reducers/email';
+import { modifyTextField } from '../../util/test_utils';
 import EmailCompositionDialog from './EmailCompositionDialog';
 
 describe('EmailCompositionDialog', () => {
@@ -37,10 +39,7 @@ describe('EmailCompositionDialog', () => {
           closeEmailDialog={closeEmailDialog}
           updateEmailEdit={updateEmailEdit}
           open={true}
-          email={{
-            ...INITIAL_EMAIL_STATE,
-            email: NEW_EMAIL_EDIT
-          }}
+          email={{ ...INITIAL_EMAIL_STATE }}
           searchkit={{
             getHitsCount: getHitsCount
           }}
@@ -77,7 +76,6 @@ describe('EmailCompositionDialog', () => {
     renderDialog({
       email: {
         ...INITIAL_EMAIL_STATE,
-        email: NEW_EMAIL_EDIT,
         fetchStatus: FETCH_PROCESSING,
       }
     });
@@ -100,13 +98,12 @@ describe('EmailCompositionDialog', () => {
         renderDialog({
           email: {
             ...INITIAL_EMAIL_STATE,
-            email: {
-              ...NEW_EMAIL_EDIT,
-              [field]: "a field value!"
+            inputs: {
+              [field]: `${field} value!`
             }
           }
         });
-        assert.equal(getField().value, "a field value!");
+        assert.equal(getField().value, `${field} value!`);
       });
 
       it('should fire the updateEmailEdit callback on change', () => {

--- a/static/js/components/email/constants.js
+++ b/static/js/components/email/constants.js
@@ -1,0 +1,2 @@
+export const SEARCH_EMAIL_TYPE = 'searchResultEmail';
+export const COURSE_EMAIL_TYPE = 'courseTeamEmail';

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -20,6 +20,7 @@ import {
 import {
   SET_EMAIL_DIALOG_VISIBILITY,
 } from '../actions/ui';
+import { SEARCH_EMAIL_TYPE } from '../components/email/constants';
 import * as api from '../lib/api';
 import { modifyTextField } from '../util/test_utils';
 
@@ -69,16 +70,13 @@ describe('LearnerSearchPage', function () {
   it('waits for a successful email send to close the dialog', () => {
     helper.programsGetStub.returns(Promise.resolve(PROGRAMS));
     helper.store.dispatch(setEmailDialogVisibility(true));
-    const query = {
-      fake: 'query'
-    };
-    helper.store.dispatch(startEmailEdit(query));
-    let sendMail = helper.sandbox.stub(api, 'sendSearchResultMail');
-    sendMail.returns(Promise.resolve());
+    helper.store.dispatch(startEmailEdit(SEARCH_EMAIL_TYPE));
+    let sendSearchResultMail = helper.sandbox.stub(api, 'sendSearchResultMail');
+    sendSearchResultMail.returns(Promise.resolve());
 
     return renderComponent('/learners').then(() => {
       let dialog = document.querySelector('.email-composition-dialog');
-      let button = dialog.querySelector(".save-button");
+      let saveButton = dialog.querySelector(".save-button");
 
       return listenForActions([
         UPDATE_EMAIL_EDIT,
@@ -92,11 +90,17 @@ describe('LearnerSearchPage', function () {
         modifyTextField(dialog.querySelector('.email-subject'), 'subject');
         modifyTextField(dialog.querySelector('.email-body'), 'body');
 
-        TestUtils.Simulate.click(button);
+        TestUtils.Simulate.click(saveButton);
         assert.isTrue(helper.store.getState().ui.emailDialogVisibility);
       }).then(() => {
-        assert.isTrue(sendMail.calledWith("subject", "body", query));
         assert.isFalse(helper.store.getState().ui.emailDialogVisibility);
+        assert.isTrue(sendSearchResultMail.calledWith("subject", "body"));
+        // Assert that 'sendSearchResultMail' is called with an object representing an ES query, which should have
+        // specific properties. func.args[0][2] == the third arg of the first call to 'func'
+        let queryArg = sendSearchResultMail.args[0][2];
+        assert.property(queryArg, 'filter');
+        assert.property(queryArg, 'aggs');
+        assert.property(queryArg, 'size');
       });
     });
   });

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -1,24 +1,23 @@
-export type Email = {
-  subject?:   ?string,
-  body?:      ?string,
-  query?:     ?Object,
-};
-
+// @flow
 export type EmailSendResponse = {
-  errorStatusCode?:  number,
+  errorStatusCode?: number,
 };
-
 export type EmailSendError = EmailSendResponse;
 
-export type EmailValidationErrors = {
+export type EmailInputs = {
   subject?:   ?string,
   body?:      ?string,
-  query?:     ?string,
 };
+export type EmailValidationErrors = EmailInputs;
 
 export type EmailState = {
-  email:  Email,
+  inputs:           EmailInputs,
   validationErrors: EmailValidationErrors,
-  sendError: EmailSendError,
-  fetchStatus?: ?string,
-}
+  sendError:        EmailSendError,
+  fetchStatus?:     ?string,
+};
+
+export type AllEmailsState = {
+  searchResultEmail:  EmailState,
+  courseTeamEmail:    EmailState,
+};

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -180,6 +180,16 @@ export function sendSearchResultMail(subject: string, body: string, searchReques
   });
 }
 
+export function sendCourseTeamMail(subject: string, body: string, courseId: number): Promise<EmailSendResponse> {
+  return fetchJSONWithCSRF(`/api/v0/mail/course/${courseId}/`, {
+    method: 'POST',
+    body: JSON.stringify({
+      email_subject: subject,
+      email_body: body
+    })
+  });
+}
+
 export function getPrograms(): Promise<AvailablePrograms> {
   return fetchJSONWithCSRF('/api/v0/programs/', {}, true);
 }

--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -11,7 +11,7 @@ import type {
   WorkHistoryEntry,
 } from '../../flow/profileTypes';
 import type { UIState } from '../../reducers/ui';
-import type { Email } from '../../flow/emailTypes';
+import type { EmailInputs } from '../../flow/emailTypes';
 import type {
   FinancialAidState,
   FinancialAidValidation,
@@ -239,8 +239,8 @@ let emailMessages: ErrorMessages = {
   'body': 'Please fill in a body',
 };
 
-export const emailValidation = (email: Email): ValidationErrors => (
-  findErrors(email, R.keys(emailMessages), emailMessages)
+export const emailValidation = (emailInputs: EmailInputs): ValidationErrors => (
+  findErrors(emailInputs, R.keys(emailMessages), emailMessages)
 );
 
 /*


### PR DESCRIPTION
#### What are the relevant tickets?

No specific ticket - it is one of two issues that will address #2420 
⚠️️ **REBASED ON #2421** ⚠️️

#### What's this PR do?

Restructures the email portion of the app state to accommodate multiple email types

#### Where should the reviewer start?

static/js/containers/LearnerSearchPage.js

#### How should this be manually tested?

With `MAILGUN_RECIPIENT_OVERRIDE` set to your email address, send a few emails from the /learners page using the "Email These Learners" button. Try a couple different filters and make sure the email you receive contains the right recipients. Also check for normal behavior of the email dialog

#### Any background context you want to provide?

This doesn't change any functionality. I put this up as a separate PR due to the amount of code it changes

