### PR TITLE
Show Coupon code on OrderSummary page

### DIFF
--- a/static/js/components/OrderSummary.js
+++ b/static/js/components/OrderSummary.js
@@ -17,6 +17,7 @@ class OrderSummary extends React.Component {
     coursePrice:      CoursePrice,
     finalPrice:       ?number,
     discount:         ?number,
+    couponCode:       ?string,
     checkout:         Function,
     checkoutStatus?:  string,
   };
@@ -62,11 +63,11 @@ class OrderSummary extends React.Component {
   }
 
   render() {
-    let { course, courseRun, checkout, checkoutStatus, discount } = this.props;
+    let { course, courseRun, checkout, checkoutStatus, couponCode} = this.props;
     let discountInfo;
-    if (discount !== null && discount !== undefined) {
+    if (couponCode) {
       discountInfo = [
-        this.showAmount('Discount from coupon', this.getDiscountAmount()),
+        this.showAmount(`Discount from coupon ${couponCode}`, this.getDiscountAmount()),
         <Cell col={10} tablet={6} phone={4} className="division-line" key="division"/>,
         this.showAmount('Total', this.getFinalPrice())
       ];

--- a/static/js/components/OrderSummary_test.js
+++ b/static/js/components/OrderSummary_test.js
@@ -74,12 +74,13 @@ describe('OrderSummary', () => {
       courseRun: firstRun,
       course: course,
       discount: COURSE_PRICES_RESPONSE[1].price,
-      finalPrice: 0
+      finalPrice: 0,
+      couponCode: '561KH'
     });
 
     let descriptions = wrapper.find(".description");
     assert.equal(descriptions.length, 3);
-    assert.equal(descriptions.children().nodes[1], 'Discount from coupon');
+    assert.equal(descriptions.children().nodes[1], 'Discount from coupon 561KH');
     let amounts = wrapper.find(".amount");
     assert.equal(amounts.length, 3);
     assert.equal(amounts.children().nodes[1], `-$${COURSE_PRICES_RESPONSE[1].price}`);

--- a/static/js/containers/OrderSummaryPage.js
+++ b/static/js/containers/OrderSummaryPage.js
@@ -114,7 +114,7 @@ class OrderSummaryPage extends React.Component {
     coursePrice = prices.coursePrices.find(coursePrice => coursePrice.program_id === currentProgramEnrollment.id);
 
     if (course && courseRun && coursePrice) {
-      const calculatedPrice = calculatePrice(courseRun.id, course.id, coursePrice, coupons.coupons);
+      const [coupon, calculatedPrice] = calculatePrice(courseRun.id, course.id, coursePrice, coupons.coupons);
       let discount = null;
       if (calculatedPrice !== null && calculatedPrice !== undefined) {
         discount = coursePrice.price - calculatedPrice;
@@ -124,6 +124,7 @@ class OrderSummaryPage extends React.Component {
         courseRun={courseRun}
         coursePrice={coursePrice}
         finalPrice={calculatedPrice}
+        couponCode={coupon ? coupon.coupon_code : null}
         discount={discount}
         checkout={this.dispatchCheckout}
         checkoutStatus={checkout.fetchStatus}

--- a/static/js/lib/coupon.js
+++ b/static/js/lib/coupon.js
@@ -43,9 +43,12 @@ function* genPrices(programs: Dashboard, prices: CoursePrices, coupons: Coupons)
   }
 }
 
-export const calculatePrice = (runId: number, courseId: number, price: CoursePrice, coupons: Coupons): ?number => {
+export const calculatePrice = (
+  runId: number, courseId: number, price: CoursePrice, coupons: Coupons
+): [?Coupon, ?number] => {
   const couponLookup: Map<number, Coupon> = makeProgramIdLookup(coupons);
-  return calculateRunPrice(runId, courseId, price.program_id, price, couponLookup.get(price.program_id));
+  let coupon = couponLookup.get(price.program_id);
+  return [coupon, calculateRunPrice(runId, courseId, price.program_id, price, coupon)];
 };
 
 export const calculatePrices = (programs: Dashboard, prices: CoursePrices, coupons: Coupons): CalculatedPrices => {

--- a/static/js/lib/coupon_test.js
+++ b/static/js/lib/coupon_test.js
@@ -45,9 +45,10 @@ describe('coupon utility functions', () => {
       let stubPrice = 5;
       let calculateRunPriceStub = sandbox.stub(couponFuncs, 'calculateRunPrice');
       calculateRunPriceStub.returns(stubPrice);
-      let actual = calculatePrice(run.id, course.id, price, coupons);
-      assert.equal(actual, stubPrice);
+      let [ actualCoupon, actualPrice ] = calculatePrice(run.id, course.id, price, coupons);
+      assert.equal(actualPrice, stubPrice);
       let coupon = coupons.find(coupon => coupon.program_id === program.id);
+      assert.deepEqual(actualCoupon, coupon);
       assert.isTrue(calculateRunPriceStub.calledWith(
         run.id, course.id, program.id, price, coupon
       ));


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #2491

#### What's this PR do?
This PR changes the the logic behind the display of the discount calculation to be based on an existing coupon, instead of the discount that is applied.

Displays the coupon code in the calculation.

#### Where should the reviewer start?

#### How should this be manually tested?
As a learner, try to 'PAY NOW' for a course without any coupons, with a coupon, and with a coupon that gives $0 discount.
#### Any background context you want to provide?

#### Screenshots (if appropriate)
![screen shot 2017-02-02 at 12 41 12 pm](https://cloud.githubusercontent.com/assets/7574259/22561108/ed0021c6-e944-11e6-8051-6d2ae7ec2a6f.png)

#### What GIF best describes this PR or how it makes you feel?
