### PR TITLE
Fixed exam authorization command and refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,21 @@ You should now be able to do the following:
 1. Click "Sign in with edX.org" and sign in by authorizing an edX client. If you're
  running edX locally, this will be the client you created in the steps above.
 
+#### 7) Authorize for exam manually
+ We can authorize user(s) for exam(s) manually using django command only if they paid and 
+ passed selected course(s). **Note:** ``course.exam_module`` and ``program.exam_series_code`` must be set.
+ 
+ **params**
+ - **--username:** (optional) If provided, command will look for given user only, 
+    and authorize him if he matches the critaria.
+ - **--program-id:** (optional) if provided, command will look for given program only, 
+    and authorize all users who matches the critaria.
+ - **--all:** (optional) if provided, command will authorize all eligible users for exams.
+ 
+```shell 
+    docker-compose run web ./manage.py authorization_user_exam --username=(value) --program-id=(value)
+```
+
 ## Wagtail CMS (Content Management System)
 
 The CMS can be found at `/cms/`. Use the CMS to manage the content of the program pages and, by extension, the home 

--- a/courses/models.py
+++ b/courses/models.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 
+from courses.utils import is_blank
 from grades.constants import FinalGradeStatus
 from micromasters.utils import first_matching_item
 
@@ -282,6 +283,18 @@ class CourseRun(models.Model):
         except self._meta.model.courserungradingstatus.RelatedObjectDoesNotExist:
             return False
         return freeze_status.status == FinalGradeStatus.COMPLETE
+
+    @property
+    def has_exam(self):
+        """
+        Check if the user is authorized for an exam for a course run
+        """
+        return (
+            self.edx_course_key and
+            self.course and
+            not is_blank(self.course.exam_module) and
+            not is_blank(self.course.program.exam_series_code)
+        )
 
     @classmethod
     def get_freezable(cls):

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -452,3 +452,21 @@ class CourseRunTests(CourseModelTests):
         assert course_runs[0].pk in freeze_run_ids
         for run in course_runs[1:]:
             assert run.pk not in freeze_run_ids
+
+    @data(
+        (None, None, False),
+        ("Foo", None, False),
+        (None, "Bar", False),
+        ("", "", False),
+        ("Foo", "", False),
+        ("", "Bar", False),
+        ("Foo", "Bar", True)
+    )
+    @unpack
+    def test_has_exam(self, exam_module, exam_series_code, expected_has_exam):
+        """Test course has exam"""
+        course_run = self.create_run()
+        course_run.course.exam_module = exam_module
+        course_run.course.program.exam_series_code = exam_series_code
+
+        assert course_run.has_exam is expected_has_exam

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -89,3 +89,16 @@ def get_year_season_from_course_run(course_run):
         return season_year_tuple[0], NUMBER_SEASON_MAP[season_year_tuple[1]]
     else:
         return season_year_tuple
+
+
+def is_blank(text):
+    """
+    Returns true of string is blank i.e None or empty.
+
+    Args:
+        text(str): any string
+
+    Returns:
+        bool: True if input is empty or none
+    """
+    return not (text and text.strip())

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -2,13 +2,21 @@
 Test cases for course utils
 """
 from datetime import datetime
+
+from ddt import (
+    ddt,
+    data,
+    unpack
+)
 from django.test import TestCase
 from courses.utils import (
-    get_year_season_from_course_run
+    get_year_season_from_course_run,
+    is_blank
 )
 from courses.factories import CourseRunFactory
 
 
+@ddt
 class CourseUtilTests(TestCase):
     """
     Test cases for course utils
@@ -34,3 +42,13 @@ class CourseUtilTests(TestCase):
         assert get_year_season_from_course_run(test_run4) == (2016, 'Fall')
         assert get_year_season_from_course_run(unparseable_test_run1) == ()
         assert get_year_season_from_course_run(unparseable_test_run2) == ()
