### PR TITLE
Exams: HTML edited to exam card on dashboard

### DIFF
--- a/static/js/components/dashboard/FinalExamCard.js
+++ b/static/js/components/dashboard/FinalExamCard.js
@@ -28,13 +28,13 @@ const cardWrapper = (...children) => (
       </div>
       <div>
         <CardTitle>
-          Final Exams
+          Final Proctored Exam
         </CardTitle>
         <p>
           {`You must take a proctored exam for each course. Exams may be taken
             at any `}
-          <a href="">
-            Pearson test center
+          <a href="http://www.pearsonvue.com/mitx/locate/" target="_blank">
+            authorized Pearson test center
           </a>
           {`. Before you can take an exam, you have to pay for the course and
           pass the online work.`}
@@ -53,7 +53,7 @@ const getPostalCode = profile => (
 const accountCreated = (profile, navigateToProfile) => (
   <div key="profile">
     <div className="info-box split">
-      <div className="flow"> 
+      <div className="flow">
         Your Pearson Testing account has been created. Your information
         should match the ID you bring to the test center.
       </div>

--- a/static/js/components/dashboard/FinalExamCard_test.js
+++ b/static/js/components/dashboard/FinalExamCard_test.js
@@ -45,7 +45,7 @@ describe('FinalExamCard', () => {
   let stringStrip = R.compose(R.join(" "), _.words);
 
   let commonText = `You must take a proctored exam for each course. Exams may
-be taken at any Pearson test center. Before you can take an exam, you have to
+be taken at any authorized Pearson test center. Before you can take an exam, you have to
 pay for the course and pass the online work.`;
 
   let renderCard = props => (mount(<FinalExamCard {...props} />));


### PR DESCRIPTION
#### What are the relevant tickets?
- fixes https://github.com/mitodl/micromasters/issues/2553

#### What's this PR do?
- edits text and html

#### How should this be manually tested?
- make ur self authorized for exam , create ExamProfile and ExamAuthorization entry
- then open dashboard and select the respected program

<img width="583" alt="screen shot 2017-02-16 at 6 59 40 pm" src="https://cloud.githubusercontent.com/assets/10431250/23024024/1a47b06e-f47a-11e6-858c-dc04ca5164eb.png">
