### PR TITLE
Pearson response processing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,6 @@ services:
       EXAMS_SFTP_HOST: sftp
       EXAMS_SFTP_USERNAME: odl
       EXAMS_SFTP_PASSWORD: 123
-      EXAMS_SFTP_UPLOAD_DIR: share
 
     env_file: .env
     ports:
@@ -102,7 +101,6 @@ services:
       EXAMS_SFTP_HOST: sftp
       EXAMS_SFTP_USERNAME: odl
       EXAMS_SFTP_PASSWORD: 123
-      EXAMS_SFTP_UPLOAD_DIR: share
     env_file: .env
     links:
       - db
@@ -113,10 +111,10 @@ services:
   sftp:
     image: atmoz/sftp
     volumes:
-        - sftp_share:/home/odl/share
+        - sftp_share:/home/odl/results
     ports:
         - "2022:22"
-    command: odl:123:1001:1001:share
+    command: odl:123:1001:1001:results,results/topvue
 
 volumes:
   django_media: {}

--- a/exams/factories.py
+++ b/exams/factories.py
@@ -51,7 +51,7 @@ class ExamAuthorizationFactory(DjangoModelFactory):
         lambda: FAKE.date_time_this_year(before_now=False, after_now=True, tzinfo=pytz.utc).date()
     )
     date_last_eligible = factory.LazyAttribute(
-        lambda exam_auth: exam_auth.date_first_eligible + timedelta(days=10)
+        lambda exam_auth: exam_auth.date_first_eligible + timedelta(days=365)
     )
 
     class Meta:

--- a/exams/management/commands/simulate_sftp_responses.py
+++ b/exams/management/commands/simulate_sftp_responses.py
@@ -1,0 +1,176 @@
+"""Command to simulate Pearson responses"""
+import csv
+import io
+import os
+import random
+import time
+import zipfile
+from datetime import datetime
+
+import pytz
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from exams.pearson.constants import (
+    PEARSON_DATETIME_FORMAT,
+    PEARSON_FILE_TYPE_EAC,
+    PEARSON_FILE_TYPE_VCDC,
+)
+from exams.pearson import sftp
+
+
+class Command(BaseCommand):
+    """Simulates Pearson responses"""
+    help = 'Simulates the SFTP backend by generating random responses'
+
+    def add_arguments(self, parser):  # pylint: disable=no-self-use
+        """Configure command args"""
+        parser.add_argument(
+            '--ratio-success',
+            dest='ratio',
+            type=float,
+            default=0.5,
+        )
+        parser.add_argument(
+            '--interval',
+            dest='interval',
+            type=int,
+            default=5,
+        )
+        parser.add_argument(
+            '--poll',
+            action='store_true',
+            dest='poll',
+            default=False,
+        )
+        parser.add_argument(
+            '--keep-files',
+            action='store_true',
+            dest='keep',
+            default=False,
+        )
+
+    def handle(self, *args, **options):
+        """Handle the command"""
+        ratio = options['ratio']
+        poll = options['poll']
+        interval = options['interval']
+        keep = options['keep']
+
+        if poll:
+            while True:
+                self.handle_poll(ratio, keep)
+
+                self.stdout.write('Next poll in {} seconds'.format(interval))
+                time.sleep(interval)
+        else:
+            self.handle_poll(ratio, keep)
+
+    def handle_poll(self, ratio, keep):
+        """Handle a poll interval"""
+        self.stdout.write('Checking sftp server')
+
+        with sftp.get_connection() as sftp_conn:
+            with sftp_conn.cd(settings.EXAMS_SFTP_UPLOAD_DIR):
+                paths = [path for path in sftp_conn.listdir() if sftp_conn.isfile(path)]
+
+                self.stdout.write('Found {} file(s)'.format(len(paths)))
+
+                for path in paths:
+                    time.sleep(2)  # ensures unique filename timestamps
+                    self.stdout.write('Found a file: {}/{}'.format(sftp_conn.pwd, path))
+
+                    if path.startswith('ead'):
+                        self.handle_ead(sftp_conn, path, ratio)
+
+                    elif path.startswith('cdd'):
+                        self.handle_cdd(sftp_conn, path, ratio)
+                    else:
+                        continue
+
+                    if not keep:
+                        sftp_conn.remove(path)
+
+    def handle_ead(self, sftp_conn, remote_path, ratio):
+        """Handle an EAD file"""
+        now = datetime.now(pytz.utc)
+        result_file = io.StringIO()
+        writer = csv.DictWriter(result_file, [
+            'ClientAuthorizationID',
+            'ClientCandidateID',
+            'Status',
+            'Date',
+            'Message',
+        ], delimiter='\t')
+        writer.writeheader()
+        with sftp_conn.open(remote_path, mode='r') as eac_file:
+            for row in csv.DictReader(eac_file, delimiter='\t'):
+                cid = row['ClientCandidateID']
+                aid = row['ClientAuthorizationID']
+                error = random.random() > ratio
+                status = 'Error' if error else 'Accepted'
+                self.stdout.write('Marking authorization {aid} for profile {cid} as {status}'.format(
+                    aid=aid,
+                    cid=cid,
+                    status=status,
+                ))
+                writer.writerow({
+                    'ClientAuthorizationID': aid,
+                    'ClientCandidateID': cid,
+                    'Status': status,
+                    'Date': now.strftime(PEARSON_DATETIME_FORMAT),
+                    'Message': 'Invalid ExamSeriesCode' if error else '',
+                })
+
+        self.write_zip(
+            sftp_conn,
+            result_file.getvalue(),
+            now.strftime('{}-%Y-%m-%d.dat'.format(PEARSON_FILE_TYPE_EAC)),
+            now
+        )
+
+    def handle_cdd(self, sftp_conn, remote_path, ratio):
+        """Handle a CDD file"""
+        now = datetime.now(pytz.utc)
+        result_file = io.StringIO()
+        writer = csv.DictWriter(result_file, [
+            'ClientCandidateID',
+            'Status',
+            'Date',
+            'Message',
+        ], delimiter='\t')
+        writer.writeheader()
+        with sftp_conn.open(remote_path, mode='r') as cdd_file:
+            for row in csv.DictReader(cdd_file, delimiter='\t'):
+                cid = row['ClientCandidateID']
+                error = random.random() > ratio
+                status = 'Error' if error else 'Accepted'
+                self.stdout.write('Marking profile {cid} as {status}'.format(
+                    cid=cid,
+                    status=status,
+                ))
+                writer.writerow({
+                    'ClientCandidateID': cid,
+                    'Status': 'Error' if error else 'Accepted',
+                    'Date': now.strftime(PEARSON_DATETIME_FORMAT),
+                    'Message': 'Invalid Address' if error else '',
+                })
+
+        self.write_zip(
+            sftp_conn,
+            result_file.getvalue(),
+            now.strftime('{}-%Y-%m-%d.dat'.format(PEARSON_FILE_TYPE_VCDC)),
+            now
+        )
+
+    def write_zip(self, sftp_conn, data, filename, now):  # pylint: disable=no-self-use
+        """Write a zip file to the sftp server"""
+        zip_path = os.path.join(
+            settings.EXAMS_SFTP_TEMP_DIR,
+            now.strftime('ORGNAME-NS-%Y-%m-%d-%H%M%S.zip'),
+        )
+        with zipfile.ZipFile(zip_path, 'w') as zf:
+            zf.writestr(filename, data)
+
+        with sftp_conn.cd(settings.EXAMS_SFTP_RESULTS_DIR):
+            sftp_conn.put(zip_path)

