### PR TITLE
Pearson SSO

### DIFF
--- a/exams/api.py
+++ b/exams/api.py
@@ -1,0 +1,34 @@
+"""
+API for exams app
+"""
+import hashlib
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+
+def sso_digest(client_candidate_id, timestamp, session_timeout):
+    """
+    Compute the sso_digest value we need to send to pearson
+
+    Args:
+        client_candidate_id (int|str): id for the user, usually Profile.student_id
+        timestamp (int): unix timestamp
+        session_timeout (int): number of seconds the session will last
+
+    Returns:
+        str: the computed digest value
+    """
+    if settings.EXAMS_SSO_PASSPHRASE is None:
+        raise ImproperlyConfigured("EXAMS_SSO_PASSPHRASE is not configured")
+    if settings.EXAMS_SSO_CLIENT_CODE is None:
+        raise ImproperlyConfigured("EXAMS_SSO_CLIENT_CODE is not configured")
+
+    data = ''.join([
+        settings.EXAMS_SSO_PASSPHRASE,
+        settings.EXAMS_SSO_CLIENT_CODE,
+        str(timestamp),
+        str(session_timeout),
+        str(client_candidate_id),
+    ]).encode('iso-8859-1')
+    return hashlib.sha256(data).hexdigest()

--- a/exams/api_test.py
+++ b/exams/api_test.py
@@ -1,0 +1,40 @@
+"""
+Tests for exams API
+"""
+from django.test import (
+    SimpleTestCase,
+    override_settings,
+)
+from django.core.exceptions import ImproperlyConfigured
+
+from exams.api import sso_digest
+
+
+class SSODigestTests(SimpleTestCase):
+    """
+    Tests for the sso_digest helper function
+    """
+
+    @override_settings(
+        EXAMS_SSO_PASSPHRASE="C is for cookie",
+        EXAMS_SSO_CLIENT_CODE="and that's good enough for me",
+    )
+    def test_that_sso_digest_computes_correctly(self):
+        """Verifies sso_digest computes correctly"""
+
+        # computed "by hand"
+        assert sso_digest(123, 1486069731, 1800) == (
+            'a64ea7218e4a67d863e03ec43ac40240af39f5924af46e02b2199e3f7974b8d3'
+        )
+
+    @override_settings(EXAMS_SSO_PASSPHRASE=None)
+    def test_that_no_passphrase_raises(self):
+        """Verifies that if we don't set the passphrase we raise an exception"""
+        with self.assertRaises(ImproperlyConfigured):
+            sso_digest(123, 1486069731, 1800)
+
+    @override_settings(EXAMS_SSO_CLIENT_CODE=None)
+    def test_that_no_client_code_raises(self):
+        """Verifies that if we don't set the passphrase we raise an exception"""
+        with self.assertRaises(ImproperlyConfigured):
+            sso_digest(123, 1486069731, 1800)

--- a/exams/urls.py
+++ b/exams/urls.py
@@ -1,12 +1,16 @@
 """URLs for exams app"""
 from django.conf.urls import url
 
-from exams.views import PearsonCallbackRedirectView
+from exams.views import (
+    PearsonCallbackRedirectView,
+    PearsonSSO,
+)
 
 urlpatterns = [
     url(
-        r'^pearson/(?P<status>success|error|timeout|logout)/?$',
+        r'^pearson/(?P<status_code>success|error|timeout|logout)/?$',
         PearsonCallbackRedirectView.as_view(),
         name='pearson_callback'
     ),
+    url(r'^api/v0/pearson/sso/$', PearsonSSO.as_view(), name='pearson_sso_api'),
 ]

--- a/exams/views.py
+++ b/exams/views.py
@@ -1,12 +1,70 @@
 """
 Views for exams app
 """
+from datetime import datetime
+
+from urllib.parse import quote_plus
+import pytz
 from django.views.generic.base import RedirectView
+from django.core.exceptions import ImproperlyConfigured
+from rest_framework import (
+    authentication,
+    permissions,
+    status,
+)
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from exams.api import sso_digest
+from exams.models import ExamProfile
 
 
 class PearsonCallbackRedirectView(RedirectView):
     """
     Redirect from Pearson callbacks to dashboard
     """
-    def get_redirect_url(self, status):  # pylint: disable=arguments-differ
-        return "/dashboard?exam={status}".format(status=status)
+    def get_redirect_url(self, status_code):  # pylint: disable=arguments-differ
+        return "/dashboard?exam={status_code}".format(status_code=quote_plus(status_code))
+
+
+class PearsonSSO(APIView):
+    """
+    Views for the Pearson SSO API
+    """
+    authentication_classes = (
+        authentication.SessionAuthentication,
+        authentication.TokenAuthentication,
+    )
+    permission_classes = (permissions.IsAuthenticated, )
+
+    def get(self, request, *args, **kargs):  # pylint: disable=unused-argument, no-self-use
+        """
+        Request for exam SSO parameters
+        """
+        profile = request.user.profile
+        student_id = profile.student_id
+
+        if not ExamProfile.objects.filter(
+                profile=profile,
+                status=ExamProfile.PROFILE_SUCCESS,
+        ).exists():
+            # UI should in theory not send a user here in this state,
+            # but it's not impossible so let's handle it politely
+            return Response(data={
+                'error': 'You are not ready to schedule an exam at this time',
+            }, status=status.HTTP_403_FORBIDDEN)
+
+        timestamp = int(datetime.now(pytz.utc).timestamp())
+        session_timeout = request.session.get_expiry_age()
+
+        try:
+            digest = sso_digest(student_id, timestamp, session_timeout)
+        except ImproperlyConfigured:
+            return Response(status=500)
+
+        return Response(data={
+            'sso_digest': digest,
+            'timestamp': timestamp,
+            'session_timeout': session_timeout,
+            'sso_redirect_url': request.build_absolute_uri('/'),
+        })

