### PR TITLE
Add link to grid for selenium container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       - docker run --name travis-watch-container --env-file .env -e NODE_ENV=production -t travis-watch ./webpack_if_prod.sh
       - docker cp travis-watch-container:/src/webpack-stats.json .
       - docker cp travis-watch-container:/src/static/bundles ./static/bundles
-      script: (docker-compose -f travis-docker-compose.yml up grid &); sleep 5; ./scripts/test/run_selenium_tests.sh
+      script: ./scripts/test/run_selenium_tests.sh
       services:
         - docker
       env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,7 @@ services:
       - db
       - elastic
       - redis
+      - grid
 
   grid:
     image: elgalu/selenium

--- a/travis-docker-compose.yml
+++ b/travis-docker-compose.yml
@@ -70,6 +70,7 @@ services:
       - db
       - elastic
       - redis
+      - grid
 
   grid:
     image: elgalu/selenium


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2646

#### What's this PR do?
Adds a link from the `selenium` container to the `grid` container. This fixes problems with running tests locally.

#### How should this be manually tested?
 - Stop all containers
 - Run `NODE_ENV=prod ./webpack_if_prod.sh` to generate javascript bundles
 - Run `./scripts/tests/run_selenium_tests.sh`