--- a/exams/management/commands/simulate_sftp_responses_test.py
+++ b/exams/management/commands/simulate_sftp_responses_test.py
@@ -1,0 +1,92 @@
+"""Tests for simulate_sftp_responses"""
+from datetime import datetime
+from unittest.mock import (
+    ANY,
+    MagicMock,
+    patch,
+)
+
+import pytz
+from django.test import (
+    TestCase,
+    override_settings,
+)
+
+from exams.management.commands import simulate_sftp_responses
+
+
+class SimulateSftpResponsesTest(TestCase):
+    """Tests for simulate_sftp_responses"""
+
+    @patch('exams.pearson.sftp.get_connection')
+    @patch('exams.management.commands.simulate_sftp_responses.Command.handle_ead')
+    @patch('exams.management.commands.simulate_sftp_responses.Command.handle_cdd')
+    def test_handle_poll(self, handle_cdd_mock, handle_ead_mock, get_connection_mock):
+        """Test that handle_poll handles ead and cdd files"""
+        sftp_mock = get_connection_mock.return_value.__enter__.return_value
+        sftp_mock.listdir.return_value = ['ead', 'cdd', 'zzz']
+        sftp_mock.isfile.return_value = [True, True, True]
+
+        cmd = simulate_sftp_responses.Command()
+        cmd.handle_poll(0.5, False)
+
+        get_connection_mock.assert_called_once_with()
+
+        sftp_mock.cd.assert_called_once_with(ANY)
+        sftp_mock.listdir.assert_called_once_with()
+
+        handle_ead_mock.assert_called_once_with(sftp_mock, 'ead', 0.5)
+        handle_cdd_mock.assert_called_once_with(sftp_mock, 'cdd', 0.5)
+
+    @patch('csv.DictReader')
+    @patch('exams.management.commands.simulate_sftp_responses.Command.write_zip')
+    def test_handle_cdd(self, write_zip_mock, dict_reader_mock):
+        """Test that handle_cdd writes a zip file"""
+        sftp_mock = MagicMock()
+
+        dict_reader_mock.return_value = [{
+            'ClientCandidateID': 1,
+        }]
+
+        cmd = simulate_sftp_responses.Command()
+        with patch('time.sleep'):  # don't slow down tests
+            cmd.handle_cdd(sftp_mock, 'file', False)
+
+        sftp_mock.open.assert_called_once_with('file', mode='r')
+        write_zip_mock.assert_called_once_with(sftp_mock, ANY, ANY, ANY)
+
+    @patch('csv.DictReader')
+    @patch('exams.management.commands.simulate_sftp_responses.Command.write_zip')
+    def test_handle_ead(self, write_zip_mock, dict_reader_mock):
+        """Test that handle_ead writes a zip file"""
+        sftp_mock = MagicMock()
+
+        dict_reader_mock.return_value = [{
+            'ClientAuthorizationID': 2,
+            'ClientCandidateID': 1,
+        }]
+
+        cmd = simulate_sftp_responses.Command()
+        with patch('time.sleep'):  # don't slow down tests
+            cmd.handle_ead(sftp_mock, 'file', False)
+
+        sftp_mock.open.assert_called_once_with('file', mode='r')
+        write_zip_mock.assert_called_once_with(sftp_mock, ANY, ANY, ANY)
+
+    @override_settings(
+        EXAMS_SFTP_RESULTS_DIR='/results',
+    )
+    @patch('zipfile.ZipFile')
+    def test_write_zip(self, zip_file_mock):
+        """Test that write_zip writes a zip file"""
+        sftp_mock = MagicMock()
+
+        cmd = simulate_sftp_responses.Command()
+        cmd.write_zip(sftp_mock, 'data string', 'file.dat', datetime.now(pytz.utc))
+
+        zip_file_mock.assert_called_once_with(ANY, 'w')
+        zf_mock = zip_file_mock.return_value.__enter__.return_value
+        zf_mock.writestr.assert_called_once_with('file.dat', 'data string')
+
+        sftp_mock.cd.assert_called_once_with('/results')
+        sftp_mock.put.assert_called_once_with(ANY)

--- a/exams/pearson/constants.py
+++ b/exams/pearson/constants.py
@@ -4,6 +4,9 @@
 PEARSON_DATE_FORMAT = "%Y/%m/%d"
 PEARSON_DATETIME_FORMAT = "%Y/%m/%d %H:%M:%S"
 
