### PR TITLE
Lower logging of unexceptional exception to debug

### DIFF
--- a/exams/signals.py
+++ b/exams/signals.py
@@ -37,7 +37,7 @@ def update_exam_authorization_final_grade(sender, instance, **kwargs):  # pylint
     try:
         authorize_for_exam(mmtrack, instance.course_run)
     except ExamAuthorizationException:
-        log.exception(
+        log.debug(
             'Unable to authorize user: %s for exam on course_id: %s',
             instance.user.username,
             instance.course_run.course.id

--- a/exams/signals_test.py
+++ b/exams/signals_test.py
@@ -122,7 +122,7 @@ class ExamSignalsTest(MockedESTestCase):
                 passed=True,
             )
 
-        log.exception.assert_called_with(
+        log.debug.assert_called_with(
             'Unable to authorize user: %s for exam on course_id: %s',
             self.profile.user.username,
             self.course_run.course.id

--- a/selenium_tests/base.py
+++ b/selenium_tests/base.py
@@ -259,6 +259,10 @@ FROM pg_stat_activity WHERE pid <> pg_backend_pid()""")
             if "'webkitURL' is deprecated. Please use 'URL' instead" in message:
                 continue
 
+            # warnings (e.g. deprecations) should not fail the tests
+            if entry['level'] in ["WARNING"]:
+                continue
+
             messages.append(entry)
 
         assert len(messages) == 0, str(messages)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2573 

#### What's this PR do?
Lowers a single `log.exception` to `log.debug`.

#### How should this be manually tested?
This is just a logging statement and the tests exercise that code, so if they pass we're good.