### PR TITLE
Fixed coupons to check enrollments instead of certs (#2561)

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -172,6 +172,18 @@ class MMTrack:
             return course_id in self.paid_course_ids
 
         # normal programs need to have a verified enrollment
+        return self.has_verified_enrollment(course_id)
+
+    def has_verified_enrollment(self, course_id):
+        """
+        Returns true if user has a verified enrollment
+
+        Args:
+            course_id (str): an edX course run id
+
+        Returns:
+            bool: whether the user has a verified enrollment
+        """
         enrollment = self.enrollments.get_enrollment_for_course(course_id)
         return bool(enrollment and enrollment.is_verified)
 

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -393,7 +393,7 @@ def is_coupon_redeemable(coupon, user):
         )
 
         # For this coupon type the user must have already purchased a course run on edX
-        return any((mmtrack.has_passing_certificate(run.edx_course_key) for run in course.courserun_set.all()))
+        return any((mmtrack.has_verified_enrollment(run.edx_course_key) for run in course.courserun_set.all()))
 
     return True
 

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -23,8 +23,8 @@ from edx_api.enrollments import Enrollment
 
 from backends.pipeline_api import EdxOrgOAuth2
 from courses.factories import CourseRunFactory, ProgramFactory
+from dashboard.factories import CachedEnrollmentFactory
 from dashboard.models import (
-    CachedCertificate,
     CachedEnrollment,
     ProgramEnrollment,
 )
@@ -638,19 +638,7 @@ class CouponTests(MockedESTestCase):
             coupon_type=Coupon.DISCOUNTED_PREVIOUS_COURSE,
             content_object=self.run1.course,
         )
-        cert_json = {
-            "username": "staff",
-            "course_id": self.run1.edx_course_key,
-            "certificate_type": "verified",
-            "status": "downloadable",
-            "download_url": "http://www.example.com/demo.pdf",
-            "grade": "0.98"
-        }
-        CachedCertificate.objects.create(
-            user=self.user,
-            course_run=self.run1,
-            data=cert_json,
-        )
+        CachedEnrollmentFactory.create(user=self.user, course_run=self.run1)
         assert is_coupon_redeemable(coupon, self.user) is True
 
     def test_prev_course_user_not_verified(self):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2561 

#### What's this PR do?
Changes the check for redeemable coupons to check enrollments instead of certificates.

#### How should this be manually tested?

With a user that has no certificates (ideally a new user to ensure a clean slate):
- Create a `Coupon` with type of `discounted-previous-course` for a course in a non-FA program
- Enroll that course (or create and enrollment for a previous course run)
- Edit your `CachedEnrollment` so you appear to have paid in edX by setting `data['mode'] = 'verified'`
- You should see a message on the course row indicating you have the discount.
- You should also now see the coupon if you go to http://localhost:8079/api/v0/coupons/
