### PR TITLE
Reduced MAX_AGE for PG connections to 0 (#2219)

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -250,7 +250,7 @@ DEFAULT_DATABASE_CONFIG = dj_database_url.parse(
         'sqlite:///{0}'.format(os.path.join(BASE_DIR, 'db.sqlite3'))
     )
 )
-DEFAULT_DATABASE_CONFIG['CONN_MAX_AGE'] = int(get_var('MICROMASTERS_DB_CONN_MAX_AGE', 500))
+DEFAULT_DATABASE_CONFIG['CONN_MAX_AGE'] = int(get_var('MICROMASTERS_DB_CONN_MAX_AGE', 0))
 
 if get_var('MICROMASTERS_DB_DISABLE_SSL', False):
     DEFAULT_DATABASE_CONFIG['OPTIONS'] = {}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2219 

#### What's this PR do?
Reduces the `CONN_MAX_AGE` for postgres connections to 0 so they are immediately closed and don't pile up.

#### How should this be manually tested?
In master, run:

`docker-compose run db watch 'psql -h db -U postgres -c "SELECT client_host, client_port, state FROM pg_stat_activity"'`

And go to the homepage and refresh repeatedly. You should see a bunch of inactive connections from the web app pile up. 

Switch to this branch, refresh repeatedly and you should see those connections not accumulate anymore.