### PR TITLE
Alert anonymous user if they try to use a coupon

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -20,6 +20,7 @@ from micromasters.serializers import serialize_maybe_user
 from micromasters.utils import webpack_dev_server_host
 from profiles.api import get_social_username
 from roles.models import Instructor, Staff
+from cms.util import get_coupon_code
 
 
 class HomePage(Page):
@@ -60,6 +61,7 @@ class HomePage(Page):
         context["js_settings_json"] = json.dumps(js_settings)
         context["title"] = self.title
         context["ga_tracking_id"] = ""
+        context["coupon_code"] = get_coupon_code(request)
 
         return context
 

--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -51,19 +51,19 @@
       <div class="banner-wrapper">
         {% if user.is_anonymous and request.GET.coupon %}
           <div role="alertdialog" class="toast">
-            <i class="material-icons">account_circle</i>
-            <div class="body">
-              <span class="message">
-                You need to Sign up or Login before you can apply this coupon.
-              </span>
-              <ul class="links">
-                <li><button class="mm-minor-action open-signup-dialog">Log In</button></li>
-                <li><button class="mm-minor-action open-signup-dialog">Sign Up</button></li>
-              </ul>
+            <div class="toast-message">
+              <i class="material-icons">account_circle</i>
+              <div class="toast-body">
+                <p>You need to Sign up or Login before you can apply this coupon.</p>
+              </div>
+              <button class="toast-close close">
+                <i class="material-icons close-icon">close</i>
+              </button>
             </div>
-            <button class="close" aria-label="Close">
-              <span aria-hidden="true">×</span>
-            </button>
+            <ul class="toast-actions">
+              <li><button class="mm-minor-action open-signup-dialog">Log In</button></li>
+              <li><button class="mm-minor-action open-signup-dialog">Sign Up</button></li>
+            </ul>
           </div>
         {% endif %}
         <div class="banner-wrapper-content">

--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -49,7 +49,7 @@
   <div class="main-content-wrapper">
     <main>
       <div class="banner-wrapper">
-        {% if user.is_anonymous and request.GET.coupon %}
+        {% if user.is_anonymous and coupon_code %}
           <div role="alertdialog" class="toast">
             <div class="toast-message">
               <i class="material-icons">account_circle</i>

--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -49,6 +49,23 @@
   <div class="main-content-wrapper">
     <main>
       <div class="banner-wrapper">
+        {% if user.is_anonymous and request.GET.coupon %}
+          <div role="alertdialog" class="toast">
+            <i class="material-icons">account_circle</i>
+            <div class="body">
+              <span class="message">
+                You need to Sign up or Login before you can apply this coupon.
+              </span>
+              <ul class="links">
+                <li><button class="mm-minor-action open-signup-dialog">Log In</button></li>
+                <li><button class="mm-minor-action open-signup-dialog">Sign Up</button></li>
+              </ul>
+            </div>
+            <button class="close" aria-label="Close">
+              <span aria-hidden="true">×</span>
+            </button>
+          </div>
+        {% endif %}
         <div class="banner-wrapper-content">
           <h1>
             MITx MicroMasters: Bringing MIT to you

--- a/cms/util.py
+++ b/cms/util.py
@@ -5,14 +5,23 @@ from urllib.parse import urlparse, parse_qs
 
 
 def get_coupon_code(request):
-    coupon_code = request.GET.get("coupon", None)
-    if coupon_code:
-        return coupon_code
-    next_url = request.GET.get("next", None)
+    """
+    Get coupon code from an HttpRequest
+
+    Args:
+        request (django.http.request.HttpRequest): An HttpRequest
+
+    Returns:
+        str: A coupon code or None if none found
+    """
+    next_url = request.GET.get("next")
     if not next_url:
         return None
     parsed = urlparse(next_url)
-    coupons = parse_qs(parsed.query).get("coupon", None)
+    path = parsed.path
+    if path not in ("/dashboard", "/dashboard/"):
+        return None
+    coupons = parse_qs(parsed.query).get("coupon")
     if coupons:
         return coupons[0]
     return None

--- a/cms/util.py
+++ b/cms/util.py
@@ -1,0 +1,18 @@
+"""
+Utility functions for CMS models
+"""
+from urllib.parse import urlparse, parse_qs
+
+
+def get_coupon_code(request):
+    coupon_code = request.GET.get("coupon", None)
+    if coupon_code:
+        return coupon_code
+    next_url = request.GET.get("next", None)
+    if not next_url:
+        return None
+    parsed = urlparse(next_url)
+    coupons = parse_qs(parsed.query).get("coupon", None)
+    if coupons:
+        return coupons[0]
+    return None

