### PR TITLE
Pearson SSO callback views

### DIFF
--- a/exams/urls.py
+++ b/exams/urls.py
@@ -1,0 +1,12 @@
+"""URLs for exams app"""
+from django.conf.urls import url
+
+from exams.views import PearsonCallbackRedirectView
+
+urlpatterns = [
+    url(
+        r'^pearson/(?P<status>success|error|timeout|logout)/?$',
+        PearsonCallbackRedirectView.as_view(),
+        name='pearson_callback'
+    ),
+]

--- a/exams/views.py
+++ b/exams/views.py
@@ -1,0 +1,5 @@
+from django.views.generic.base import RedirectView
+
+class PearsonCallbackRedirectView(RedirectView):
+    def get_redirect_url(self, status):
+        return "/dashboard?exam={status}".format(status=status)

--- a/exams/views.py
+++ b/exams/views.py
@@ -1,5 +1,12 @@
+"""
+Views for exams app
+"""
 from django.views.generic.base import RedirectView
 
+
 class PearsonCallbackRedirectView(RedirectView):
-    def get_redirect_url(self, status):
+    """
+    Redirect from Pearson callbacks to dashboard
+    """
+    def get_redirect_url(self, status):  # pylint: disable=arguments-differ
         return "/dashboard?exam={status}".format(status=status)

--- a/exams/views_test.py
+++ b/exams/views_test.py
@@ -1,42 +1,13 @@
 """
 Tests for exam views
 """
-from unittest.mock import patch
-from django.test import SimpleTestCase
-
-# These fake middlewares allow us to use Django.test.SimpleTestCase,
-# which runs faster and doesn't touch the database at all.
-
-
-class FakeSiteMiddleware(object):  # pylint: disable=missing-docstring
-    def process_request(self, request):  # pylint: disable=missing-docstring,no-self-use
-        request.site = None
-        return None
-
-
-class FakeRedirectMiddleware(object):  # pylint: disable=missing-docstring
-    def process_request(self, request):  # pylint: disable=missing-docstring,no-self-use,unused-argument
-        return None
+from micromasters.test import SimpleTestCase
 
 
 class PearsonSSOCallbackTests(SimpleTestCase):
     """
     Tests for Pearson callback URLs
     """
