### PR TITLE
Fixed ES search result email bug

### DIFF
--- a/static/js/containers/LearnerSearchPage.js
+++ b/static/js/containers/LearnerSearchPage.js
@@ -61,7 +61,7 @@ class LearnerSearchPage extends React.Component {
       startEmailEdit(
         {
           type: SEARCH_EMAIL_TYPE,
-          params: {query: searchkit.query.query},
+          params: {searchkit: searchkit},
           subheading: `${searchkit.getHitsCount() || 0} recipients selected`
         }
       )
@@ -84,7 +84,7 @@ class LearnerSearchPage extends React.Component {
         sendSearchResultMail(
           inputs.subject || '',
           inputs.body || '',
-          params.query
+          params.searchkit.buildQuery().query
         )
       ).then(() => {
         this.closeAndClearEmailComposer();

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -68,12 +68,15 @@ describe('LearnerSearchPage', function () {
   });
 
   it('waits for a successful email send to close the dialog', () => {
+    let searchKitStub = {
+      buildQuery: () => ({query: {abc: 123}})
+    };
     helper.programsGetStub.returns(Promise.resolve(PROGRAMS));
     helper.store.dispatch(
       startEmailEdit({
         type: SEARCH_EMAIL_TYPE,
         params: {
-          query: {filter: {}}
+          searchkit: searchKitStub
         }
       })
     );
@@ -97,11 +100,11 @@ describe('LearnerSearchPage', function () {
         modifyTextField(dialog.querySelector('.email-subject'), 'subject');
         modifyTextField(dialog.querySelector('.email-body'), 'body');
 
-        TestUtils.Simulate.click(saveButton);
         assert.isTrue(helper.store.getState().ui.emailDialogVisibility);
+        TestUtils.Simulate.click(saveButton);
       }).then(() => {
         assert.isFalse(helper.store.getState().ui.emailDialogVisibility);
-        assert.isTrue(sendSearchResultMail.calledWith("subject", "body", {filter: {}}));
+        assert.isTrue(sendSearchResultMail.calledWith("subject", "body", {abc: 123}));
       });
     });
   });


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #2513 

#### What's this PR do?

Fixes the bug we were experiencing with sending an email to users that match a search query

#### How should this be manually tested?

Send a search result email from `/learners`, and without reloading the page, change the filters several times and attempt additional search result emails with that new search result set. Confirm that you're getting the expected recipients in the body of the emails you receive