+
+    @data(
+        (None, True),
+        ("", True),
+        ("Foo", False),
+    )
+    @unpack
+    def test_is_blank(self, text, expected):
+        """Test is_blank"""
+        assert is_blank(text) is expected

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -19,7 +19,6 @@ from financialaid.models import FinancialAid, TierProgram
 from grades.constants import FinalGradeStatus
 from grades.models import FinalGrade
 from exams.models import ExamProfile, ExamAuthorization
-from exams.utils import course_has_exam
 
 
 log = logging.getLogger(__name__)
@@ -362,7 +361,7 @@ class MMTrack:
             course__program=self.program
         )
 
-        if not any(course_has_exam(self, cr) for cr in course_runs_for_program):
+        if not any(course_run.has_exam for course_run in course_runs_for_program):
             return ""
 
         user = self.user

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -844,6 +844,7 @@ class MMTrackTest(MockedESTestCase):
         if not set_series_code:
             exam_series_code = self.program.exam_series_code
             self.program.exam_series_code = None
+            self.program.save()
 
         if make_profile:
             ExamProfileFactory.create(

--- a/exams/management/commands/test_authorization_user_exam.py
+++ b/exams/management/commands/test_authorization_user_exam.py
@@ -1,0 +1,54 @@
+"""authorization command test"""
+
+from unittest.mock import patch
+from django.test import TestCase
+from django.db.models.signals import post_save
+from factory.django import mute_signals
+
+from financialaid.api_test import create_program
+from exams.management.commands import authorization_user_exam
+from profiles.factories import ProfileFactory
+
+
+class AuthorizationCommandTests(TestCase):
+    """Authorization command tests"""
+    @classmethod
+    def setUpTestData(cls):
+        with mute_signals(post_save):
+            profile1 = ProfileFactory.create()
+            profile2 = ProfileFactory.create()
+
+        cls.program, _ = create_program(past=True)
+        cls.users = [profile1.user, profile2.user]
+
+        cls.command = authorization_user_exam.Command()
+
+    def test_bulk_exam_authorization(self):
+        """For all users in any program"""
+        with patch('exams.management.commands.authorization_user_exam.bulk_authorize_for_exam') as mocked_bafe:
+            self.command.handle("authorization_user_exam", all=True)
+
+        mocked_bafe.assert_called_once_with()
+
+    def test_bulk_exam_authorization_given_user_name(self):
+        """For given user"""
+        user1 = self.users[0]
+        with patch('exams.management.commands.authorization_user_exam.bulk_authorize_for_exam') as mocked_bafe:
+            self.command.handle("authorization_user_exam", username=user1.username)
+
+        mocked_bafe.assert_called_once_with(program_id=None, username=user1.username)
+
+    def test_bulk_exam_authorization_given_program(self):
+        """For given program id"""
+        with patch('exams.management.commands.authorization_user_exam.bulk_authorize_for_exam') as mocked_bafe:
+            self.command.handle("authorization_user_exam", program_id=self.program.id)
+
+        mocked_bafe.assert_called_once_with(program_id=self.program.id, username=None)
+
+    def test_bulk_exam_authorization_given_program_username(self):
+        """For given program id and user name"""
+        user1 = self.users[0]
+        with patch('exams.management.commands.authorization_user_exam.bulk_authorize_for_exam') as mocked_bafe:
+            self.command.handle("authorization_user_exam", program_id=self.program.id, username=user1.username)
+
+        mocked_bafe.assert_called_once_with(program_id=self.program.id, username=user1.username)

--- a/exams/utils.py
+++ b/exams/utils.py
@@ -6,7 +6,14 @@ import pytz
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.db.models import Q
 
+from courses.models import Program
+from dashboard.models import (
+    CachedEnrollment,
+    ProgramEnrollment
+)
+from dashboard.utils import get_mmtrack
 from exams.models import (
     ExamProfile,
     ExamAuthorization
@@ -15,6 +22,14 @@ from seed_data.utils import add_year
 
 
 log = logging.getLogger(__name__)
+message_not_passed_or_exist_template = '''
+[Exam authorization] Unable to authorize user "{user}" for exam,
+Course id is "{course_id}". Either user has not passed course or already authorize.
+'''
+message_not_eligible_template = '''
+[Exam authorization] Unable to authorize user "{user}" for exam,
+course id is "{course_id}". User does not match the criteria.
+'''
 
 
 def exponential_backoff(retries):
@@ -36,24 +51,9 @@ def exponential_backoff(retries):
         raise ImproperlyConfigured('EXAMS_SFTP_BACKOFF_BASE must be an integer') from ex
 
 
-def course_has_exam(mmtrack, course_run):
-    """
-    Check if the user is authorized for an exam for a course run
-
-    Args:
-        mmtrack (dashboard.utils.MMTrack): mmtrack for the user/program
-        course_run (courses.models.CourseRun): CourseRun to check against
-
-    Returns:
-        bool: True if the course has an exam
-    """
-    return bool(
-        course_run and
-        course_run.edx_course_key and
-        course_run.course and
-        course_run.course.exam_module and
-        mmtrack.program.exam_series_code
-    )
+class ExamAuthorizationException(Exception):
+    """Exception when exam authorization fail"""
+    pass
 
 
 def is_eligible_for_exam(mmtrack, course_run):
@@ -68,7 +68,7 @@ def is_eligible_for_exam(mmtrack, course_run):
     Returns:
         bool: whether use is eligible or not
     """
-    return course_has_exam(mmtrack, course_run) and mmtrack.has_paid(course_run.edx_course_key)
+    return course_run.has_exam and mmtrack.has_paid(course_run.edx_course_key)
 
 
 def authorize_for_exam(mmtrack, course_run):
@@ -79,44 +79,151 @@ def authorize_for_exam(mmtrack, course_run):
         mmtrack (dashboard.utils.MMTrack): a instance of all user information about a program.
         course_run (courses.models.CourseRun): A CourseRun object.
     """
-    if is_eligible_for_exam(mmtrack, course_run):
-        now = datetime.datetime.now(tz=pytz.UTC)
-        # if user paid for a course then create his exam profile if it is not creaated yet.
-        ExamProfile.objects.get_or_create(profile=mmtrack.user.profile)
-
-        # if user passed the course and currently not authorization for that run then give
-        # her authorizations.
-        try:
-            passed = mmtrack.has_passed_course(course_run.edx_course_key)
-        except:  # pylint: disable=bare-except
-            log.exception(
-                'Unable to check if user %s passed course %s',
-                mmtrack.user.username,
-                course_run.edx_course_key
-            )
-            return
-        ok_for_authorization = (
-            passed and
-            not ExamAuthorization.objects.filter(
-                user=mmtrack.user,
-                course=course_run.course,
-                date_first_eligible__lte=now,
-                date_last_eligible__gte=now
-            ).exists()
+    # If exam is not set on selected course then we dont need to process authorization
+    if not course_run.has_exam:
+        errors_message = message_not_eligible_template.format(
+            user=mmtrack.user.username,
+            course_id=course_run.edx_course_key
         )
+        raise ExamAuthorizationException(errors_message)
 
-        if ok_for_authorization:
-            ExamAuthorization.objects.create(
-                user=mmtrack.user,
-                course=course_run.course,
-                date_first_eligible=now,
-                date_last_eligible=add_year(now)
+    # If user has not paid for course then we dont need to process authorization
+    if not mmtrack.has_paid(course_run.edx_course_key):
+        errors_message = message_not_eligible_template.format(
+            user=mmtrack.user.username,
+            course_id=course_run.edx_course_key
+        )
+        raise ExamAuthorizationException(errors_message)
+
+    now = datetime.datetime.now(tz=pytz.UTC)
+    # if user paid for a course then create his exam profile if it is not creaated yet.
+    ExamProfile.objects.get_or_create(profile=mmtrack.user.profile)
+
+    # if user passed the course and currently not authorization for that run then give
+    # her authorizations.
+    ok_for_authorization = (
+        mmtrack.has_passed_course(course_run.edx_course_key) and
+        not ExamAuthorization.objects.filter(
+            user=mmtrack.user,
+            course=course_run.course,
+            date_first_eligible__lte=now,
+            date_last_eligible__gte=now
+        ).exists()
+    )
+
+    if not ok_for_authorization:
+        errors_message = message_not_passed_or_exist_template.format(
+            user=mmtrack.user.username,
+            course_id=course_run.edx_course_key
+        )
+        raise ExamAuthorizationException(errors_message)
+
+    ExamAuthorization.objects.create(
+        user=mmtrack.user,
+        course=course_run.course,
+        date_first_eligible=now,
+        date_last_eligible=add_year(now)
+    )
+    log.info(
+        '[Exam authorization] user "%s" is authorize for exam the for course id "%s"',
+        mmtrack.user.username,
+        course_run.edx_course_key
+    )
+
+
+def bulk_authorize_for_exam(program_id=None, username=None):
+    """
+    Authorize user(s) for exam(s).
+
+    Args:
+        program_id(str): Program id (optional) if you want authorization on specific program exams
+        username(str): User name (optional) whom you want to authorize for exam(s)
+    """
+    programs = Program.objects.filter(
+        ~Q(exam_series_code__exact=""),
+        live=True,
+        exam_series_code__isnull=False
+    )
+    if program_id is not None:
+        programs = programs.filter(id=program_id)
+
+    if not programs.exists():
+        if program_id is not None:
+            raise ExamAuthorizationException('[Exam authorization] Invalid program id: %s', program_id)
+        else:
+            raise ExamAuthorizationException(
+                '[Exam authorization] Program(s) are not available for exam authorization.'
             )
-            log.info(
-                'user "%s" is authorize for exam the for course id "%s"',
-                mmtrack.user.username,
-                course_run.edx_course_key
+        return
+
+    for program in programs:
+        authorize_for_exam_given_program(program, username)
+
+
+def authorize_for_exam_given_program(program, username=None):
+    """
+    Authorize user(s) for exam on given program.
+    Args:
+        program(courses.models.Program): Program object.
+        username(str): User name (optional) whom you want to authorize for exam(s)
+    """
+    program_enrollment_qset = ProgramEnrollment.objects.filter(program=program)
+    if username is not None:
+        program_enrollment_qset = program_enrollment_qset.filter(user__username=username)
+
+    if not program_enrollment_qset.exists():
+        if username is not None:
+            raise ExamAuthorizationException('[Exam authorization] Invalid username: %s', username)
+        else:
+            raise ExamAuthorizationException(
+                '[Exam authorization] Eligible users do not exist for exam authorization.'
             )
+        return
+
+    for program_enrollment in program_enrollment_qset:
+        mmtrack = get_mmtrack(
+            program_enrollment.user,
+            program_enrollment.program
+        )
+        course_ids = set(mmtrack.edx_key_course_map.values())
+
+        # get latest course_run from given course
+        for course_id in course_ids:
+            authorize_for_latest_passed_course(mmtrack, course_id)
+
+
+def authorize_for_latest_passed_course(mmtrack, course_id):
+    """
+    Authorize user for exam on given course. Using latest passed run.
+
+    Args:
+        course_id(int): Course id
+        mmtrack (dashboard.utils.MMTrack): An instance of all user information about a program
+    """
+    enrollments_qset = CachedEnrollment.objects.filter(
+        user=mmtrack.user, course_run__course__id=course_id
+    ).order_by('-course_run__end_date')
+
+    for enrollment in enrollments_qset:
+        # only latest passed course_run per course allowed
+        edx_course_key = enrollment.course_run.edx_course_key
+        has_paid_and_passed = (
+            mmtrack.has_passed_course(edx_course_key) and
+            mmtrack.has_paid(edx_course_key)
+        )
+        if has_paid_and_passed:
+            # if user has passed and paid for the course
+            # and not already authorized for exam the create authorizations.
+            try:
+                authorize_for_exam(mmtrack, enrollment.course_run)
+            except ExamAuthorizationException:
+                log.exception(
+                    'Unable to authorize user: %s for exam on course_id: %s',
+                    mmtrack.user.username,
+                    enrollment.course_run.course.id
+                )
+            else:
+                break
 
 
 def _match_field(profile, field):

--- a/exams/utils.py
+++ b/exams/utils.py
@@ -211,7 +211,7 @@ def authorize_for_latest_passed_course(mmtrack, course_id):
     ).order_by('-course_run__end_date')
 
     if not enrollments_qset.exists():
-        log.info(
+        log.error(
             '[Exam authorization] exam_module is not set for course id="%s"',
             course_id
         )

--- a/exams/utils.py
+++ b/exams/utils.py
@@ -212,8 +212,9 @@ def authorize_for_latest_passed_course(mmtrack, course_id):
 
     if not enrollments_qset.exists():
         log.error(
-            '[Exam authorization] exam_module is not set for course id="%s"',
-            course_id
+            'Either exam_module is not set for course id="%s" or user="%s" has no enrollment(s)',
+            course_id,
+            mmtrack.user.username
         )
         return
 

--- a/exams/utils_test.py
+++ b/exams/utils_test.py
@@ -309,7 +309,7 @@ class BulkExamUtilTests(TestCase):
                 program_id=self.program.id
             )
 
-        log.info.assert_called_with(
+        log.error.assert_called_with(
             '[Exam authorization] exam_module is not set for course id="%s"',
             self.course_run.course.id
         )

--- a/exams/utils_test.py
+++ b/exams/utils_test.py
@@ -1,7 +1,11 @@
 """Test cases for the exam util"""
-from unittest.mock import patch
+from datetime import datetime, timedelta
 
+from unittest.mock import patch
+import ddt
 from django.core.exceptions import ImproperlyConfigured
+import pytz
+from django.test import TestCase
 from django.db.models.signals import post_save
 from django.test import (
     SimpleTestCase,
@@ -10,15 +14,30 @@ from django.test import (
 from factory.django import mute_signals
 from ddt import ddt, data, unpack
 
+from courses.factories import CourseRunFactory
 from dashboard.factories import (
     CachedCertificateFactory,
     CachedCurrentGradeFactory,
     CachedEnrollmentFactory,
 )
+from dashboard.models import ProgramEnrollment
 from dashboard.utils import get_mmtrack
+from financialaid.api_test import create_program
+from exams.utils import (
+    authorize_for_exam,
+    bulk_authorize_for_exam,
+    ExamAuthorizationException,
+    message_not_passed_or_exist_template,
+    message_not_eligible_template
+)
+from exams.models import (
+    ExamProfile,
+    ExamAuthorization
+)
 from ecommerce.factories import (
     OrderFactory,
     LineFactory,
+    CoursePriceFactory
 )
 from grades.factories import FinalGradeFactory
 from exams.utils import (
@@ -79,7 +98,7 @@ class ExamAuthorizationUtilsTests(TestCase):
         cls.program, _ = create_program(past=True)
         cls.user = profile.user
         cls.course_run = course_run = cls.program.course_set.first().courserun_set.first()
-        cls.enrollment = CachedEnrollmentFactory.create(user=cls.user, course_run=course_run)
+        CachedEnrollmentFactory.create(user=cls.user, course_run=course_run)
         CachedCurrentGradeFactory.create(
             user=cls.user,
             course_run=course_run,
@@ -107,29 +126,34 @@ class ExamAuthorizationUtilsTests(TestCase):
         self.assertTrue(mmtrack.has_passed_course(self.course_run.edx_course_key))
 
         authorize_for_exam(mmtrack, self.course_run)
-
-        # assert Exam Authorization and profile created.
-        self.assertTrue(ExamProfile.objects.filter(profile=mmtrack.user.profile).exists())
-        self.assertTrue(ExamAuthorization.objects.filter(
+        assert ExamProfile.objects.filter(profile=mmtrack.user.profile).exists() is True
+        assert ExamAuthorization.objects.filter(
             user=mmtrack.user,
             course=self.course_run.course
-        ).exists())
+        ).exists() is True
 
     def test_exam_authorization_when_not_paid(self):
         """
         test exam_authorization when user has passed course but not paid.
         """
         mmtrack = get_mmtrack(self.user, self.program)
-        self.assertFalse(mmtrack.has_paid(self.course_run.edx_course_key))
+        assert mmtrack.has_paid(self.course_run.edx_course_key) is False
 
-        authorize_for_exam(mmtrack, self.course_run)
+        expected_errors_message = message_not_eligible_template.format(
+            user=mmtrack.user.username,
+            course_id=self.course_run.edx_course_key
+        )
 
+        with self.assertRaises(ExamAuthorizationException) as eae:
+            authorize_for_exam(mmtrack, self.course_run)
+
+        assert eae.exception.args[0] == expected_errors_message
         # assert Exam Authorization and profile created.
-        self.assertFalse(ExamProfile.objects.filter(profile=mmtrack.user.profile).exists())
-        self.assertFalse(ExamAuthorization.objects.filter(
+        assert ExamProfile.objects.filter(profile=mmtrack.user.profile).exists() is False
+        assert ExamAuthorization.objects.filter(
             user=mmtrack.user,
             course=self.course_run.course
-        ).exists())
+        ).exists() is False
 
     def test_exam_authorization_when_not_passed_course(self):
         """
@@ -138,17 +162,150 @@ class ExamAuthorizationUtilsTests(TestCase):
         create_order(self.user, self.course_run)
         with patch('dashboard.utils.MMTrack.has_passed_course', autospec=True, return_value=False):
             mmtrack = get_mmtrack(self.user, self.program)
-            self.assertTrue(mmtrack.has_paid(self.course_run.edx_course_key))
-            self.assertFalse(mmtrack.has_passed_course(self.course_run.edx_course_key))
+            expected_errors_message = message_not_passed_or_exist_template.format(
+                user=mmtrack.user.username,
+                course_id=self.course_run.edx_course_key
+            )
+            assert mmtrack.has_paid(self.course_run.edx_course_key) is True
+            assert mmtrack.has_passed_course(self.course_run.edx_course_key) is False
 
-            authorize_for_exam(mmtrack, self.course_run)
+            with self.assertRaises(ExamAuthorizationException) as eae:
+                authorize_for_exam(mmtrack, self.course_run)
 
+            assert eae.exception.args[0] == expected_errors_message
             # assert Exam Authorization and profile created.
-            self.assertTrue(ExamProfile.objects.filter(profile=mmtrack.user.profile).exists())
-            self.assertFalse(ExamAuthorization.objects.filter(
+            assert ExamProfile.objects.filter(profile=mmtrack.user.profile).exists() is True
+            assert ExamAuthorization.objects.filter(
                 user=mmtrack.user,
                 course=self.course_run.course
-            ).exists())
+            ).exists() is False
+
+
+class BulkExamUtilTests(TestCase):
+    """Tests for authorization_user_exam command operations"""
+    @classmethod
+    def set_data(cls, user, course_run):
+        """
+        creates user records like CachedGrades, CachedEnrollments and CachedCertificate
+        """
+        CachedEnrollmentFactory.create(user=user, course_run=course_run)
+        CachedCurrentGradeFactory.create(
+            user=user,
+            course_run=course_run,
+            data={
+                "passed": True,
+                "percent": 0.9,
+                "course_key": course_run.edx_course_key,
+                "username": user.username
+            }
+        )
+        CachedCertificateFactory.create(user=user, course_run=course_run)
+        create_order(user, course_run)
+
+    @classmethod
+    def setUpTestData(cls):
+        with mute_signals(post_save):
+            profile1 = ProfileFactory.create()
+            profile2 = ProfileFactory.create()
+
+        cls.program, _ = create_program(past=True)
+        cls.course_run = cls.program.course_set.first().courserun_set.first()
+        cls.users = [profile1.user, profile2.user]
+
+        for user in cls.users:
+            with mute_signals(post_save):
+                ProgramEnrollment.objects.create(user=user, program=cls.program)
+            cls.set_data(user, cls.course_run)
+
+        # second passed run on same courses
+        course_run2 = CourseRunFactory.create(
+            end_date=datetime.now(tz=pytz.UTC) - timedelta(days=366),
+            enrollment_end=datetime.now(tz=pytz.UTC) - timedelta(days=500),
+            course=cls.course_run.course
+        )
+        CoursePriceFactory.create(
+            course_run=course_run2,
+            is_valid=True
+        )
+
+        for user in cls.users:
+            cls.set_data(user, course_run2)
+
+    def test_exam_authorization(self):
+        """For all users in any program"""
+        bulk_authorize_for_exam()
+        for user in self.users:
+            assert ExamProfile.objects.filter(profile=user.profile).exists() is True
+            assert ExamAuthorization.objects.filter(
+                user=user,
+                course=self.course_run.course
+            ).exists() is True
+
+    def test_exam_authorization_specific_user(self):
+        """Authorize a user for exams of passed and paid courses"""
+        user = self.users[0]
+        bulk_authorize_for_exam(username=user.username)
+        assert ExamProfile.objects.filter(profile=user.profile).exists() is True
+        assert ExamAuthorization.objects.filter(
+            user=user,
+            course=self.course_run.course
+        ).exists() is True
+
+    def test_exam_authorization_specific_user_specific_course(self):
+        """Authorize a user for exams of passed and paid courses"""
+        user1 = self.users[0]
+        user2 = self.users[1]
+        bulk_authorize_for_exam(
+            username=user1.username
+        )
+
+        # user 1 is authorized for exam
+        assert ExamProfile.objects.filter(profile=user1.profile).exists() is True
+        assert ExamAuthorization.objects.filter(
+            user=user1,
+            course=self.course_run.course
+        ).exists() is True
+
+        # user 2 is not authorized
+        assert ExamProfile.objects.filter(profile=user2.profile).exists() is False
+        assert ExamAuthorization.objects.filter(
+            user=user2,
+            course=self.course_run.course
+        ).exists() is False
+
+    def test_exam_authorization_wrong_program_id(self):
+        """Assert user not authorize when program id is wrong"""
+        user = self.users[0]
+
+        with self.assertRaises(ExamAuthorizationException) as e:
+            bulk_authorize_for_exam(
+                program_id=-1,
+                username=user.username
+            )
+
+        assert e.exception.args[0] == '[Exam authorization] Invalid program id: %s', -1
+        assert ExamProfile.objects.filter(profile=user.profile).exists() is False
+        assert ExamAuthorization.objects.filter(
+            user=user,
+            course=self.course_run.course
+        ).exists() is False
+
+    def test_exam_authorization_invalid_user(self):
+        """Assert user not authorize when username wrong"""
+        user = self.users[0]
+
+        with self.assertRaises(ExamAuthorizationException) as e:
+            bulk_authorize_for_exam(
+                username="invalid_user"
+            )
+
+        assert e.exception.args[0] == '[Exam authorization] Invalid username: %s', "invalid_user"
+        for user in self.users:
+            assert ExamProfile.objects.filter(profile=user.profile).exists() is False
+            assert ExamAuthorization.objects.filter(
+                user=user,
+                course=self.course_run.course
+            ).exists() is False
 
 
 @ddt

--- a/exams/utils_test.py
+++ b/exams/utils_test.py
@@ -310,8 +310,9 @@ class BulkExamUtilTests(TestCase):
             )
 
         log.error.assert_called_with(
-            '[Exam authorization] exam_module is not set for course id="%s"',
-            self.course_run.course.id
+            'Either exam_module is not set for course id="%s" or user="%s" has no enrollment(s)',
+            self.course_run.course.id,
+            user.username
         )
 
         assert ExamProfile.objects.filter(profile=user.profile).exists() is False

--- a/exams/utils_test.py
+++ b/exams/utils_test.py
@@ -2,17 +2,15 @@
 from datetime import datetime, timedelta
 
 from unittest.mock import patch
-import ddt
-from django.core.exceptions import ImproperlyConfigured
+from ddt import ddt, data, unpack
 import pytz
-from django.test import TestCase
+from django.core.exceptions import ImproperlyConfigured
 from django.db.models.signals import post_save
 from django.test import (
     SimpleTestCase,
     TestCase,
 )
 from factory.django import mute_signals
-from ddt import ddt, data, unpack
 
 from courses.factories import CourseRunFactory
 from dashboard.factories import (
@@ -22,13 +20,14 @@ from dashboard.factories import (
 )
 from dashboard.models import ProgramEnrollment
 from dashboard.utils import get_mmtrack
-from financialaid.api_test import create_program
 from exams.utils import (
     authorize_for_exam,
     bulk_authorize_for_exam,
     ExamAuthorizationException,
+    exponential_backoff,
     message_not_passed_or_exist_template,
-    message_not_eligible_template
+    message_not_eligible_template,
+    validate_profile
 )
 from exams.models import (
     ExamProfile,
@@ -40,15 +39,6 @@ from ecommerce.factories import (
     CoursePriceFactory
 )
 from grades.factories import FinalGradeFactory
-from exams.utils import (
-    authorize_for_exam,
-    exponential_backoff,
-    validate_profile,
-)
-from exams.models import (
-    ExamProfile,
-    ExamAuthorization
-)
 from financialaid.api_test import create_program
 from profiles.factories import ProfileFactory
 from search.base import MockedESTestCase


### PR DESCRIPTION
#### What are the relevant tickets?
- fixes https://github.com/mitodl/micromasters/issues/2445
- Fixed ripples of #2331

#### What's this PR do?
- Refactored the code of exam authorization command
- Added exceptions and logging to see behaviour of code
- Added new tests for authorization code.

### How to test:
- In .env add `FEATURE_FINAL_GRADE_ALGORITHM=v1`
- Set program.exam_series_code
- Set course.exam_module
- Pay for course
- Create final grade http://192.168.99.100:8079/admin/grades/finalgrade/
- Run command ```docker-compose run web ./manage.py authorization_user_exam --username=(value) --program-id=(value)```
- Check weather ( ExamAuthoriztion) object created 
  - ``docker-compose run web ./manage.py shell``
  - ``from exams.models import ExamAuthorization``
  -  ``ExamAuthorization.objects.all()``

#### To create dummy data:
```docker-compose run web ./manage.py shell```

```shell
from courses.models import CourseRun
from dashboard.models import CachedEnrollment
from dashboard.factories import CachedEnrollmentFactory
from ecommerce.factories import (OrderFactory, LineFactory)
from django.contrib.auth.models import User
from exams.models import ExamAuthorization

user = User.objects.get(username='amirq')
# use same  `edx_course_key` for final grade entry
course_run = CourseRun.objects.get(edx_course_key='course-v1:MITx+Digital+Learning+100+Jan_2016')
CachedEnrollmentFactory.create(user=user, course_run=course_run)
# enter  `total_price_paid` according to income threshold
order = OrderFactory.create(user=user, status='fulfilled', total_price_paid=1200)
LineFactory.create(order=order, course_key=course_run.edx_course_key)
ExamAuthorization.objects.all()
```

@pdpinch @giocalitri 