--- a/cms/util_test.py
+++ b/cms/util_test.py
@@ -1,0 +1,46 @@
+"""
+Tests for cms/util.py
+"""
+from micromasters.test import SimpleTestCase
+from django.http.request import HttpRequest
+from cms.util import get_coupon_code
+
+
+class UtilTestCase(SimpleTestCase):
+    """
+    Tests for get_coupon_code()
+    """
+    def setUp(self):
+        super().setUp()
+        self.request = HttpRequest()
+
+    def test_coupon_in_query(self):
+        """
+        Test if the coupon is directly in the query string
+        """
+        self.request.GET["coupon"] = "abc"
+        coupon = get_coupon_code(self.request)
+        assert coupon == "abc"
+
+    def test_coupon_in_next_url(self):
+        """
+        Test if the coupon is in the query string of the `next` url
+        """
+        self.request.GET["next"] = "/dashboard?coupon=abc"
+        coupon = get_coupon_code(self.request)
+        assert coupon == "abc"
+
+    def test_no_coupon(self):
+        """
+        Test without a query string
+        """
+        coupon = get_coupon_code(self.request)
+        assert coupon is None
+
+    def test_no_coupon_in_next(self):
+        """
+        Test with a `next` url that doesn't have a coupon
+        """
+        self.request.GET["next"] = "/dashboard"
+        coupon = get_coupon_code(self.request)
+        assert coupon is None

--- a/cms/util_test.py
+++ b/cms/util_test.py
@@ -1,9 +1,10 @@
 """
 Tests for cms/util.py
 """
-from micromasters.test import SimpleTestCase
 from django.http.request import HttpRequest
+
 from cms.util import get_coupon_code
+from micromasters.test import SimpleTestCase
 
 
 class UtilTestCase(SimpleTestCase):
@@ -14,14 +15,6 @@ class UtilTestCase(SimpleTestCase):
         super().setUp()
         self.request = HttpRequest()
 
-    def test_coupon_in_query(self):
-        """
-        Test if the coupon is directly in the query string
-        """
-        self.request.GET["coupon"] = "abc"
-        coupon = get_coupon_code(self.request)
-        assert coupon == "abc"
-
     def test_coupon_in_next_url(self):
         """
         Test if the coupon is in the query string of the `next` url
@@ -29,6 +22,14 @@ class UtilTestCase(SimpleTestCase):
         self.request.GET["next"] = "/dashboard?coupon=abc"
         coupon = get_coupon_code(self.request)
         assert coupon == "abc"
+
+    def test_coupon_in_wrong_next_url(self):
+        """
+        We should ignore a coupon code that's not for the dashboard
+        """
+        self.request.GET["next"] = "/profile?coupon=abc"
+        coupon = get_coupon_code(self.request)
+        assert coupon is None
 
     def test_no_coupon(self):
         """

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -187,18 +187,32 @@ class App extends React.Component {
       return null;
     }
 
-    const { icon: iconName, title, message } = toastMessage;
+    const {
+      icon: iconName,
+      title: titleText,
+      message: messageText
+    } = toastMessage;
 
     let icon;
     if (iconName) {
       icon = <Icon name={iconName} key="icon" />;
     }
 
+    let title, message;
+    if (titleText) {
+      title = <h1>{titleText}</h1>;
+    }
+    if (messageText) {
+      message = <p>{messageText}</p>;
+    }
+
     return <Toast onTimeout={this.clearMessage}>
-      {icon}
-      <div className="body">
-        <span className="title">{title}</span>
-        <span className="message">{message}</span>
+      <div className="toast-message">
+        {icon}
+        <div className="toast-body">
+          {title}
+          {message}
+        </div>
       </div>
     </Toast>;
   }

