### PR TITLE
Use docker image on travis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,4 @@
 htmlcov
 .coverage
 node_modules
-static/bundles
 staticfiles/

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       - docker run --name travis-watch-container --env-file .env -e NODE_ENV=production -t travis-watch ./webpack_if_prod.sh
       - docker cp travis-watch-container:/src/webpack-stats.json .
       - docker cp travis-watch-container:/src/static/bundles ./static/bundles
-      script: ./scripts/test/run_selenium_tests.sh
+      script: docker-compose -f travis-docker-compose.yml run -e DEBUG=False -e DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8286 selenium py.test ./selenium_tests
       services:
         - docker
       env:


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2647 

#### What's this PR do?
References `travis-docker-compose.yml` which uses a prebuilt micromasters_python image

#### How should this be manually tested?
No manual testing needed, tests just have to pass
