### PR TITLE
Don't needlessly set a `next` query param

### DIFF
--- a/static/js/containers/SignupDialog.js
+++ b/static/js/containers/SignupDialog.js
@@ -23,7 +23,11 @@ const SignupDialog = ({
   open,
   setDialogVisibility,
 }: signupProps) => {
-  let next = URI(window.location.search).query(true).next;
+  let loginUrl = URI('/login/edxorg');
+  const nextUrl = URI(window.location.search).query(true).next;
+  if ( nextUrl ) {
+    loginUrl = loginUrl.setSearch("next", nextUrl);
+  }
   return <Dialog
     titleClassName="dialog-title"
     contentClassName="dialog signup-dialog"
@@ -45,7 +49,7 @@ const SignupDialog = ({
 
       <a
         className="mdl-button signup-modal-button"
-        href={`/login/edxorg?next=${encodeURIComponent(next)}`}
+        href={loginUrl}
       >
         Continue with edX
       </a>

--- a/static/js/containers/SignupDialog_test.js
+++ b/static/js/containers/SignupDialog_test.js
@@ -40,4 +40,13 @@ describe("SignupDialog", () => {
     let link = document.body.querySelector(".signup-dialog a");
     assert.equal(link.getAttribute('href'), `/login/edxorg${queryParams}`);
   });
+
+  it("doesn't needlessly set a next query param", () => {
+    window.location = "http://fake/";
+    helper.store.dispatch(setDialogVisibility(true));
+    renderDialog();
+
+    let link = document.body.querySelector(".signup-dialog a");
+    assert.equal(link.getAttribute('href'), "/login/edxorg");
+  });
 });


### PR DESCRIPTION
Follow-up from #2406. If the URL doesn't have a `next` query parameter, don't set a `next` query parameter when logging into Micromasters.