### PR TITLE
Exams: Added environment variable to suppress payment requirement

### DIFF
--- a/exams/signals_test.py
+++ b/exams/signals_test.py
@@ -32,6 +32,7 @@ from search.base import MockedESTestCase
 
 # pylint: disable=no-self-use
 
+@override_settings(FEATURES={"SUPPRESS_PAYMENT_FOR_EXAM": False})
 class ExamSignalsTest(MockedESTestCase):
     """
     Tests for exam signals
@@ -104,7 +105,7 @@ class ExamSignalsTest(MockedESTestCase):
             course=self.course_run.course
         ).exists() is True
 
-    @override_settings(FEATURES={"FINAL_GRADE_ALGORITHM": "v1"})
+    @override_settings(FEATURES={"FINAL_GRADE_ALGORITHM": "v1", "SUPPRESS_PAYMENT_FOR_EXAM": False})
     def test_update_exam_authorization_final_grade_when_user_not_paid(self):
         """
         Verify that update_exam_authorization_final_grade is called and log exception when

--- a/exams/signals_test.py
+++ b/exams/signals_test.py
@@ -32,7 +32,6 @@ from search.base import MockedESTestCase
 
 # pylint: disable=no-self-use
 
-@override_settings(FEATURES={"SUPPRESS_PAYMENT_FOR_EXAM": False})
 class ExamSignalsTest(MockedESTestCase):
     """
     Tests for exam signals
@@ -105,7 +104,7 @@ class ExamSignalsTest(MockedESTestCase):
             course=self.course_run.course
         ).exists() is True
 
-    @override_settings(FEATURES={"FINAL_GRADE_ALGORITHM": "v1", "SUPPRESS_PAYMENT_FOR_EXAM": False})
+    @override_settings(FEATURES={"FINAL_GRADE_ALGORITHM": "v1"})
     def test_update_exam_authorization_final_grade_when_user_not_paid(self):
         """
         Verify that update_exam_authorization_final_grade is called and log exception when
@@ -146,6 +145,7 @@ class ExamSignalsTest(MockedESTestCase):
         CachedEnrollmentFactory.create(user=self.profile.user, course_run=self.course_run)
         assert ExamProfile.objects.filter(profile=self.profile).exists() is True
 
+    @override_settings(FEATURES={"SUPPRESS_PAYMENT_FOR_EXAM": False})
     def test_update_exam_authorization_cached_enrollment_user_not_paid(self):
         """
         Test no exam profile created when user enrolled in the course but not paid for it.

--- a/exams/utils.py
+++ b/exams/utils.py
@@ -68,22 +68,24 @@ def is_eligible_for_exam(mmtrack, course_run):
     Returns:
         bool: whether user is eligible or not
     """
-    return course_run.has_exam and has_paid(mmtrack, course_run.edx_course_key)
+    return course_run.has_exam and _has_paid_for_exam(mmtrack, course_run.edx_course_key)
 
 
-def has_paid(mmtrack, edx_course_key):
+def _has_paid_for_exam(mmtrack, edx_course_key):
     """
     Returns True if user has paid for the course or payment check is suppressed using feature flag
     FEATURE_SUPPRESS_PAYMENT_FOR_EXAM.
+
     Args:
         mmtrack (dashboard.utils.MMTrack): a instance of all user information about a program.
         edx_course_key (str): An edX course key (CourseRun.edx_course_key)
 
-    bool: whether user has paid or not.
+    Returns:
+        bool: whether user has paid or not.
     """
     # if FEATURE_SUPPRESS_PAYMENT_FOR_EXAM=True then bypass payment check
-    suppress_payment_for_exam = settings.FEATURES.get("SUPPRESS_PAYMENT_FOR_EXAM", True)
-    return mmtrack.has_paid(edx_course_key) or suppress_payment_for_exam
+    suppress_payment_for_exam = settings.FEATURES.get("SUPPRESS_PAYMENT_FOR_EXAM", False)
+    return suppress_payment_for_exam or mmtrack.has_paid(edx_course_key)
 
 
 def authorize_for_exam(mmtrack, course_run):
@@ -103,7 +105,7 @@ def authorize_for_exam(mmtrack, course_run):
         raise ExamAuthorizationException(errors_message)
 
     # If user has not paid for course then we dont need to process authorization
-    if not has_paid(mmtrack, course_run.edx_course_key):
+    if not _has_paid_for_exam(mmtrack, course_run.edx_course_key):
         errors_message = message_not_eligible_template.format(
             user=mmtrack.user.username,
             course_id=course_run.edx_course_key

--- a/exams/utils.py
+++ b/exams/utils.py
@@ -66,9 +66,24 @@ def is_eligible_for_exam(mmtrack, course_run):
         course_run (courses.models.CourseRun): A CourseRun object.
 
     Returns:
-        bool: whether use is eligible or not
+        bool: whether user is eligible or not
     """
-    return course_run.has_exam and mmtrack.has_paid(course_run.edx_course_key)
+    return course_run.has_exam and has_paid(mmtrack, course_run.edx_course_key)
+
+
+def has_paid(mmtrack, edx_course_key):
+    """
+    Returns True if user has paid for the course or payment check is suppressed using feature flag
+    FEATURE_SUPPRESS_PAYMENT_FOR_EXAM.
+    Args:
+        mmtrack (dashboard.utils.MMTrack): a instance of all user information about a program.
+        edx_course_key (str): An edX course key (CourseRun.edx_course_key)
+
+    bool: whether user has paid or not.
+    """
+    # if FEATURE_SUPPRESS_PAYMENT_FOR_EXAM=True then bypass payment check
+    suppress_payment_for_exam = settings.FEATURES.get("SUPPRESS_PAYMENT_FOR_EXAM", True)
+    return mmtrack.has_paid(edx_course_key) or suppress_payment_for_exam
 
 
 def authorize_for_exam(mmtrack, course_run):
@@ -88,7 +103,7 @@ def authorize_for_exam(mmtrack, course_run):
         raise ExamAuthorizationException(errors_message)
 
     # If user has not paid for course then we dont need to process authorization
-    if not mmtrack.has_paid(course_run.edx_course_key):
+    if not has_paid(mmtrack, course_run.edx_course_key):
         errors_message = message_not_eligible_template.format(
             user=mmtrack.user.username,
             course_id=course_run.edx_course_key


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2560

#### What's this PR do?
Adds feature flag `FEATURE_SUPPRESS_PAYMENT_FOR_EXAM=True` to suppress the payment check for exam authorization

#### How should this be manually tested?
-Authorize for course after passing it, no need to pay.

@pdpinch 

