### PR TITLE
Added selenium testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,7 @@ omit =
     */migrations/*
     *_test.py
     *_tests.py
+    ./selenium_tests/*
 
 [report]
 exclude_lines =

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ matrix:
       - env | grep TRAVIS > .env
       - env | grep CI >> .env
       - docker build -t travis-watch -f ./travis/Dockerfile-travis-watch .
-      - docker run --volume $PWD:/src --env-file .env -e NODE_ENV=production -t travis-watch ./webpack_if_prod.sh
+      - docker run --name travis-watch-container --env-file .env -e NODE_ENV=production -t travis-watch ./webpack_if_prod.sh
+      - docker cp travis-watch-container:/src/webpack-stats.json .
+      - docker cp travis-watch-container:/src/static/bundles ./static/bundles
       - docker-compose -f travis-docker-compose.yml build
       script: (docker-compose -f travis-docker-compose.yml up grid &); sleep 5; ./scripts/test/run_selenium_tests.sh
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,17 @@ matrix:
       - env | grep TRAVIS > .env
       - env | grep CI >> .env
       - docker build -t travis-watch -f ./travis/Dockerfile-travis-watch .
+      - docker run --env-file .env -e NODE_ENV=production -t travis-watch ./webpack_if_prod.sh
+      - docker-compose -f travis-docker-compose.yml build
+      script: (docker-compose -f travis-docker-compose.yml up grid &); sleep 5; ./scripts/test/run_selenium_tests.sh
+      services:
+        - docker
+      env:
+        name: Python-Selenium
+    - install:
+      - env | grep TRAVIS > .env
+      - env | grep CI >> .env
+      - docker build -t travis-watch -f ./travis/Dockerfile-travis-watch .
       script: bash ./travis/js_tests.sh
       services:
         - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       - env | grep TRAVIS > .env
       - env | grep CI >> .env
       - docker build -t travis-watch -f ./travis/Dockerfile-travis-watch .
-      - docker run --env-file .env -e NODE_ENV=production -t travis-watch ./webpack_if_prod.sh
+      - docker run --volume $PWD:/src --env-file .env -e NODE_ENV=production -t travis-watch ./webpack_if_prod.sh
       - docker-compose -f travis-docker-compose.yml build
       script: (docker-compose -f travis-docker-compose.yml up grid &); sleep 5; ./scripts/test/run_selenium_tests.sh
       services:

--- a/apt.txt
+++ b/apt.txt
@@ -8,5 +8,3 @@ net-tools
 
 # developer requirements
 postgresql-client
-unzip
-xvfb

--- a/apt.txt
+++ b/apt.txt
@@ -8,3 +8,5 @@ net-tools
 
 # developer requirements
 postgresql-client
+unzip
+xvfb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - elastic
       - redis
       - sftp
+      - grid
 
   watch:
     build:
@@ -115,6 +116,9 @@ services:
     ports:
         - "2022:22"
     command: odl:123:1001:1001:results,results/topvue
+
+  grid:
+    image: elgalu/selenium
 
 volumes:
   django_media: {}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 addopts = --cov . --pep8 --pylint --cov-report term --cov-report html --ds=micromasters.settings --reuse-db
-norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.egg
+norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.egg selenium_tests
 pep8ignore =
    */migrations/* ALL
-
 pep8maxlinelength = 119

--- a/pytest_minimal.ini
+++ b/pytest_minimal.ini
@@ -1,3 +1,3 @@
 [pytest]
 addopts = --ds=micromasters.settings
-norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.egg
+norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.egg selenium_tests

--- a/scripts/test/run_selenium_tests.sh
+++ b/scripts/test/run_selenium_tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# cd to root of repo
+cd "$( dirname "${BASH_SOURCE[0]}" )"/../../
+
+if [[ ! -e "webpack-stats.json" ]]
+then
+    echo "webpack-stats.json must exist before running the selenium tests. Run webpack to create it."
+    exit 1
+fi
+docker-compose run -e DEBUG=False -e DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8286 web py.test ./selenium_tests

--- a/scripts/test/run_selenium_tests.sh
+++ b/scripts/test/run_selenium_tests.sh
@@ -9,6 +9,3 @@ then
     exit 1
 fi
 docker-compose run -e DEBUG=False -e DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8286 web py.test ./selenium_tests
-
-# Update code coverage
-docker-compose run web ./travis/codecov_python.sh

--- a/scripts/test/run_selenium_tests.sh
+++ b/scripts/test/run_selenium_tests.sh
@@ -9,6 +9,3 @@ then
     exit 1
 fi
 docker-compose run -e DEBUG=False -e DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8286 web py.test ./selenium_tests
-
-# Update code coverage
-./travis/codecov_python.sh

--- a/scripts/test/run_selenium_tests.sh
+++ b/scripts/test/run_selenium_tests.sh
@@ -9,3 +9,6 @@ then
     exit 1
 fi
 docker-compose run -e DEBUG=False -e DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8286 web py.test ./selenium_tests
+
+# Update code coverage
+./travis/codecov_python.sh

--- a/scripts/test/run_selenium_tests.sh
+++ b/scripts/test/run_selenium_tests.sh
@@ -11,4 +11,4 @@ fi
 docker-compose run -e DEBUG=False -e DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8286 web py.test ./selenium_tests
 
 # Update code coverage
-./travis/codecov_python.sh
+docker-compose run web ./travis/codecov_python.sh

--- a/selenium_tests/base.py
+++ b/selenium_tests/base.py
@@ -160,7 +160,7 @@ FROM pg_stat_activity WHERE pid <> pg_backend_pid()""")
                 continue
             messages.append(entry)
 
-        assert len(messages) == 0
+        self.assertEquals(len(messages), 0, str(messages))
 
     def dump_console_logs(self):
         """Helper method to print out selenium logs (will consume the logs)"""

--- a/selenium_tests/base.py
+++ b/selenium_tests/base.py
@@ -116,6 +116,7 @@ FROM pg_stat_activity WHERE pid <> pg_backend_pid()""")
         ).geturl()
         self.selenium.get(new_url)
         self.wait().until(lambda driver: driver.find_element_by_tag_name("body"))
+        self.assert_console_logs()
 
     def login_via_admin(self, user):
         """Make user a superuser, login via admin, then undo user superuser status"""
@@ -156,8 +157,14 @@ FROM pg_stat_activity WHERE pid <> pg_backend_pid()""")
         """Assert that console logs don't contain anything unexpected"""
         messages = []
         for entry in self.selenium.get_log("browser"):
-            if 'chrome-extension' in entry['message']:
+            message = entry['message']
+            if 'chrome-extension' in message:
                 continue
+            if 'This page includes a password or credit card input in a non-secure context' in message:
+                continue
+            if 'favicon.ico' in message:
+                continue
+
             messages.append(entry)
 
         self.assertEquals(len(messages), 0, str(messages))

--- a/selenium_tests/base.py
+++ b/selenium_tests/base.py
@@ -8,16 +8,25 @@ from urllib.parse import (
     urlparse,
 )
 
+from backends.edxorg import EdxOrgOAuth2
+from profiles.factories import ProfileFactory
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.db import (
     connection,
     transaction,
 )
+from django.db.models.signals import post_save
+from factory.django import mute_signals
 from selenium.webdriver import (
     DesiredCapabilities,
     Remote,
 )
 from selenium.webdriver.support.wait import WebDriverWait
+
+from search.indexing_api import (
+    delete_index,
+    recreate_index,
+)
 
 
 log = logging.getLogger(__name__)
@@ -29,6 +38,9 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # ensure index exists
+        recreate_index()
+
         capabilities = DesiredCapabilities.CHROME.copy()
         capabilities['chromeOptions'] = {
             'binary': os.getenv('CHROME_BIN', '/usr/bin/google-chrome-stable'),
@@ -40,9 +52,27 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
         )
         cls.selenium.implicitly_wait(10)
 
+    def setUp(self):
+        super().setUp()
+        # Ensure index exists
+        recreate_index()
+
+        with mute_signals(post_save):
+            profile = ProfileFactory.create()
+        self.user = profile.user
+        self.password = "pass"
+        self.user.set_password(self.password)
+        self.user.save()
+        username = "{}_edx".format(self.user.username)
+        self.user.social_auth.create(
+            provider=EdxOrgOAuth2.name,
+            uid=username,
+        )
+
     @classmethod
     def tearDownClass(cls):
         cls.selenium.quit()
+        delete_index()
         super().tearDownClass()
 
     def tearDown(self):
@@ -62,7 +92,7 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
                 cursor.execute("CREATE TABLE wagtailsearch_editorspick ()")
 
                 # Terminate all other db connections. There's an exception regarding
-                # multiple connections at the same time and I'm not sure how to work around it.
+                # multiple connections at the same time and I'm not sure how else to work around it.
                 cursor.execute("""SELECT pg_terminate_backend(pg_stat_activity.pid)
 FROM pg_stat_activity WHERE pid <> pg_backend_pid()""")
 
@@ -85,8 +115,27 @@ FROM pg_stat_activity WHERE pid <> pg_backend_pid()""")
             pieces.fragment,
         ).geturl()
         self.selenium.get(new_url)
+        self.wait().until(lambda driver: driver.find_element_by_tag_name("body"))
 
-    def take_screenshot(self):
+    def login_via_admin(self, user):
+        """Make user a superuser, login via admin, then undo user superuser status"""
+        user.refresh_from_db()
+        is_staff = user.is_staff
+        user.is_staff = True
+        user.save()
+
+        self.get("{}/admin/".format(self.live_server_url))
+        self.wait().until(lambda driver: driver.find_element_by_id("id_username"))
+        self.selenium.find_element_by_id("id_username").send_keys(user.username)
+        self.selenium.find_element_by_id("id_password").send_keys(self.password)
+        self.selenium.find_element_by_css_selector("input[type=submit]").click()
+        # This is the 'Welcome, username' box on the upper right
+        self.wait().until(lambda driver: driver.find_element_by_id("user-tools"))
+
+        user.is_staff = is_staff
+        user.save()
+
+    def take_screenshot(self, output_base64=False):
         """Helper method to take a screenshot and put it in a temp directory"""
         test_method_name = self._testMethodName
 
@@ -94,12 +143,24 @@ FROM pg_stat_activity WHERE pid <> pg_backend_pid()""")
         filename = os.path.join(repo_root, "{}.png".format(test_method_name))
 
         self.selenium.save_screenshot(filename)
-        with open(filename, 'rb') as f:
-            print("PNG screenshot for {test} output to {filename}, base64: {base64}".format(
-                test=test_method_name,
-                filename=filename,
-                base64=b64encode(f.read()),
-            ))
+        print("PNG screenshot for {test} output to {filename}".format(
+            test=test_method_name,
+            filename=filename,
+        ))
+        if output_base64:
+            # Can be useful for travis where we don't have access to build artifacts
+            with open(filename, 'rb') as f:
+                print("Screenshot as base64: {}".format(b64encode(f.read())))
+
+    def assert_console_logs(self):
+        """Assert that console logs don't contain anything unexpected"""
+        messages = []
+        for entry in self.selenium.get_log("browser"):
+            if 'chrome-extension' in entry['message']:
+                continue
+            messages.append(entry)
+
+        assert len(messages) == 0
 
     def dump_console_logs(self):
         """Helper method to print out selenium logs (will consume the logs)"""

--- a/selenium_tests/base.py
+++ b/selenium_tests/base.py
@@ -256,6 +256,8 @@ FROM pg_stat_activity WHERE pid <> pg_backend_pid()""")
                 continue
             if 'favicon.ico' in message:
                 continue
+            if "'webkitURL' is deprecated. Please use 'URL' instead" in message:
+                continue
 
             messages.append(entry)
 

--- a/selenium_tests/base.py
+++ b/selenium_tests/base.py
@@ -1,0 +1,111 @@
+"""Basic selenium tests for MicroMasters"""
+from base64 import b64encode
+import logging
+import os
+import socket
+from urllib.parse import (
+    ParseResult,
+    urlparse,
+)
+
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.db import (
+    connection,
+    transaction,
+)
+from selenium.webdriver import (
+    DesiredCapabilities,
+    Remote,
+)
+from selenium.webdriver.support.wait import WebDriverWait
+
+
+log = logging.getLogger(__name__)
+
+
+class SeleniumTestsBase(StaticLiveServerTestCase):
+    """Base class for selenium tests"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        capabilities = DesiredCapabilities.CHROME.copy()
+        capabilities['chromeOptions'] = {
+            'binary': os.getenv('CHROME_BIN', '/usr/bin/google-chrome-stable'),
+            'args': ['--no-sandbox'],
+        }
+        cls.selenium = Remote(
+            os.getenv('SELENIUM_URL', 'http://grid:24444/wd/hub'),
+            capabilities,
+        )
+        cls.selenium.implicitly_wait(10)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.selenium.quit()
+        super().tearDownClass()
+
+    def tearDown(self):
+        if self._outcome.errors:
+            try:
+                self.take_screenshot()
+            except:  # pylint: disable=bare-except
+                log.exception("Unable to take selenium screenshot")
+
+        with connection.cursor() as cursor:
+            # Drop a troublesome unused table
+            # This table is preventing the flush command from working:
+            # https://github.com/wagtail/wagtail/issues/1824
+            # It seems unused so it's easiest just to replace it behind the scenes
+            with transaction.atomic():
+                cursor.execute("DROP TABLE IF EXISTS wagtailsearch_editorspick")
+                cursor.execute("CREATE TABLE wagtailsearch_editorspick ()")
+
+                # Terminate all other db connections. There's an exception regarding
+                # multiple connections at the same time and I'm not sure how to work around it.
+                cursor.execute("""SELECT pg_terminate_backend(pg_stat_activity.pid)
+FROM pg_stat_activity WHERE pid <> pg_backend_pid()""")
+
+        super().tearDown()
+
+    def wait(self):
+        """Helper function for WebDriverWait"""
+        return WebDriverWait(self.selenium, 5)
+
+    def get(self, url):
+        """Use self.live_server_url with a URL which will work for external services"""
+        pieces = urlparse(url)
+        host = socket.gethostbyname(socket.gethostname())
+        new_url = ParseResult(
+            pieces.scheme,
+            "{host}:{port}".format(host=host, port=pieces.port),
+            pieces.path,
+            pieces.params,
+            pieces.query,
+            pieces.fragment,
+        ).geturl()
+        self.selenium.get(new_url)
+
+    def take_screenshot(self):
+        """Helper method to take a screenshot and put it in a temp directory"""
+        test_method_name = self._testMethodName
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+        filename = os.path.join(repo_root, "{}.png".format(test_method_name))
+
+        self.selenium.save_screenshot(filename)
+        with open(filename, 'rb') as f:
+            print("PNG screenshot for {test} output to {filename}, base64: {base64}".format(
+                test=test_method_name,
+                filename=filename,
+                base64=b64encode(f.read()),
+            ))
+
+    def dump_console_logs(self):
+        """Helper method to print out selenium logs (will consume the logs)"""
+        for row in self.selenium.get_log("browser"):
+            print(row)
+
+    def dump_html(self):
+        """Helper method to print out body HTML"""
+        print(self.selenium.find_element_by_tag_name("body").get_attribute("innerHTML"))

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -10,9 +10,8 @@ class BasicTests(SeleniumTestsBase):
         """
         Do a $0 purchase
         """
+        self.login_via_admin(self.user)
         self.get(self.live_server_url)
-        self.wait().until(lambda driver: driver.find_element_by_tag_name("body"))
-        self.selenium.find_element_by_class_name("open-signup-dialog").click()
 
-        self.wait().until(lambda driver: driver.find_element_by_class_name("signup-modal-button"))
+        self.assert_console_logs()
         self.take_screenshot()

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -14,3 +14,4 @@ class BasicTests(SeleniumTestsBase):
         self.get(self.live_server_url)
 
         self.selenium.find_element_by_class_name("header-dashboard-link").click()
+        import pdb;pdb.set_trace()

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -14,6 +14,7 @@ class BasicTests(SeleniumTestsBase):
 
         self.selenium.find_element_by_class_name("header-dashboard-link").click()
         self.wait().until(lambda driver: driver.find_element_by_class_name("pay-button"))
+        self.assert_console_logs()
         self.selenium.find_element_by_class_name("pay-button").click()
         self.wait().until(lambda driver: driver.find_element_by_class_name("continue-payment"))
         self.selenium.find_element_by_class_name("continue-payment").click()
@@ -21,3 +22,4 @@ class BasicTests(SeleniumTestsBase):
         assert self.selenium.find_element_by_css_selector(".course-action .description").text == (
             "Something went wrong. You paid for this course but are not enrolled. Contact us for help."
         )
+        self.assert_console_logs()

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -1,0 +1,18 @@
+"""Basic selenium tests for MicroMasters"""
+
+from selenium_tests.base import SeleniumTestsBase
+
+
+class BasicTests(SeleniumTestsBase):
+    """Basic selenium tests for MicroMasters"""
+
+    def test_zero_price_purchase(self):
+        """
+        Do a $0 purchase
+        """
+        self.get(self.live_server_url)
+        self.wait().until(lambda driver: driver.find_element_by_tag_name("body"))
+        self.selenium.find_element_by_class_name("open-signup-dialog").click()
+
+        self.wait().until(lambda driver: driver.find_element_by_class_name("signup-modal-button"))
+        self.take_screenshot()

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -1,5 +1,4 @@
 """Basic selenium tests for MicroMasters"""
-
 from selenium_tests.base import SeleniumTestsBase
 
 
@@ -8,10 +7,17 @@ class BasicTests(SeleniumTestsBase):
 
     def test_zero_price_purchase(self):
         """
-        Do a $0 purchase
+        Do a $0 purchase using a 100% off program-level coupon
         """
         self.login_via_admin(self.user)
         self.get(self.live_server_url)
 
         self.selenium.find_element_by_class_name("header-dashboard-link").click()
-        import pdb;pdb.set_trace()
+        self.wait().until(lambda driver: driver.find_element_by_class_name("pay-button"))
+        self.selenium.find_element_by_class_name("pay-button").click()
+        self.wait().until(lambda driver: driver.find_element_by_class_name("continue-payment"))
+        self.selenium.find_element_by_class_name("continue-payment").click()
+        self.wait().until(lambda driver: driver.find_element_by_class_name("description"))
+        assert self.selenium.find_element_by_css_selector(".course-action .description").text == (
+            "Something went wrong. You paid for this course but are not enrolled. Contact us for help."
+        )

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -13,5 +13,4 @@ class BasicTests(SeleniumTestsBase):
         self.login_via_admin(self.user)
         self.get(self.live_server_url)
 
-        self.assert_console_logs()
-        self.take_screenshot()
+        self.selenium.find_element_by_class_name("header-dashboard-link").click()

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -12,13 +12,18 @@ class BasicTests(SeleniumTestsBase):
         self.login_via_admin(self.user)
         self.get(self.live_server_url)
 
+        # Click the dashboard link on the upper right of the homepage
         self.selenium.find_element_by_class_name("header-dashboard-link").click()
         self.wait().until(lambda driver: driver.find_element_by_class_name("pay-button"))
         self.assert_console_logs()
+        # Click the Pay $0 button on dashboard
         self.selenium.find_element_by_class_name("pay-button").click()
         self.wait().until(lambda driver: driver.find_element_by_class_name("continue-payment"))
+        # Click 'Continue' on the order summary page
         self.selenium.find_element_by_class_name("continue-payment").click()
         self.wait().until(lambda driver: driver.find_element_by_class_name("description"))
+        # Assert that the purchase went through fine but enrolling in edX failed
+        # Which makes sense since there is no edX for these tests
         assert self.selenium.find_element_by_css_selector(".course-action .description").text == (
             "Something went wrong. You paid for this course but are not enrolled. Contact us for help."
         )

--- a/selenium_tests/pytest.ini
+++ b/selenium_tests/pytest.ini
@@ -1,0 +1,4 @@
+# This lacks --reuse-db because it won't work properly with selenium tests
+[pytest]
+addopts = --cov . --pep8 --pylint --cov-report term --cov-report html --ds=micromasters.settings
+pep8maxlinelength = 119

--- a/test_requirements.in
+++ b/test_requirements.in
@@ -15,5 +15,6 @@ pytest-django
 pytest-pep8
 pytest-pylint
 semantic-version
+selenium
 testfixtures
 tox

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,6 +5,7 @@
 #    pip-compile --output-file test_requirements.txt test_requirements.in
 #
 apipkg==1.4               # via execnet
+appdirs==1.4.0            # via setuptools
 argparse==1.4.0           # via codecov
 astroid==1.4.9            # via pylint, pylint-plugin-utils
 blessings==1.6            # via curtsies
@@ -17,7 +18,7 @@ curtsies==0.2.11          # via bpython
 ddt==1.1.1
 decorator==4.0.10         # via ipython, traitlets
 django-debug-toolbar==1.6
-Django==1.10.3            # via django-debug-toolbar
+django==1.10.3            # via django-debug-toolbar
 execnet==1.4.1            # via pytest-cache
 fancycompleter==0.7       # via pdbpp
 first==2.0.1              # via pip-tools
@@ -30,6 +31,7 @@ lazy-object-proxy==1.2.2  # via astroid
 mccabe==0.5.3             # via pylint
 nplusone==0.7.3
 ordereddict==1.1          # via pdbpp
+packaging==16.8           # via setuptools
 pdbpp==0.8.3
 pep8==1.7.0               # via pytest-pep8
 pexpect==4.2.1            # via ipython
@@ -43,6 +45,7 @@ pygments==2.1.3           # via bpython, ipython, pdbpp
 pylint-django==0.7.2
 pylint-plugin-utils==0.2.4  # via pylint-django
 pylint==1.6.4
+pyparsing==2.1.10         # via packaging
 pytest-cache==1.0         # via pytest-pep8
 pytest-cov==2.4.0
 pytest-django==3.1.2
@@ -50,9 +53,10 @@ pytest-pep8==1.0.6
 pytest-pylint==0.6.0
 pytest==3.0.5
 requests==2.11.1          # via bpython, codecov
+selenium==3.0.2
 semantic-version==2.6.0
 simplegeneric==0.8.1      # via ipython
-six==1.10.0               # via astroid, bpython, nplusone, pip-tools, prompt-toolkit, pylint, pytest-pylint, traitlets
+six==1.10.0               # via astroid, bpython, nplusone, packaging, pip-tools, prompt-toolkit, pylint, pytest-pylint, setuptools, traitlets
 sqlparse==0.2.2           # via django-debug-toolbar
 testfixtures==4.13.3
 tox==2.5.0
@@ -62,6 +66,5 @@ wcwidth==0.1.7            # via curtsies, prompt-toolkit
 wmctrl==0.3               # via pdbpp
 wrapt==1.10.8             # via astroid
 
-# The following packages are commented out because they are
-# considered to be unsafe in a requirements file:
+# The following packages are considered to be unsafe in a requirements file:
 # setuptools                # via ipdb, ipython

--- a/travis-docker-compose.yml
+++ b/travis-docker-compose.yml
@@ -36,6 +36,7 @@ services:
     links:
       - db
       - elastic
+      - grid
 
   celery:
     image: micromasters_web
@@ -65,3 +66,6 @@ services:
     command: elasticsearch -Des.network.host=0.0.0.0
     ports:
       - "9200"
+
+  grid:
+    image: elgalu/selenium


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2414 
#### What's this PR do?
Adds a selenium test and runs it on Travis. The selenium test logs in and does a $0 purchase using a 100% off coupon.

Other Python tests should be unaffected. In Travis there will be a third job to run the selenium tests. `pytest.ini` has a directive to ignore `selenium_tests` so you don't have to do anything different to run the Python tests locally.

#### How should this be manually tested?
To run it locally:
- turn off the webpack server to prevent interfering with the `webpack-stats.json` file
- run `NODE_ENV=prod ./webpack_if_prod.sh` to generate the webpack bundles
- run `./scripts/test/run_selenium_tests.sh`. This will run only the selenium tests.