+PEARSON_FILE_TYPE_EAC = 'eac'
+PEARSON_FILE_TYPE_VCDC = 'vcdc'
+
 # SFTP Upload constants
 PEARSON_UPLOAD_REQUIRED_SETTINGS = [
     "EXAMS_SFTP_HOST",
@@ -18,7 +21,16 @@ PEARSON_DIALECT_OPTIONS = {
     'delimiter': '\t',
 }
 
+# Only for these countries does Pearson require/support state/zip
 PEARSON_STATE_SUPPORTED_COUNTRIES = (
     "US",
     "CA",
 )
+
+# Vue Candidate Data Confirmation (VCDC) file statuses
+VCDC_SUCCESS_STATUS = "Accepted"
+VCDC_FAILURE_STATUS = "Error"
+
+# Exam Authorization Confirmation (EAC) file statuses
+EAC_SUCCESS_STATUS = "Accepted"
+EAC_FAILURE_STATUS = "Error"

--- a/exams/pearson/download.py
+++ b/exams/pearson/download.py
@@ -1,0 +1,248 @@
+"""Pearson SFTP download implementation"""
+import logging
+import os
+import zipfile
+from contextlib import contextmanager
+
+from django.conf import settings
+from paramiko import SSHException
+
+from exams.pearson.constants import (
+    EAC_SUCCESS_STATUS,
+    PEARSON_FILE_TYPE_EAC,
+    PEARSON_FILE_TYPE_VCDC,
+    VCDC_SUCCESS_STATUS,
+)
+from exams.pearson.exceptions import RetryableSFTPException
+from exams.pearson.readers import (
+    EACReader,
+    VCDCReader,
+)
+from exams.pearson import utils
+from exams.models import (
+    ExamAuthorization,
+    ExamProfile,
+)
+
+log = logging.getLogger(__name__)
+
+
+@contextmanager
+def locally_extracted(zip_file, member):
+    """
+    Context manager for temporarily extracting a zip file member to the local filesystem
+
+    Args:
+        zip_file (zipfile.ZipFile): the zip file to extract from
+        member (str): the name of the file to extract
+
+    Yields:
+        file: the extracted file object
+    """
+    extracted_file_path = zip_file.extract(member, path=settings.EXAMS_SFTP_TEMP_DIR)
+    try:
+        # csv.reader requires files to be opened in text mode, not binary
+        with open(extracted_file_path, 'r') as extracted_file:
+            yield extracted_file
+    finally:
+        if os.path.exists(extracted_file_path):
+            os.remove(extracted_file_path)
+
+
+class ArchivedResponseProcessor:
+    """
+    Handles fetching and processing of files stored in a ZIP archive on Pearson SFTP
+    """
+    def __init__(self, sftp):
+        self.sftp = sftp
+
+    def fetch_file(self, remote_path):
+        """        Fetches a remote file and returns the local path
+
+        Args:
+            remote_path (str): the remote path of the file to fetch
+
+        Returns:
+            str: the local path of the file
+        """
+        local_path = os.path.join(settings.EXAMS_SFTP_TEMP_DIR, remote_path)
+
+        self.sftp.get(remote_path, localpath=local_path)
+
+        return local_path
+
+    def filtered_files(self):
+        """
+        Walks a directory and yields files that match the pattern
+
+        Yields:
+            (str, str): a tuple of (remote_path, local_path)
+        """
+        for remote_path in self.sftp.listdir():
+            if self.sftp.isfile(remote_path) and utils.is_zip_file(remote_path):
+                yield remote_path, self.fetch_file(remote_path)
+
+    def process(self):
+        """
+        Process response files
+        """
+        try:
+            with self.sftp.cd(settings.EXAMS_SFTP_RESULTS_DIR):
+                for remote_path, local_path in self.filtered_files():
+                    try:
+                        if self.process_zip(local_path):
+                            self.sftp.remove(remote_path)
+                        log.debug("Processed remote file: %s", remote_path)
+                    except SSHException:
+                        raise
+                    except:  # pylint: disable=bare-except
+                        log.exception("Error processing file: %s", remote_path)
+                    finally:
+                        if os.path.exists(local_path):
+                            os.remove(local_path)
+        except SSHException as exc:
+            raise RetryableSFTPException("Exception processing response files") from exc
+
+    def process_zip(self, local_path):
+        """
+        Process a single zip file
+
+        Args:
+            local_path (str): path to the zip file on the local filesystem
+
+        Returns:
+            bool: True if all files processed successfully
+        """
+        processed = True
+
+        log.info('Processing Pearson zip file: %s', local_path)
+
+        # extract the zip and walk the files
+        with zipfile.ZipFile(local_path) as zip_file:
+            for extracted_filename in zip_file.namelist():
+                log.info('Processing file %s extracted from %s', extracted_filename, local_path)
+                with locally_extracted(zip_file, extracted_filename) as extracted_file:
+                    result, errors = self.process_extracted_file(extracted_file, extracted_filename)
+
+                    processed = result and processed
+
+                    if len(errors) > 0:
+                        utils.email_processing_failures(extracted_filename, local_path, errors)
+
+        return processed
+
+    def process_extracted_file(self, extracted_file, extracted_filename):
+        """
+        Processes an individual file extracted from the zip
+
+        Args:
+            extracted_file (zipfile.ZipExtFile): the extracted file-like or iterable object
+            extracted_filename (str): the filename of the extracted file
+
+        Returns:
+            (bool, list(str)): bool is True if file processed successfuly, error messages are returned in the list
+        """
+        file_type = utils.get_file_type(extracted_filename)
+
+        if file_type == PEARSON_FILE_TYPE_VCDC:
+            # We send Pearson CDD files and get the results as VCDC files
+            return self.process_vcdc_file(extracted_file)
+        elif file_type == PEARSON_FILE_TYPE_EAC:
+            # We send Pearson EAD files and get the results as EAC files
+            return self.process_eac_file(extracted_file)
+
+        return False, []
+
+    def process_vcdc_file(self, extracted_file):  # pylint: disable=no-self-use
+        """
+        Processes a VCDC file extracted from the zip
+
+        Args:
+            extracted_file (zipfile.ZipExtFile): the extracted file-like object
+
+        Returns:
+            (bool, list(str)): bool is True if file processed successfuly, error messages are returned in the list
+        """
+        log.debug('Found VCDC file: %s', extracted_file)
+        results = VCDCReader().read(extracted_file)
+        messages = []
+        for result in results:
+            try:
+                exam_profile = ExamProfile.objects.get(profile_id=result.client_candidate_id)
+            except ExamProfile.DoesNotExist:
+                error_message = "Unable to find an ExamProfile record for profile_id `{profile_id}`".format(
+                    profile_id=result.client_candidate_id
+                )
+                log.error(error_message)
+                messages.append(error_message)
+                continue
+
+            if result.status == EAC_SUCCESS_STATUS:
+                exam_profile.status = ExamProfile.PROFILE_SUCCESS
+            else:
+                exam_profile.status = ExamProfile.PROFILE_FAILED
+                error_message = "ExamProfile sync failed for user `{username}`.{error_message}".format(
+                    username=exam_profile.profile.user.username,
+                    error_message=(
+                        " Received error: '{error}'.".format(
+                            error=result.message
+                        ) if result.message else ''
+                    )
+                )
+                log.error(error_message)
+                messages.append(error_message)
+
+            exam_profile.save()
+
+        return True, messages
+
+    def process_eac_file(self, extracted_file):  # pylint: disable=no-self-use
+        """
+        Processes a EAC file extracted from the zip
+
+        Args:
+            extracted_file (zipfile.ZipExtFile): the extracted file-like object
+
+        Returns:
+            (bool, list(str)): bool is True if file processed successfuly, error messages are returned in the list
+        """
+        log.debug('Found EAC file: %s', extracted_file)
+        results = EACReader().read(extracted_file)
+        messages = []
+        for result in results:
+            try:
+                exam_authorization = ExamAuthorization.objects.get(id=result.exam_authorization_id)
+            except ExamAuthorization.DoesNotExist:
+                error_message = (
+                    'Unable to find information for authorization_id: `{authorization_id}` and '
+                    'candidate_id: `{candidate_id}` in our system.'
+                ).format(
+                    authorization_id=result.exam_authorization_id,
+                    candidate_id=result.candidate_id
+                )
+                log.error(error_message)
+                messages.append(error_message)
+                continue
+
+            if result.status == VCDC_SUCCESS_STATUS:
+                exam_authorization.status = ExamAuthorization.STATUS_SUCCESS
+            else:
+                exam_authorization.status = ExamAuthorization.STATUS_FAILED
+                error_message = (
+                    "Exam authorization failed for user `{username}` "
+                    "with authorization id `{authorization_id}`. {error_message}"
+                ).format(
+                    username=exam_authorization.user.username,
+                    authorization_id=result.exam_authorization_id,
+                    error_message=(
+                        "Received error: '{error}'.".format(
+                            error=result.message
+                        ) if result.message else ''
+                    )
+                )
+                log.error(error_message)
+                messages.append(error_message)
+
+            exam_authorization.save()
+
+        return True, messages

--- a/exams/pearson/download_test.py
+++ b/exams/pearson/download_test.py
@@ -1,0 +1,481 @@
+"""Pearson SFTP download tests"""
+from datetime import datetime
+from unittest.mock import (
+    MagicMock,
+    Mock,
+    call,
+    mock_open,
+    patch
+)
+
+import ddt
+import pytz
+from factory.django import mute_signals
+from django.db.models.signals import post_save
+from django.test import (
+    override_settings,
+    SimpleTestCase,
+)
+from paramiko import SSHException
+
+from courses.factories import CourseFactory
+from exams.factories import (
+    ExamAuthorizationFactory,
+    ExamProfileFactory,
+)
+from exams.models import (
+    ExamAuthorization,
+    ExamProfile,
+)
+from exams.pearson.constants import (
+    EAC_SUCCESS_STATUS,
+    EAC_FAILURE_STATUS,
+    VCDC_SUCCESS_STATUS,
+    VCDC_FAILURE_STATUS,
+)
+from exams.pearson import download
+from exams.pearson.exceptions import RetryableSFTPException
+from exams.pearson.readers import (
+    EACResult,
+    VCDCResult,
+)
+from exams.pearson.sftp_test import EXAMS_SFTP_SETTINGS
+from search.base import MockedESTestCase
+
+FIXED_DATETIME = datetime(2016, 5, 15, 15, 2, 55, tzinfo=pytz.UTC)
+
+
+# pylint: disable=too-many-arguments
+@ddt.ddt
+@override_settings(**EXAMS_SFTP_SETTINGS)
+class PearsonDownloadTest(SimpleTestCase):
+    """
+    Tests for non-connection Pearson download code
+    """
+    def setUp(self):
+        self.sftp = Mock()
+
+    def test_fetch_file(self):
+        """
+        Tests that fetch_file works as expected
+        """
+        remote_path = 'file.ext'
+        expected_local_path = '/tmp/file.ext'
+        processor = download.ArchivedResponseProcessor(self.sftp)
+
+        local_path = processor.fetch_file(remote_path)
+
+        assert local_path == expected_local_path
+        self.sftp.get.assert_called_once_with(remote_path, localpath=expected_local_path)
+
+    def test_filtered_files(self):
+        """
+        Test that filtered_files filters on the regex
+        """
+        listdir_values = ['a.zip', 'b.zip', 'b']
+        isfile_values = [True, False, True]
+        self.sftp.listdir.return_value = listdir_values
+        self.sftp.isfile.side_effect = isfile_values
+        processor = download.ArchivedResponseProcessor(self.sftp)
+
+        result = list(processor.filtered_files())
+
+        assert result == [('a.zip', '/tmp/a.zip')]
+
+        self.sftp.listdir.assert_called_once_with()
+        assert self.sftp.isfile.call_args_list == [call(arg) for arg in listdir_values]
+
+    @patch('exams.pearson.utils.get_file_type')
+    @patch('exams.pearson.download.ArchivedResponseProcessor.process_eac_file')
+    @patch('exams.pearson.download.ArchivedResponseProcessor.process_vcdc_file')
+    def test_process_extracted_file(self, process_vcdc_file_mock, process_eac_file_mock, get_file_type_mock):
+        """
+        Test that process_extracted_file handles file types correctly
+        """
+        extracted_file = Mock()
+        process_eac_file_mock.return_value = (True, ['EAC'])
+        process_vcdc_file_mock.return_value = (True, ['VCDC'])
+        processor = download.ArchivedResponseProcessor(self.sftp)
+
+        get_file_type_mock.return_value = 'eac'
+        assert processor.process_extracted_file(extracted_file, '') == process_eac_file_mock.return_value
+        processor.process_eac_file.assert_called_once_with(extracted_file)
+
+        get_file_type_mock.return_value = 'vcdc'
+        assert processor.process_extracted_file(extracted_file, '') == process_vcdc_file_mock.return_value
+        processor.process_vcdc_file.assert_called_once_with(extracted_file)
+
+        get_file_type_mock.return_value = None
+        assert processor.process_extracted_file(extracted_file, '') == (False, [])
+
+    @ddt.data(
+        (['a.file', 'b.file'], [(True, []), (True, [])], True),
+        (['a.file', 'b.file'], [(True, []), (False, [])], False),
+        (['a.file', 'b.file'], [(False, []), (True, [])], False),
+        (['a.file', 'b.file'], [(False, []), (False, [])], False),
+    )
+    @ddt.unpack
+    @patch('zipfile.ZipFile', spec=True)
+    @patch('exams.pearson.download.ArchivedResponseProcessor.process_extracted_file')
+    def test_process_zip(self, files, results, expected_result, process_extracted_file_mock, zip_file_mock):
+        """Tests that process_zip behaves correctly"""
+        process_extracted_file_mock.side_effect = results
+        zip_file_mock.return_value.__enter__.return_value.namelist.return_value = files
+
+        processor = download.ArchivedResponseProcessor(self.sftp)
+        with patch(
+            'exams.pearson.utils.email_processing_failures'
+        ) as email_processing_failures_mock, patch(
+            'exams.pearson.download.locally_extracted'
+        ) as locally_extracted_mock:
+            locally_extracted_mock.__enter__.return_value = []
+            assert processor.process_zip('local.zip') == expected_result
+
+        email_processing_failures_mock.assert_not_called()
+
+    @patch('zipfile.ZipFile', spec=True)
+    @patch('exams.pearson.download.ArchivedResponseProcessor.process_extracted_file')
+    def test_process_zip_email(self, process_extracted_file_mock, zip_file_mock):  # pylint: disable=no-self-use
+        """Tests that an email is sent if errors returned"""
+        process_extracted_file_mock.return_value = (True, ['ERROR'])
+        zip_file_mock.return_value.__enter__.return_value.namelist.return_value = ['a.dat']
+
+        processor = download.ArchivedResponseProcessor(self.sftp)
+        with patch('exams.pearson.utils.email_processing_failures') as email_processing_failures_mock:
+            processor.process_zip('local.zip')
+
+        email_processing_failures_mock.assert_called_once_with('a.dat', 'local.zip', ['ERROR'])
+
+    @ddt.data(
+        (True, 1),
+        (False, 0),
+    )
+    @ddt.unpack
+    @patch('os.path.exists')
+    @patch('os.remove')
+    def test_locally_extracted(self, exists, remove_count, remove_mock, exists_mock):
+        """
+        Tests that the local file gets removed on error if it exists
+        """
+        zip_mock = Mock(return_value='path')
+        exists_mock.return_value = exists
+        with patch('exams.pearson.download.open', mock_open(), create=True) as open_mock:
+            open_mock.side_effect = Exception('exception')
+            with self.assertRaises(Exception):
+                with download.locally_extracted(zip_mock, 'file'):
+                    pass
+            open_mock.assert_called_once_with(zip_mock.extract.return_value, 'r')
+
+        exists_mock.assert_called_once_with(zip_mock.extract.return_value)
+
+        assert remove_mock.call_count == remove_count
+
+
+@override_settings(**EXAMS_SFTP_SETTINGS)
+@patch('os.remove')
+@patch('os.path.exists', return_value=True)
+@patch(
+    'exams.pearson.download.ArchivedResponseProcessor.filtered_files',
+    return_value=[
+        ('a.zip', '/tmp/a.zip'),
+    ]
+)
+@patch('exams.pearson.download.ArchivedResponseProcessor.process_zip', return_value=True)
+class ArchivedResponseProcessorProcessTest(SimpleTestCase):
+    """Tests around ArchivedResponseProcessor.process"""
+    def setUp(self):
+        self.sftp = MagicMock()
+
+    def test_process_success(self, process_zip_mock, filtered_files_mock, os_path_exists_mock, os_remove_mock):
+        """Test the happy path"""
+        processor = download.ArchivedResponseProcessor(self.sftp)
+        processor.process()
+
+        filtered_files_mock.assert_called_once_with()
+        self.sftp.remove.assert_called_once_with('a.zip')
+        process_zip_mock.assert_called_once_with('/tmp/a.zip')
+        os_path_exists_mock.assert_called_once_with('/tmp/a.zip')
+        os_remove_mock.assert_called_once_with('/tmp/a.zip')
+
+    def test_process_failure(self, process_zip_mock, filtered_files_mock, os_path_exists_mock, os_remove_mock):
+        """Test the unhappy path"""
+        process_zip_mock.return_value = False
+        processor = download.ArchivedResponseProcessor(self.sftp)
+        processor.process()
+
+        filtered_files_mock.assert_called_once_with()
+        self.sftp.remove.assert_not_called()
+        process_zip_mock.assert_called_once_with('/tmp/a.zip')
+        os_path_exists_mock.assert_called_once_with('/tmp/a.zip')
+        os_remove_mock.assert_called_once_with('/tmp/a.zip')
+
+    def test_process_exception(self, process_zip_mock, filtered_files_mock, os_path_exists_mock, os_remove_mock):
+        """Test that process() cleans up the local but not the remote on any processing exception"""
+        process_zip_mock.side_effect = Exception('exception')
+
+        processor = download.ArchivedResponseProcessor(self.sftp)
+        processor.process()
+
+        filtered_files_mock.assert_called_once_with()
+        self.sftp.remove.assert_not_called()
+        process_zip_mock.assert_called_once_with('/tmp/a.zip')
+        os_path_exists_mock.assert_called_once_with('/tmp/a.zip')
+        os_remove_mock.assert_called_once_with('/tmp/a.zip')
+
+    def test_process_ssh_exception_remove(
+            self, process_zip_mock, filtered_files_mock, os_path_exists_mock, os_remove_mock):
+        """Test that SSH exceptions bubble up"""
+        self.sftp.remove.side_effect = SSHException('exception')
+
+        processor = download.ArchivedResponseProcessor(self.sftp)
+        with self.assertRaises(RetryableSFTPException):
+            processor.process()
+
+        filtered_files_mock.assert_called_once_with()
+        self.sftp.remove.assert_called_once_with('a.zip')
+        process_zip_mock.assert_called_once_with('/tmp/a.zip')
+        os_path_exists_mock.assert_called_once_with('/tmp/a.zip')
+        os_remove_mock.assert_called_once_with('/tmp/a.zip')
+
+    def test_process_ssh_exception_cd(
+            self, process_zip_mock, filtered_files_mock, os_path_exists_mock, os_remove_mock):
+        """Test that SSH exceptions bubble up"""
+        self.sftp.cd.side_effect = SSHException('exception')
+
+        processor = download.ArchivedResponseProcessor(self.sftp)
+        with self.assertRaises(RetryableSFTPException):
+            processor.process()
+
+        filtered_files_mock.assert_not_called()
+        self.sftp.remove.assert_not_called()
+        process_zip_mock.assert_not_called()
+        os_path_exists_mock.assert_not_called()
+        os_remove_mock.assert_not_called()
+
+    def test_process_missing_local(self, process_zip_mock, filtered_files_mock, os_path_exists_mock, os_remove_mock):
+        """Test that a missing local file doesn't fail"""
+        os_path_exists_mock.return_value = False
+
+        processor = download.ArchivedResponseProcessor(self.sftp)
+        processor.process()
+
+        filtered_files_mock.assert_called_once_with()
+        self.sftp.remove.assert_called_once_with('a.zip')
+        process_zip_mock.assert_called_once_with('/tmp/a.zip')
+        os_path_exists_mock.assert_called_once_with('/tmp/a.zip')
+        os_remove_mock.assert_not_called()
+
+
+@override_settings(**EXAMS_SFTP_SETTINGS)
+@ddt.ddt
+class VCDCDownloadTest(MockedESTestCase):
+    """
+    Test for Vue Candidate Data Confirmation files (VCDC) files processing.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        sftp = Mock()
+        cls.now = datetime.now(pytz.utc)
+        cls.processor = download.ArchivedResponseProcessor(sftp)
+        with mute_signals(post_save):
+            cls.success_profiles = ExamProfileFactory.create_batch(2)
+            cls.failure_profiles = ExamProfileFactory.create_batch(2)
+
+        cls.success_results = [VCDCResult(
+            client_candidate_id=exam_profile.profile.student_id,
+            status=VCDC_SUCCESS_STATUS,
+            date=cls.now,
+            message='',
+        ) for exam_profile in cls.success_profiles]
+        cls.failed_results = [
+            VCDCResult(
+                client_candidate_id=cls.failure_profiles[0].profile.student_id,
+                status=VCDC_FAILURE_STATUS,
+                date=cls.now,
+                message='',
+            ),
+            VCDCResult(
+                client_candidate_id=cls.failure_profiles[1].profile.student_id,
+                status=VCDC_FAILURE_STATUS,
+                date=cls.now,
+                message='Bad address',
+            ),
+        ]
+
+        cls.all_results = cls.success_results + cls.failed_results
+
+    def test_process_result_vcdc(self):
+        """
+        Test file processing, happy case.
+        """
+
+        with patch('exams.pearson.download.VCDCReader.read', return_value=self.success_results):
+            assert self.processor.process_vcdc_file("/tmp/file.ext") == (True, [])
+
+            for profile in self.success_profiles:
+                profile.refresh_from_db()
+                assert profile.status == ExamProfile.PROFILE_SUCCESS
+
+    def test_process_result_vcdc_when_error(self):
+        """
+        Test situation where we get failure results back
+        """
+
+        with patch('exams.pearson.download.VCDCReader.read', return_value=self.all_results):
+            assert self.processor.process_vcdc_file("/tmp/file.ext") == (
+                True,
+                [
+                    "ExamProfile sync failed for user `{username}`.".format(
+                        username=self.failure_profiles[0].profile.user.username),
+                    "ExamProfile sync failed for user `{username}`. Received error: 'Bad address'.".format(
+                        username=self.failure_profiles[1].profile.user.username),
+                ]
+            )
+            for profile in self.success_profiles:
+                profile.refresh_from_db()
+                assert profile.status == ExamProfile.PROFILE_SUCCESS
+
+            for profile in self.failure_profiles:
+                profile.refresh_from_db()
+                assert profile.status == ExamProfile.PROFILE_FAILED
+
+    def test_process_result_vcdc_when_invalid_data_in_file(self):
+        """Tests for the situation where we don't have a matching record"""
+        results = [
+            VCDCResult(
+                client_candidate_id=10,
+                status=VCDC_SUCCESS_STATUS,
+                date=self.now,
+                message=''
+            ),
+            VCDCResult(
+                client_candidate_id=11,
+                status=VCDC_FAILURE_STATUS,
+                date=self.now,
+                message='Invalid address'
+            )
+        ]
+
+        with patch('exams.pearson.download.VCDCReader.read', return_value=results):
+            assert self.processor.process_vcdc_file("/tmp/file.ext") == (
+                True,
+                [
+                    'Unable to find an ExamProfile record for profile_id `10`',
+                    'Unable to find an ExamProfile record for profile_id `11`',
+                ]
+            )
+
+
+@override_settings(**EXAMS_SFTP_SETTINGS)
+@ddt.ddt
+class EACDownloadTest(MockedESTestCase):
+    """
+    Test for Exam Authorization Confirmation files (EAC) files processing.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        sftp = Mock()
+        cls.processor = download.ArchivedResponseProcessor(sftp)
+        cls.course = course = CourseFactory.create()
+        cls.success_auths = ExamAuthorizationFactory.create_batch(2, course=course)
+        cls.failure_auths = ExamAuthorizationFactory.create_batch(2, course=course)
+
+        cls.success_results = [EACResult(
+            exam_authorization_id=auth.id,
+            candidate_id=auth.user.profile.student_id,
+            date=FIXED_DATETIME,
+            status=EAC_SUCCESS_STATUS,
+            message='',
+        ) for auth in cls.success_auths]
+        cls.failed_results = [
+            EACResult(
+                exam_authorization_id=cls.failure_auths[0].id,
+                candidate_id=cls.failure_auths[0].user.profile.student_id,
+                date=FIXED_DATETIME,
+                status=EAC_FAILURE_STATUS,
+                message='',
+            ),
+            EACResult(
+                exam_authorization_id=cls.failure_auths[1].id,
+                candidate_id=cls.failure_auths[1].user.profile.student_id,
+                date=FIXED_DATETIME,
+                status=EAC_FAILURE_STATUS,
+                message='wrong username',
+            ),
+        ]
+
+        cls.all_results = cls.success_results + cls.failed_results
+
+    def test_process_result_eac(self):
+        """
+        Test Exam Authorization Confirmation files (EAC) file processing, happy case.
+        """
+
+        with patch('exams.pearson.download.EACReader.read', return_value=self.success_results):
+            assert self.processor.process_eac_file("/tmp/file.ext") == (True, [])
+
+            for auth in self.success_auths:
+                auth.refresh_from_db()
+                assert auth.status == ExamAuthorization.STATUS_SUCCESS
+
+    def test_process_result_eac_when_error(self):
+        """
+        Test Exam Authorization Confirmation files (EAC) file processing, failure case.
+        """
+
+        with patch('exams.pearson.download.EACReader.read', return_value=self.all_results):
+            assert self.processor.process_eac_file("/tmp/file.ext") == (
+                True,
+                [
+                    "Exam authorization failed for user `{username}` with authorization "
+                    "id `{auth_id}`. ".format(
+                        username=self.failure_auths[0].user.username,
+                        auth_id=self.failure_auths[0].id
+                    ),
+                    "Exam authorization failed for user `{username}` with authorization id `{auth_id}`. "
+                    "Received error: 'wrong username'.".format(
+                        username=self.failure_auths[1].user.username,
+                        auth_id=self.failure_auths[1].id
+                    )
+                ]
+            )
+            for auth in self.success_auths:
+                auth.refresh_from_db()
+                assert auth.status == ExamAuthorization.STATUS_SUCCESS
+
+            for auth in self.failure_auths:
+                auth.refresh_from_db()
+                assert auth.status == ExamAuthorization.STATUS_FAILED
+
+    def test_process_result_eac_when_invalid_data_in_file(self):
+        """
+        Test Exam Authorization Confirmation files (EAC) file processing, when this is
+        record in EAC corresponding to which there in no record in ExamAuthorization model.
+        """
+        results = [
+            EACResult(
+                exam_authorization_id=10,
+                candidate_id=10,
+                date=FIXED_DATETIME,
+                status=EAC_SUCCESS_STATUS,
+                message=''
+            ),
+            EACResult(
+                exam_authorization_id=11,
+                candidate_id=11,
+                date=FIXED_DATETIME,
+                status=EAC_FAILURE_STATUS,
+                message='wrong user name'
+            )
+        ]
+
+        with patch('exams.pearson.download.EACReader.read', return_value=results):
+            assert self.processor.process_eac_file("/tmp/file.ext") == (
+                True,
+                [
+                    "Unable to find information for authorization_id: `10` and candidate_id: `10` "
+                    "in our system.",
+                    "Unable to find information for authorization_id: `11` and candidate_id: `11` "
+                    "in our system."
+                ]
+            )

--- a/exams/pearson/sftp.py
+++ b/exams/pearson/sftp.py
@@ -1,0 +1,48 @@
+"""
+Pearson SFTP upload implementation
+"""
+import logging
+
+import pysftp
+from pysftp.exceptions import ConnectionException
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from paramiko import SSHException
+
+from exams.pearson.exceptions import RetryableSFTPException
+from exams.pearson.constants import PEARSON_UPLOAD_REQUIRED_SETTINGS
+
+log = logging.getLogger(__name__)
+
+
+def get_connection():
+    """
+    Creates a new SFTP connection
+
+    Returns:
+        connection(pysftp.Connection):
+            the configured connection
+    """
+    missing_settings = []
+    for key in PEARSON_UPLOAD_REQUIRED_SETTINGS:
+        if getattr(settings, key) is None:
+            missing_settings.append(key)
+
+    if missing_settings:
+        raise ImproperlyConfigured(
+            "The setting(s) {} are required".format(', '.join(missing_settings))
+        )
+
+    cnopts = pysftp.CnOpts()
+    cnopts.hostkeys = None  # ignore knownhosts
+
+    try:
+        return pysftp.Connection(
+            host=str(settings.EXAMS_SFTP_HOST),
+            port=int(settings.EXAMS_SFTP_PORT),
+            username=str(settings.EXAMS_SFTP_USERNAME),
+            password=str(settings.EXAMS_SFTP_PASSWORD),
+            cnopts=cnopts,
+        )
+    except (ConnectionException, SSHException) as ex:
+        raise RetryableSFTPException() from ex

--- a/exams/pearson/sftp_test.py
+++ b/exams/pearson/sftp_test.py
@@ -1,0 +1,70 @@
+
+"""
+Tests for Pearson SFTP
+"""
+from unittest.mock import (
+    ANY,
+    patch,
+)
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase, override_settings
+from ddt import ddt, data
+
+from exams.pearson.constants import PEARSON_UPLOAD_REQUIRED_SETTINGS
+from exams.pearson.sftp import get_connection
+
+
+EXAMS_SFTP_FILENAME = 'FILENAME'
+EXAMS_SFTP_HOST = 'l0calh0st'
+EXAMS_SFTP_PORT = '345'
+EXAMS_SFTP_USERNAME = 'username'
+EXAMS_SFTP_PASSWORD = 'password'
+EXAMS_SFTP_UPLOAD_DIR = 'tmp'
+EXAMS_SFTP_RESULTS_DIR = '/tmp'
+EXAMS_SFTP_SETTINGS = {
+    'EXAMS_SFTP_HOST': EXAMS_SFTP_HOST,
+    'EXAMS_SFTP_PORT': EXAMS_SFTP_PORT,
+    'EXAMS_SFTP_USERNAME': EXAMS_SFTP_USERNAME,
+    'EXAMS_SFTP_PASSWORD': EXAMS_SFTP_PASSWORD,
+    'EXAMS_SFTP_UPLOAD_DIR': EXAMS_SFTP_UPLOAD_DIR,
+    'EXAMS_SFTP_RESULTS_DIR': EXAMS_SFTP_RESULTS_DIR,
+}
+
+
+@ddt
+@override_settings(**EXAMS_SFTP_SETTINGS)
+@patch('pysftp.Connection')
+class PeasonSFTPTest(SimpleTestCase):
+    """
+    Tests for Pearson upload_tsv
+    """
+
+    def test_get_connection_settings(self, connection_mock):  # pylint: disable=no-self-use
+        """
+        Tests that get_connection calls psftp.Connection with the correct values
+        """
+        connection = get_connection()
+        connection_mock.assert_called_once_with(
+            host=EXAMS_SFTP_HOST,
+            port=int(EXAMS_SFTP_PORT),
+            username=EXAMS_SFTP_USERNAME,
+            password=EXAMS_SFTP_PASSWORD,
+            cnopts=ANY,
+        )
+
+        assert connection == connection_mock.return_value
+
+    @data(*PEARSON_UPLOAD_REQUIRED_SETTINGS)
+    def test_get_connection_missing_settings(self, settings_key, connection_mock):
+        """
+        Tests that get_connection ImproperlyConfigured if settings.{0} is not set
+        """
+        kwargs = {settings_key: None}
+
+        with self.settings(**kwargs):
+            with self.assertRaises(ImproperlyConfigured) as cm:
+                get_connection()
+
+            connection_mock.assert_not_called()
+            assert settings_key in cm.exception.args[0]

--- a/exams/pearson/upload.py
+++ b/exams/pearson/upload.py
@@ -1,51 +1,11 @@
 """
 Pearson SFTP upload implementation
 """
-import logging
-
-import pysftp
-from pysftp.exceptions import ConnectionException
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from paramiko import SSHException
 
 from exams.pearson.exceptions import RetryableSFTPException
-from exams.pearson.constants import PEARSON_UPLOAD_REQUIRED_SETTINGS
-
-log = logging.getLogger(__name__)
-
-
-def get_connection():
-    """
-    Creates a new SFTP connection
-
-    Returns:
-        connection(pysftp.Connection):
-            the configured connection
-    """
-    missing_settings = []
-    for key in PEARSON_UPLOAD_REQUIRED_SETTINGS:
-        if getattr(settings, key) is None:
-            missing_settings.append(key)
-
-    if missing_settings:
-        raise ImproperlyConfigured(
-            "The setting(s) {} are required".format(', '.join(missing_settings))
-        )
-
-    cnopts = pysftp.CnOpts()
-    cnopts.hostkeys = None  # ignore knownhosts
-
-    try:
-        return pysftp.Connection(
-            host=str(settings.EXAMS_SFTP_HOST),
-            port=int(settings.EXAMS_SFTP_PORT),
-            username=str(settings.EXAMS_SFTP_USERNAME),
-            password=str(settings.EXAMS_SFTP_PASSWORD),
-            cnopts=cnopts,
-        )
-    except (ConnectionException, SSHException) as ex:
-        raise RetryableSFTPException() from ex
+from exams.pearson.sftp import get_connection
 
 
 def upload_tsv(file_path):

--- a/exams/pearson/upload_test.py
+++ b/exams/pearson/upload_test.py
@@ -1,34 +1,20 @@
 """
 Tests for Pearson SFTP
 """
-from unittest.mock import (
-    ANY,
-    patch,
-)
+from unittest.mock import patch
 
-from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase, override_settings
 from ddt import ddt, data
 from paramiko import SSHException
 from pysftp.exceptions import ConnectionException
 
 from exams.pearson import upload
-from exams.pearson.constants import PEARSON_UPLOAD_REQUIRED_SETTINGS
 from exams.pearson.exceptions import RetryableSFTPException
-
-EXAMS_SFTP_FILENAME = 'FILENAME'
-EXAMS_SFTP_HOST = 'l0calh0st'
-EXAMS_SFTP_PORT = '345'
-EXAMS_SFTP_USERNAME = 'username'
-EXAMS_SFTP_PASSWORD = 'password'
-EXAMS_SFTP_UPLOAD_DIR = 'tmp'
-EXAMS_SFTP_SETTINGS = {
-    'EXAMS_SFTP_HOST': EXAMS_SFTP_HOST,
-    'EXAMS_SFTP_PORT': EXAMS_SFTP_PORT,
-    'EXAMS_SFTP_USERNAME': EXAMS_SFTP_USERNAME,
-    'EXAMS_SFTP_PASSWORD': EXAMS_SFTP_PASSWORD,
-    'EXAMS_SFTP_UPLOAD_DIR': EXAMS_SFTP_UPLOAD_DIR,
-}
+from exams.pearson.sftp_test import (
+    EXAMS_SFTP_FILENAME,
+    EXAMS_SFTP_UPLOAD_DIR,
+    EXAMS_SFTP_SETTINGS,
+)
 
 
 @ddt
@@ -36,7 +22,7 @@ EXAMS_SFTP_SETTINGS = {
 @patch('pysftp.Connection')
 class PeasonUploadTest(SimpleTestCase):
     """
-    Tests for Pearson upload
+    Tests for Pearson upload_tsv
     """
 
     def test_upload_tsv(self, connection_mock):
@@ -44,13 +30,6 @@ class PeasonUploadTest(SimpleTestCase):
         Tests that upload uses the correct settings values
         """
         upload.upload_tsv(EXAMS_SFTP_FILENAME)
-        connection_mock.assert_called_once_with(
-            host=EXAMS_SFTP_HOST,
-            port=int(EXAMS_SFTP_PORT),
-            username=EXAMS_SFTP_USERNAME,
-            password=EXAMS_SFTP_PASSWORD,
-            cnopts=ANY,
-        )
 
         ftp_mock = connection_mock.return_value.__enter__.return_value
         ftp_mock.cd.assert_called_once_with(EXAMS_SFTP_UPLOAD_DIR)
@@ -70,17 +49,3 @@ class PeasonUploadTest(SimpleTestCase):
 
         assert isinstance(cm.exception, RetryableSFTPException)
         assert cm.exception.__cause__ == expected_exc
-
-    @data(*PEARSON_UPLOAD_REQUIRED_SETTINGS)
-    def test_upload_tsv_fails_if_settings_missing(self, settings_key, connection_mock):
-        """
-        Tests that upload raises ImproperlyConfigured if settings.{0} is not set
-        """
-        kwargs = {settings_key: None}
-
-        with self.settings(**kwargs), patch('pysftp.Connection') as connection_mock:
-            with self.assertRaises(ImproperlyConfigured) as cm:
-                upload.upload_tsv('file.tsv')
-
-            connection_mock.assert_not_called()
-            assert settings_key in cm.exception.args[0]

--- a/exams/pearson/utils.py
+++ b/exams/pearson/utils.py
@@ -1,0 +1,78 @@
+"""Utilities for Pearson-specific code"""
+import re
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from mail import api as mail_api
+
+ZIP_FILE_RE = re.compile(r'^.+\.zip$')
+EXTRACTED_FILE_RE = re.compile(r"""
+    ^
+    (                        # supported file types
+        vcdc |               # Vue Candidate Data Confirmation
+        eac                  # Exam Authorization Confirmation
+    )
+    \-
+    (\d{4}\-\d{2}\-\d{2})    # date of file export
+    .*?                      # nothing standard after the date
+    \.dat                    # extension
+    $
+""", re.VERBOSE)
+
+
+def is_zip_file(filename):
+    """
+    Checks if a filename looks like a zip file
+
+    Args:
+        filename (str): filename to check
+    Returns:
+        bool: True if the file is a zip file
+    """
+    return bool(ZIP_FILE_RE.match(filename))
+
+
+def get_file_type(filename):
+    """
+    Determines the file type of a Pearson response file
+    Args:
+        filename (str): the filename to determine the type of
+
+    Returns:
+        str: the file type of the file
+    """
+    match = EXTRACTED_FILE_RE.match(filename)
+    return match.group(1) if match else None
+
+
+def email_processing_failures(filename, zipfile, messages):
+    """
+    Email summary of failures to mm admin
+
+    Args:
+        filename(str): Path of file on local machine.
+        zipfile(str): Filename of the zip file
+        messages(list): List of error messages compiled in processing
+            Exam Authorization Confirmation files (EAC) file.
+    """
+    if getattr(settings, 'ADMIN_EMAIL', None) is None:
+        raise ImproperlyConfigured('Setting ADMIN_EMAIL is not set')
+
+    error_messages = '\n'.join('- {}'.format(message) for message in messages)
+    subject = "Summary of failures of Pearson file='{file}'".format(file=filename)
+    body = (
+        "Hi,\n"
+        "The following errors were found in the file {filename} in {zipfile}:\n\n"
+        "{messages}"
+    ).format(
+        messages=error_messages,
+        filename=filename,
+        zipfile=zipfile
+    )
+
+    mail_api.MailgunClient().send_individual_email(
+        subject,
+        body,
+        settings.ADMIN_EMAIL
+    )

--- a/exams/pearson/utils_test.py
+++ b/exams/pearson/utils_test.py
@@ -1,0 +1,41 @@
+"""Tests for Pearson utils"""
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from exams.pearson import utils
+
+
+class PearsonUtilsTest(SimpleTestCase):
+    """Tests for Pearson utils"""
+    def test_is_zip_file(self):  # pylint: disable=no-self-use
+        """Tests is_zip_file"""
+        assert utils.is_zip_file('file.zip') is True
+        assert utils.is_zip_file('file.not') is False
+        assert utils.is_zip_file('file') is False
+
+    def test_get_file_type(self):  # pylint: disable=no-self-use
+        """Tests get_file_type"""
+        assert utils.get_file_type('vcdc-2016-02-08-a.dat') == 'vcdc'
+        assert utils.get_file_type('eac-2016-02-08-a.dat') == 'eac'
+        assert utils.get_file_type('eac-2016-02-08-a.not') is None
+        assert utils.get_file_type('asdfsad-2016-02-08-a.dat') is None
+
+    @patch('mail.api.MailgunClient')
+    def test_email_processing_failures(self, mailgun_client_mock):  # pylint: disable=no-self-use
+        """Test email_processing_failures for correct calls and formatting"""
+
+        with self.settings(ADMIN_EMAIL='admin@example.com'):
+            utils.email_processing_failures('b.dat', 'a.zip', [
+                'ERROR',
+                'ERROR2',
+            ])
+
+        client_instance = mailgun_client_mock.return_value
+        client_instance.send_individual_email.assert_called_once_with(
+            "Summary of failures of Pearson file='b.dat'",
+            "Hi,\nThe following errors were found in the "
+            "file b.dat in a.zip:\n\n"
+            "- ERROR\n- ERROR2",
+            "admin@example.com"
+        )

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -501,6 +501,10 @@ CELERYBEAT_SCHEDULE = {
         'task': 'exams.tasks.export_exam_authorizations',
         'schedule': crontab(minute=0, hour='*')
     },
+    'pearson-zip-files-processing-every-1-hrs': {
+        'task': 'exams.tasks.batch_process_pearson_zip_files',
+        'schedule': crontab(minute=0, hour='*')
+    },
 }
 CELERY_TIMEZONE = 'UTC'
 
