### PR TITLE
allow fetching dashboard info for other users

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -126,8 +126,9 @@ def get_user_program_info(user, edx_client):
     """
     # update cache
     # NOTE: this part can be moved to an asynchronous task
-    for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
-        CachedEdxDataApi.update_cache_if_expired(user, edx_client, cache_type)
+    if edx_client is not None:
+        for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
+            CachedEdxDataApi.update_cache_if_expired(user, edx_client, cache_type)
 
     edx_user_data = CachedEdxUserData(user)
 

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1173,6 +1173,12 @@ class UserProgramInfoIntegrationTest(MockedESTestCase):
             }
             assert is_subset_dict(expected, result[i])
 
+    @patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cache_if_expired', new_callable=MagicMock)
+    def test_when_edx_client_is_none(self, mock_cache_refresh):
+        """Test that the edx data is not refreshed"""
+        api.get_user_program_info(self.user, None)
+        assert mock_cache_refresh.call_count == 0
+
     def test_past_course_runs(self):
         """Test that past course runs are returned in the API results"""
         # Set a course run to be failed

--- a/dashboard/permissions.py
+++ b/dashboard/permissions.py
@@ -1,0 +1,44 @@
+"""
+Permission classes for the dashboard
+"""
+from django.contrib.auth.models import User
+from django.http import Http404
+from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import BasePermission
+
+from backends.edxorg import EdxOrgOAuth2
+from roles.roles import (
+    Instructor,
+    Staff,
+)
+
+
+class CanReadIfStaffOrSelf(BasePermission):
+    """
+    Only staff on a program the learner is enrolled in can
+    see their dashboard. Learners can view their own dashboard.
+    """
+
+    def has_permission(self, request, view):
+        if request.user.is_anonymous():
+            raise Http404
+
+        user = get_object_or_404(
+            User,
+            social_auth__uid=view.kwargs['username'],
+            social_auth__provider=EdxOrgOAuth2.name
+        )
+
+        # if the user is looking for their own profile, they're good
+        if request.user == user:
+            return True
+
+        # if the user is looking for someone enrolled in a program they
+        # are staff on, they're good
+        if request.user.role_set.filter(
+                role__in=(Staff.ROLE_ID, Instructor.ROLE_ID),
+                program__programenrollment__user=user,
+        ).exists():
+            return True
+        else:
+            raise Http404

--- a/dashboard/permissions_test.py
+++ b/dashboard/permissions_test.py
@@ -1,0 +1,109 @@
+"""
+Tests for the dashboard permissions
+"""
+from unittest.mock import Mock
+from django.http import Http404
+from django.db.models.signals import post_save
+from factory.django import mute_signals
+import ddt
+
+from backends.edxorg import EdxOrgOAuth2
+from courses.factories import ProgramFactory
+from micromasters.factories import UserFactory
+from dashboard.models import ProgramEnrollment
+from dashboard.permissions import CanReadIfStaffOrSelf
+from search.base import MockedESTestCase
+from roles.models import Role
+from roles.roles import (
+    Instructor,
+    Staff,
+)
+
+
+@ddt.ddt
+class CanReadIfStaffOrSelfTests(MockedESTestCase):
+    """
+    Tests
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        with mute_signals(post_save):
+            cls.learner1 = UserFactory.create()
+            cls.learner1_username = 'learner1_username'
+            cls.learner1.social_auth.create(
+                provider=EdxOrgOAuth2.name,
+                uid=cls.learner1_username
+            )
+            cls.learner2 = UserFactory.create()
+            cls.learner2_username = 'learner2_username'
+            cls.learner2.social_auth.create(
+                provider=EdxOrgOAuth2.name,
+                uid=cls.learner2_username
+            )
+            cls.program = ProgramFactory.create()
+            cls.staff = UserFactory.create()
+            cls.staff_username = 'staff_username'
+            for learner in (cls.learner1, cls.learner2):
+                ProgramEnrollment.objects.create(
+                    program=cls.program,
+                    user=learner,
+                )
+
+    def test_anonymous_users_blocked(self):
+        """
+        Test that anonymous users get a 404
+        """
+        perm = CanReadIfStaffOrSelf()
+        request = Mock(user=Mock(is_anonymous=Mock(return_value=True)))
+        view = Mock(kwargs={'user': 'username'})
+        with self.assertRaises(Http404):
+            perm.has_permission(request, view)
+
+    def test_raise_if_requested_record_doesnt_exist(self):
+        """
+        Test that requests a nonexistent user gives a  404
+        """
+        for user in (self.learner1, self.staff):
+            perm = CanReadIfStaffOrSelf()
+            request = Mock(user=user)
+            view = Mock(kwargs={'username': 'AFSDFASDFASDF'})
+            with self.assertRaises(Http404):
+                perm.has_permission(request, view)
+
+    def test_learner_can_get_own_dashboard(self):
+        """
+        Test that a user can get their own dashboard
+        """
+        perm = CanReadIfStaffOrSelf()
+        request = Mock(user=self.learner1)
+        view = Mock(kwargs={'username': self.learner1_username})
+        assert perm.has_permission(request, view) is True
+
+    def test_learners_cannot_get_other_learners(self):
+        """
+        Normal users shouldn't be able to read each other
+        """
+        perm = CanReadIfStaffOrSelf()
+        with mute_signals(post_save):
+            request = Mock(user=self.learner1)
+            view = Mock(kwargs={'username': self.learner2_username})
+            with self.assertRaises(Http404):
+                perm.has_permission(request, view)
+
+    @ddt.data(Instructor, Staff)
+    def test_staff_can_read_learners(self, role):
+        """
+        A staff or instructor on a program a learner is also in should
+        be able to read their dashboard
+        """
+        perm = CanReadIfStaffOrSelf()
+        with mute_signals(post_save):
+            Role.objects.create(
+                user=self.staff,
+                program=self.program,
+                role=role.ROLE_ID,
+            )
+            request = Mock(user=self.staff)
+            view = Mock(kwargs={'username': self.learner1_username})
+            assert perm.has_permission(request, view) is True

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -7,6 +7,6 @@ from dashboard.views import (
 )
 
 urlpatterns = [
-    url(r'^api/v0/dashboard/$', UserDashboard.as_view(), name='dashboard_api'),
+    url(r'^api/v0/dashboard/(?P<username>[-\w.]+)/$', UserDashboard.as_view(), name='dashboard_api'),
     url(r'^api/v0/course_enrollments/$', UserCourseEnrollment.as_view(), name='user_course_enrollments'),
 ]

