### PR TITLE
CoursePrice.price is a decimal

### DIFF
--- a/financialaid/serializers.py
+++ b/financialaid/serializers.py
@@ -10,7 +10,9 @@ from rest_framework.fields import (
     CharField,
     ChoiceField,
     FloatField,
-    IntegerField
+    IntegerField,
+    DecimalField,
+    BooleanField,
 )
 
 from courses.models import Program
@@ -185,3 +187,15 @@ class FinancialAidSerializer(serializers.ModelSerializer):
     class Meta:
         model = FinancialAid
         fields = ("date_documents_sent", )
+
+
+class FormattedCoursePriceSerializer(serializers.Serializer):
+    """
+    Serializer for the format returned by
+    `financialaid.api.get_formatted_course_price`.
+    Primarily exists to convert `price` from decimal to string.
+    """
+    program_id = IntegerField()
+    price = DecimalField(max_digits=None, decimal_places=2)
+    financial_aid_availability = BooleanField()
+    has_financial_aid_request = BooleanField()

--- a/financialaid/views.py
+++ b/financialaid/views.py
@@ -47,6 +47,7 @@ from financialaid.serializers import (
     FinancialAidActionSerializer,
     FinancialAidRequestSerializer,
     FinancialAidSerializer,
+    FormattedCoursePriceSerializer,
 )
 from mail.serializers import GenericMailSerializer
 from roles.models import (
@@ -340,11 +341,15 @@ class CoursePriceListView(APIView):
             .select_related('user', 'program')
             .filter(user=user, program__live=True).all()
         )
-        formatted_course_prices = []
-        for program_enrollment in program_enrollments:
-            response_dict = get_formatted_course_price(program_enrollment)
-            formatted_course_prices.append(response_dict)
-        return Response(data=formatted_course_prices)
+        formatted_course_prices = [
+            get_formatted_course_price(program_enrollment)
+            for program_enrollment in program_enrollments
+        ]
+        serializer = FormattedCoursePriceSerializer(
+            formatted_course_prices,
+            many=True
+        )
+        return Response(data=serializer.data)
 
 
 class CoursePriceDetailView(APIView):
@@ -368,6 +373,7 @@ class CoursePriceDetailView(APIView):
             program__id=self.kwargs["program_id"],
             program__live=True
         )
