### PR TITLE
Personal Pricing: Added validation on income so that it can only be an integer

### DIFF
--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -23,7 +23,6 @@ import {
 import { createSimpleActionHelpers } from '../lib/redux';
 import { currencyOptions } from '../lib/currency';
 import { validateFinancialAid } from '../lib/validation/profile';
-import { sanitizeNumberString } from '../lib/validation/date';
 import type { AvailableProgram } from '../flow/enrollmentTypes';
 import type {
   FinancialAidState,

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -57,7 +57,7 @@ const currencySelect = (update, current) => (
 
 const salaryUpdate = R.curry((update, current, e) => {
   let newEdit = R.clone(current);
-  newEdit.income = sanitizeNumberString(20, e.target.value);
+  newEdit.income = e.target.value
   update(newEdit);
 });
 

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -56,7 +56,7 @@ const currencySelect = (update, current) => (
 
 const salaryUpdate = R.curry((update, current, e) => {
   let newEdit = R.clone(current);
-  newEdit.income = e.target.value
+  newEdit.income = e.target.value;
   update(newEdit);
 });
 

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -158,14 +158,14 @@ describe('FinancialAidCalculator', () => {
         modifyTextField(document.querySelector('#user-salary-input'), '1000');
       }).then(() => {
         assert.deepEqual(helper.store.getState().financialAid, {
-          income: '1000',
+          income: "1000",
           currency: 'USD',
           checkBox: false,
           fetchAddStatus: undefined,
           fetchSkipStatus: undefined,
           programId: program.id,
           validation: {
-            'checkBox': 'You must agree to these terms'
+            'checkBox': 'You must agree to these terms',
           },
           fetchError: null,
         });
@@ -205,6 +205,26 @@ describe('FinancialAidCalculator', () => {
       });
     });
   });
+
+  for (let income of ["2000.00", "2000.50", "2Adb", "two thousand"]) {
+    it(`should show validation errors if invalid income=${income}`, () => {
+      return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
+        return listenForActions([
+          START_CALCULATOR_EDIT,
+          UPDATE_CALCULATOR_EDIT,
+          SET_CALCULATOR_DIALOG_VISIBILITY,
+          UPDATE_CALCULATOR_VALIDATION,
+          UPDATE_CALCULATOR_EDIT
+        ], () => {
+          wrapper.find('.pricing-actions').find('.calculate-cost-button').simulate('click');
+          modifyTextField(document.querySelector('#user-salary-input'), income);
+        }).then(() => {
+          let state = helper.store.getState().financialAid;
+          assert.equal(state.validation["income"], "Please only use whole numbers.");
+        });
+      });
+    });
+  }
 
   it('should let you enter your preferred currency', () => {
     return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -158,14 +158,14 @@ describe('FinancialAidCalculator', () => {
         modifyTextField(document.querySelector('#user-salary-input'), '1000');
       }).then(() => {
         assert.deepEqual(helper.store.getState().financialAid, {
-          income: "1000",
+          income: '1000',
           currency: 'USD',
           checkBox: false,
           fetchAddStatus: undefined,
           fetchSkipStatus: undefined,
           programId: program.id,
           validation: {
-            'checkBox': 'You must agree to these terms',
+            'checkBox': 'You must agree to these terms'
           },
           fetchError: null,
         });

--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -296,18 +296,11 @@ const financialAidMessages: ErrorMessages = {
 
 export const validateFinancialAid = (edit: FinancialAidState): FinancialAidValidation => {
   let errors: FinancialAidValidation = findErrors(edit, R.keys(financialAidMessages), financialAidMessages);
-  const income = edit.income;
-  const not_whole_num = (
-    income && (
-      /[.]/.test(income) || /[a-z]/.test(income.toLowerCase())
-    )
-  );
-
   if (!edit.checkBox) {
     errors['checkBox'] = 'You must agree to these terms';
   }
 
-  if (not_whole_num) {
+  if (edit.income && !/^\d+$/.test(edit.income)) {
     errors['income'] = 'Please only use whole numbers.';
   }
 

--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -300,7 +300,7 @@ export const validateFinancialAid = (edit: FinancialAidState): FinancialAidValid
     errors['checkBox'] = 'You must agree to these terms';
   }
 
-  if (edit.income && !/^\d+$/.test(edit.income)) {
+  if (edit.income && /\D+/.test(edit.income)) {
     errors['income'] = 'Please only use whole numbers.';
   }
 

--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -296,8 +296,20 @@ const financialAidMessages: ErrorMessages = {
 
 export const validateFinancialAid = (edit: FinancialAidState): FinancialAidValidation => {
   let errors: FinancialAidValidation = findErrors(edit, R.keys(financialAidMessages), financialAidMessages);
+  const income = edit.income;
+  const not_whole_num = (
+    income && (
+      /[.]/.test(income) || /[a-z]/.test(income.toLowerCase())
+    )
+  );
+
   if (!edit.checkBox) {
     errors['checkBox'] = 'You must agree to these terms';
   }
+
+  if (not_whole_num) {
+    errors['income'] = 'Please only use whole numbers.';
+  }
+
   return errors;
 };

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -498,6 +498,16 @@ describe('Financial aid validation', () => {
     });
   });
 
+  for (let income of ["2000.00", "2000.50", "2Adb", "two thousand"]) {
+    it(`should complain if income='${income}' is invalid`, () => {
+      financialAid.income = income;
+      let errors = validateFinancialAid(financialAid);
+      assert.deepEqual(errors, {
+        income: 'Please only use whole numbers.'
+      });
+    });
+  }
+
   it('should complain if currency is empty', () => {
     financialAid.currency = undefined;
     let errors = validateFinancialAid(financialAid);


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes https://github.com/mitodl/micromasters/issues/2470#issuecomment-279479984

#### What's this PR do?
- Throws error when prices entered on 

#### How should this be manually tested?
(Required)
- Open dashboard and then `Cost Calculator`
 - Try to input string, alpha numeric
 - Try to enter decimal number
 - Try to enter special character 
 - Try to enter whole numbers

<img width="726" alt="screen shot 2017-02-14 at 8 09 17 pm" src="https://cloud.githubusercontent.com/assets/10431250/22934837/3d38c54c-f2f2-11e6-9685-c637cf86e78f.png">

<img width="782" alt="screen shot 2017-02-14 at 8 12 35 pm" src="https://cloud.githubusercontent.com/assets/10431250/22934838/3d74ec52-f2f2-11e6-9cd7-ddadd42e9c96.png">
