### PR TITLE
Added search test

### DIFF
--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -1,4 +1,16 @@
 """Basic selenium tests for MicroMasters"""
+from django.conf import settings
+from django.db.models.signals import post_save
+from factory.django import mute_signals
+
+from courses.factories import ProgramFactory
+from dashboard.models import ProgramEnrollment
+from profiles.factories import ProfileFactory
+from roles.models import (
+    Staff,
+    Role,
+)
+from search.indexing_api import index_program_enrolled_users
 from selenium_tests.base import SeleniumTestsBase
 
 
@@ -28,3 +40,53 @@ class BasicTests(SeleniumTestsBase):
             "Something went wrong. You paid for this course but are not enrolled. Contact us for help."
         )
         self.assert_console_logs()
+
+    def test_learners(self):
+        """
+        Look at the learners page
+        """
+        self.login_via_admin(self.user)
+        self.get(self.live_server_url)
+
+        Role.objects.create(
+            user=self.user,
+            program=self.program,
+            role=Staff.ROLE_ID,
+        )
+
+        page_size = settings.ELASTICSEARCH_DEFAULT_PAGE_SIZE
+        with mute_signals(post_save):
+            for _ in range((page_size * 2) - 5):
+                profile = ProfileFactory.create(filled_out=True)
+                ProgramEnrollment.objects.create(program=self.program, user=profile.user)
+
+        other_program = ProgramFactory.create(live=True)
+        ProgramEnrollment.objects.create(
+            user=self.user,
+            program=other_program,
+        )
+
+        # Update for new users and new role
+        index_program_enrolled_users(ProgramEnrollment.objects.iterator())
+        self.get("{}/learners".format(self.live_server_url))
+        assert self.selenium.execute_script("return document.querySelectorAll('.learner-result').length") == page_size
+        self.selenium.find_elements_by_class_name('sk-pagination-option')[1].click()
+        # Verify that second page has 5 less elements
+        self.wait().until(
+            lambda driver: driver.execute_script(
+                "return document.querySelectorAll('.learner-result').length"
+            ) == page_size - 5
+        )
+
+        # Go to profile and back to learners to verify that nothing breaks
+        self.selenium.find_element_by_class_name("user-menu").click()
+        self.wait().until(
+            lambda driver: "open" in driver.find_element_by_class_name("user-menu-dropdown").get_attribute("class")
+        )
+        self.selenium.find_element_by_css_selector(
+            ".user-menu-dropdown a[href='/learner/{}']".format(self.username)
+        ).click()
+        self.wait().until(lambda driver: driver.find_element_by_class_name("user-page"))
+        # Go back to learners
+        self.selenium.find_element_by_css_selector("a[href='/learners']").click()
+        self.wait().until(lambda driver: driver.find_element_by_class_name('learner-result'))

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -56,6 +56,8 @@ class BasicTests(SeleniumTestsBase):
 
         page_size = settings.ELASTICSEARCH_DEFAULT_PAGE_SIZE
         with mute_signals(post_save):
+            # Create enough profiles for two pages, but make the second page slightly smaller than the first
+            # So we can assert that we're on the second page by counting the results
             for _ in range((page_size * 2) - 5):
                 profile = ProfileFactory.create(filled_out=True)
                 ProgramEnrollment.objects.create(program=self.program, user=profile.user)


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #2632 
Fixes #2569

#### What's this PR do?
Adds a selenium test for learner search. This will make it easier to detect problems that show up when something's not quite right with searchkit

#### How should this be manually tested?
The test should pass

#### Any background context you want to provide?
The test runs migrations in `setUp` which is very slow. Each test takes about 35 seconds just to run migrations. At some point we should dump and restore the database, but that's another PR