### PR TITLE
Make separate selenium container for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
     - install:
       - env | grep TRAVIS > .env
       - env | grep CI >> .env
-      - docker-compose -f travis-docker-compose.yml build
       - docker-compose -f travis-docker-compose.yml run celery echo
       script: (docker-compose -f travis-docker-compose.yml up celery &); sleep 5; docker-compose -f travis-docker-compose.yml run web tox
       services:
@@ -21,7 +20,6 @@ matrix:
       - docker run --name travis-watch-container --env-file .env -e NODE_ENV=production -t travis-watch ./webpack_if_prod.sh
       - docker cp travis-watch-container:/src/webpack-stats.json .
       - docker cp travis-watch-container:/src/static/bundles ./static/bundles
-      - docker-compose -f travis-docker-compose.yml build
       script: (docker-compose -f travis-docker-compose.yml up grid &); sleep 5; ./scripts/test/run_selenium_tests.sh
       services:
         - docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - web
       - watch
 
-  web:
+  python:
     build: .
     command: >
       /bin/bash -c '
@@ -54,8 +54,12 @@ services:
       EXAMS_SFTP_HOST: sftp
       EXAMS_SFTP_USERNAME: odl
       EXAMS_SFTP_PASSWORD: 123
-
     env_file: .env
+
+  web:
+    image: micromasters_python
+    extends:
+      service: python
     ports:
       - "8077:8077"
     links:
@@ -63,7 +67,6 @@ services:
       - elastic
       - redis
       - sftp
-      - grid
 
   watch:
     build:
@@ -83,26 +86,12 @@ services:
 
   celery:
     image: micromasters_web
-    mem_limit: 384m
+    extends:
+      service: python
     command: >
       /bin/bash -c '
       sleep 3;
       celery -A micromasters worker -B -l debug'
-    volumes_from:
-      - web
-    environment:
-      DEBUG: 'True'
-      MICROMASTERS_DB_DISABLE_SSL: 'True'
-      DJANGO_LOG_LEVEL: INFO
-      DATABASE_URL: postgres://postgres@db:5432/postgres
-      BROKER_URL: redis://redis:6379/4
-      CELERY_RESULT_BACKEND: redis://redis:6379/4
-      ELASTICSEARCH_URL: elastic:9200
-      CELERY_ALWAYS_EAGER: 'False'
-      EXAMS_SFTP_HOST: sftp
-      EXAMS_SFTP_USERNAME: odl
-      EXAMS_SFTP_PASSWORD: 123
-    env_file: .env
     links:
       - db
       - elastic
@@ -116,6 +105,14 @@ services:
     ports:
         - "2022:22"
     command: odl:123:1001:1001:results,results/topvue
+
+  selenium:
+    image: micromasters_web
+    extends:
+      service: python
+    links:
+      - db
+      - elastic
 
   grid:
     image: elgalu/selenium

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,7 @@ services:
     links:
       - db
       - elastic
+      - redis
 
   grid:
     image: elgalu/selenium

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,7 @@ services:
 
   python:
     build: .
-    command: >
-      /bin/bash -c '
-      sleep 3 &&
-      python3 manage.py migrate &&
-      uwsgi uwsgi.ini'
+    command: /bin/true
     volumes:
       - .:/src
       - django_media:/var/media
@@ -60,6 +56,11 @@ services:
     image: micromasters_python
     extends:
       service: python
+    command: >
+      /bin/bash -c '
+      sleep 3 &&
+      python3 manage.py migrate &&
+      uwsgi uwsgi.ini'
     ports:
       - "8077:8077"
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
     env_file: .env
 
   celery:
-    image: micromasters_web
+    image: micromasters_python
     extends:
       service: python
     command: >
@@ -107,7 +107,7 @@ services:
     command: odl:123:1001:1001:results,results/topvue
 
   selenium:
-    image: micromasters_web
+    image: micromasters_python
     extends:
       service: python
     links:

--- a/scripts/test/run_selenium_tests.sh
+++ b/scripts/test/run_selenium_tests.sh
@@ -8,4 +8,4 @@ then
     echo "webpack-stats.json must exist before running the selenium tests. Run webpack to create it."
     exit 1
 fi
-docker-compose run -e DEBUG=False -e DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8286 web py.test ./selenium_tests
+docker-compose run -e DEBUG=False -e DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8286 selenium py.test ./selenium_tests

--- a/travis-docker-compose.yml
+++ b/travis-docker-compose.yml
@@ -14,11 +14,7 @@ services:
     build:
       context: .
       dockerfile: ./travis/Dockerfile-travis-web
-    command: >
-      /bin/bash -c '
-      sleep 3 &&
-      python3 manage.py migrate &&
-      ./with_host.sh python3 manage.py runserver 0.0.0.0:8079'
+    command: /bin/true
     environment:
       DEBUG: 'False'
       COVERAGE_DIR: htmlcov
@@ -36,6 +32,11 @@ services:
     image: micromasters_python
     extends:
       service: python
+    command: >
+      /bin/bash -c '
+      sleep 3 &&
+      python3 manage.py migrate &&
+      ./with_host.sh python3 manage.py runserver 0.0.0.0:8079'
     ports:
       - "8079:8079"
     links:

--- a/travis-docker-compose.yml
+++ b/travis-docker-compose.yml
@@ -33,7 +33,7 @@ services:
     env_file: .env
 
   web:
-    image: micromasters_web
+    image: micromasters_python
     extends:
       service: python
     ports:
@@ -43,7 +43,7 @@ services:
       - elastic
 
   celery:
-    image: micromasters_web
+    image: micromasters_python
     extends:
       service: python
     command: >
@@ -62,7 +62,7 @@ services:
       - "9200"
 
   selenium:
-    image: micromasters_web
+    image: micromasters_python
     extends:
       service: python
     links:

--- a/travis-docker-compose.yml
+++ b/travis-docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "6379"
 
-  web:
+  python:
     build:
       context: .
       dockerfile: ./travis/Dockerfile-travis-web
@@ -31,31 +31,25 @@ services:
       BROKER_URL: redis://redis:6379/4
       CELERY_RESULT_BACKEND: redis://redis:6379/4
     env_file: .env
+
+  web:
+    image: micromasters_web
+    extends:
+      service: python
     ports:
       - "8079:8079"
     links:
       - db
       - elastic
-      - grid
 
   celery:
     image: micromasters_web
-    mem_limit: 384m
+    extends:
+      service: python
     command: >
       /bin/bash -c '
       sleep 3;
       celery -A micromasters worker -B -l debug'
-    volumes_from:
-      - web
-    environment:
-      DEBUG: 'False'
-      MICROMASTERS_DB_DISABLE_SSL: 'True'
-      DATABASE_URL: postgres://postgres@db:5432/postgres
-      BROKER_URL: redis://redis:6379/4
-      CELERY_RESULT_BACKEND: redis://redis:6379/4
-      ELASTICSEARCH_URL: elastic:9200
-      CELERY_ALWAYS_EAGER: 'True'
-    env_file: .env
     links:
       - db
       - elastic
@@ -66,6 +60,15 @@ services:
     command: elasticsearch -Des.network.host=0.0.0.0
     ports:
       - "9200"
+
+  selenium:
+    image: micromasters_web
+    extends:
+      service: python
+    links:
+      - db
+      - elastic
+      - redis
 
   grid:
     image: elgalu/selenium


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2628

#### What's this PR do?
Creates a separate selenium container so that the grid container is not pulled with everything else when it's not needed.

#### How should this be manually tested?
Make sure you can run the tests locally and that you can see the website as before

