### PR TITLE
Financial Aid: Allowed course team to reset students financial aid review form

### DIFF
--- a/financialaid/constants.py
+++ b/financialaid/constants.py
@@ -52,7 +52,7 @@ class FinancialAidStatus:
         SKIPPED: "Skipped",
     }
 
-FINANCIAL_AID_RESET_SUBJECT = "Your personalized course price for {program_name} MicroMasters"
+FINANCIAL_AID_RESET_SUBJECT = "Update to your personalized course price for {program_name} MicroMasters"
 FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT = "Documents received for {program_name} MicroMasters"
 FINANCIAL_AID_APPROVAL_SUBJECT = "Your personalized course price for {program_name} MicroMasters"
 

--- a/financialaid/constants.py
+++ b/financialaid/constants.py
@@ -52,6 +52,8 @@ class FinancialAidStatus:
         SKIPPED: "Skipped",
     }
 
+
+FINANCIAL_AID_RESET_SUBJECT = "Financial aid review application is reset for {program_name} MicroMasters"
 FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT = "Documents received for {program_name} MicroMasters"
 FINANCIAL_AID_APPROVAL_SUBJECT = "Your personalized course price for {program_name} MicroMasters"
 
@@ -72,6 +74,10 @@ FINANCIAL_AID_APPROVAL_MESSAGE = (
     "that your personalized course price is ${price}.\n\n"
     "You can pay for MicroMasters courses through the MITx MicroMasters portal "
     "(https://micromasters.mit.edu/dashboard). All coursework will be conducted on edx.org."
+)
+
+FINANCIAL_AID_DOCUMENTS_RESET_MESSAGE = (
+    "Your Financial aid review application is reset."
 )
 
 DEFAULT_INCOME_THRESHOLD = 75000

--- a/financialaid/constants.py
+++ b/financialaid/constants.py
@@ -52,8 +52,7 @@ class FinancialAidStatus:
         SKIPPED: "Skipped",
     }
 
-
-FINANCIAL_AID_RESET_SUBJECT = "Financial aid review application is reset for {program_name} MicroMasters"
+FINANCIAL_AID_RESET_SUBJECT = "Your personalized course price for {program_name} MicroMasters"
 FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT = "Documents received for {program_name} MicroMasters"
 FINANCIAL_AID_APPROVAL_SUBJECT = "Your personalized course price for {program_name} MicroMasters"
 
@@ -77,7 +76,8 @@ FINANCIAL_AID_APPROVAL_MESSAGE = (
 )
 
 FINANCIAL_AID_DOCUMENTS_RESET_MESSAGE = (
-    "Your Financial aid review application is reset."
+    "As requested, we have reset your personalized course price. Please visit "
+    "the MITx MicroMasters dashboard and re-submit your annual income information."
 )
 
 DEFAULT_INCOME_THRESHOLD = 75000

--- a/financialaid/serializers.py
+++ b/financialaid/serializers.py
@@ -151,7 +151,7 @@ class FinancialAidActionSerializer(serializers.Serializer):
             # This is intentionally left blank for clarity that this is a valid status for .save()
             pass
         elif self.instance.status == FinancialAidStatus.RESET:
-            self.instance.justification = "Requested by the learner"
+            self.instance.justification = "Reset via the financial aid review form"
 
         self.instance.save()
 

--- a/financialaid/serializers.py
+++ b/financialaid/serializers.py
@@ -95,7 +95,8 @@ class FinancialAidActionSerializer(serializers.Serializer):
     action = ChoiceField(
         choices=[
             FinancialAidStatus.APPROVED,
-            FinancialAidStatus.PENDING_MANUAL_APPROVAL
+            FinancialAidStatus.PENDING_MANUAL_APPROVAL,
+            FinancialAidStatus.RESET
         ],
         write_only=True
     )
@@ -149,6 +150,9 @@ class FinancialAidActionSerializer(serializers.Serializer):
         elif self.instance.status == FinancialAidStatus.PENDING_MANUAL_APPROVAL:
             # This is intentionally left blank for clarity that this is a valid status for .save()
             pass
+        elif self.instance.status == FinancialAidStatus.RESET:
+            self.instance.justification = "Requested by the learner"
+
         self.instance.save()
 
         # Send email notification

--- a/financialaid/templates/review_financial_aid.html
+++ b/financialaid/templates/review_financial_aid.html
@@ -246,6 +246,12 @@
                   </button>
                 </td>
                 {% endif %}
+                 <td style="white-space: nowrap;">
+                     <button class="btn btn-default" style="color: #0074e1; padding-top: 7px;"
+                          onclick="financialAidReview.actionReset({{ financial_aid.id }}, '{% url 'financial_aid_action' financial_aid_id=financial_aid.id %}', '{{ statuses.RESET }}');">
+                    Reset
+                  </button>
+                 </td>
                 <!-- /Actions -->
               </tr>
               <!-- /Financial aid application information -->