--- a/static/js/containers/SignupDialog.js
+++ b/static/js/containers/SignupDialog.js
@@ -24,7 +24,11 @@ const SignupDialog = ({
   setDialogVisibility,
 }: signupProps) => {
   let loginUrl = URI('/login/edxorg');
-  const nextUrl = URI(window.location.search).query(true).next;
+  const urlQuery = URI(window.location.search).query(true);
+  let nextUrl = urlQuery.next;
+  if (!nextUrl && urlQuery.coupon) {
+    nextUrl = `/dashboard/?coupon=${urlQuery.coupon}`;
+  }
   if (nextUrl) {
     loginUrl = loginUrl.setSearch("next", nextUrl);
   }

--- a/static/js/containers/SignupDialog.js
+++ b/static/js/containers/SignupDialog.js
@@ -27,7 +27,7 @@ const SignupDialog = ({
   const urlQuery = URI(window.location.search).query(true);
   let nextUrl = urlQuery.next;
   if (!nextUrl && urlQuery.coupon) {
-    nextUrl = `/dashboard/?coupon=${urlQuery.coupon}`;
+    nextUrl = URI('/dashboard/').setSearch("coupon", urlQuery.coupon);
   }
   if (nextUrl) {
     loginUrl = loginUrl.setSearch("next", nextUrl);

--- a/static/js/containers/SignupDialog_test.js
+++ b/static/js/containers/SignupDialog_test.js
@@ -2,6 +2,7 @@
 import { mount } from 'enzyme';
 import { assert } from 'chai';
 import React from 'react';
+import URI from 'urijs';
 import { Provider } from 'react-redux';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
@@ -42,16 +43,14 @@ describe("SignupDialog", () => {
   });
 
   it('also checks the coupon query param', () => {
-    window.location = "http://fake/?coupon=whee";
+    window.location = "http://fake/?coupon=aBc-123.";
     helper.store.dispatch(setDialogVisibility(true));
     renderDialog();
 
     const link = document.body.querySelector(".signup-dialog a");
-    const expectedNext = "/dashboard/?coupon=whee";
-    assert.equal(
-      link.getAttribute('href'),
-      `/login/edxorg?next=${encodeURIComponent(expectedNext)}`
-    );
+    const expectedNext = URI("/dashboard/").setQuery("coupon", "aBc-123.");
+    const expectedUrl = URI("/login/edxorg").setQuery("next", expectedNext);
+    assert.equal(link.getAttribute('href'), expectedUrl.toString());
   });
 
   it('chooses next over coupon', () => {

--- a/static/js/containers/SignupDialog_test.js
+++ b/static/js/containers/SignupDialog_test.js
@@ -37,8 +37,30 @@ describe("SignupDialog", () => {
     helper.store.dispatch(setDialogVisibility(true));
     renderDialog();
 
-    let link = document.body.querySelector(".signup-dialog a");
+    const link = document.body.querySelector(".signup-dialog a");
     assert.equal(link.getAttribute('href'), `/login/edxorg${queryParams}`);
+  });
+
+  it('also checks the coupon query param', () => {
+    window.location = "http://fake/?coupon=whee";
+    helper.store.dispatch(setDialogVisibility(true));
+    renderDialog();
+
+    const link = document.body.querySelector(".signup-dialog a");
+    const expectedNext = "/dashboard/?coupon=whee";
+    assert.equal(
+      link.getAttribute('href'),
+      `/login/edxorg?next=${encodeURIComponent(expectedNext)}`
+    );
+  });
+
+  it('chooses next over coupon', () => {
+    window.location = "http://fake/?next=a&coupon=b";
+    helper.store.dispatch(setDialogVisibility(true));
+    renderDialog();
+
+    const link = document.body.querySelector(".signup-dialog a");
+    assert.equal(link.getAttribute('href'), "/login/edxorg?next=a");
   });
 
   it("doesn't needlessly set a next query param", () => {
@@ -46,7 +68,7 @@ describe("SignupDialog", () => {
     helper.store.dispatch(setDialogVisibility(true));
     renderDialog();
 
-    let link = document.body.querySelector(".signup-dialog a");
+    const link = document.body.querySelector(".signup-dialog a");
     assert.equal(link.getAttribute('href'), "/login/edxorg");
   });
 });

--- a/static/js/entry/public.js
+++ b/static/js/entry/public.js
@@ -52,7 +52,7 @@ if (carouselEl && !_.isEmpty(facultyList)) {
 
 // Toast dialog
 const toastClose = document.querySelector('.toast .close');
-if ( toastClose ) {
+if (toastClose) {
   toastClose.onclick = () => document.querySelector('.toast').remove();
 }
 

--- a/static/js/entry/public.js
+++ b/static/js/entry/public.js
@@ -50,6 +50,12 @@ if (carouselEl && !_.isEmpty(facultyList)) {
   );
 }
 
+// Toast dialog
+const toastClose = document.querySelector('.toast .close');
+if ( toastClose ) {
+  toastClose.onclick = () => document.querySelector('.toast').remove();
+}
+
 // Signup dialog
 const store = signupDialogStore();
 

--- a/static/scss/toast.scss
+++ b/static/scss/toast.scss
@@ -1,7 +1,7 @@
 .toast {
   display: flex;
   align-items: center;
-  flex-direction: row;
+  flex-direction: column;
   position: fixed;
   background-color: $black-transparent;
   color: #c5c5c5;
@@ -14,39 +14,59 @@
   z-index: 100;
   font-size: 16px;
 
-  .material-icons {
-    padding: 10px;
-    font-size: 40px;
-  }
-
-  .body {
+  .toast-message {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+
+    .toast-body {
+      padding: 0 10px;
+
+      h1 {
+        font-size: 18px;
+        margin: 0;
+      }
+
+      p {
+        font-size: 16px;
+      }
+
+      p:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    .material-icons {
+      font-size: 40px;
+    }
   }
 
-  .title {
-    font-size: 18px;
-  }
-
-  ul.links {
+  .toast-actions {
     margin: 0 auto;
     padding: 0;
 
     li {
       display: inline;
       padding: 0 1em;
-      border-right: 1px solid $medgrey;
+      border-right: 1px solid #7b7b7b;
 
       &:last-child {
         border-right: 0;
       }
     }
+
+    .mm-minor-action {
+      color: #4c8399;
+      padding: 0;
+    }
   }
 
-  .close {
+  .toast-close {
     color: #c5c5c5;
     opacity: 1;
     align-self: flex-start;
-    padding: 0 0 .5em .5em;
+
+    .material-icons {
+      font-size: 16px;
+    }
   }
 }

--- a/static/scss/toast.scss
+++ b/static/scss/toast.scss
@@ -27,4 +27,26 @@
   .title {
     font-size: 18px;
   }
+
+  ul.links {
+    margin: 0 auto;
+    padding: 0;
+
+    li {
+      display: inline;
+      padding: 0 1em;
+      border-right: 1px solid $medgrey;
+
+      &:last-child {
+        border-right: 0;
+      }
+    }
+  }
+
+  .close {
+    color: #c5c5c5;
+    opacity: 1;
+    align-self: flex-start;
+    padding: 0 0 .5em .5em;
+  }
 }

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -3,6 +3,7 @@ Test end to end django views.
 """
 import json
 from unittest.mock import patch, Mock
+from urllib.parse import quote_plus
 
 import ddt
 from django.db.models.signals import post_save
@@ -254,6 +255,16 @@ class TestHomePage(ViewsTests):
         content = response.content.decode('utf-8')
         indexes = [content.find("Program {}".format(i + 1)) for i in range(10)]
         assert indexes == sorted(indexes)
+
+    def test_anonymous_coupon(self):
+        """
+        Assert that a coupon in the query parameter will show up in the context and in the page
+        """
+        code = "co de"
+        next_url = "/dashboard?coupon={}".format(quote_plus(code))
+        resp = self.client.get("/?next={}".format(quote_plus(next_url)))
+        assert resp.context['coupon_code'] == code
+        self.assertContains(resp, "You need to Sign up or Login before you can apply this coupon")
 
 
 class DashboardTests(ViewsTests):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2405.

#### What's this PR do?
If an anonymous user visits the home page with a `coupon` query parameter in the URL, this code will pop a toast-like alert dialog, informing the user that they must log in to use their coupon. If the user does log in, the `coupon` query parameter is retained through the login process, so that it can be automatically applied after the user is logged in.

#### How should this be manually tested?
Log out of the app, and visit the home page with a `coupon` query parameter in the URL. For example: `http://192.168.99.100:8079/?coupon=fake`. Verify that the toast-like notification appears, and that it can be dismissed by clicking the "x". (Unlike other toast notifications in the app, it will not fade away by itself.)

Verify that you can log in, either using the links in the toast-like notification, or using the standing "Log In" and "Sign Up" buttons. When you do, verify that the coupon code is retained: when you land on the dashboard, you should get confirmation dialog that the coupon has been applied, or a toast message that coupon code is invalid.

#### Screenshots (if appropriate)
![coupon login notification](https://cloud.githubusercontent.com/assets/132355/22441921/599a46bc-e707-11e6-9525-9fd28758c1da.png)
