### PR TITLE
Round to the nearest cent, formatPrice util

### DIFF
--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -378,8 +378,12 @@ export function formatPrice(price: ?string|number|Decimal): string {
   if (price === null || price === undefined) {
     return '';
   } else {
-    const formatedPrice = Decimal(price).todp(2, Decimal.ROUND_DOWN).toFixed(2);
-    let dollars = `$${formatedPrice}`;
+    let formattedPrice: Decimal = Decimal(price);
+    if (!formattedPrice.isInteger()) {
+      formattedPrice =  formattedPrice.toFixed(2, Decimal.ROUND_HALF_UP);
+    }
+
+    let dollars = `$${formattedPrice}`;
     return dollars.replace(/\.00$/,'');
   }
 }

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -378,7 +378,9 @@ export function formatPrice(price: ?string|number|Decimal): string {
   if (price === null || price === undefined) {
     return '';
   } else {
-    return `$${price}`;
+    const formatedPrice = Decimal(price).todp(2, Decimal.ROUND_DOWN).toFixed(2);
+    let dollars = `$${formatedPrice}`;
+    return dollars.replace(/\.00$/,'');
   }
 }
 

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -379,12 +379,13 @@ export function formatPrice(price: ?string|number|Decimal): string {
     return '';
   } else {
     let formattedPrice: Decimal = Decimal(price);
-    if (!formattedPrice.isInteger()) {
+
+    if (formattedPrice.isInteger()) {
+      formattedPrice =  formattedPrice.toFixed(0);
+    } else {
       formattedPrice =  formattedPrice.toFixed(2, Decimal.ROUND_HALF_UP);
     }
-
-    let dollars = `$${formattedPrice}`;
-    return dollars.replace(/\.00$/,'');
+    return `$${formattedPrice}`;
   }
 }
 

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -485,6 +485,11 @@ describe('utility functions', () => {
   describe('formatPrice', () => {
     it('format price', () => {
       assert.equal(formatPrice(20), "$20");
+      assert.equal(formatPrice(20.005), "$20");
+      assert.equal(formatPrice(20.10), "$20.10");
+      assert.equal(formatPrice(20.6059), "$20.60");
+      assert.equal(formatPrice(20.6959), "$20.69");
+      assert.equal(formatPrice(20.1234567), "$20.12");
     });
 
     it('returns an empty string if null or undefined', () => {

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -485,10 +485,10 @@ describe('utility functions', () => {
   describe('formatPrice', () => {
     it('format price', () => {
       assert.equal(formatPrice(20), "$20");
-      assert.equal(formatPrice(20.005), "$20");
+      assert.equal(formatPrice(20.005), "$20.01");
       assert.equal(formatPrice(20.10), "$20.10");
-      assert.equal(formatPrice(20.6059), "$20.60");
-      assert.equal(formatPrice(20.6959), "$20.69");
+      assert.equal(formatPrice(20.6059), "$20.61");
+      assert.equal(formatPrice(20.6959), "$20.70");
       assert.equal(formatPrice(20.1234567), "$20.12");
     });
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/micromasters/issues/2464

#### What's this PR do?
- Rounded the nearest cent, or leave off the cents entirely when it's a whole number.

#### How should this be manually tested?
- See order summery or action btn 

@pdpinch @noisecapella 