--- a/financialaid/views_test.py
+++ b/financialaid/views_test.py
@@ -654,9 +654,16 @@ class FinancialAidActionTests(FinancialAidBaseTestCase, APIClient):
         assert called_kwargs["body"] == financial_aid_email["body"]
 
     @patch("financialaid.serializers.MailgunClient")
-    def test_reset_financial_aid_review(self, mock_mailgun_client):
+    @ddt.data(
+        *([
+            [status] for status in FinancialAidStatus.ALL_STATUSES
+            if status != FinancialAidStatus.RESET
+        ])
+    )
+    @ddt.unpack
+    def test_reset_financial_aid_review(self, financial_aid_status, mock_mailgun_client):
         """
-        Tests FinancialAidActionView when action is RESET
+        Tests FinancialAidActionView, when submitted action is RESET
         """
         mock_mailgun_client.send_financial_aid_email.return_value = Mock(
             spec=Response,
@@ -664,7 +671,7 @@ class FinancialAidActionTests(FinancialAidBaseTestCase, APIClient):
             json=mocked_json()
         )
         # Set status to docs sent
-        self.financialaid.status = FinancialAidStatus.DOCS_SENT
+        self.financialaid.status = financial_aid_status
         self.financialaid.save()
         # Set action to pending manual approval from pending-docs
         self.make_http_request(

--- a/mail/utils.py
+++ b/mail/utils.py
@@ -15,6 +15,8 @@ from financialaid.constants import (
     FINANCIAL_AID_APPROVAL_MESSAGE,
     FINANCIAL_AID_APPROVAL_SUBJECT,
     FINANCIAL_AID_DOCUMENTS_RECEIVED_MESSAGE,
+    FINANCIAL_AID_DOCUMENTS_RESET_MESSAGE,
+    FINANCIAL_AID_RESET_SUBJECT,
     FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT,
     FINANCIAL_AID_EMAIL_BODY,
     FinancialAidStatus
@@ -46,6 +48,11 @@ def generate_financial_aid_email(financial_aid):
     elif financial_aid.status == FinancialAidStatus.PENDING_MANUAL_APPROVAL:
         message = FINANCIAL_AID_DOCUMENTS_RECEIVED_MESSAGE
         subject = FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT.format(
+            program_name=financial_aid.tier_program.program.title
+        )
+    elif financial_aid.status == FinancialAidStatus.RESET:
+        message = FINANCIAL_AID_DOCUMENTS_RESET_MESSAGE
+        subject = FINANCIAL_AID_RESET_SUBJECT.format(
             program_name=financial_aid.tier_program.program.title
         )
     else:

--- a/mail/utils_test.py
+++ b/mail/utils_test.py
@@ -15,6 +15,8 @@ from financialaid.constants import (
     FINANCIAL_AID_APPROVAL_SUBJECT,
     FINANCIAL_AID_DOCUMENTS_RECEIVED_SUBJECT,
     FINANCIAL_AID_DOCUMENTS_RECEIVED_MESSAGE,
+    FINANCIAL_AID_DOCUMENTS_RESET_MESSAGE,
+    FINANCIAL_AID_RESET_SUBJECT,
     FINANCIAL_AID_EMAIL_BODY,
     FinancialAidStatus
 )
@@ -63,6 +65,18 @@ class MailUtilsTests(MockedESTestCase):
             ),
             program_name=self.financial_aid.tier_program.program.title
         )
