### PR TITLE
fix ready to schedule display

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -14,6 +14,7 @@ from dashboard.api_edx_cache import CachedEdxDataApi, CachedEdxUserData
 from dashboard.utils import MMTrack
 from grades import api
 from grades.models import FinalGrade
+from exams.models import ExamAuthorization
 
 log = logging.getLogger(__name__)
 
@@ -200,6 +201,7 @@ def get_info_for_course(course, mmtrack):
         "description": course.description,
         "prerequisites": course.prerequisites,
         "has_contact_email": bool(course.contact_email),
+        "can_schedule_exam": is_exam_schedulable(mmtrack.user, course),
         "runs": [],
     }
 
@@ -406,3 +408,10 @@ def format_courserun_for_dashboard(course_run, status_for_user, mmtrack, positio
         formatted_run['current_grade'] = mmtrack.get_current_grade(course_run.edx_course_key)
 
     return formatted_run
+
+
+def is_exam_schedulable(user, course):
+    """
+    Check if a course is ready to schedule an exam or not
+    """
+    return ExamAuthorization.objects.filter(course=course, user=user).exists()

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -66,7 +66,8 @@ const COURSE: Course = {
   title: "Horse",
   has_contact_email: false,
   position_in_program: 1,
-  runs: []
+  runs: [],
+  can_schedule_exam: false,
 };
 
 const PROGRAM: AvailableProgram = {

--- a/static/js/components/dashboard/FinalExamCard.js
+++ b/static/js/components/dashboard/FinalExamCard.js
@@ -126,6 +126,16 @@ const errorDisplay = pearson => (
   R.isNil(pearson.error) ? null : <div className="error" key="error">{ pearson.error }</div>
 );
 
+const listItem = (text, index) => (<li key={index}>{ text }</li>);
+
+const schedulableCourseList = R.compose(
+  R.addIndex(R.map)(listItem),
+  R.map(R.prop('title')),
+  R.filter(R.propEq('can_schedule_exam', true)),
+  R.propOr([], 'courses'),
+  R.defaultTo({}),
+);
+
 const schedulableCard = (profile, program, navigateToProfile, submitPearsonSSO, pearson) => cardWrapper(
   accountCreated(profile, navigateToProfile),
   <div key="schedulable" className="exam-scheduling">
@@ -141,7 +151,7 @@ const schedulableCard = (profile, program, navigateToProfile, submitPearsonSSO, 
     <div className="program-info">
       You are ready to schedule an exam for:
       <ul>
-        <li>{ program.title }</li>
+        { schedulableCourseList(program) }
       </ul>
     </div>
   </div>,

--- a/static/js/components/dashboard/FinalExamCard_test.js
+++ b/static/js/components/dashboard/FinalExamCard_test.js
@@ -110,12 +110,21 @@ pay for the course and pass the online work.`;
   it('should show a schedule button when an exam is schedulable', () => {
     props.program.pearson_exam_status = PEARSON_PROFILE_SCHEDULABLE;
     let card = renderCard(props);
+    let button = card.find(".exam-button");
+    assert.equal(button.text(), 'Schedule an exam');
+    button.simulate('click');
+    assert(submitPearsonSSOStub.called);
+  });
+
+  it('should show the titles of schedulable exams', () => {
+    props.program.pearson_exam_status = PEARSON_PROFILE_SCHEDULABLE;
+    let course  = props.program.courses[0];
+    course.can_schedule_exam = true;
+    let card = renderCard(props);
     assert.include(
       stringStrip(card.text()),
-      `You are ready to schedule an exam for ${props.program.title}`
+      `You are ready to schedule an exam for ${stringStrip(course.title)}`
     );
-    card.find(".exam-button").simulate('click');
-    assert(submitPearsonSSOStub.called);
   });
 
   it('should show a scheduling error, when there is one', () => {

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -78,7 +78,8 @@ export const makeCourse = (positionInProgram: number): Course => {
     runs: R.reverse(R.range(1, 3)).map(makeRun),
     has_contact_email: false,
     position_in_program: positionInProgram,
-    title: `Title for course ${courseId}`
+    title: `Title for course ${courseId}`,
+    can_schedule_exam: false,
   };
 };
 

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -43,6 +43,7 @@ export type Course = {
   has_contact_email: boolean,
   id: number,
   position_in_program: number,
+  can_schedule_exam: boolean,
 };
 
 export type ProgramPageCourse = {


### PR DESCRIPTION
#### What are the relevant tickets?
closes #2534 

#### What's this PR do?

fixes the display for the 'schedulable' state (on the final exam card) so that it will show the titles of the courses for which the user is allowed to schedule an exam.

#### How should this be manually tested?

1. Make an `ExamProfile` for your user with status 'success'
2. find a course run in the program you want to use
3. make sure it has an edx course key
4. add an `exam_module` to the course associated with the run
5. add an `exam_series_code` to the program
6. create an `ExamAuthorization` for the user x course combination
7. set the `status` to be `success` on the authorization.

I think that's it!

then confirm that the final exam card (on the dashboard) shows the title of the course.