@@ -526,12 +530,14 @@ OPEN_EXCHANGE_RATES_URL = get_var("OPEN_EXCHANGE_RATES_URL", None)
 OPEN_EXCHANGE_RATES_APP_ID = get_var("OPEN_EXCHANGE_RATES_APP_ID", "")
 
 # Exams SFTP
+EXAMS_SFTP_TEMP_DIR = get_var('EXAMS_SFTP_TEMP_DIR', '/tmp')
 EXAMS_SFTP_HOST = get_var('EXAMS_SFTP_HOST', 'localhost')
 EXAMS_SFTP_PORT = get_var('EXAMS_SFTP_PORT', '22')
 EXAMS_SFTP_USERNAME = get_var('EXAMS_SFTP_USERNAME', None)
 EXAMS_SFTP_PASSWORD = get_var('EXAMS_SFTP_PASSWORD', None)
-EXAMS_SFTP_UPLOAD_DIR = get_var('EXAMS_SFTP_UPLOAD_DIR', 'results/topvue')
-EXAMS_SFTP_BACKOFF_BASE = get_var('EXAMS_SFTP_BACKOFF_BASE', 5)
+EXAMS_SFTP_UPLOAD_DIR = get_var('EXAMS_SFTP_UPLOAD_DIR', '/results/topvue')
+EXAMS_SFTP_RESULTS_DIR = get_var('EXAMS_SFTP_RESULTS_DIR', '/results')
+EXAMS_SFTP_BACKOFF_BASE = get_var('EXAMS_SFTP_BACKOFF_BASE', '5')
 
 # Pearson SSO
 EXAMS_SSO_PASSPHRASE = get_var('EXAMS_SSO_PASSPHRASE', None)


