### PR TITLE
The Frozen grade should be taken in account before enything else in case they exist

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -292,11 +292,7 @@ def get_status_for_courserun(course_run, mmtrack):
     """
     get_grade_algorithm_version = settings.FEATURES.get("FINAL_GRADE_ALGORITHM", "v0")
     if get_grade_algorithm_version == "v1":
-        try:
-            mmtrack.extract_final_grade(course_run.edx_course_key)
-        except FinalGrade.DoesNotExist:
-            pass
-        else:
+        if mmtrack.has_paid_frozen_grade(course_run.edx_course_key):
             return CourseRunUserStatus(CourseRunStatus.CHECK_IF_PASSED, course_run)
     if not mmtrack.is_enrolled(course_run.edx_course_key):
         if mmtrack.has_paid(course_run.edx_course_key):
@@ -311,17 +307,7 @@ def get_status_for_courserun(course_run, mmtrack):
         # the following statement needs to happen only with the new version of the algorithm
         elif course_run.has_frozen_grades and get_grade_algorithm_version == "v1":
             # be sure that the user has a final grade or freeze now
-            try:
-                mmtrack.extract_final_grade(course_run.edx_course_key)
-            except FinalGrade.DoesNotExist:
-                # this is a very special case that happens if the user has logged in
-                # for the first time after we have already frozen the final grades
-                log.warning(
-                    'The user "%s" doesn\'t have a final grade for the course run "%s" '
-                    'but the course run has already been frozen. Trying to freeze the user now.',
-                    mmtrack.user.username,
-                    course_run.edx_course_key,
-                )
+            if not mmtrack.has_frozen_grade(course_run.edx_course_key):
                 api.freeze_user_final_grade(mmtrack.user, course_run, raise_on_exception=True)
             status = CourseRunStatus.CHECK_IF_PASSED
         # this last check needs to be done as last one
@@ -410,7 +396,11 @@ def format_courserun_for_dashboard(course_run, status_for_user, mmtrack, positio
         formatted_run['final_grade'] = mmtrack.get_final_grade(course_run.edx_course_key)
     # if the course is not passed the final grade is the current grade
     elif status_for_user == CourseStatus.NOT_PASSED:
-        formatted_run['final_grade'] = mmtrack.get_current_grade(course_run.edx_course_key)
+        get_grade_algorithm_version = settings.FEATURES.get("FINAL_GRADE_ALGORITHM", "v0")
+        if get_grade_algorithm_version == "v1":
+            formatted_run['final_grade'] = mmtrack.get_final_grade(course_run.edx_course_key)
+        else:
+            formatted_run['final_grade'] = mmtrack.get_current_grade(course_run.edx_course_key)
     # any other status but "offered" should have the current grade
     elif status_for_user != CourseStatus.OFFERED:
         formatted_run['current_grade'] = mmtrack.get_current_grade(course_run.edx_course_key)

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -189,16 +189,26 @@ class FormatRunTest(CourseTests):
             expected_ret_data
         )
 
-        # with not passed
+        # with not passed in v0
         expected_ret_data.update({
             'status': api.CourseStatus.NOT_PASSED,
             'position': 1,
             'final_grade': 33.33,
         })
-        self.assertEqual(
-            api.format_courserun_for_dashboard(crun, api.CourseStatus.NOT_PASSED, self.mmtrack),
-            expected_ret_data
-        )
+        with override_settings(FEATURES={"FINAL_GRADE_ALGORITHM": 'v0'}):
+            self.assertEqual(
+                api.format_courserun_for_dashboard(crun, api.CourseStatus.NOT_PASSED, self.mmtrack),
+                expected_ret_data
+            )
+        # with not passed in v1
+        expected_ret_data.update({
+            'final_grade': 99.99,
+        })
+        with override_settings(FEATURES={"FINAL_GRADE_ALGORITHM": 'v1'}):
+            self.assertEqual(
+                api.format_courserun_for_dashboard(crun, api.CourseStatus.NOT_PASSED, self.mmtrack),
+                expected_ret_data
+            )
 
         # with currently enrolled
         expected_ret_data.update({
@@ -270,7 +280,8 @@ class CourseRunTest(CourseTests):
         """test for get_status_for_courserun for course without enrollment"""
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': False,
-            'has_paid.return_value': False
+            'has_paid.return_value': False,
+            'has_paid_frozen_grade.return_value': False,
         })
         crun = self.create_run(
             start=self.now+timedelta(weeks=52),
@@ -289,7 +300,9 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': True,
-            'has_paid.return_value': True
+            'has_paid.return_value': True,
+            'has_paid_frozen_grade.return_value': False,
+            'has_frozen_grade.return_value': False,
         })
         # create a run that is current
         crun = self.create_run(
@@ -311,7 +324,7 @@ class CourseRunTest(CourseTests):
         """
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
-            'extract_final_grade.return_value': Mock()
+            'has_paid_frozen_grade.return_value': True,
         })
         # create a run that is past
         crun = self.create_run(
@@ -342,7 +355,8 @@ class CourseRunTest(CourseTests):
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': True,
             'has_paid.return_value': True,
-            'extract_final_grade.return_value': Mock()
+            'has_paid_frozen_grade.return_value': False,
+            'has_frozen_grade.return_value': True,
         })
         if not has_frozen_grades:
             self.mmtrack.extract_final_grade.side_effect = FinalGrade.DoesNotExist
