### PR TITLE
Cap coupon-adjusted price to between 0 and the full price

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -443,16 +443,20 @@ def calculate_coupon_price(coupon, price, course_key):
     Returns:
         decimal.Decimal: An adjusted price
     """
-    if course_key not in coupon.course_keys:
-        return price
-    if coupon.amount_type == Coupon.PERCENT_DISCOUNT:
-        return price * (1-coupon.amount)
-    elif coupon.amount_type == Coupon.FIXED_DISCOUNT:
-        return price - coupon.amount
-    elif coupon.amount_type == Coupon.FIXED_PRICE:
-        return coupon.amount
-    else:
-        return price
+    new_price = price
+    if course_key in coupon.course_keys:
+        if coupon.amount_type == Coupon.PERCENT_DISCOUNT:
+            new_price = price * (1-coupon.amount)
+        elif coupon.amount_type == Coupon.FIXED_DISCOUNT:
+            new_price = price - coupon.amount
+        elif coupon.amount_type == Coupon.FIXED_PRICE:
+            new_price = coupon.amount
+
+    if new_price < 0:
+        new_price = 0
+    elif new_price > price:
+        new_price = price
+    return new_price
 
 
 def calculate_run_price(course_run, user):

--- a/static/js/lib/coupon.js
+++ b/static/js/lib/coupon.js
@@ -58,16 +58,25 @@ export const calculatePrices = (programs: Dashboard, prices: CoursePrices, coupo
 };
 
 export const _calculateDiscount = (price: number, amountType: string, amount: number) => {
+  let newPrice = price;
   switch (amountType) {
   case COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT:
-    return price * (1 - amount);
+    newPrice = price * (1 - amount);
+    break;
   case COUPON_AMOUNT_TYPE_FIXED_DISCOUNT:
-    return price - amount;
+    newPrice = price - amount;
+    break;
   case COUPON_AMOUNT_TYPE_FIXED_PRICE:
-    return amount;
-  default:
-    return price;
+    newPrice = amount;
+    break;
   }
+  if (newPrice < 0) {
+    newPrice = 0;
+  }
+  if (newPrice > price) {
+    newPrice = price;
+  }
+  return newPrice;
 };
 // allow mocking of function
 export { _calculateDiscount as calculateDiscount };

--- a/static/js/lib/coupon_test.js
+++ b/static/js/lib/coupon_test.js
@@ -175,7 +175,7 @@ describe('coupon utility functions', () => {
 
     it('calculates a fixed price', () => {
       assert.equal(calculateDiscount(123, COUPON_AMOUNT_TYPE_FIXED_PRICE, 50), 50);
-      assert.equal(calculateDiscount(123, COUPON_AMOUNT_TYPE_FIXED_PRICE, 150), 150);
+      assert.equal(calculateDiscount(123, COUPON_AMOUNT_TYPE_FIXED_PRICE, 150), 123);
     });
 
     it('caps the minimum price between 0 and the current price', () => {

--- a/static/js/lib/coupon_test.js
+++ b/static/js/lib/coupon_test.js
@@ -177,6 +177,11 @@ describe('coupon utility functions', () => {
       assert.equal(calculateDiscount(123, COUPON_AMOUNT_TYPE_FIXED_PRICE, 50), 50);
       assert.equal(calculateDiscount(123, COUPON_AMOUNT_TYPE_FIXED_PRICE, 150), 150);
     });
+
+    it('caps the minimum price between 0 and the current price', () => {
+      assert.equal(calculateDiscount(123, COUPON_AMOUNT_TYPE_FIXED_DISCOUNT, 150), 0);
+      assert.equal(calculateDiscount(50, COUPON_AMOUNT_TYPE_FIXED_DISCOUNT, -50), 50);
+    });
   });
 
   describe('makeAmountMessage', () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2438 

#### What's this PR do?
Caps the coupon adjusted price to have a minimum price of $0 and maximum price of the full price.

#### How should this be manually tested?
Create a fixed discount coupon and set it to -987654321. Apply it to the user, then check the dashboard and verify that the price is $0.