### PR DESCRIPTION
_**Before starting review on this, please message me so I can share the documentation with you**_

---

#### What are the relevant tickets?

Fixes #1797 and #2422

#### What's this PR do?

This PR primarily adds processing of two types of Pearson result files. Each row in these files is a result of a corresponding row in a file we uploaded. The results are asynchronous and since Pearson only processes our uploads every 12 hours it can be a while between upload and results. You can think of this as RPC-over-SFTP. Pearson places these files on their SFTP server so we have to periodically poll and check for new ones. They also need to be removed once we've processed them.

The two types of files we're immediately interested in:

- VCDC - results to CDD (profile data) files we upload. Corresspond to `ExamProfile` records.
- EAD - results to EAD (exam authorization) files we upload. Correspond to `ExamAuthorization` records.

Both of these records go through a status lifecycle roughly `PENDING` -> `IN_PROGRESS` -> (`SUCCESS` | `FAILURE`). This code handles processing response files from Pearson to determine if our original request was a success or failure.

A slight complication is that these result files are contained in ZIP files and there's no documented convention of which result files show up in which zip files. The approach I've taken here is to basically walk all the zip files and then walk their contents file-by-file, handling the files that we currently support parsing for. ZIP files we don't consume fully are left on the server (in case we change our mind down the road and want to re-parse all historic data of that type). In my observations, the VCDC and EAD files always come together in the same zip file with no other file types.