--- a/micromasters/urls_test.py
+++ b/micromasters/urls_test.py
@@ -15,7 +15,7 @@ class URLTests(TestCase):
         assert reverse('terms_of_service') == '/terms_of_service/'
         assert reverse('program-list') == '/api/v0/programs/'
         assert reverse('profile-detail', kwargs={'user': 'xyz'}) == '/api/v0/profiles/xyz/'
-        assert reverse('dashboard_api') == '/api/v0/dashboard/'
+        assert reverse('dashboard_api', args=['username']) == '/api/v0/dashboard/username/'
         assert reverse('search_api', kwargs={'elastic_url': 'elastic'}) == '/api/v0/search/elastic'
         assert reverse('checkout') == '/api/v0/checkout/'
         assert reverse('user_program_enrollments') == '/api/v0/enrolledprograms/'

--- a/static/js/actions/course_enrollments.js
+++ b/static/js/actions/course_enrollments.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import type { Dispatch } from 'redux';
 import { createAction } from 'redux-actions';
 
@@ -24,7 +25,7 @@ export const addCourseEnrollment = (courseId: string): Dispatcher<*> => {
     return api.addCourseEnrollment(courseId).
       then(() => {
         dispatch(receiveAddCourseEnrollmentSuccess());
-        dispatch(fetchDashboard());
+        dispatch(fetchDashboard(SETTINGS.user.username));
         dispatch(fetchCoursePrices());
       }).
       catch(() => {

--- a/static/js/actions/documents.js
+++ b/static/js/actions/documents.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import { createAction } from 'redux-actions';
 import type { Dispatch } from 'redux';
 
@@ -27,7 +28,7 @@ export const updateDocumentSentDate = (financialAidId: number, dateSent: string)
     return api.updateDocumentSentDate(financialAidId, dateSent).then(
       () => {
         dispatch(receiveUpdateDocumentSentDateSuccess());
-        dispatch(fetchDashboard());
+        dispatch(fetchDashboard(SETTINGS.user.username));
         dispatch(fetchCoursePrices());
         return Promise.resolve();
       },

--- a/static/js/actions/financial_aid.js
+++ b/static/js/actions/financial_aid.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import type { Dispatch } from 'redux';
 import { createAction } from 'redux-actions';
 
@@ -37,7 +38,7 @@ export const addFinancialAid = (income: number, currency: string, programId: num
       () => {
         dispatch(receiveAddFinancialAidSuccess());
         dispatch(fetchCoursePrices());
-        dispatch(fetchDashboard());
+        dispatch(fetchDashboard(SETTINGS.user.username));
         return Promise.resolve();
       },
       err => {
@@ -66,7 +67,7 @@ export const skipFinancialAid = (programId: number): Dispatcher<*> => {
       () => {
         dispatch(receiveSkipFinancialAidSuccess());
         dispatch(fetchCoursePrices());
-        dispatch(fetchDashboard());
+        dispatch(fetchDashboard(SETTINGS.user.username));
         return Promise.resolve();
       },
       () => {

--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import type { Dispatch } from 'redux';
 import { createAction } from 'redux-actions';
 
@@ -35,10 +36,10 @@ export const receiveDashboardFailure = (errorInfo: APIErrorInfo): Action => ({
 export const CLEAR_DASHBOARD = 'CLEAR_DASHBOARD';
 export const clearDashboard = () => ({ type: CLEAR_DASHBOARD });
 
-export function fetchDashboard(noSpinner: boolean = false): Dispatcher<Dashboard> {
+export function fetchDashboard(username: string, noSpinner: boolean = false): Dispatcher<Dashboard> {
   return (dispatch: Dispatch) => {
     dispatch(requestDashboard(noSpinner));
-    return api.getDashboard().
+    return api.getDashboard(username).
       then(dashboard => dispatch(receiveDashboardSuccess(dashboard))).
       catch(error => {
         dispatch(receiveDashboardFailure(error));

--- a/static/js/actions/programs.js
+++ b/static/js/actions/programs.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import type { Dispatch } from 'redux';
 import { createAction } from 'redux-actions';
 
@@ -62,7 +63,7 @@ export const addProgramEnrollment = (programId: number): Dispatcher<AvailablePro
           icon: TOAST_SUCCESS
         }));
         dispatch(setEnrollProgramDialogVisibility(false));
-        dispatch(fetchDashboard());
+        dispatch(fetchDashboard(SETTINGS.user.username));
         dispatch(fetchCoursePrices());
       }).
       catch(error => {

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -109,11 +109,9 @@ class DashboardPage extends React.Component {
     dashboard:                DashboardState,
     prices:                   CoursePricesState,
     dispatch:                 Dispatch,
-    setCalculatorVisibility:  (b: boolean) => void,
     ui:                       UIState,
     email:                    AllEmailsState,
     documents:                DocumentsState,
-    fetchDashboard:           () => void,
     orderReceipt:             OrderReceiptState,
     courseEnrollments:        CourseEnrollmentsState,
     financialAid:             FinancialAidState,
@@ -231,7 +229,7 @@ class DashboardPage extends React.Component {
         let deadline = moment(orderReceipt.initialTime).add(2, 'minutes');
         let now = moment();
         if (now.isBefore(deadline)) {
-          dispatch(fetchDashboard(true));
+          dispatch(fetchDashboard(SETTINGS.user.username, true));
         } else {
           dispatch(setToastMessage({
             message: 'Order was not processed',
@@ -254,7 +252,7 @@ class DashboardPage extends React.Component {
   fetchDashboard() {
     const { dashboard, dispatch } = this.props;
     if (dashboard.fetchStatus === undefined) {
-      dispatch(fetchDashboard());
+      dispatch(fetchDashboard(SETTINGS.user.username));
     }
   }
 

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -1,4 +1,4 @@
-/* global document: false, window: false */
+/* global document: false, window: false, SETTINGS: false */
 import '../global_init';
 
 import { assert } from 'chai';
@@ -328,7 +328,7 @@ describe('DashboardPage', () => {
             type: 'fake'
           }));
           clock.tick(3501);
-          assert(fetchDashboardStub.calledWith(true), 'expected fetchDashboard called');
+          assert(fetchDashboardStub.calledWith(SETTINGS.user.username, true), 'expected fetchDashboard called');
         });
       });
 

--- a/static/js/containers/OrderSummaryPage.js
+++ b/static/js/containers/OrderSummaryPage.js
@@ -60,7 +60,7 @@ class OrderSummaryPage extends React.Component {
   fetchDashboard() {
     const { dashboard, dispatch } = this.props;
     if (dashboard.fetchStatus === undefined) {
-      dispatch(fetchDashboard());
+      dispatch(fetchDashboard(SETTINGS.user.username));
     }
   }
   fetchCoursePrices() {

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -157,8 +157,8 @@ export function patchUserProfile(username: string, profile: Profile): Promise<Pr
   });
 }
 
-export function getDashboard(): Promise<Dashboard> {
-  return fetchJSONWithCSRF('/api/v0/dashboard/', {}, true);
+export function getDashboard(username: string): Promise<Dashboard> {
+  return fetchJSONWithCSRF(`/api/v0/dashboard/${username}/`, {}, true);
 }
 
 export function checkout(courseId: string): Promise<CheckoutResponse> {

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -138,8 +138,8 @@ describe('api', function() {
 
     it('gets the dashboard', () => {
       fetchJSONStub.returns(Promise.resolve(DASHBOARD_RESPONSE));
-      return getDashboard().then(dashboard => {
-        assert.ok(fetchJSONStub.calledWith('/api/v0/dashboard/', {}, true));
+      return getDashboard('beep').then(dashboard => {
+        assert.ok(fetchJSONStub.calledWith('/api/v0/dashboard/beep/', {}, true));
         assert.deepEqual(dashboard, DASHBOARD_RESPONSE);
       });
     });
@@ -147,8 +147,8 @@ describe('api', function() {
     it('fails to get the dashboard', () => {
       fetchJSONStub.returns(Promise.reject());
 
-      return assert.isRejected(getDashboard()).then(() => {
-        assert.ok(fetchJSONStub.calledWith('/api/v0/dashboard/', {}, true));
+      return assert.isRejected(getDashboard('user')).then(() => {
+        assert.ok(fetchJSONStub.calledWith('/api/v0/dashboard/user/', {}, true));
       });
     });
 


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #2531

#### What's this PR do?

This does just the backend work to support fetching dashboard information based on a username URL parameter. For now the only change in the frontend it to the `getDashboard` function and adding `SETTINGS.user.username` in when necessary.

#### How should this be manually tested?

Make sure that the dashboard and all the frontend stuff works fine. If it does, I think things should be good.

If you wanted you could do the following (but I think it's not essential):

1. edit `DashboardPage.js` or `App.js`, adding:

```js
import * as api from '../lib/api';

window.api = api
```

then, from the JavaScript console, call:

```js
api.getDashboard('fake_username');
```

this should return a 404. confirm getting your own username returns a 200.

then, find the username of a real learner in your database, and ensure your user does not have a `Staff` or `Instructor` role in a program that learner is enrolled in. then call:

```js
api.getDashboard('real_learner_username');
```

this should return a 404. then add a staff or instructor role to your user for that program, and try again. you should now get a 200 and the user's dashboard data.
