### PR TITLE
Added runtime feature flags via cookie (#2558)

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -557,6 +557,17 @@ FEATURES = {
     in get_all_config_keys() if key.startswith(MM_FEATURES_PREFIX)
 }
 
+MIDDLEWARE_FEATURE_FLAG_QS_PREFIX = get_var("MIDDLEWARE_FEATURE_FLAG_QS_PREFIX", None)
+MIDDLEWARE_FEATURE_FLAG_COOKIE_NAME = get_var('MIDDLEWARE_FEATURE_FLAG_COOKIE_NAME', 'MM_FEATURE_FLAGS')
+MIDDLEWARE_FEATURE_FLAG_COOKIE_MAX_AGE_SECONDS = get_var('MIDDLEWARE_FEATURE_FLAG_COOKIE_MAX_AGE_SECONDS', 60 * 60)
+
+
+if MIDDLEWARE_FEATURE_FLAG_QS_PREFIX:
+    MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + (
+        'ui.middleware.QueryStringFeatureFlagMiddleware',
+        'ui.middleware.CookieFeatureFlagMiddleware',
+    )
+
 
 # django debug toolbar only in debug mode
 if DEBUG:

--- a/static/js/components/dashboard/FinalExamCard.js
+++ b/static/js/components/dashboard/FinalExamCard.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import React from 'react';
 import { Card, CardTitle } from 'react-mdl/lib/Card';
 import Button from 'react-mdl/lib/Button';
@@ -175,6 +176,10 @@ export default class FinalExamCard extends React.Component<void, Props, void> {
       submitPearsonSSO,
       pearson,
     } = this.props;
+
+    if (!SETTINGS.FEATURES.EXAMS) {
+      return null;
+    }
 
     switch (program.pearson_exam_status) {
     case PEARSON_PROFILE_ABSENT:

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -13,6 +13,9 @@ declare var SETTINGS: {
   edx_base_url: string,
   EXAMS_SSO_CLIENT_CODE: string,
   EXAMS_SSO_URL: string,
+  FEATURES: {
+    [key: string]: boolean,
+  },
   support_email: string,
   es_page_size: number,
   search_url: string,

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -13,6 +13,9 @@ const _createSettings = () => ({
   es_page_size: 40,
   EXAMS_SSO_CLIENT_CODE: 'foobarcode',
   EXAMS_SSO_URL: 'http://foo.bar/baz',
+  FEATURES: {
+    EXAMS: true,
+  },
   get username() {
     throw new Error("username was removed");
   }

--- a/ui/middleware.py
+++ b/ui/middleware.py
@@ -1,0 +1,121 @@
+"""Common MicroMasters middleware"""
+from django.conf import settings
+from django import shortcuts
+from django.utils.deprecation import MiddlewareMixin
+
+from ui.utils import FeatureFlag
+
+
+class QueryStringFeatureFlagMiddleware(MiddlewareMixin):
+    """
+    Extracts feature flags from the query string
+    """
+
+    @classmethod
+    def get_flag_key(cls, suffix):
+        """
+        Determines the full key for a given feature flag suffix
+
+        Args:
+            suffix (str): suffix to append to the key prefix
+
+        Returns:
+            str: the full key value
+        """
+        return '{prefix}_FEATURE_{suffix}'.format(
+            prefix=settings.MIDDLEWARE_FEATURE_FLAG_QS_PREFIX,
+            suffix=suffix,
+        )
+
+    @classmethod
+    def encode_feature_flags(cls, data):
+        """
+        Encodes the set of feature flags from the request by creating a bit mask
+
+        Args:
+            data (dict): request query dict
+
+        Returns:
+            str: value encoded as a str
+        """
+        mask = 0
+        if data is None:
+            return str(mask)
+
+        for member in FeatureFlag:
+            if cls.get_flag_key(member.name) in data:
+                mask = mask | member.value
+        return str(mask)
+
+    def process_request(self, request):
+        """
+        Processes an individual request for the feature flag query parameters
+
+        Args:
+            request (django.http.request.Request): the request to inspect
+        """
+        prefix = self.get_flag_key('')
+        print(prefix)
+        if request.GET and any(key.startswith(prefix) for key in request.GET.keys()):
+            response = shortcuts.redirect(request.path)
+            if self.get_flag_key('CLEAR') in request.GET:
+                response.delete_cookie(settings.MIDDLEWARE_FEATURE_FLAG_COOKIE_NAME)
+            else:
+                response.set_signed_cookie(
+                    settings.MIDDLEWARE_FEATURE_FLAG_COOKIE_NAME,
+                    self.encode_feature_flags(request.GET),
+                    max_age=settings.MIDDLEWARE_FEATURE_FLAG_COOKIE_MAX_AGE_SECONDS,
+                    httponly=True,
+                )
+            return response
+
+        return None
+
+
+class CookieFeatureFlagMiddleware(MiddlewareMixin):
+    """
+    Extracts feature flags from a cookie
+    """
+
+    @classmethod
+    def decode_feature_flags(cls, value):
+        """
+        Decodes a set of feature flags from a bitmask value
+
+        Args:
+            value (int): the bitmask value
+
+        Returns:
+            set: the set of feature values in the value
+        """
+        return set(member for member in FeatureFlag if member.value & value)
+
+    @classmethod
+    def get_feature_flags(cls, request):
+        """
+        Determines the set of features enabled on a request via cookie
+
+        Args:
+            request (django.http.request.Request): the request to inspect
+
+        Returns:
+            set: the set of FeatureFlag values set in the cookie if present
+        """
+        if settings.MIDDLEWARE_FEATURE_FLAG_COOKIE_NAME in request.COOKIES:
+            try:
+                value = int(request.get_signed_cookie(settings.MIDDLEWARE_FEATURE_FLAG_COOKIE_NAME))
+            except ValueError:
+                return set()
+            return cls.decode_feature_flags(value)
+        else:
+            return set()
+
+    def process_request(self, request):
+        """
+        Processes an individual request for the feature flag cookie
+
+        Args:
+            request (django.http.request.Request): the request to inspect
+        """
+        request.mm_feature_flags = self.get_feature_flags(request)
+        return None

--- a/ui/middleware_test.py
+++ b/ui/middleware_test.py
@@ -1,0 +1,127 @@
+"""Unit tests for ui middleware"""
+from unittest.mock import (
+    Mock,
+    patch,
+)
+
+import ddt
+from django.test import (
+    override_settings,
+    TestCase,
+)
+
+from ui.middleware import (
+    CookieFeatureFlagMiddleware,
+    QueryStringFeatureFlagMiddleware,
+)
+from ui.utils import FeatureFlag
+
+FEATURE_FLAG_COOKIE_NAME = 'TEST_COOKIE'
+FEATURE_FLAG_COOKIE_MAX_AGE_SECONDS = 60
+
+
+# pylint: disable=missing-docstring
+@ddt.ddt
+@override_settings(
+    MIDDLEWARE_FEATURE_FLAG_QS_PREFIX='ZZ',
+    MIDDLEWARE_FEATURE_FLAG_COOKIE_NAME=FEATURE_FLAG_COOKIE_NAME,
+    MIDDLEWARE_FEATURE_FLAG_COOKIE_MAX_AGE_SECONDS=FEATURE_FLAG_COOKIE_MAX_AGE_SECONDS,
+)
+class QueryStringFeatureFlagMiddlewareTest(TestCase):
+    """Test QueryStringFeatureFlagMiddleware"""
+    def setUp(self):
+        self.middleware = QueryStringFeatureFlagMiddleware()
+
+    def test_get_flag_key(self):
+        assert self.middleware.get_flag_key('EXAMS') == 'ZZ_FEATURE_EXAMS'
+
+    def test_encode_feature_flags(self):
+        assert self.middleware.encode_feature_flags(None) == '0'
+        assert self.middleware.encode_feature_flags({
+            'ZZ_FEATURE_NOTHING': 1,
+        }) == '0'
+
+        assert self.middleware.encode_feature_flags({
+            'ZZ_FEATURE_EXAMS': 1,
+        }) == '1'
+
+    @ddt.data(None, {})
+    def test_process_request_no_qs(self, get_value):
+        request = Mock()
+        request.GET = get_value
+        assert self.middleware.process_request(request) is None
+
+    @patch('django.shortcuts.redirect')
+    def test_process_request_clear(self, redirect_mock):
+        request = Mock()
+        request.GET = {
+            'ZZ_FEATURE_CLEAR': 1,
+        }
+        request.path = '/dashboard/'
+        assert self.middleware.process_request(request) == redirect_mock.return_value
+
+        redirect_mock.assert_called_once_with('/dashboard/')
+
+        response = redirect_mock.return_value
+        response.delete_cookie.assert_called_once_with(FEATURE_FLAG_COOKIE_NAME)
+
+    @patch('django.shortcuts.redirect')
+    def test_process_request_query(self, redirect_mock):
+        request = Mock()
+        request.GET = {
+            'ZZ_FEATURE_EXAMS': 1,
+        }
+        request.path = '/dashboard/'
+        assert self.middleware.process_request(request) == redirect_mock.return_value
+
+        redirect_mock.assert_called_once_with('/dashboard/')
+
+        response = redirect_mock.return_value
+        response.set_signed_cookie.assert_called_once_with(
+            FEATURE_FLAG_COOKIE_NAME,
+            '1',
+            max_age=FEATURE_FLAG_COOKIE_MAX_AGE_SECONDS,
+            httponly=True,
+        )
+
+
+@override_settings(
+    MIDDLEWARE_FEATURE_FLAG_QS_PREFIX='ZZ',
+    MIDDLEWARE_FEATURE_FLAG_COOKIE_NAME=FEATURE_FLAG_COOKIE_NAME,
+    MIDDLEWARE_FEATURE_FLAG_COOKIE_MAX_AGE_SECONDS=FEATURE_FLAG_COOKIE_MAX_AGE_SECONDS,
+)
+class CookieFeatureFlagMiddlewareTest(TestCase):
+    """Test QueryStringFeatureFlagMiddleware"""
+    def setUp(self):
+        self.middleware = CookieFeatureFlagMiddleware()
+
+    def test_decode_feature_flags(self):
+        assert self.middleware.decode_feature_flags(0) == set()
+        assert self.middleware.decode_feature_flags(1) == set([FeatureFlag.EXAMS])
+
+    def test_process_request_valid_cookie(self):
+        request = Mock()
+        request.COOKIES = {
+            FEATURE_FLAG_COOKIE_NAME: 1,
+        }
+        request.get_signed_cookie.return_value = 1
+        assert self.middleware.process_request(request) is None
+        assert request.mm_feature_flags == set([FeatureFlag.EXAMS])
+        request.get_signed_cookie.assert_called_once_with(FEATURE_FLAG_COOKIE_NAME)
+
+    def test_process_request_invalid_cookie(self):
+        request = Mock()
+        request.COOKIES = {
+            FEATURE_FLAG_COOKIE_NAME: 1,
+        }
+        request.get_signed_cookie.side_effect = ValueError
+        assert self.middleware.process_request(request) is None
+        assert request.mm_feature_flags == set()
+        request.get_signed_cookie.assert_called_once_with(FEATURE_FLAG_COOKIE_NAME)
+
+    def test_process_request_no_cookie(self):
+        request = Mock()
+        request.COOKIES = {}
+        assert self.middleware.process_request(request) is None
+        request.get_signed_cookie.assert_not_called()
+        assert request.mm_feature_flags == set()

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -1,0 +1,17 @@
+"""ui utilities"""
+from enum import (
+    Enum,
+    unique,
+)
+
+
+# Python 3.6: this should be upgraded to enum.Flag
+@unique
+class FeatureFlag(Enum):
+    """
+    FeatureFlag enum
+
+    Members should have values of increasing powers of 2 (1, 2, 4, 8, ...)
+
+    """
+    EXAMS = 1

--- a/ui/views.py
+++ b/ui/views.py
@@ -22,6 +22,7 @@ from profiles.permissions import CanSeeIfNotPrivate
 from roles.models import Instructor, Staff
 from ui.decorators import require_mandatory_urls
 from ui.templatetags.render_bundle import public_path
+from ui.utils import FeatureFlag
 
 log = logging.getLogger(__name__)
 
@@ -61,6 +62,9 @@ class ReactView(View):  # pylint: disable=unused-argument
             "public_path": public_path(request),
             "EXAMS_SSO_CLIENT_CODE": settings.EXAMS_SSO_CLIENT_CODE,
             "EXAMS_SSO_URL": settings.EXAMS_SSO_URL,
+            "FEATURES": {
+                "EXAMS": FeatureFlag.EXAMS in getattr(request, 'mm_feature_flags', []),
+            },
         }
 
         return render(

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -329,6 +329,9 @@ class DashboardTests(ViewsTests):
                 'public_path': '/static/bundles/',
                 'EXAMS_SSO_CLIENT_CODE': 'itsacode',
                 'EXAMS_SSO_URL': 'url',
+                'FEATURES': {
+                    'EXAMS': False,
+                },
             }
             assert resp.context['is_public'] is False
             assert resp.context['has_zendesk_widget'] is True
@@ -725,6 +728,9 @@ class TestUsersPage(ViewsTests):
                     'public_path': '/static/bundles/',
                     'EXAMS_SSO_CLIENT_CODE': 'itsacode',
                     'EXAMS_SSO_URL': 'url',
+                    'FEATURES': {
+                        'EXAMS': False,
+                    },
                 }
                 assert has_permission.called
 
@@ -791,6 +797,9 @@ class TestUsersPage(ViewsTests):
                     'public_path': '/static/bundles/',
                     'EXAMS_SSO_CLIENT_CODE': 'itsacode',
                     'EXAMS_SSO_URL': 'url',
+                    'FEATURES': {
+                        'EXAMS': False,
+                    },
                 }
                 assert has_permission.called
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2558 

#### What's this PR do?
Adds a general mechanism for enabling feature flags per user and implements one for exams ui.

It does so by setting a signed cookie to the bitmask of the feature(s) you've turned on. This is implemented as middleware and I've made an effort to keep the code as minimal and unobtrusive as possible.

**Note:** the middleware uses `django.utils.deprecation.MiddlewareMixin`. I briefly explored upgrading our settings to avoid usage of this, but ran into difficulties and it's probably better dealt with separately anyway. I logged #2565 to address it later and noted the issues I ran into.

#### How should this be manually tested?

- In `.env` set `FEATURE_FLAG_QS_PREFIX=MM`
- Create an `ExamProfile` record for your user.
- Login and go to http://localhost:8079/dashboard/?MM_FEATURE_EXAMS=1
- Ensure you can get redirected to /dashboard/ (no querystring) and that you see the exam card
- Add `?MM_FEATURE_CLEAR` to the url to clear the cookie and verify the card goes away.

#### Where should the reviewer start?

ui/middleware.py

#### What GIF best describes this PR or how it makes you feel?
![semaphore](https://cloud.githubusercontent.com/assets/28598/22981982/c116aeb4-f36b-11e6-8945-223cadeb8181.gif)

