### PR TITLE
Added redis django cache backend

### DIFF
--- a/grades/management/commands/check_final_grade_freeze_status.py
+++ b/grades/management/commands/check_final_grade_freeze_status.py
@@ -1,13 +1,16 @@
 """
 Checks the freeze status for a final grade
 """
-from django.core.cache import cache
+from django.core.cache import caches
 from django.core.management import BaseCommand, CommandError
 
 from courses.models import CourseRun
 from dashboard.models import CachedEnrollment
 from grades.models import CourseRunGradingStatus, FinalGrade
 from grades.tasks import CACHE_ID_BASE_STR
+
+
+cache_redis = caches['redis']
 
 
 class Command(BaseCommand):
@@ -33,7 +36,7 @@ class Command(BaseCommand):
                 )
             )
         elif CourseRunGradingStatus.is_pending(run):
-            if cache.get(CACHE_ID_BASE_STR.format(course_id)):
+            if cache_redis.get(CACHE_ID_BASE_STR.format(course_id)):
                 self.stdout.write(
                     self.style.WARNING(
                         'Final grades for course "{0}" are being processed'.format(course_id)

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -509,6 +509,23 @@ CELERYBEAT_SCHEDULE = {
 }
 CELERY_TIMEZONE = 'UTC'
 
+
+# django cache back-ends
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'local-in-memory-cache',
+    },
+    'redis': {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": BROKER_URL,
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient"
+        },
+    },
+}
+
+
 # Elasticsearch
 ELASTICSEARCH_DEFAULT_PAGE_SIZE = get_var('ELASTICSEARCH_DEFAULT_PAGE_SIZE', 50)
 ELASTICSEARCH_URL = get_var("ELASTICSEARCH_URL", None)

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ boto==2.39.0
 celery==3.1.23
 dj-database-url==0.3.0
 dj-static==0.0.6
+django-redis==4.7.0
 django-role-permissions==1.2
 django-server-status==0.3.2
 django-storages-redux==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,13 +20,14 @@ dj-database-url==0.3.0
 dj-static==0.0.6
 django-discover-runner==1.0  # via django-role-permissions
 django-modelcluster==2.0  # via wagtail
+django-redis==4.7.0
 django-role-permissions==1.2
 django-server-status==0.3.2
 django-storages-redux==1.3.2
 django-taggit==0.18.3     # via wagtail
 django-treebeard==4.1.0   # via wagtail
 django-webpack-loader==0.4.1
-Django==1.10.3            # via django-role-permissions, django-server-status, django-treebeard, jsonfield, wagtail
+django==1.10.3
 djangorestframework==3.5.2
 edx-api-client==0.3.0
 edx-opaque-keys==0.4
@@ -47,7 +48,7 @@ paramiko==2.1.1           # via pysftp
 pbr==1.10.0               # via stevedore
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
-Pillow==3.4.2             # via wagtail
+pillow==3.4.2
 prompt-toolkit==1.0.13    # via ipython
 psycopg2==2.6
 ptyprocess==0.5.1         # via pexpect
@@ -55,7 +56,7 @@ pyasn1==0.2.2             # via cryptography, paramiko
 pycountry==16.11.27.1
 pycparser==2.17           # via cffi
 pygments==2.2.0           # via ipython
-PyJWT==1.4.2              # via python-social-auth
+pyjwt==1.4.2              # via python-social-auth
 pymongo==3.4.0            # via edx-opaque-keys
 pyparsing==2.1.10         # via packaging
 pysftp==0.2.9
@@ -73,13 +74,13 @@ six==1.10.0               # via cryptography, django-role-permissions, django-se
 static3==0.5.1
 stevedore==1.20.0         # via edx-opaque-keys
 traitlets==4.3.1          # via ipython
-Unidecode==0.4.20         # via wagtail
+unidecode==0.4.20         # via wagtail
 urllib3==1.20             # via elasticsearch
 uwsgi==2.0.14
 wagtail==1.8
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5         # via html5lib
-Willow==0.4               # via wagtail
+willow==0.4               # via wagtail
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools                # via cryptography, html5lib, ipython


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #2659 

#### What's this PR do?
Adds a redis django cache backend to have a persistent cache to be used by the asynchronous tasks. 

#### How should this be manually tested?
The async tasks should just keep working (and there are tests for that).
If you want to test the persistence of the cache:
open the django shell, then:
```
from django.core.cache import caches
cache_redis = caches['redis']
cache_default = caches['default']
cache_redis.set('foo1', 'bar1')
cache_default.set('foo2', 'bar2')
```
if you type 
```
cache_redis.get('foo1')
cache_default.get('foo2')
```
both should give the right result back.
if you exit the django shell and enter again (you re-instanciate the docker instance)
```
cache_redis.get('foo1')
```
should give you the right result while the other should return `None`