### PR TITLE
Completed implementation for front-end course team email API

### DIFF
--- a/static/js/actions/email.js
+++ b/static/js/actions/email.js
@@ -8,6 +8,7 @@ import type {
 } from '../flow/emailTypes';
 import {
   SEARCH_EMAIL_TYPE,
+  COURSE_EMAIL_TYPE
 } from '../components/email/constants';
 import * as api from '../lib/api';
 
@@ -45,6 +46,23 @@ export function sendSearchResultMail(
         return Promise.resolve(response);
       }).catch(error => {
         dispatch(sendEmailFailure({type: SEARCH_EMAIL_TYPE, error: error}));
+      });
+  };
+}
+
+export function sendCourseTeamMail(
+  subject: string,
+  body: string,
+  courseId: number
+): Dispatcher<EmailSendResponse> {
+  return (dispatch: Dispatch) => {
+    dispatch(initiateSendEmail(COURSE_EMAIL_TYPE));
+    return api.sendCourseTeamMail(subject, body, courseId).
+      then(response => {
+        dispatch(sendEmailSuccess(COURSE_EMAIL_TYPE));
+        return Promise.resolve(response);
+      }).catch(error => {
+        dispatch(sendEmailFailure({type: COURSE_EMAIL_TYPE, error: error}));
       });
   };
 }

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -304,8 +304,9 @@ export default class LearnerSearch extends SearchkitComponent {
           updateEmailEdit={updateEmailEdit}
           email={email}
           sendEmail={sendEmail}
-          searchkit={this.searchkit}
-        />
+        >
+          {this.getHitsCount() || 0} recipients selected
+        </EmailCompositionDialog>
         <Grid className="search-grid">
           <Cell col={3} className="search-sidebar">
             { this.renderFacets(currentProgramEnrollment) }

--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -21,15 +21,14 @@ const showSubjectError = showValidationError(R.prop('subject'));
 
 const showBodyError = showValidationError(R.prop('body'));
 
-const hitsCount = searchkit => R.isNil(searchkit) ? 0 : searchkit.getHitsCount();
-
 type EmailDialogProps = {
   closeEmailDialog: () => void,
   updateEmailEdit:  Function,
   open:             boolean,
   email:            EmailState,
-  searchkit:        Object,
   sendEmail:        () => void,
+  title?:           string,
+  children?:        any,
 };
 
 const EmailCompositionDialog = (props: EmailDialogProps) => {
@@ -38,12 +37,18 @@ const EmailCompositionDialog = (props: EmailDialogProps) => {
     updateEmailEdit,
     open,
     email: { inputs, validationErrors, fetchStatus },
-    searchkit,
     sendEmail,
+    title,
+    children
   } = props;
 
+  let subHeading;
+  if (children) {
+    subHeading = <h5 className="sub-heading">{ children }</h5>;
+  }
+
   return <Dialog
-    title="New Email"
+    title={title || "New Email"}
     titleClassName="dialog-title"
     contentClassName="dialog email-composition-dialog"
     className="email-composition-dialog-wrapper"
@@ -52,9 +57,7 @@ const EmailCompositionDialog = (props: EmailDialogProps) => {
     onRequestClose={closeEmailDialog}
   >
     <div className="email-composition-contents">
-      <span className="user-count">
-        {hitsCount(searchkit)} recipients selected
-      </span>
+      { subHeading }
       <textarea
         rows="1"
         className="email-subject"

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -15,12 +15,11 @@ import { modifyTextField } from '../../util/test_utils';
 import EmailCompositionDialog from './EmailCompositionDialog';
 
 describe('EmailCompositionDialog', () => {
-  let sandbox, updateStub, getHitsCount, closeEmailDialog, updateEmailEdit, sendEmail;
+  let sandbox, updateStub, closeEmailDialog, updateEmailEdit, sendEmail;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     updateStub = sandbox.stub();
-    getHitsCount = sandbox.stub().returns(20);
     closeEmailDialog = sandbox.stub().returns(updateStub);
     updateEmailEdit = sandbox.stub().returns(updateStub);
     sendEmail = sandbox.stub();
@@ -32,7 +31,7 @@ describe('EmailCompositionDialog', () => {
 
   const getDialog = () => document.querySelector('.email-composition-dialog');
 
-  const renderDialog = (props = {}) => (
+  const renderDialog = (props = {}, subHeading = null) => (
     mount (
       <MuiThemeProvider muiTheme={getMuiTheme()}>
         <EmailCompositionDialog
@@ -40,12 +39,11 @@ describe('EmailCompositionDialog', () => {
           updateEmailEdit={updateEmailEdit}
           open={true}
           email={{ ...INITIAL_EMAIL_STATE }}
-          searchkit={{
-            getHitsCount: getHitsCount
-          }}
           sendEmail={sendEmail}
           {...props}
-        />
+        >
+          { subHeading }
+        </EmailCompositionDialog>
       </MuiThemeProvider>
     )
   );
@@ -55,20 +53,10 @@ describe('EmailCompositionDialog', () => {
     assert.equal(document.querySelector('h3').textContent, 'New Email');
   });
 
-  it('should have a results count', () => {
-    renderDialog();
-    let count = document.querySelector('.user-count').textContent;
-    assert.equal(count, '20 recipients selected');
-    assert(
-      getHitsCount.called,
-      "called searchkit getHitsCount method"
-    );
-  });
-
-  it('should fire sendSearchResultMail when the "send" button is clicked', () => {
+  it('should fire the send handler when the "send" button is clicked', () => {
     renderDialog();
     TestUtils.Simulate.click(getDialog().querySelector('.save-button'));
-    assert.isTrue(sendEmail.called, "called sendSearchResultMail method");
+    assert.isTrue(sendEmail.called, "called send handler");
   });
 
   it('should show a disabled spinner button if email send is in progress', () => {
@@ -83,6 +71,26 @@ describe('EmailCompositionDialog', () => {
     // assert that inFlight is true
     assert.isTrue(dialogActionsSpy.calledWith(sinon.match.any, sinon.match.any, true));
     assert.equal(dialogActionsSpy.callCount, 1);
+  });
+
+  it('should show a subheader when text is passed in', () => {
+    renderDialog({}, 'Some subheader text');
+    assert.equal(document.querySelector('h5').textContent, 'Some subheader text');
+  });
+
+  it('should not show a subheader when text is not passed in', () => {
+    renderDialog({}, null);
+    assert.isNull(document.querySelector('h5'));
+  });
+
+  it('should show a specific title when one is passed in', () => {
+    renderDialog({title: 'Some Title'});
+    assert.equal(document.querySelector('h3').textContent, 'Some Title');
+  });
+
+  it('should show a default title when one is not passed in', () => {
+    renderDialog();
+    assert.equal(document.querySelector('h3').textContent, 'New Email');
   });
 
   ['subject', 'body'].forEach(field => {

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -16,6 +16,7 @@ import {
   csrfSafeMethod,
   checkout,
   sendSearchResultMail,
+  sendCourseTeamMail,
   getPrograms,
   addProgramEnrollment,
   updateProfileImage,
@@ -182,8 +183,9 @@ describe('api', function() {
     describe('for email', () => {
       let MAIL_RESPONSE = {errorStatusCode: 200};
       let searchRequest = {size: 50};
+      let courseId = 123;
 
-      it('returns expected values when a POST to send email succeeds', () => {
+      it('returns expected values when a POST to send a search result email succeeds', () => {
         fetchJSONStub.returns(Promise.resolve(MAIL_RESPONSE));
         return sendSearchResultMail('subject', 'body', searchRequest).then(mailResp => {
           assert.ok(fetchJSONStub.calledWith('/api/v0/mail/', {
@@ -198,7 +200,21 @@ describe('api', function() {
         });
       });
 
-      it('returns a rejected Promise when a POST to send email fails', () => {
+      it('returns expected values when a POST to send a course team email succeeds', () => {
+        fetchJSONStub.returns(Promise.resolve(MAIL_RESPONSE));
+        return sendCourseTeamMail('subject', 'body', courseId).then(mailResp => {
+          assert.ok(fetchJSONStub.calledWith(`/api/v0/mail/course/${courseId}/`, {
+            method: 'POST',
+            body: JSON.stringify({
+              email_subject: 'subject',
+              email_body: 'body',
+            })
+          }));
+          assert.deepEqual(mailResp, MAIL_RESPONSE);
+        });
+      });
+
+      it('returns a rejected Promise when a POST to any email sending function fails', () => {
         fetchJSONStub.returns(Promise.reject());
         return assert.isRejected(sendSearchResultMail('subject', 'body', searchRequest));
       });

--- a/static/js/reducers/email_test.js
+++ b/static/js/reducers/email_test.js
@@ -8,6 +8,7 @@ import {
   clearEmailEdit,
   updateEmailValidation,
   sendSearchResultMail,
+  sendCourseTeamMail,
   START_EMAIL_EDIT,
   UPDATE_EMAIL_EDIT,
   CLEAR_EMAIL_EDIT,
@@ -79,7 +80,7 @@ describe('email reducers', () => {
     });
   });
 
-  describe('for send actions', () => {
+  describe('for the sendSearchResultMail action', () => {
     let sendSearchResultMailStub;
     let MAIL_SUCCESS_RESPONSE: EmailSendResponse = { errorStatusCode: 200 },
       searchRequest = { size: 50 };
@@ -88,7 +89,7 @@ describe('email reducers', () => {
       sendSearchResultMailStub = sandbox.stub(api, 'sendSearchResultMail');
     });
 
-    it('should go through expected state changes when sendSearchResultMail succeeds', () => {
+    it('should go through expected state changes when the send function succeeds', () => {
       sendSearchResultMailStub.returns(Promise.resolve(MAIL_SUCCESS_RESPONSE));
 
       return dispatchThen(
@@ -101,11 +102,45 @@ describe('email reducers', () => {
       });
     });
 
-    it('should go through expected state changes when sendSearchResultMail fails', () => {
+    it('should go through expected state changes when the send function fails', () => {
       sendSearchResultMailStub.returns(Promise.reject());
 
       return dispatchThen(
         sendSearchResultMail('subject', 'body', searchRequest),
+        [INITIATE_SEND_EMAIL, SEND_EMAIL_FAILURE]
+      ).then(emailState => {
+        assert.equal(emailState[emailType].fetchStatus, FETCH_FAILURE);
+      });
+    });
+  });
+
+  describe('for the sendCourseTeamMail action', () => {
+    let sendCourseTeamMailStub;
+    let MAIL_SUCCESS_RESPONSE: EmailSendResponse = { errorStatusCode: 200 },
+      courseId = 123;
+
+    beforeEach(() => {
+      sendCourseTeamMailStub = sandbox.stub(api, 'sendCourseTeamMail');
+    });
+
+    it('should go through expected state changes when the send function succeeds', () => {
+      sendCourseTeamMailStub.returns(Promise.resolve(MAIL_SUCCESS_RESPONSE));
+
+      return dispatchThen(
+        sendCourseTeamMail('subject', 'body', courseId),
+        [INITIATE_SEND_EMAIL, SEND_EMAIL_SUCCESS]
+      ).then(emailState => {
+        assert.equal(emailState[emailType].fetchStatus, FETCH_SUCCESS);
+        assert.equal(sendCourseTeamMailStub.callCount, 1);
+        assert.deepEqual(sendCourseTeamMailStub.args[0], ['subject', 'body', courseId]);
+      });
+    });
+
+    it('should go through expected state changes when the send function fails', () => {
+      sendCourseTeamMailStub.returns(Promise.reject());
+
+      return dispatchThen(
+        sendCourseTeamMail('subject', 'body', courseId),
         [INITIATE_SEND_EMAIL, SEND_EMAIL_FAILURE]
       ).then(emailState => {
         assert.equal(emailState[emailType].fetchStatus, FETCH_FAILURE);

--- a/static/scss/email-composition-dialog.scss
+++ b/static/scss/email-composition-dialog.scss
@@ -3,9 +3,14 @@
     display: flex;
     flex-direction: column;
 
-    .user-count {
+    h5.sub-heading {
+      letter-spacing: normal;
+      margin: 0;
       padding-bottom: 20px;
+      padding-top: 0px;
+      font-size: 16px;
       font-style: italic;
+      font-weight: normal;
     }
 
     .validation-error {


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #2420 
⚠️️  REBASED ON #2446 ⚠️️

#### What's this PR do?

- Completes implementation for the front-end API for course team emails
- Makes `EmailCompositionDialog` a generic component for use with any type of email (not just search result emails)

#### How should this be manually tested?

Just review the code. The actual end-to-end implementation of the course team email dialog will be in a the PR for #2284. If tests pass and code looks good, this should be ready to merge

#### Any background context you want to provide?

This was done as a separate PR to limit the PR size

