### PR TITLE
testing out solutions to yarn build problem

### DIFF
--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install libelf1
 
 RUN adduser --disabled-password --gecos "" mitodl
 
-RUN npm install -g yarn@0.18.1
+RUN npm install -g yarn@0.19.1
 
 RUN mkdir -p /home/mitodl/.cache/yarn
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "minimist": "^1.2.0",
     "mocha": "2.4.5",
     "moment": "^2.17.0",
-    "node-sass": "^4.1.0",
+    "node-sass": "^4.3.0",
     "object.entries": "1.0.3",
     "postcss-loader": "^1.2.1",
     "ramda": "^0.23.0",
@@ -102,7 +102,7 @@
     "rrssb": "^1.10.0",
     "sanctuary": "^0.11.1",
     "sass-lint": "^1.10.2",
-    "sass-loader": "^4.1.0",
+    "sass-loader": "^4.1.1",
     "searchkit": "0.10.0",
     "searchkit-multiselect": "^0.0.1",
     "sinon": "1.17.4",
@@ -120,7 +120,7 @@
   },
   "engines": {
     "node": "6.2.0",
-    "yarn": "0.18.1"
+    "yarn": "0.19.1"
   },
   "scripts": {
     "postinstall": "./webpack_if_prod.sh",

--- a/travis/Dockerfile-travis-watch-build
+++ b/travis/Dockerfile-travis-watch-build
@@ -8,7 +8,7 @@ LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 RUN apt-get update && apt-get install libelf1
 
-RUN npm install -g yarn@0.18.1
+RUN npm install -g yarn@0.19.1
 
 RUN mkdir /src
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4347,9 +4347,9 @@ node-pre-gyp@^0.6.29:
     tar "~2.2.1"
     tar-pack "~3.3.0"
 
-node-sass@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.1.0.tgz#d6d304f104b0815b076921e87ef71090555bbfdb"
+node-sass@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.3.0.tgz#d014f64595d77b26af99e9f7a7e74704d9976bda"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -5810,9 +5810,9 @@ sass-lint@^1.10.2:
     path-is-absolute "^1.0.0"
     util "^0.10.3"
 
-sass-loader@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-4.1.0.tgz#fd8604c5bf90001b173bb27540e8f2f5ed64602b"
+sass-loader@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-4.1.1.tgz#79ef9468cf0bf646c29529e1f2cba6bd6e51c7bc"
   dependencies:
     async "^2.0.1"
     loader-utils "^0.2.15"


### PR DESCRIPTION
This just upgrades `node-sass` and `sass-loader`, which gets rid of two of the unmet peer dependency errors we were getting with yarn + heroku. We don't _need_ to do this but I think it would be a good idea.