### PR TITLE
Don't send email on order cancellations, ignore duplicate cancellations

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -262,8 +262,7 @@ def make_reference_id(order):
 
 def get_new_order_by_reference_number(reference_number):
     """
-    Parse a reference number received from CyberSource and lookup the corresponding Order. If the Order
-    is already fulfilled an EcommerceException is raised.
+    Parse a reference number received from CyberSource and lookup the corresponding Order.
 
     Args:
         reference_number (str):
@@ -292,9 +291,9 @@ def get_new_order_by_reference_number(reference_number):
         raise ParseException("CyberSource prefix doesn't match")
 
     try:
-        return Order.objects.get(id=order_id, status=Order.CREATED)
+        return Order.objects.get(id=order_id)
     except Order.DoesNotExist:
-        raise EcommerceException("Order {} is expected to have status 'created'".format(order_id))
+        raise EcommerceException("Unable to find order {}".format(order_id))
 
 
 def enroll_user_on_success(order):

--- a/ecommerce/constants.py
+++ b/ecommerce/constants.py
@@ -1,0 +1,9 @@
+"""Ecommerce constants"""
+
+# From secure acceptance documentation, under API reply fields:
+# http://apps.cybersource.com/library/documentation/dev_guides/Secure_Acceptance_SOP/Secure_Acceptance_SOP.pdf
+CYBERSOURCE_DECISION_ACCEPT = 'ACCEPT'
+CYBERSOURCE_DECISION_DECLINE = 'DECLINE'
+CYBERSOURCE_DECISION_REVIEW = 'REVIEW'
+CYBERSOURCE_DECISION_ERROR = 'ERROR'
+CYBERSOURCE_DECISION_CANCEL = 'CANCEL'

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -26,6 +26,7 @@ from ecommerce.api import (
     make_dashboard_receipt_url,
     pick_coupons,
 )
+from ecommerce.exceptions import EcommerceException
 from ecommerce.models import (
     Coupon,
     Order,
@@ -148,29 +149,36 @@ class OrderFulfillmentView(APIView):
         receipt.order = order
         receipt.save()
 
-        if request.data['decision'] != 'ACCEPT':
-            # This may happen if the user clicks 'Cancel Order'
+        decision = request.data['decision']
+        if order.status == Order.FAILED and decision == 'CANCEL':
+            # This is a duplicate message, ignore since it's already handled
+            return Response()
+        elif order.status != Order.CREATED:
+            raise EcommerceException("Order {} is expected to have status 'created'".format(order.id))
+
+        if decision != 'ACCEPT':
             order.status = Order.FAILED
             log.warning(
                 "Order fulfillment failed: received a decision that wasn't ACCEPT for order %s",
                 order,
             )
-            try:
-                MailgunClient().send_individual_email(
-                    "Order fulfillment failed, decision={decision}".format(
-                        decision=request.data['decision']
-                    ),
-                    "Order fulfillment failed for order {order}".format(
-                        order=order,
-                    ),
-                    settings.ECOMMERCE_EMAIL
-                )
-            except:  # pylint: disable=bare-except
-                log.exception(
-                    "Error occurred when sending the email to notify "
-                    "about order fulfillment failure for order %s",
-                    order,
-                )
+            if decision != 'CANCEL':
+                try:
+                    MailgunClient().send_individual_email(
+                        "Order fulfillment failed, decision={decision}".format(
+                            decision=decision
+                        ),
+                        "Order fulfillment failed for order {order}".format(
+                            order=order,
+                        ),
+                        settings.ECOMMERCE_EMAIL
+                    )
+                except:  # pylint: disable=bare-except
+                    log.exception(
+                        "Error occurred when sending the email to notify "
+                        "about order fulfillment failure for order %s",
+                        order,
+                    )
         else:
             order.status = Order.FULFILLED
         order.save_and_log(None)

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -152,7 +152,7 @@ class OrderFulfillmentView(APIView):
         decision = request.data['decision']
         if order.status == Order.FAILED and decision == 'CANCEL':
             # This is a duplicate message, ignore since it's already handled
-            return Response()
+            return Response(status=HTTP_200_OK)
         elif order.status != Order.CREATED:
             raise EcommerceException("Order {} is expected to have status 'created'".format(order.id))
 
@@ -209,7 +209,7 @@ class OrderFulfillmentView(APIView):
                         order,
                     )
         # The response does not matter to CyberSource
-        return Response()
+        return Response(status=HTTP_200_OK)
 
 
 class CouponsView(ListModelMixin, GenericViewSet):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2272 

#### What's this PR do?
- Ignores duplicate Cybersource cancellation messages
- Doesn't sent email alerting to cancellations

#### How should this be manually tested?
This is difficult to test since we're not sure why Cybersource sends duplicate Cybersource cancellation emails. For the other part of this, it's probably easiest just to test this on RC since all the environment variables and Cybersource configuration is already done there