### PR TITLE
Use testindex when running selenium tests

### DIFF
--- a/scripts/test/run_selenium_tests.sh
+++ b/scripts/test/run_selenium_tests.sh
@@ -8,4 +8,8 @@ then
     echo "webpack-stats.json must exist before running the selenium tests. Run webpack to create it."
     exit 1
 fi
-docker-compose run -e DEBUG=False -e DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8286 selenium py.test ./selenium_tests
+docker-compose run \
+   -e DEBUG=False \
+   -e DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8286 \
+   -e ELASTICSEARCH_INDEX=testindex \
+   selenium py.test ./selenium_tests


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Defines `ELASTICSEARCH_INDEX` when running selenium tests locally, so that running the tests won't clobber your existing index. This change isn't done on `.travis.yml` but it doesn't matter there since there is no other index

#### How should this be manually tested?
Run the selenium tests locally then start the docker container and verify that you can view the `/learners` page without a problem.