--- a/exams/views_test.py
+++ b/exams/views_test.py
@@ -1,7 +1,20 @@
 """
 Tests for exam views
 """
+from unittest.mock import patch
+
+from datetime import datetime
+import ddt
+from rest_framework import status
+from rest_framework.test import APITestCase
+from django.core.exceptions import ImproperlyConfigured
+from django.core.urlresolvers import reverse
+import pytz
+
+from exams.models import ExamProfile
 from micromasters.test import SimpleTestCase
+from micromasters.factories import UserFactory
+from search.base import MockedESTestCase
 
 
 class PearsonSSOCallbackTests(SimpleTestCase):
@@ -13,7 +26,7 @@ class PearsonSSOCallbackTests(SimpleTestCase):
         Test /pearson/success URL
         """
         response = self.client.get('/pearson/success/')
-        assert response.status_code == 302
+        assert response.status_code == status.HTTP_302_FOUND
         assert response.url == "/dashboard?exam=success"
 
     def test_error(self):
@@ -21,7 +34,7 @@ class PearsonSSOCallbackTests(SimpleTestCase):
         Test /pearson/error URL
         """
         response = self.client.get('/pearson/error/')
-        assert response.status_code == 302
+        assert response.status_code == status.HTTP_302_FOUND
         assert response.url == "/dashboard?exam=error"
 
     def test_timeout(self):
@@ -29,7 +42,7 @@ class PearsonSSOCallbackTests(SimpleTestCase):
         Test /pearson/error URL
         """
         response = self.client.get('/pearson/timeout/')
-        assert response.status_code == 302
+        assert response.status_code == status.HTTP_302_FOUND
         assert response.url == "/dashboard?exam=timeout"
 
     def test_logout(self):
@@ -37,7 +50,7 @@ class PearsonSSOCallbackTests(SimpleTestCase):
         Test /pearson/logout URL
         """
         response = self.client.get('/pearson/logout/')
-        assert response.status_code == 302
+        assert response.status_code == status.HTTP_302_FOUND
         assert response.url == "/dashboard?exam=logout"
 
     def test_not_found(self):
@@ -45,4 +58,93 @@ class PearsonSSOCallbackTests(SimpleTestCase):
         Test a URL under /pearson that doesn't exist
         """
         response = self.client.get('/pearson/other/')
-        assert response.status_code == 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@ddt.ddt
+class PearsonSSOViewTests(MockedESTestCase, APITestCase):
+    """
+    Tests for the SSO views
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        # create an user
+        cls.user = UserFactory()
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_login(self.user)
+
+    def test_sso_get_no_exam_profile(self):
+        """
+        Test issuing a GET request when user has no ExamProfile
+        """
+        with patch('exams.views.sso_digest', return_value='test value'):
+            response = self.client.get(reverse("pearson_sso_api"))
+            assert response.status_code == status.HTTP_403_FORBIDDEN
+            assert response.json() == {
+                'error': 'You are not ready to schedule an exam at this time',
+            }
+
+    @ddt.data(
+        (ExamProfile.PROFILE_INVALID, ),
+        (ExamProfile.PROFILE_IN_PROGRESS, ),
+        (ExamProfile.PROFILE_PENDING, ),
+    )
+    @ddt.unpack
+    def test_sso_get_with_exam_profile_not_success(self, profile_status):
+        """
+        Test issuing a GET request when user has an ExamProfile in non-success status
+        """
+        ExamProfile.objects.create(
+            profile=self.user.profile,
+            status=profile_status,
+        )
+
+        with patch('exams.views.sso_digest', return_value='test value'):
+            response = self.client.get(reverse("pearson_sso_api"))
+            assert response.status_code == status.HTTP_403_FORBIDDEN
+            assert response.json() == {
+                'error': 'You are not ready to schedule an exam at this time',
+            }
+
+    def test_sso_get_with_exam_profile_success(self):
+        """
+        Test issuing a GET request when user has an ExamProfile in PROFILE_SUCCESS status
+        """
+        ExamProfile.objects.create(
+            profile=self.user.profile,
+            status=ExamProfile.PROFILE_SUCCESS,
+        )
+
+        with patch('exams.views.sso_digest', return_value='test value'):
+            response = self.client.get(reverse("pearson_sso_api"))
+            result = response.json()
+            assert response.status_code == status.HTTP_200_OK
+
+            timestamp = result['timestamp']
+            assert isinstance(timestamp, int)
+
+            now = int(datetime.now(pytz.utc).timestamp())
+            assert now - timestamp < 5
+
+            assert result['sso_digest'] == 'test value'
+
+            # best we can assert is that this is an integer
+            assert isinstance(result['session_timeout'], int)
+
+            assert result['sso_redirect_url'] == 'http://testserver/'
+
+    def test_sso_improperly_configured_response(self):
+        """
+        Test issuing a GET request when user has an ExamProfile in PROFILE_SUCCESS status
+        """
+        ExamProfile.objects.create(
+            profile=self.user.profile,
+            status=ExamProfile.PROFILE_SUCCESS,
+        )
+
+        with patch('exams.views.sso_digest', side_effect=ImproperlyConfigured):
+            response = self.client.get(reverse("pearson_sso_api"))
+            assert response.status_code == 500

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -533,6 +533,11 @@ EXAMS_SFTP_PASSWORD = get_var('EXAMS_SFTP_PASSWORD', None)
 EXAMS_SFTP_UPLOAD_DIR = get_var('EXAMS_SFTP_UPLOAD_DIR', 'results/topvue')
 EXAMS_SFTP_BACKOFF_BASE = get_var('EXAMS_SFTP_BACKOFF_BASE', 5)
 