-    def setUp(self):
-        site_patcher = patch(
-            'wagtail.wagtailcore.middleware.SiteMiddleware',
-            new=FakeSiteMiddleware
-        )
-        redirect_patcher = patch(
-            'wagtail.wagtailredirects.middleware.RedirectMiddleware',
-            new=FakeRedirectMiddleware
-        )
-        site_patcher.start()
-        self.addCleanup(site_patcher.stop)
-        redirect_patcher.start()
-        self.addCleanup(redirect_patcher.stop)
-
     def test_success(self):
         """
         Test /pearson/success URL

--- a/exams/views_test.py
+++ b/exams/views_test.py
@@ -1,0 +1,76 @@
+"""
+Tests for exam views
+"""
+from unittest.mock import patch
+from django.test import SimpleTestCase
+
+# These fake middlewares allow us to use Django.test.SimpleTestCase,
+# which runs faster and doesn't touch the database at all.
+
+class FakeSiteMiddleware(object):  # pylint: disable=missing-docstring
+    def process_request(self, request):  # pylint: disable=missing-docstring,no-self-use
+        request.site = None
+        return None
+
+
+class FakeRedirectMiddleware(object):  # pylint: disable=missing-docstring
+    def process_request(self, request):  # pylint: disable=missing-docstring,no-self-use,unused-argument
+        return None
+
+
+class PearsonSSOCallbackTests(SimpleTestCase):
+    """
+    Tests for Pearson callback URLs
+    """
+    def setUp(self):
+        site_patcher = patch(
+            'wagtail.wagtailcore.middleware.SiteMiddleware',
+            new=FakeSiteMiddleware
+        )
+        redirect_patcher = patch(
+            'wagtail.wagtailredirects.middleware.RedirectMiddleware',
+            new=FakeRedirectMiddleware
+        )
+        site_patcher.start()
+        self.addCleanup(site_patcher.stop)
+        redirect_patcher.start()
+        self.addCleanup(redirect_patcher.stop)
+
+    def test_success(self):
+        """
+        Test /pearson/success URL
+        """
+        response = self.client.get('/pearson/success/')
+        assert response.status_code == 302
+        assert response.url == "/dashboard?exam=success"
+
+    def test_error(self):
+        """
+        Test /pearson/error URL
+        """
+        response = self.client.get('/pearson/error/')
+        assert response.status_code == 302
+        assert response.url == "/dashboard?exam=error"
+
+    def test_timeout(self):
+        """
+        Test /pearson/error URL
+        """
+        response = self.client.get('/pearson/timeout/')
+        assert response.status_code == 302
+        assert response.url == "/dashboard?exam=timeout"
+
+    def test_logout(self):
+        """
+        Test /pearson/logout URL
+        """
+        response = self.client.get('/pearson/logout/')
+        assert response.status_code == 302
+        assert response.url == "/dashboard?exam=logout"
+
+    def test_not_found(self):
+        """
+        Test a URL under /pearson that doesn't exist
+        """
+        response = self.client.get('/pearson/other/')
+        assert response.status_code == 404

--- a/exams/views_test.py
+++ b/exams/views_test.py
@@ -7,6 +7,7 @@ from django.test import SimpleTestCase
 # These fake middlewares allow us to use Django.test.SimpleTestCase,
 # which runs faster and doesn't touch the database at all.
 
+
 class FakeSiteMiddleware(object):  # pylint: disable=missing-docstring
     def process_request(self, request):  # pylint: disable=missing-docstring,no-self-use
         request.site = None

--- a/micromasters/test.py
+++ b/micromasters/test.py
@@ -1,0 +1,46 @@
+"""
+Test utilities
+"""
+from unittest.mock import patch
+import django.test
+
+
+class FakeSiteMiddleware(object):
+    """
+    A mock implementation of `wagtail.wagtailcore.middleware.SiteMiddleware`
+    that doesn't make any database calls.
+    """
+    def process_request(self, request):  # pylint: disable=missing-docstring,no-self-use
+        request.site = None
+        return None
+
+
+class FakeRedirectMiddleware(object):
+    """
+    A mock implementation of `wagtail.wagtailredirects.middleware.RedirectMiddleware`
+    that doesn't make any database calls.
+    """
+    def process_request(self, request):  # pylint: disable=missing-docstring,no-self-use,unused-argument
+        return None
+
+
+class SimpleTestCase(django.test.SimpleTestCase):
+    """
+    Inherits from `django.test.SimpleTestCase`, which doesn't set up the
+    database at all. Mocks out the Wagtail middlewares that make
+    database calls.
+    """
+    def setUp(self):
+        site_patcher = patch(
+            'wagtail.wagtailcore.middleware.SiteMiddleware',
+            new=FakeSiteMiddleware
+        )
+        redirect_patcher = patch(
+            'wagtail.wagtailredirects.middleware.RedirectMiddleware',
+            new=FakeRedirectMiddleware
+        )
+        site_patcher.start()
+        self.addCleanup(site_patcher.stop)
+        redirect_patcher.start()
+        self.addCleanup(redirect_patcher.stop)
+        super().setUp()

--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -27,6 +27,7 @@ urlpatterns += [
     url('', include('search.urls')),
     url('', include('mail.urls')),
     url('', include('profiles.urls')),
+    url('', include('exams.urls')),
     url(r'^status/', include('server_status.urls')),
     url('', include('ui.urls')),
     # Wagtail


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2173.

#### What's this PR do?
Sets up the following redirects:
```
/pearson/success => /dashboard?exam=success
/pearson/error => /dashboard?exam=error
/pearson/timeout => /dashboard?exam=timeout
/pearson/logout => /dashboard?exam=logout
```

#### How should this be manually tested?
Visit those four URLs in your browser, and make sure you are redirected correctly.
