### PR TITLE
Moved sorting UI to column headers

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -33,6 +33,7 @@ import HitsCount from './search/HitsCount';
 import CustomNoHits from './search/CustomNoHits';
 import type { Option } from '../flow/generalTypes';
 import type { AvailableProgram } from '../flow/enrollmentTypes';
+import type { SearchSortItem } from '../flow/searchTypes';
 import { EDUCATION_LEVELS } from '../constants';
 
 import PatchedPagination from './search/PatchedPagination';
@@ -74,7 +75,7 @@ const sortSemesterBuckets = R.compose(
     ))
 );
 
-const sortOptions = [
+export const sortOptions: Array<SearchSortItem> = [
   {
     label: "Last Name A-Z", key: "name_a_z", fields: [
       { field: "profile.last_name", options: { order: "asc" } },
@@ -157,7 +158,7 @@ export default class LearnerSearch extends SearchkitComponent {
           </button>
           <HitsStats component={HitsCount} />
         </Cell>
-        <Cell col={8} className="pagination-sort">
+        <Cell col={8} className="pagination-search">
           <SearchBox
             queryBuilder={() => ({})}  // we only care about prefix query
             searchOnChange={true}
@@ -170,12 +171,14 @@ export default class LearnerSearch extends SearchkitComponent {
               analyzer: "folding"
             }}
           />
-          <SortingSelector options={sortOptions} listComponent={CustomSortingSelect} />
           <PatchedPagination showText={false} listComponent={CustomPaginationDisplay} />
         </Cell>
         <Cell col={12} className="mm-filters">
           <SelectedFilters />
           <ResetFilters component={CustomResetFiltersDisplay} />
+        </Cell>
+        <Cell col={12} className="sorting-header">
+          <SortingSelector options={sortOptions} listComponent={CustomSortingSelect} />
         </Cell>
       </Grid>
     );

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -27,7 +27,7 @@ import PatchedMenuFilter from './search/PatchedMenuFilter';
 import WorkHistoryFilter from './search/WorkHistoryFilter';
 import CustomPaginationDisplay from './search/CustomPaginationDisplay';
 import CustomResetFiltersDisplay from './search/CustomResetFiltersDisplay';
-import CustomSortingSelect from './search/CustomSortingSelect';
+import CustomSortingColumnHeaders from './search/CustomSortingColumnHeaders';
 import FilterVisibilityToggle from './search/FilterVisibilityToggle';
 import HitsCount from './search/HitsCount';
 import CustomNoHits from './search/CustomNoHits';
@@ -178,7 +178,7 @@ export default class LearnerSearch extends SearchkitComponent {
           <ResetFilters component={CustomResetFiltersDisplay} />
         </Cell>
         <Cell col={12} className="sorting-header">
-          <SortingSelector options={sortOptions} listComponent={CustomSortingSelect} />
+          <SortingSelector options={sortOptions} listComponent={CustomSortingColumnHeaders} />
         </Cell>
       </Grid>
     );

--- a/static/js/components/search/CustomSortingColumnHeaders.js
+++ b/static/js/components/search/CustomSortingColumnHeaders.js
@@ -4,6 +4,10 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 
 import type { SearchSortItem } from '../../flow/searchTypes';
 
+const nameKeys = ['name_a_z', 'name_z_a'];
+const locationKeys = ['loc-a-z', 'loc-z-a'];
+const gradeKeys = ['grade-high-low', 'grade-low-high'];
+
 export default class CustomSortingColumnHeaders extends React.Component {
   // these props are all passed down by searchkit
   props: {
@@ -57,10 +61,6 @@ export default class CustomSortingColumnHeaders extends React.Component {
   };
 
   render() {
-    const nameKeys = ['name_a_z', 'name_z_a'];
-    const locationKeys = ['loc-a-z', 'loc-z-a'];
-    const gradeKeys = ['grade-high-low', 'grade-low-high'];
-
     return (
       <Grid className="sorting-row">
         <Cell col={1}/>

--- a/static/js/components/search/CustomSortingColumnHeaders.js
+++ b/static/js/components/search/CustomSortingColumnHeaders.js
@@ -4,7 +4,7 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 
 import type { SearchSortItem } from '../../flow/searchTypes';
 
-export default class CustomSortingSelect extends React.Component {
+export default class CustomSortingColumnHeaders extends React.Component {
   props: {
     items: Array<SearchSortItem>,
     setItems: (keys: Array<string>) => void,

--- a/static/js/components/search/CustomSortingColumnHeaders.js
+++ b/static/js/components/search/CustomSortingColumnHeaders.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
+import R from 'ramda';
 
 import type { SearchSortItem } from '../../flow/searchTypes';
 
@@ -27,6 +28,10 @@ export default class CustomSortingColumnHeaders extends React.Component {
       setItems([defaultSort]);
     }
   };
+
+  toggleNameSort = R.partial(this.toggleSort, [nameKeys]);
+  toggleLocationSort = R.partial(this.toggleSort, [locationKeys]);
+  toggleGradeSort = R.partial(this.toggleSort, [gradeKeys]);
 
   sortDirection = (keys: [string, string]) => {
     let selectedItem = this.getSelectedItem(keys);
@@ -64,19 +69,19 @@ export default class CustomSortingColumnHeaders extends React.Component {
     return (
       <Grid className="sorting-row">
         <Cell col={1}/>
-        <Cell col={3} onClick={() => this.toggleSort(nameKeys)} className={`name ${this.selectedClass(nameKeys)}`}>
+        <Cell col={3} onClick={this.toggleNameSort} className={`name ${this.selectedClass(nameKeys)}`}>
           Name {this.sortDirection(nameKeys)}
         </Cell>
         <Cell
           col={4}
-          onClick={() => this.toggleSort(locationKeys)}
+          onClick={this.toggleLocationSort}
           className={`residence ${this.selectedClass(locationKeys)}`}
         >
           Residence {this.sortDirection(locationKeys)}
         </Cell>
         <Cell
           col={3}
-          onClick={() => this.toggleSort(gradeKeys)}
+          onClick={this.toggleGradeSort}
           className={`grade ${this.selectedClass(gradeKeys)}`}
         >
           Program grade {this.sortDirection(gradeKeys)}

--- a/static/js/components/search/CustomSortingColumnHeaders.js
+++ b/static/js/components/search/CustomSortingColumnHeaders.js
@@ -53,8 +53,7 @@ export default class CustomSortingColumnHeaders extends React.Component {
   };
 
   selectedClass = (keys: [string, string]) => {
-    let selectedItem = this.getSelectedItem(keys);
-    return selectedItem ? 'selected' : '';
+    return this.getSelectedItem(keys) ? 'selected' : '';
   };
 
   render() {

--- a/static/js/components/search/CustomSortingColumnHeaders.js
+++ b/static/js/components/search/CustomSortingColumnHeaders.js
@@ -5,9 +5,13 @@ import Grid, { Cell } from 'react-mdl/lib/Grid';
 import type { SearchSortItem } from '../../flow/searchTypes';
 
 export default class CustomSortingColumnHeaders extends React.Component {
+  // these props are all passed down by searchkit
   props: {
+    // A list of available options for sorting
     items: Array<SearchSortItem>,
+    // A function to set the new sorting keys
     setItems: (keys: Array<string>) => void,
+    // The currently selected set of sorting keys, if any are selected
     selectedItems: ?Array<string>,
   };
 

--- a/static/js/components/search/CustomSortingColumnHeaders_test.js
+++ b/static/js/components/search/CustomSortingColumnHeaders_test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import { assert } from 'chai';
 import sinon from 'sinon';
 
-import CustomSortingSelect from './CustomSortingSelect';
+import CustomSortingColumnHeaders from './CustomSortingColumnHeaders';
 import { sortOptions } from '../../components/LearnerSearch';
 
 describe('CustomSortingSelect', () => {
@@ -20,7 +20,7 @@ describe('CustomSortingSelect', () => {
 
   const renderSelect = (props = {}) => {
     return shallow(
-      <CustomSortingSelect
+      <CustomSortingColumnHeaders
         items={sortOptions}
         setItems={setItemsStub}
         selectedItems={null}

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -6,3 +6,18 @@ export type SearchResult = {
   profile: Profile,
   program: UserProgram
 };
+
+export type SearchSortItem = {
+  key: string,
+  label: string,
+  fields?: Array<SearchSortItemField>,
+  field?: string,
+  order?: string,
+};
+
+export type SearchSortItemField = {
+  field: string,
+  options: {
+    order: string,
+  },
+};

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -202,7 +202,7 @@
       align-items: center;
     }
 
-    .pagination-sort {
+    .pagination-search {
       justify-content: flex-end;
 
       .sk-pagination-navigation {
@@ -314,6 +314,31 @@
         padding-right: 5px;
       }
     }
+
+    .sorting-header {
+      margin: 0;
+
+      .sorting-row {
+        width: 100%;
+        padding: 20px 0;
+        text-transform: uppercase;
+        font-size: 12px;
+        color: $font-gray;
+
+        .selected {
+          color: black;
+        }
+
+        >div {
+          cursor: pointer;
+          user-select: none;
+        }
+
+        .grade {
+          text-align: center;
+        }
+      }
+    }
   }
 
   .learner-results {
@@ -378,37 +403,6 @@
     .learner-result:hover {
       background: $bg-light-gray;
     }
-  }
-}
-
-.sk-select {
-  display: flex;
-  flex-flow: row;
-  border-radius: 3px;
-  border: 1px solid #e4e4e4;
-  height: 30px !important;
-  max-height: 35px;
-  background: white;
-  min-width: 206px;
-
-  > select {
-    border: 0;
-    padding: 5px 26px 5px 0;
-  }
-
-  .label-before-selected {
-    margin-right: 5px;
-    padding: 5px 0 5px 8px;
-    font-size: 14px;
-    font-weight: normal;
-    color: rgba(0,0,0,0.8);
-  }
-
-  select, option {
-    font-size: 14px;
-    font-weight: normal;
-    color: rgba(0,0,0,0.8);
-    line-height: 1.4em;
   }
 }
 

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -329,7 +329,7 @@
           color: black;
         }
 
-        >div {
+        .mdl-cell {
           cursor: pointer;
           user-select: none;
         }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2632

#### What's this PR do?
Removes the sort select box and adds column headers to do the sorting instead

#### How should this be manually tested?
Go to the learner page and click the column headers. It should sort the results. You should also be able to refresh the browser and preserve the existing sort

#### Screenshots (if appropriate)
![screenshot from 2017-02-22 09-37-39](https://cloud.githubusercontent.com/assets/863262/23216049/96bf33ee-f8e2-11e6-837d-2dca4054cb4f.png)