+# Pearson SSO
+EXAMS_SSO_PASSPHRASE = get_var('EXAMS_SSO_PASSPHRASE', None)
+EXAMS_SSO_CLIENT_CODE = get_var('EXAMS_SSO_CLIENT_CODE', None)
+EXAMS_SSO_URL = get_var('EXAMS_SSO_URL', None)
+
 
 # features flags
 def get_all_config_keys():

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -219,6 +219,7 @@ class ProfileSerializer(ProfileBaseSerializer):
             'preferred_language',
             'gender',
             'pretty_printed_student_id',
+            'student_id',
             'work_history',
             'edx_level_of_education',
             'education',
@@ -235,6 +236,7 @@ class ProfileSerializer(ProfileBaseSerializer):
             'agreed_to_terms_of_service',
             'image_small',
             'image_medium',
+            'student_id',
         )
 
 

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -96,6 +96,7 @@ class ProfileTests(MockedESTestCase):
             'romanized_first_name': profile.romanized_first_name,
             'romanized_last_name': profile.romanized_last_name,
             'phone_number': profile.phone_number,
+            'student_id': profile.student_id,
         }
 
     def test_limited(self):

--- a/static/js/actions/pearson.js
+++ b/static/js/actions/pearson.js
@@ -1,0 +1,39 @@
+// @flow
+import { createAction } from 'redux-actions';
+import type { Dispatch } from 'redux';
+
+import { getPearsonSSO } from '../lib/api';
+
+export const REQUEST_GET_PEARSON_SSO_DIGEST = 'REQUEST_GET_PEARSON_SSO_DIGEST';
+export const requestGetPearsonSSODigest = createAction(REQUEST_GET_PEARSON_SSO_DIGEST);
+
+export const RECEIVE_GET_PEARSON_SSO_FAILURE = 'RECEIVE_GET_PEARSON_SSO_FAILURE';
+export const receiveGetPearsonSSOFailure = createAction(RECEIVE_GET_PEARSON_SSO_FAILURE);
+
+export const RECEIVE_GET_PEARSON_SSO_SUCCESS = 'RECEIVE_GET_PEARSON_SSO_SUCCESS';
+export const receiveGetPearsonSSOSuccess = createAction(RECEIVE_GET_PEARSON_SSO_SUCCESS);
+
+export function getPearsonSSODigest() {
+  return (dispatch: Dispatch) => {
+    dispatch(requestGetPearsonSSODigest());
+    return getPearsonSSO().then(
+      ok => {
+        dispatch(receiveGetPearsonSSOSuccess());
+        return Promise.resolve(ok);
+      },
+      err => {
+        dispatch(receiveGetPearsonSSOFailure());
+        return Promise.reject(err);
+      }
+    );
+  };
+}
+
+export const PEARSON_SSO_IN_PROGRESS = 'PEARSON_SSO_IN_PROGRESS';
+export const pearsonSSOInProgress = createAction(PEARSON_SSO_IN_PROGRESS);
+
+export const PEARSON_SSO_FAILURE = 'PEARSON_SSO_FAILURE';
+export const pearsonSSOFailure = createAction(PEARSON_SSO_FAILURE);
+
+export const SET_PEARSON_ERROR = 'SET_PEARSON_ERROR';
+export const setPearsonError = createAction(SET_PEARSON_ERROR);

--- a/static/js/actions/pearson_test.js
+++ b/static/js/actions/pearson_test.js
@@ -1,0 +1,26 @@
+// @flow
+import { assertCreatedActionHelper } from './util';
+import {
+  REQUEST_GET_PEARSON_SSO_DIGEST,
+  requestGetPearsonSSODigest,
+
+  RECEIVE_GET_PEARSON_SSO_FAILURE,
+  receiveGetPearsonSSOFailure,
+
+  RECEIVE_GET_PEARSON_SSO_SUCCESS,
+  receiveGetPearsonSSOSuccess,
+
+  SET_PEARSON_ERROR,
+  setPearsonError,
+} from './pearson';
+
+describe('generated pearson action helpers', () => {
+  it('should create all action helpers', () => {
+    [
+      [requestGetPearsonSSODigest, REQUEST_GET_PEARSON_SSO_DIGEST],
+      [receiveGetPearsonSSOFailure , RECEIVE_GET_PEARSON_SSO_FAILURE],
+      [receiveGetPearsonSSOSuccess , RECEIVE_GET_PEARSON_SSO_SUCCESS],
+      [setPearsonError, SET_PEARSON_ERROR],
+    ].forEach(assertCreatedActionHelper);
+  });
+});

