### PR TITLE
Only certificates with status "downloadable" are passing certificates

### DIFF
--- a/dashboard/factories.py
+++ b/dashboard/factories.py
@@ -42,6 +42,7 @@ class CachedCertificateFactory(DjangoModelFactory):
         "grade": randint(60, 100)/100.0,
         "course_id": x.course_run.edx_course_key,
         "username": x.user.username,
+        "status": "downloadable",
     })
 
     class Meta:

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -95,6 +95,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
                         "grade": certificate_grades_vals[i],
                         "certificate_type": "verified",
                         "course_id": enrollment.course_run.edx_course_key,
+                        "status": "downloadable",
                     }
                 )
             )

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -167,16 +167,19 @@ class MMTrack:
         enrollment = self.enrollments.get_enrollment_for_course(course_id)
         return enrollment and enrollment.is_verified
 
-    def has_verified_cert(self, course_id):
+    def has_passing_certificate(self, course_id):
         """
-        Returns whether the user has a verified cert.
+        Returns whether the user has a passing certificate.
 
         Args:
             course_id (str): An edX course key
         Returns:
-            bool: whether the user has a verified cert meaning that they passed the course on edX
+            bool: whether the user has a passing certificate meaning that the user passed the course on edX
         """
-        return self.certificates.has_verified_cert(course_id)
+        if not self.certificates.has_verified_cert(course_id):
+            return False
+        certificate = self.certificates.get_verified_cert(course_id)
+        return certificate.status == 'downloadable'
 
     def extract_final_grade(self, course_id):
         """
@@ -248,7 +251,7 @@ class MMTrack:
 
         # for normal programs need to check the certificate
         if not self.financial_aid_available:
-            return self.has_verified_cert(course_id)
+            return self.has_passing_certificate(course_id)
         # financial aid programs need to have an audit enrollment,
         # a current grade with a passed attribute and the course should be ended
         else:

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -392,7 +392,7 @@ def is_coupon_redeemable(coupon, user):
         )
 
         # For this coupon type the user must have already purchased a course run on edX
-        return any((mmtrack.has_verified_cert(run.edx_course_key) for run in course.courserun_set.all()))
+        return any((mmtrack.has_passing_certificate(run.edx_course_key) for run in course.courserun_set.all()))
 
     return True
 

--- a/grades/api.py
+++ b/grades/api.py
@@ -34,7 +34,7 @@ def _compute_grade_for_fa(user_edx_run_data):
     run_passed = None
     grade = None
     if user_edx_run_data.certificate is not None:
-        run_passed = True
+        run_passed = user_edx_run_data.certificate.status == 'downloadable'
         grade = user_edx_run_data.certificate.grade
     else:
         run_passed = user_edx_run_data.current_grade.passed
@@ -55,8 +55,11 @@ def _compute_grade_for_non_fa(user_edx_run_data):
         UserFinalGrade: a namedtuple of (float, bool,) representing the final grade
             of the user in the course run and whether she passed it
     """
-    run_passed = user_edx_run_data.certificate is not None
-    grade = user_edx_run_data.certificate.grade if run_passed else user_edx_run_data.current_grade.percent
+    run_passed = user_edx_run_data.certificate is not None and user_edx_run_data.certificate.status == 'downloadable'
+    if user_edx_run_data.certificate is not None:
+        grade = user_edx_run_data.certificate.grade
+    else:
+        grade = user_edx_run_data.current_grade.percent
     return UserFinalGrade(grade=grade, passed=run_passed)
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
closes #2537

#### What's this PR do?
Updates the rule for passing certificates to take in account the status `"downloadable"`.
Other statuses are considered not passing.

#### How should this be manually tested?
set the edx cache last refresh in the future
```
from datetime import timedelta
from dashboard.models import *
refr = UserCacheRefreshTime.objects.get(user__username='<your_username>')
refr.enrollment = refr.enrollment + timedelta(days=2)
refr.certificate = refr.enrollment
refr.current_grade = refr.enrollment
refr.save()
```

for the dashboard:

In a non financial aid program, create a verified cached enrollment and a verified certificate with status different from `"downloadable"` for a past course run. 
The course should be Failed.
Modifying just the status to `"downloadable"` in the cached data should turn the course to be Passed.

for the grades:
for each of the previous cases, in a shell run `grades.api._compute_grade_for_non_fa` and check that the result is consistent with the dashboard.

#### Where should the reviewer start?
`dashboard/utils.py`
`grades/api.py`