#### Where should the reviewer start?

The meat of this implementation is in two places:

- `exams/pearson/readers.py` - implementation of VCDC- and EAC-specific readers. These parse TSV files into a list of rows, in this case using `namedtuple`s (could be classes, but that's overkill).
- `exams/pearson/download.py` - this code walks the SFTP server and downloads each zip file into a temporary directory. Each TSV file within is then extracted locally, parsed, and processed based on the filename prefix (e.g.` vcdc-2016-02-15-a.dat` is a VCDC file). Errors are logged and emailed.

#### How should this be manually tested?

To test first ensure you're enrolled in a course and have a fully filled out profile and then you can run this in shell (keep it open!):

```python
from django.contrib.auth.models import User
from exams.models import ExamProfile, ExamAuthorization
from courses.models import Course

user = User.objects.get(username=<YOU>)
course = Course.objects.get(id=<COURSE_ID>)

# fudge the records to sync
ep = ExamProfile.objects.create(profile=user.profile)
ea = ExamAuthorization.objects.create(user=user, course=course)

# sync each object type to the sftp server
tasks.export_exam_profiles()
tasks.export_exam_authorizations()
```

Then, run this command to simulate the processing of the files you just exported:

`docker-compose run web ./manage.py simulate_sftp_responses --poll`

That command will randomly assign success/failure response, write them out to a response file and put that file in a zip file on the local sftp container. This is basically a dumb simulation of what Pearson will do. You can check the sftp server to verify these files are in place :

```shell
sftp -P 2022 odl@localhost # password: 123
cd results
ls
```

Then you can finally run the real deal of this PR in the first shell you opened (you won't see much output since it all going to the logging module):

```python
tasks.batch_process_pearson_zip_files()
ea.refresh_from_db()
ep.refresh_from_db()
print((ea.id, ea.status))
print((ep.id, ep.status))
```

That should process and remove the zip files from the SFTP server and the respective record statuses should now be either success or failure matching what `simulate_sftp_responses` output (our model constants differ from the response file constants).

#### What GIF best describes this PR or how it makes you feel?

![Processing](http://i.giphy.com/5rVv3TyEzGcwM.gif)