@@ -375,7 +389,8 @@ class CourseRunTest(CourseTests):
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': True,
             'has_paid.return_value': True,
-            'extract_final_grade.side_effect': FinalGrade.DoesNotExist
+            'has_paid_frozen_grade.return_value': False,
+            'has_frozen_grade.return_value': False,
         })
         has_frozen_mock.return_value = True
         # create a run that is past
@@ -400,7 +415,8 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': True,
-            'has_paid.return_value': True
+            'has_paid.return_value': True,
+            'has_paid_frozen_grade.return_value': False,
         })
         # create a run that is future
         crun = self.create_run(
@@ -419,7 +435,9 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': False,
-            'has_paid.return_value': False
+            'has_paid.return_value': False,
+            'has_paid_frozen_grade.return_value': False,
+            'has_frozen_grade.return_value': False,
         })
         # create a run that is future
         future_run = self.create_run(
@@ -449,7 +467,9 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': False,
-            'has_paid.return_value': False
+            'has_paid.return_value': False,
+            'has_paid_frozen_grade.return_value': False,
+            'has_frozen_grade.return_value': False,
         })
         # create a run that is current with upgrade deadline None
         current_run = self.create_run(
@@ -483,7 +503,9 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': True,
-            'has_paid.return_value': True
+            'has_paid.return_value': True,
+            'has_paid_frozen_grade.return_value': False,
+            'has_frozen_grade.return_value': False,
         })
         crun = self.create_run(
             start=None,
@@ -505,7 +527,9 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': False,
-            'has_paid.return_value': False
+            'has_paid.return_value': False,
+            'has_paid_frozen_grade.return_value': False,
+            'has_frozen_grade.return_value': False,
         })
         # create a run that is past
         crun = self.create_run(
@@ -545,7 +569,9 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': False,
-            'has_paid.return_value': False
+            'has_paid.return_value': False,
+            'has_paid_frozen_grade.return_value': False,
+            'has_frozen_grade.return_value': False,
         })
         # create a run that is past
         crun = self.create_run(
@@ -577,7 +603,9 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': False,
-            'has_paid.return_value': False
+            'has_paid.return_value': False,
+            'has_paid_frozen_grade.return_value': False,
+            'has_frozen_grade.return_value': False,
         })
         # create a run that is past
         crun = self.create_run(
@@ -613,7 +641,9 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': True,
             'is_enrolled_mmtrack.return_value': False,
-            'has_paid.return_value': False
+            'has_paid.return_value': False,
+            'has_paid_frozen_grade.return_value': False,
+            'has_frozen_grade.return_value': True,
         })
         # create a run that is past
         crun = self.create_run(
@@ -633,7 +663,9 @@ class CourseRunTest(CourseTests):
         self.mmtrack.configure_mock(**{
             'is_enrolled.return_value': False,
             'is_enrolled_mmtrack.return_value': False,
-            'has_paid.return_value': True
+            'has_paid.return_value': True,
+            'has_paid_frozen_grade.return_value': False,
+            'has_frozen_grade.return_value': True,
         })
         crun = self.create_run(
             start=self.now+timedelta(weeks=52),

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -199,6 +199,32 @@ class MMTrack:
             raise
         return final_grade
 
+    def has_frozen_grade(self, course_id):
+        """
+        Checks if there is a frozen grade for the course run
+
+        Args:
+            course_id (str): an edX course run id
+        Returns:
+            bool: whether a frozen final grade exists
+        """
+        try:
+            self.extract_final_grade(course_id)
+            return True
+        except FinalGrade.DoesNotExist:
+            return False
+
+    def has_paid_frozen_grade(self, course_id):
+        """
+        Checks if there is a a frozen final grade and the user paid for it.
+
+        Args:
+            course_id (str): an edX course run id
+        Returns:
+            bool: whether a frozen final grade exists
+        """
+        return self.has_frozen_grade(course_id) and self.has_paid(course_id)
+
     def has_passed_course(self, course_id):
         """
         Returns whether the user has passed a course run.


### PR DESCRIPTION
#### What are the relevant tickets?
N/A
#### What's this PR do?
In case there are final grades, they are taken in account in the dashboard before checking anything else. The reason is because we cannot rely on the existence of cached data long term.

#### Where should the reviewer start?
`dashboard/api.py`

#### How should this be manually tested?
Create a final grade for the user in a course run with a verified cached enrollment in a non financial aid program. The user should see if she passed (or not, depending on the final grade you created) the course on the dashboard.
#### What GIF best describes this PR or how it makes you feel?
![](http://i.giphy.com/HHEUkVUnF8lfq.gif)