+
+    def test_generate_financial_aid_email_reset(self):
+        """
+        Tests generate_financial_aid_email() with status RESET.
+        """
+        self.financial_aid.status = FinancialAidStatus.RESET
+        self.financial_aid.save()
+        email_dict = generate_financial_aid_email(self.financial_aid)
+        assert email_dict["subject"] == FINANCIAL_AID_RESET_SUBJECT.format(
+            program_name=self.financial_aid.tier_program.program.title
+        )
+        assert FINANCIAL_AID_DOCUMENTS_RESET_MESSAGE in email_dict["body"]
 
     def test_generate_financial_aid_email_docs_sent(self):
         """

--- a/static/js/financial_aid/functions.js
+++ b/static/js/financial_aid/functions.js
@@ -56,7 +56,7 @@ window.financialAidReview = (function(window, document, $) {
 
   /**
    * Submits a financial aid application approval
-   * 
+   *
    * @param financialAidId {number} Financial aid application id
    * @param url {string} URL to submit request to
    * @param action {string} FinancialAidStatus to send in request
@@ -87,10 +87,43 @@ window.financialAidReview = (function(window, document, $) {
       });
     }
   }
-  
+
+  /**
+   * Resets a financial aid application
+   *
+   * @param financialAidId {number} Financial aid application id
+   * @param url {string} URL to submit request to
+   * @param action {string} FinancialAidStatus to send in request
+   **/
+  function actionReset(financialAidId, url, action) {
+    var name = $("#full-name-" + financialAidId).text().trim();
+    if (confirm("Click OK to reset " + name + "'s financial aid application. This action can not undone.")) {
+      $.ajax({
+        "url": url,
+        "type": "PATCH",
+        "headers": {
+          "X-CSRFToken": CSRF_TOKEN
+        },
+        "data": {
+          "action": action,
+        },
+        "success": function() {
+          displayMessage("Successfully reset " + name + "'s financial aid application.", "success");
+          $("#application-row-" + financialAidId + ", #application-email-row-" + financialAidId).remove();
+        },
+        "error": function(result) {
+          displayMessage(
+            "Error: " + result.responseText + " on " + name + "'s financial aid application reset.",
+            "danger"
+          );
+        }
+      });
+    }
+  }
+
   /**
    * Submits a financial aid email request
-   * 
+   *
    * @param financialAidId {number} Financial aid application id
    * @param url {string} URL to submit request to
    */
@@ -120,7 +153,7 @@ window.financialAidReview = (function(window, document, $) {
       });
     }
   }
-  
+
   /**
    * Redirects to initiate search
    */
@@ -128,10 +161,10 @@ window.financialAidReview = (function(window, document, $) {
     var searchQuery = $("#search-query").val();
     window.location = BASE_PATH + searchQuery;
   }
-  
+
   /**
    * Toggles currency display
-   * 
+   *
    * @param currency {int} The currency to display
    */
   function toggleCurrency(currency) {
@@ -143,19 +176,19 @@ window.financialAidReview = (function(window, document, $) {
       $(".income-local").show();
     }
   }
-  
+
   /**
    * Toggles email display
-   * 
+   *
    * @param financialAidId {str} FinancialAid.id to toggle
    */
   function toggleEmailDisplay(financialAidId) {
     $("#application-email-row-" + financialAidId).toggle();
   }
-  
+
   /**
    * Displays a dismissible alert message.
-   * 
+   *
    * @param message {string} Message to display
    * @param type {string} Type of Bootstrap alert
    */
@@ -166,8 +199,9 @@ window.financialAidReview = (function(window, document, $) {
     $("#messages").append(template);
     template.slideDown();
   }
-  
+
   return {
+    actionReset: actionReset,
     submitDocsReceived: submitDocsReceived,
     submitApproval: submitApproval,
     sendEmail: sendEmail,
@@ -175,5 +209,5 @@ window.financialAidReview = (function(window, document, $) {
     toggleCurrency: toggleCurrency,
     toggleEmailDisplay: toggleEmailDisplay
   };
-  
+
 })(window, document, jQuery);

--- a/static/js/financial_aid/functions.js
+++ b/static/js/financial_aid/functions.js
@@ -97,7 +97,7 @@ window.financialAidReview = (function(window, document, $) {
    **/
   function actionReset(financialAidId, url, action) {
     var name = $("#full-name-" + financialAidId).text().trim();
-    if (confirm("Click OK to reset " + name + "'s financial aid application. This action can not undone.")) {
+    if (confirm("Click OK to reset " + name + "'s financial aid application. This action cannot be undone.")) {
       $.ajax({
         "url": url,
         "type": "PATCH",


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2117

#### What's this PR do?
- Allow staff to reset financial aid review form from `http://192.168.99.100:8079/financial_aid/review/6/auto-approved`

#### How should this be manually tested?
- Go to `http://192.168.99.100:8079/financial_aid/review/6/auto-approved`
- where 6 is `id` of financial aid program.

@pdpinch 

<img width="1191" alt="screen shot 2017-02-21 at 8 21 22 pm" src="https://cloud.githubusercontent.com/assets/10431250/23171094/5d9950dc-f873-11e6-8e9a-788e17a1563b.png">

<img width="663" alt="screen shot 2017-02-21 at 8 23 10 pm" src="https://cloud.githubusercontent.com/assets/10431250/23171186/9b0cd2ae-f873-11e6-805b-8e5adc7751f2.png">

<img width="843" alt="screen shot 2017-02-21 at 8 23 33 pm" src="https://cloud.githubusercontent.com/assets/10431250/23171201/a83f9e48-f873-11e6-972b-adad4f45cf6c.png">

<img width="1114" alt="screen shot 2017-02-22 at 1 16 11 am" src="https://cloud.githubusercontent.com/assets/10431250/23183067/8a6ae5c0-f89c-11e6-97d5-9647a53557c0.png">


