### PR TITLE
Pinned pytest-pylint because of weird behavior of 0.7.0

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -12,7 +12,7 @@ pytest
 pytest-cov
 pytest-django
 pytest-pep8
-pytest-pylint
+pytest-pylint==0.6.0
 semantic-version
 selenium
 testfixtures


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Pins `pytest-pylint` to 0.6.0 to avoid the weird behavior of version `0.7.0`

#### How should this be manually tested?
Run the tests locally: if you have version `0.7.0` the linting should happen all ahead of time.
Rebuilding the web container and removing the `.tox` with this PR should bring the behavior as it was last week.