--- a/static/js/components/SpinnerButton.js
+++ b/static/js/components/SpinnerButton.js
@@ -2,12 +2,13 @@ import React from 'react';
 import Spinner from 'react-mdl/lib/Spinner';
 
 type SpinnerButtonProps = {
-  spinning: bool,
-  component: React.Component<*, *, *>,
-  className?: string,
-  onClick?: Function,
-  children?: any,
-  disabled?: ?bool,
+  spinning:               bool,
+  component:              React.Component<*, *, *>,
+  className?:             string,
+  onClick?:               Function,
+  children?:              any,
+  disabled?:              ?bool,
+  ignoreRecentlyClicked:  ?bool,
 };
 
 export default class SpinnerButton extends React.Component {
@@ -50,11 +51,12 @@ export default class SpinnerButton extends React.Component {
       className,
       children,
       disabled,
+      ignoreRecentlyClicked,
       ...otherProps
     } = this.props;
     const { recentlyClicked } = this.state;
 
-    if (spinning && !disabled && recentlyClicked) {
+    if (spinning && !disabled && (ignoreRecentlyClicked || recentlyClicked)) {
       if (!className) {
         className = '';
       }

--- a/static/js/components/SpinnerButton_test.js
+++ b/static/js/components/SpinnerButton_test.js
@@ -72,6 +72,22 @@ describe("SpinnerButton", () => {
     assert.equal(button.children().text(), "<Spinner />");
   });
 
+
+  it('shows the spinner is spinning is true, recentlyClicked is false, but ignoreRecentlyClicked is true', () => {
+    let wrapper = shallow(<SpinnerButton
+      component={Button}
+      spinning={true}
+      ignoreRecentlyClicked={true}
+    >
+      text
+    </SpinnerButton>);
+    wrapper.setState({
+      recentlyClicked: false
+    });
+    let button = wrapper.find("Button");
+    assert.equal(button.children().text(), "<Spinner />");
+  });
+
   it("does not show the spinner when it's disabled", () => {
     let wrapper = shallow(<SpinnerButton
       disabled={true}
@@ -122,6 +138,7 @@ describe("SpinnerButton", () => {
     assert.equal(buttonProps.onClick, undefined);
     assert.equal("text", wrapper.find("button").text());
   });
+
 
   it('sets recentlyClicked back to false if the spinning prop changes back to false', () => {
     let wrapper = shallow(

--- a/static/js/components/dashboard/FinalExamCard_test.js
+++ b/static/js/components/dashboard/FinalExamCard_test.js
@@ -19,22 +19,26 @@ import {
   PEARSON_PROFILE_INVALID,
   PEARSON_PROFILE_SCHEDULABLE
 } from '../../constants';
+import { INITIAL_PEARSON_STATE } from '../../reducers/pearson';
 
 describe('FinalExamCard', () => {
   let sandbox;
-  let navigateToProfileStub;
+  let navigateToProfileStub, submitPearsonSSOStub;
   let props;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     navigateToProfileStub = sandbox.stub();
+    submitPearsonSSOStub = sandbox.stub();
     let program = _.cloneDeep(DASHBOARD_RESPONSE.find(program => (
       program.pearson_exam_status !== undefined
     )));
     props = {
       profile: USER_PROFILE_RESPONSE,
       program: program,
-      navigateToProfile: navigateToProfileStub
+      navigateToProfile: navigateToProfileStub,
+      submitPearsonSSO: submitPearsonSSOStub,
+      pearson: { ...INITIAL_PEARSON_STATE },
     };
   });
 
@@ -100,6 +104,27 @@ pay for the course and pass the online work.`;
     assert.include(
       stringStrip(card.text()),
       "You need to update your profile in order to take a test at a Pearson Test center"
+    );
+  });
+
+  it('should show a schedule button when an exam is schedulable', () => {
+    props.program.pearson_exam_status = PEARSON_PROFILE_SCHEDULABLE;
+    let card = renderCard(props);
+    assert.include(
+      stringStrip(card.text()),
+      `You are ready to schedule an exam for ${props.program.title}`
+    );
+    card.find(".exam-button").simulate('click');
+    assert(submitPearsonSSOStub.called);
+  });
+
+  it('should show a scheduling error, when there is one', () => {
+    props.pearson.error = 'ERROR ERROR';
+    props.program.pearson_exam_status = PEARSON_PROFILE_SCHEDULABLE;
+    let card = renderCard(props);
+    assert.include(
+      stringStrip(card.text()),
+      'ERROR ERROR'
     );
   });
 });

--- a/static/js/factories/pearson.js
+++ b/static/js/factories/pearson.js
@@ -1,0 +1,11 @@
+// @flow
+import type { PearsonSSOParameters } from '../flow/pearsonTypes';
+
+export const makeSSOParameters = (): PearsonSSOParameters => {
+  let timestamp = Math.round(new Date().getTime() / 1000);
+  return {
+    sso_digest: '63a428fade2a0366230044a31bcd5c7592e30f030ede3b38b299278d526d09c1',
+    timestamp: timestamp,
+    session_timeout: timestamp + 5000,
+  };
+};

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -1,7 +1,23 @@
 // @flow
 /* eslint-disable no-unused-vars */
-import type { Settings } from './generalTypes';
-declare var SETTINGS: Settings;
+declare var SETTINGS: {
+  gaTrackingID: string,
+  reactGaDebug: boolean,
+  authenticated: boolean,
+  name: string,
+  username: string,
+  user: {
+    username: string,
+  },
+  host: string,
+  edx_base_url: string,
+  EXAMS_SSO_CLIENT_CODE: string,
+  EXAMS_SSO_URL: string,
+  support_email: string,
+  es_page_size: number,
+  search_url: string,
+  roles: Array<{ role: string }>,
+};
 
 // mocha
 declare var it: Function;
@@ -11,3 +27,8 @@ declare var describe: Function;
 
 // webpack
 declare var __webpack_public_path__: string; // eslint-disable-line camelcase
+
+declare class FormData {
+  get(s: string): any,
+  append(x: any, y: any): void,
+}

--- a/static/js/flow/generalTypes.js
+++ b/static/js/flow/generalTypes.js
@@ -1,18 +1,8 @@
 // @flow
-
 export type Option = {
   value:     any,
   label:     string,
   disabled?: boolean,
-};
-export type Settings = {
-  gaTrackingID: string,
-  reactGaDebug: boolean,
-  authenticated: boolean,
-  name: string,
-  username: string,
-  host: string,
-  edx_base_url: string,
 };
 
 export type APIErrorInfo = {

--- a/static/js/flow/pearsonTypes.js
+++ b/static/js/flow/pearsonTypes.js
@@ -1,0 +1,6 @@
+// @flow
+export type PearsonSSOParameters = {
+  sso_digest: string,
+  timestamp: number,
+  session_timeout: number
+};

--- a/static/js/flow/profileTypes.js
+++ b/static/js/flow/profileTypes.js
@@ -95,6 +95,7 @@ export type Profile = {
   about_me:                    ?string,
   romanized_first_name:        ?string,
   romanized_last_name:         ?string,
+  student_id:                  number,
 };
 
 export type Profiles = {

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -11,6 +11,8 @@ const _createSettings = () => ({
   roles: [],
   support_email: "a_real_email@example.com",
   es_page_size: 40,
+  EXAMS_SSO_CLIENT_CODE: 'foobarcode',
+  EXAMS_SSO_URL: 'http://foo.bar/baz',
   get username() {
     throw new Error("username was removed");
   }

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -11,6 +11,7 @@ import type { Coupons, AttachCouponResponse } from '../flow/couponTypes';
 import type { Dashboard } from '../flow/dashboardTypes';
 import type { AvailableProgram, AvailablePrograms } from '../flow/enrollmentTypes';
 import type { EmailSendResponse } from '../flow/emailTypes';
+import type { PearsonSSOParameters } from '../flow/pearsonTypes';
 
 export function getCookie(name: string): string|null {
   let cookieValue = null;
@@ -213,6 +214,11 @@ export function updateProfileImage(username: string, image: Blob, name: string):
     method: 'PATCH',
     body: formData
   });
+}
+
+// this hits our endpoint to get the sso_digest, session_timout, etc
+export function getPearsonSSO(): Promise<PearsonSSOParameters> {
+  return fetchJSONWithCSRF('/api/v0/pearson/sso/');
 }
 
 export function addFinancialAid(income: number, currency: string, programId: number): Promise<*> {

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -26,6 +26,7 @@ import {
   addCourseEnrollment,
   getCoupons,
   attachCoupon,
+  getPearsonSSO,
 } from './api';
 import * as api from './api';
 import {
@@ -40,6 +41,7 @@ import {
   USER_PROFILE_RESPONSE,
   PROGRAMS,
 } from '../test_constants';
+import { makeSSOParameters } from '../factories/pearson';
 
 describe('api', function() {
   this.timeout(5000);  // eslint-disable-line no-invalid-this
@@ -477,6 +479,27 @@ describe('api', function() {
               username: SETTINGS.user.username,
             })
           }));
+        });
+      });
+    });
+
+    describe('Pearson API functions', () => {
+      describe('getPearsonSSO', () => {
+        it('fetches the pearson sso parameters', () => {
+          let params = makeSSOParameters();
+          fetchJSONStub.returns(Promise.resolve(params));
+
+          return getPearsonSSO().then(() => {
+            assert(fetchJSONStub.calledWith('/api/v0/pearson/sso/'));
+          });
+        });
+
+        it('fails to fetch the pearson sso parameters', () => {
+          fetchJSONStub.returns(Promise.reject());
+
+          return assert.isRejected(getPearsonSSO()).then(() => {
+            assert(fetchJSONStub.calledWith('/api/v0/pearson/sso/'));
+          });
         });
       });
     });

--- a/static/js/lib/pearson.js
+++ b/static/js/lib/pearson.js
@@ -1,0 +1,61 @@
+// @flow
+/* global SETTINGS:false */
+import R from 'ramda';
+
+export const staticFormEntries: Array<[string, string]> = [
+];
+
+const ssoFormEntries = (studentId, timestamp, timeout, ssoDigest, ssoRedirectURL) => {
+  let baseURL = ssoRedirectURL.replace(/\/$/, '');
+  if (R.isNil(SETTINGS.EXAMS_SSO_CLIENT_CODE)) {
+    throw "EXAMS_SSO_CLIENT_CODE not configured";
+  }
+  return [
+    ["ACTION", "scheduleExam"],
+    ["CLIENT_CODE", SETTINGS.EXAMS_SSO_CLIENT_CODE],
+    ["EXTERNAL_ERROR_URL", `${baseURL}/pearson/error`],
+    ["EXTERNAL_LOGOUT_URL", `${baseURL}/pearson/logout`],
+    ["EXTERNAL_RETURN_URL", `${baseURL}/pearson/success`],
+    ["EXTERNAL_TIMEOUT_URL", `${baseURL}/pearson/timeout`],
+    ["CLIENT_CANDIDATE_ID", String(studentId)],
+    ["EXTERNAL_PAGE_TIMESTAMP", String(timestamp)],
+    ["EXTERNAL_SESSION_TIMEOUT", String(timeout)],
+    ["EXTERNAL_AUTH_HASH", ssoDigest],
+  ];
+};
+
+export const createFormInput = R.curry((form, [name, value]) => {
+  let node = document.createElement("input");
+  node.type = "hidden";
+  node.name = name;
+  node.value = value;
+  form.appendChild(node);
+});
+
+const createForm = () => {
+  let form = document.createElement('form');
+  document.body.appendChild(form);
+  if (R.isNil(SETTINGS.EXAMS_SSO_URL)) {
+    throw "EXAMS_SSO_URL not configured";
+  }
+  form.action = SETTINGS.EXAMS_SSO_URL;
+  return form;
+};
+
+export const generateSSOForm = (
+  studentId: number,
+  timestamp: number,
+  timeout: number,
+  ssoDigest: string,
+  ssoRedirectURL: string,
+) => {
+  let form = createForm();
+  R.map(createFormInput(form), ssoFormEntries(
+    studentId,
+    timestamp,
+    timeout,
+    ssoDigest,
+    ssoRedirectURL,
+  ));
+  return form;
+};

--- a/static/js/lib/pearson_test.js
+++ b/static/js/lib/pearson_test.js
@@ -1,0 +1,61 @@
+import { assert } from 'chai';
+
+import {
+  generateSSOForm,
+  staticFormEntries,
+  createFormInput,
+} from './pearson';
+
+describe('pearson library', () => {
+  describe('createFormInput', () => {
+    it('returns an input, given a form, name, and value', () => {
+      let form = document.createElement('form');
+      document.body.appendChild(form);
+      createFormInput(form, ['foo', 'bar']);
+      let input = form.querySelector('input');
+      assert.equal(input.name, 'foo');
+      assert.equal(input.type, 'hidden');
+      assert.equal(input.value, 'bar');
+    });
+  });
+
+  describe('generateSSOForm', () => {
+    const timestamp = Math.round(new Date().getTime() / 1000);
+    const hex = 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2';
+    let form, inputs;
+
+    beforeEach(() => {
+      form = generateSSOForm(12, timestamp, timestamp + 1000, hex, 'http://foo.bar/');
+      inputs = [...form.querySelectorAll('input')].map(el => [el.name, el.value]);
+    });
+
+    const checkInputs = entriesToFind => {
+      entriesToFind.forEach(([k1, v1]) => {
+        assert.notEqual(-1, inputs.find(([k2, v2]) => (
+          k1 === k2 && v1 === v2
+        )));
+      });
+    };
+
+    it('should accept arguments and return a form', () => {
+      assert(form.nodeName === 'FORM');
+    });
+
+    it('should contain all the static form entries', () => {
+      checkInputs(staticFormEntries);
+    });
+
+    it('should contain all the values it was passed', () => {
+      checkInputs(
+        ["CLIENT_CANDIDATE_ID", String(12)],
+        ["EXTERNAL_PAGE_TIMESTAMP", String(timestamp)],
+        ["EXTERNAL_SESSION_TIMEOUT", String(timestamp + 1000)],
+        ["EXTERNAL_AUTH_HASH", hex],
+        ["EXTERNAL_ERROR_URL", "http://foo.bar/pearson/error"],
+        ["EXTERNAL_LOGOUT_URL", "http://foo.bar/pearson/logout"],
+        ["EXTERNAL_RETURN_URL", "http://foo.bar/pearson/success"],
+        ["EXTERNAL_TIMEOUT_URL", "http://foo.bar/pearson/timeout"],
+      );
+    });
+  });
+});

--- a/static/js/reducers/image_upload_test.js
+++ b/static/js/reducers/image_upload_test.js
@@ -1,3 +1,7 @@
+import { assert } from 'chai';
+import sinon from 'sinon';
+import configureTestStore from 'redux-asserts';
+
 import {
   startPhotoEdit,
   START_PHOTO_EDIT,
@@ -19,10 +23,7 @@ import {
   FETCH_PROCESSING,
   FETCH_SUCCESS,
 } from '../actions';
-import configureTestStore from 'redux-asserts';
 import rootReducer from '../reducers';
-import { assert } from 'chai';
-import sinon from 'sinon';
 import * as api from '../lib/api';
 
 describe('image upload reducer', () => {

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -57,6 +57,7 @@ import { financialAid } from './financial_aid';
 import { documents } from './documents';
 import { orderReceipt } from './order_receipt';
 import { coupons } from './coupons';
+import { pearson } from './pearson';
 import { ALL_ERRORS_VISIBLE } from '../constants';
 
 export const INITIAL_PROFILES_STATE = {};
@@ -305,4 +306,5 @@ export default combineReducers({
   documents,
   orderReceipt,
   coupons,
+  pearson,
 });

--- a/static/js/reducers/pearson.js
+++ b/static/js/reducers/pearson.js
@@ -1,0 +1,44 @@
+// @flow
+import {
+  REQUEST_GET_PEARSON_SSO_DIGEST,
+  RECEIVE_GET_PEARSON_SSO_FAILURE,
+  RECEIVE_GET_PEARSON_SSO_SUCCESS,
+  PEARSON_SSO_IN_PROGRESS,
+  PEARSON_SSO_FAILURE,
+  SET_PEARSON_ERROR,
+} from '../actions/pearson';
+import {
+  FETCH_FAILURE,
+  FETCH_PROCESSING,
+  FETCH_SUCCESS,
+} from '../actions';
+import type { Action } from '../flow/reduxTypes';
+
+export const INITIAL_PEARSON_STATE = {
+  getStatus: null,
+  error: null,
+};
+
+export type PearsonAPIState = {
+  getStatus: ?string,
+  error: ?string,
+};
+
+export const pearson = (state: PearsonAPIState = INITIAL_PEARSON_STATE, action: Action) => {
+  switch (action.type) {
+  case REQUEST_GET_PEARSON_SSO_DIGEST:
+    return { ...state, getStatus: FETCH_PROCESSING };
+  case RECEIVE_GET_PEARSON_SSO_FAILURE:
+    return { ...state, getStatus: FETCH_FAILURE };
+  case RECEIVE_GET_PEARSON_SSO_SUCCESS:
+    return { ...state, getStatus: FETCH_SUCCESS };
+  case PEARSON_SSO_IN_PROGRESS:
+    return { ...state, postStatus: FETCH_PROCESSING };
+  case PEARSON_SSO_FAILURE:
+    return { ...state, postStatus: FETCH_FAILURE };
+  case SET_PEARSON_ERROR:
+    return { ...state, error: action.payload };
+  default:
+    return state;
+  }
+};

--- a/static/js/reducers/pearson_test.js
+++ b/static/js/reducers/pearson_test.js
@@ -1,0 +1,69 @@
+// @flow
+import configureTestStore from 'redux-asserts';
+import sinon from 'sinon';
+import { assert } from 'chai';
+
+import {
+  FETCH_FAILURE,
+  FETCH_PROCESSING,
+  FETCH_SUCCESS,
+} from '../actions';
+import {
+  requestGetPearsonSSODigest,
+  receiveGetPearsonSSOFailure,
+  receiveGetPearsonSSOSuccess,
+  setPearsonError,
+  REQUEST_GET_PEARSON_SSO_DIGEST,
+  RECEIVE_GET_PEARSON_SSO_FAILURE,
+  RECEIVE_GET_PEARSON_SSO_SUCCESS,
+  SET_PEARSON_ERROR,
+} from '../actions/pearson';
+import { INITIAL_PEARSON_STATE } from './pearson';
+import rootReducer from '../reducers';
+
+describe('pearson reducer', () => {
+  let sandbox,
+    store,
+    dispatchThen;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    store = configureTestStore(rootReducer);
+    dispatchThen = store.createDispatchThen(state => state.pearson);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should have some initial state', () => {
+    return dispatchThen({type: 'unknown'}, ['unknown']).then(state => {
+      assert.deepEqual(state, INITIAL_PEARSON_STATE);
+    });
+  });
+
+  it('should let you mark a request in flight', () => {
+    return dispatchThen(requestGetPearsonSSODigest(), [REQUEST_GET_PEARSON_SSO_DIGEST]).then(state => {
+      assert.deepEqual(state, { getStatus: FETCH_PROCESSING, error: null });
+    });
+  });
+
+
+  it('should let you mark a fetch error', () => {
+    return dispatchThen(receiveGetPearsonSSOFailure(), [RECEIVE_GET_PEARSON_SSO_FAILURE]).then(state => {
+      assert.deepEqual(state, { getStatus: FETCH_FAILURE, error: null });
+    });
+  });
+
+  it('should let you mark fetch success', () => {
+    return dispatchThen(receiveGetPearsonSSOSuccess(), [RECEIVE_GET_PEARSON_SSO_SUCCESS]).then(state => {
+      assert.deepEqual(state, { getStatus: FETCH_SUCCESS, error: null });
+    });
+  });
+
+  it('should let you set an error', () => {
+    return dispatchThen(setPearsonError('AN ERROR OH NO'), [SET_PEARSON_ERROR]).then(state => {
+      assert.deepEqual(state, { getStatus: null, error: 'AN ERROR OH NO' });
+    });
+  });
+});

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -20,7 +20,7 @@
     padding: 0 23px;
   }
 
-  &.next {
+  &.next, &.exam-button {
     background: $button-color;
     color: #fff;
   }
@@ -213,7 +213,7 @@ a.btn {
   }
 }
 
-.dialog, .course-action, .document-sent-button-container {
+.dialog, .course-action, .document-sent-button-container, .final-exam-card  {
   .disabled-with-spinner {
     display: inline-block !important;
     box-shadow: none;

--- a/static/scss/final-exam-card.scss
+++ b/static/scss/final-exam-card.scss
@@ -1,6 +1,11 @@
 .final-exam-card {
   font-size: 14px;
 
+  .error {
+    font-size: 12px;
+    color: $validation-red;
+  }
+
   .card-header {
     display: flex;
     flex-direction: row;
@@ -8,6 +13,24 @@
     .exam-icon {
       width: 40px;
       margin-right: 10px;
+    }
+  }
+
+  .exam-scheduling {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 12px;
+
+    > * {
+      margin: auto;
+    }
+
+    .program-info {
+      margin-top: 8px;
+    }
+
+    li {
+      font-weight: 600;
     }
   }
 

--- a/ui/views.py
+++ b/ui/views.py
@@ -59,6 +59,8 @@ class ReactView(View):  # pylint: disable=unused-argument
             "user": serialize_maybe_user(request.user),
             "es_page_size": settings.ELASTICSEARCH_DEFAULT_PAGE_SIZE,
             "public_path": public_path(request),
+            "EXAMS_SSO_CLIENT_CODE": settings.EXAMS_SSO_CLIENT_CODE,
+            "EXAMS_SSO_URL": settings.EXAMS_SSO_URL,
         }
 
         return render(

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -291,7 +291,9 @@ class DashboardTests(ViewsTests):
             EMAIL_SUPPORT=email_support,
             VERSION='0.0.1',
             RAVEN_CONFIG={'dsn': ''},
-            ELASTICSEARCH_DEFAULT_PAGE_SIZE=10
+            ELASTICSEARCH_DEFAULT_PAGE_SIZE=10,
+            EXAMS_SSO_CLIENT_CODE='itsacode',
+            EXAMS_SSO_URL='url',
         ), patch('ui.templatetags.render_bundle._get_bundle') as get_bundle:
             resp = self.client.get(DASHBOARD_URL)
 
@@ -325,6 +327,8 @@ class DashboardTests(ViewsTests):
                 'sentry_dsn': None,
                 'es_page_size': 10,
                 'public_path': '/static/bundles/',
+                'EXAMS_SSO_CLIENT_CODE': 'itsacode',
+                'EXAMS_SSO_URL': 'url',
             }
             assert resp.context['is_public'] is False
             assert resp.context['has_zendesk_widget'] is True
@@ -683,7 +687,9 @@ class TestUsersPage(ViewsTests):
             EMAIL_SUPPORT=email_support,
             VERSION='0.0.1',
             RAVEN_CONFIG={'dsn': ''},
-            ELASTICSEARCH_DEFAULT_PAGE_SIZE=10
+            ELASTICSEARCH_DEFAULT_PAGE_SIZE=10,
+            EXAMS_SSO_CLIENT_CODE='itsacode',
+            EXAMS_SSO_URL='url',
         ):
             # Mock has_permission so we don't worry about testing permissions here
             has_permission = Mock(return_value=True)
@@ -717,6 +723,8 @@ class TestUsersPage(ViewsTests):
                     'sentry_dsn': None,
                     'es_page_size': 10,
                     'public_path': '/static/bundles/',
+                    'EXAMS_SSO_CLIENT_CODE': 'itsacode',
+                    'EXAMS_SSO_URL': 'url',
                 }
                 assert has_permission.called
 
@@ -751,7 +759,9 @@ class TestUsersPage(ViewsTests):
             EMAIL_SUPPORT=email_support,
             VERSION='0.0.1',
             RAVEN_CONFIG={'dsn': ''},
-            ELASTICSEARCH_DEFAULT_PAGE_SIZE=10
+            ELASTICSEARCH_DEFAULT_PAGE_SIZE=10,
+            EXAMS_SSO_CLIENT_CODE='itsacode',
+            EXAMS_SSO_URL='url',
         ):
             # Mock has_permission so we don't worry about testing permissions here
             has_permission = Mock(return_value=True)
@@ -778,7 +788,9 @@ class TestUsersPage(ViewsTests):
                     'release_version': '0.0.1',
                     'sentry_dsn': None,
                     'es_page_size': 10,
-                    'public_path': '/static/bundles/'
+                    'public_path': '/static/bundles/',
+                    'EXAMS_SSO_CLIENT_CODE': 'itsacode',
+                    'EXAMS_SSO_URL': 'url',
                 }
                 assert has_permission.called
 


### PR DESCRIPTION
closes #2408 

this implements the SSO functionality for Pearson.

basically, what you should do to test the functionality is:

1. get your user into a state where you'll be eligible to schedule an exam
    - make an `ExamProfile` for your user's profile and set status to `success`
    - do the same for an `ExamAuthorization`, ensuring that the `date_first_eligible` and `date_last_eligible` values imply that the `ExamAuthorization` is eligible right now.
    - ensure your courses and programs are set up correctly, courses should have an `exam_module` and programs should have an `exam_series_code`
2. get the correct environment variable settings
3. go to `/dashboard` and click the `schedule` button on the final exam card.