-        return Response(
-            data=get_formatted_course_price(program_enrollment)
+        serializer = FormattedCoursePriceSerializer(
+            get_formatted_course_price(program_enrollment)
         )
+        return Response(data=serializer.data)

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -128,7 +128,7 @@ export const makeCoupons = (programs: Dashboard): Coupons => (
 
 export const makeCoursePrice = (program: Program): CoursePrice => ({
   program_id: program.id,
-  price: program.id * 100,
+  price: Decimal(program.id * 100),
   financial_aid_availability: true,
   has_financial_aid_request: true
 });

--- a/static/js/flow/couponTypes.js
+++ b/static/js/flow/couponTypes.js
@@ -30,4 +30,4 @@ export type AttachCouponResponse = {
   coupon: Coupon,
 };
 
-export type CalculatedPrices = Map<number, number>;
+export type CalculatedPrices = Map<number, Decimal>;

--- a/static/js/flow/dashboardTypes.js
+++ b/static/js/flow/dashboardTypes.js
@@ -1,4 +1,5 @@
 // @flow
+import Decimal from 'decimal.js-light';
 import type { Program } from './programTypes';
 // likely to change in very near future
 export type Dashboard = Array<Program>;
@@ -9,7 +10,7 @@ export type DashboardState = {
 
 export type CoursePrice = {
   program_id: number,
-  price: number,
+  price: Decimal,
   financial_aid_availability: boolean,
   has_financial_aid_request: boolean
 };

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -8,7 +8,7 @@ import Decimal from 'decimal.js-light';
 import type { Profile, ProfileGetResult, ProfilePatchResult } from '../flow/profileTypes';
 import type { CheckoutResponse } from '../flow/checkoutTypes';
 import type { Coupons, AttachCouponResponse } from '../flow/couponTypes';
-import type { Dashboard } from '../flow/dashboardTypes';
+import type { Dashboard, CoursePrices } from '../flow/dashboardTypes';
 import type { AvailableProgram, AvailablePrograms } from '../flow/enrollmentTypes';
 import type { EmailSendResponse } from '../flow/emailTypes';
 
@@ -226,8 +226,11 @@ export function addFinancialAid(income: number, currency: string, programId: num
   });
 }
 
-export function getCoursePrices(): Promise<*> {
-  return fetchJSONWithCSRF('/api/v0/course_prices/', {});
+export function getCoursePrices(): Promise<CoursePrices> {
+  return fetchJSONWithCSRF('/api/v0/course_prices/', {}).then(coursePrices => {
+    // turn `price` from string into decimal
+    return R.map(R.evolve({price: Decimal}), coursePrices);
+  });
 }
 
 export function skipFinancialAid(programId: number): Promise<*> {

--- a/static/js/lib/coupon_test.js
+++ b/static/js/lib/coupon_test.js
@@ -164,23 +164,39 @@ describe('coupon utility functions', () => {
 
   describe('calculateDiscount', () => {
     it('calculates a percent discount', () => {
-      assert.equal(calculateDiscount(123, COUPON_AMOUNT_TYPE_FIXED_DISCOUNT, 50), 73);
-      assert.equal(calculateDiscount(123, COUPON_AMOUNT_TYPE_FIXED_DISCOUNT, 123), 0);
+      const actual1 = calculateDiscount(Decimal('123'), COUPON_AMOUNT_TYPE_FIXED_DISCOUNT, Decimal('50'));
+      const expected1 = Decimal('73');
+      assert(actual1.equals(expected1));
+      const actual2 = calculateDiscount(Decimal('123'), COUPON_AMOUNT_TYPE_FIXED_DISCOUNT, Decimal('123'));
+      const expected2 = Decimal('0');
+      assert(actual2.equals(expected2));
     });
 
     it('calculates a fixed discount', () => {
-      assert.equal(calculateDiscount(123, COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT, 0.5), 123 / 2);
-      assert.equal(calculateDiscount(123, COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT, 1), 0);
+      const actual1 = calculateDiscount(Decimal('123'), COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT, Decimal('0.5'));
+      const expected1 = Decimal('61.5');
+      assert(actual1.equals(expected1));
+      const actual2 = calculateDiscount(Decimal(123), COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT, Decimal(1));
+      const expected2 = Decimal('0');
+      assert(actual2.equals(expected2));
     });
 
     it('calculates a fixed price', () => {
-      assert.equal(calculateDiscount(123, COUPON_AMOUNT_TYPE_FIXED_PRICE, 50), 50);
-      assert.equal(calculateDiscount(123, COUPON_AMOUNT_TYPE_FIXED_PRICE, 150), 123);
+      const actual1 = calculateDiscount(Decimal('123'), COUPON_AMOUNT_TYPE_FIXED_PRICE, Decimal('50'));
+      const expected1 = Decimal('50');
+      assert(actual1.equals(expected1));
+      const actual2 = calculateDiscount(Decimal('123'), COUPON_AMOUNT_TYPE_FIXED_PRICE, Decimal('150'));
+      const expected2 = Decimal('123');
+      assert(actual2.equals(expected2));
     });
 
     it('caps the minimum price between 0 and the current price', () => {
-      assert.equal(calculateDiscount(123, COUPON_AMOUNT_TYPE_FIXED_DISCOUNT, 150), 0);
-      assert.equal(calculateDiscount(50, COUPON_AMOUNT_TYPE_FIXED_DISCOUNT, -50), 50);
+      const actual1 = calculateDiscount(Decimal('123'), COUPON_AMOUNT_TYPE_FIXED_DISCOUNT, Decimal('150'));
+      const expected1 = Decimal('0');
+      assert(actual1.equals(expected1));
+      const actual2 = calculateDiscount(Decimal('50'), COUPON_AMOUNT_TYPE_FIXED_DISCOUNT, Decimal('-50'));
+      const expected2 = Decimal('50');
+      assert(actual2.equals(expected2));
     });
   });
 

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -704,7 +704,7 @@ export const FINANCIAL_AID_PARTIAL_RESPONSE: FinancialAidUserInfo = deepFreeze({
 
 export const COURSE_PRICES_RESPONSE: CoursePrices = deepFreeze(DASHBOARD_RESPONSE.map(program => ({
   program_id: program.id,
-  price: program.id * 1000,
+  price: Decimal(program.id * 1000),
   financial_aid_availability: false,
   has_financial_aid_request: false
 })));

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -8,6 +8,7 @@ import { codeToCountryName } from '../lib/location';
 import { S } from '../lib/sanctuary';
 const { Maybe, Just, Nothing } = S;
 import R from 'ramda';
+import Decimal from 'decimal.js-light';
 
 import {
   STATUS_PASSED,
@@ -373,7 +374,7 @@ export function createForm(url: string, payload: CheckoutPayload): HTMLFormEleme
 /**
  * Formats course price.
  */
-export function formatPrice(price: ?string|number): string {
+export function formatPrice(price: ?string|number|Decimal): string {
   if (price === null || price === undefined) {
     return '';
   } else {


### PR DESCRIPTION
#### What are the relevant tickets?
#2523. Related to #2467.

#### What's this PR do?
This pull request modifies the course price API to return decimal values as strings rather than floating-point numbers, since Javascript/JSON does not have a decimal primitive type. This pull request also modifies the code that fetches from the course price API to automatically parse these strings into [`decimal.js-light`](http://mikemcl.github.io/decimal.js-light/) instances.

#### Where should the reviewer start?
`financialaid/serializers.py` to verify that the back-end API serializes decimals correctly. Then `static/js/lib/api.js` to verify that the front-end code parses the serialized decimals correctly.

#### How should this be manually tested?
There should be **no user-visible changes** as a result of this pull request.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
