### PR TITLE
move dashboard actions and reducer into separate files

### DIFF
--- a/static/js/actions/course_enrollments.js
+++ b/static/js/actions/course_enrollments.js
@@ -3,10 +3,8 @@
 import type { Dispatch } from 'redux';
 import { createAction } from 'redux-actions';
 
-import {
-  fetchCoursePrices,
-  fetchDashboard,
-} from './';
+import { fetchDashboard } from './dashboard';
+import { fetchCoursePrices } from './';
 import type { Dispatcher } from '../flow/reduxTypes';
 import * as api from '../lib/api';
 

--- a/static/js/actions/dashboard.js
+++ b/static/js/actions/dashboard.js
@@ -1,0 +1,41 @@
+// @flow
+import { createAction } from 'redux-actions';
+import type { Dispatch } from 'redux';
+
+import * as api from '../lib/api';
+import type { Dispatcher } from '../flow/reduxTypes';
+import type { Dashboard } from '../flow/dashboardTypes';
+import type { APIErrorInfo } from '../flow/generalTypes';
+
+export const UPDATE_COURSE_STATUS = 'UPDATE_COURSE_STATUS';
+export const updateCourseStatus = createAction(UPDATE_COURSE_STATUS, (courseId, status) => ({
+  courseId, status
+}));
+
+// dashboard list actions
+export const REQUEST_DASHBOARD = 'REQUEST_DASHBOARD';
+export const requestDashboard = createAction(REQUEST_DASHBOARD, (noSpinner: boolean) => ({ noSpinner }));
+
+export const RECEIVE_DASHBOARD_SUCCESS = 'RECEIVE_DASHBOARD_SUCCESS';
+export const receiveDashboardSuccess = createAction(RECEIVE_DASHBOARD_SUCCESS, (programs: Object[]) => ({ programs }));
+
+export const RECEIVE_DASHBOARD_FAILURE = 'RECEIVE_DASHBOARD_FAILURE';
+export const receiveDashboardFailure = createAction(
+  RECEIVE_DASHBOARD_FAILURE,
+  (errorInfo: APIErrorInfo) => ({ errorInfo })
+);
+
+export const CLEAR_DASHBOARD = 'CLEAR_DASHBOARD';
+export const clearDashboard = createAction(CLEAR_DASHBOARD);
+
+export function fetchDashboard(username: string, noSpinner: boolean = false): Dispatcher<Dashboard> {
+  return (dispatch: Dispatch) => {
+    dispatch(requestDashboard(noSpinner));
+    return api.getDashboard(username).
+      then(dashboard => dispatch(receiveDashboardSuccess(dashboard))).
+      catch(error => {
+        dispatch(receiveDashboardFailure(error));
+        // the exception is assumed handled and will not be propagated
+      });
+  };
+}

--- a/static/js/actions/dashboard_test.js
+++ b/static/js/actions/dashboard_test.js
@@ -1,0 +1,63 @@
+// @flow
+import { assert } from 'chai';
+
+import {
+  requestDashboard,
+  receiveDashboardSuccess,
+  receiveDashboardFailure,
+  clearDashboard,
+  updateCourseStatus,
+
+  REQUEST_DASHBOARD,
+  RECEIVE_DASHBOARD_SUCCESS,
+  RECEIVE_DASHBOARD_FAILURE,
+  CLEAR_DASHBOARD,
+  UPDATE_COURSE_STATUS,
+} from './dashboard';
+import {
+  DASHBOARD_RESPONSE,
+  ERROR_RESPONSE,
+} from '../constants';
+
+describe('dashboard actions', () => {
+  it('requestDashboard should pass noSpinner in the payload', () => {
+    assert.deepEqual(requestDashboard(true), {
+      type: REQUEST_DASHBOARD,
+      payload: {
+        noSpinner: true
+      }
+    });
+  });
+
+  it('receiveDashboardSuccess should pass a list of programs', () => {
+    assert.deepEqual(receiveDashboardSuccess(DASHBOARD_RESPONSE), {
+      type: RECEIVE_DASHBOARD_SUCCESS,
+      payload: {
+        programs: DASHBOARD_RESPONSE
+      }
+    });
+  });
+
+  it('receiveDashboardFailure should pass an error response', () => {
+    assert.deepEqual(receiveDashboardFailure(ERROR_RESPONSE), {
+      type: RECEIVE_DASHBOARD_FAILURE,
+      payload: {
+        errorInfo: ERROR_RESPONSE
+      }
+    });
+  });
+
+  it('clearDashboard should only have its type', () => {
+    assert.deepEqual(clearDashboard(), { type: CLEAR_DASHBOARD });
+  });
+
+  it('updateCourseStatus has courseId and status in its payload', () => {
+    assert.deepEqual(updateCourseStatus('course_id', 'status'), {
+      type: UPDATE_COURSE_STATUS,
+      payload: {
+        courseId: 'course_id',
+        status: 'status'
+      }
+    });
+  });
+});

--- a/static/js/actions/documents.js
+++ b/static/js/actions/documents.js
@@ -3,10 +3,8 @@
 import { createAction } from 'redux-actions';
 import type { Dispatch } from 'redux';
 
-import {
-  fetchDashboard,
-  fetchCoursePrices,
-} from './';
+import { fetchDashboard } from './dashboard';
+import { fetchCoursePrices } from './';
 import * as api from '../lib/api';
 import type { Dispatcher } from '../flow/reduxTypes';
 

--- a/static/js/actions/financial_aid.js
+++ b/static/js/actions/financial_aid.js
@@ -5,10 +5,8 @@ import { createAction } from 'redux-actions';
 
 import type { Dispatcher } from '../flow/reduxTypes';
 import * as api from '../lib/api';
-import {
-  fetchCoursePrices,
-  fetchDashboard,
-} from '.';
+import { fetchDashboard } from './dashboard';
+import { fetchCoursePrices } from './';
 
 export const START_CALCULATOR_EDIT = 'START_CALCULATOR_EDIT';
 export const startCalculatorEdit = createAction(START_CALCULATOR_EDIT);

--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -7,51 +7,13 @@ import * as api from '../lib/api';
 import type { CheckoutResponse } from '../flow/checkoutTypes';
 import type { APIErrorInfo } from '../flow/generalTypes';
 import type { Action, Dispatcher } from '../flow/reduxTypes';
-import type { Dashboard, CoursePrices } from '../flow/dashboardTypes';
+import type { CoursePrices } from '../flow/dashboardTypes';
 
 // constants for fetch status (these are not action types)
 export const FETCH_FAILURE = 'FETCH_FAILURE';
 export const FETCH_SUCCESS = 'FETCH_SUCCESS';
 export const FETCH_PROCESSING = 'FETCH_PROCESSING';
 
-// dashboard list actions
-export const REQUEST_DASHBOARD = 'REQUEST_DASHBOARD';
-export const requestDashboard = (noSpinner: boolean) => ({
-  type: REQUEST_DASHBOARD,
-  payload: { noSpinner }
-});
-
-export const RECEIVE_DASHBOARD_SUCCESS = 'RECEIVE_DASHBOARD_SUCCESS';
-export const receiveDashboardSuccess = (programs: Object[]): Action => ({
-  type: RECEIVE_DASHBOARD_SUCCESS,
-  payload: { programs }
-});
-
-export const RECEIVE_DASHBOARD_FAILURE = 'RECEIVE_DASHBOARD_FAILURE';
-export const receiveDashboardFailure = (errorInfo: APIErrorInfo): Action => ({
-  type: RECEIVE_DASHBOARD_FAILURE,
-  payload: { errorInfo }
-});
-
-export const CLEAR_DASHBOARD = 'CLEAR_DASHBOARD';
-export const clearDashboard = () => ({ type: CLEAR_DASHBOARD });
-
-export function fetchDashboard(username: string, noSpinner: boolean = false): Dispatcher<Dashboard> {
-  return (dispatch: Dispatch) => {
-    dispatch(requestDashboard(noSpinner));
-    return api.getDashboard(username).
-      then(dashboard => dispatch(receiveDashboardSuccess(dashboard))).
-      catch(error => {
-        dispatch(receiveDashboardFailure(error));
-        // the exception is assumed handled and will not be propagated
-      });
-  };
-}
-
-export const UPDATE_COURSE_STATUS = 'UPDATE_COURSE_STATUS';
-export const updateCourseStatus = createAction(UPDATE_COURSE_STATUS, (courseId, status) => ({
-  courseId, status
-}));
 
 export const REQUEST_CHECKOUT = 'REQUEST_CHECKOUT';
 export const requestCheckout = (courseId: string) => ({

--- a/static/js/actions/index_test.js
+++ b/static/js/actions/index_test.js
@@ -2,11 +2,6 @@
 import { assert } from 'chai';
 
 import {
-  requestDashboard,
-  receiveDashboardSuccess,
-  receiveDashboardFailure,
-  clearDashboard,
-  updateCourseStatus,
   requestCheckout,
   receiveCheckoutSuccess,
   receiveCheckoutFailure,
@@ -15,11 +10,6 @@ import {
   receiveCoursePricesFailure,
   clearCoursePrices,
 
-  REQUEST_DASHBOARD,
-  RECEIVE_DASHBOARD_SUCCESS,
-  RECEIVE_DASHBOARD_FAILURE,
-  CLEAR_DASHBOARD,
-  UPDATE_COURSE_STATUS,
   REQUEST_CHECKOUT,
   RECEIVE_CHECKOUT_SUCCESS,
   RECEIVE_CHECKOUT_FAILURE,
@@ -29,10 +19,7 @@ import {
   CLEAR_COURSE_PRICES,
 } from './';
 import { assertCreatedActionHelper } from './util';
-import {
-  DASHBOARD_RESPONSE,
-  ERROR_RESPONSE,
-} from '../constants';
+import { ERROR_RESPONSE } from '../constants';
 
 describe('generated index action helpers', () => {
   it('should create all action creators', () => {
@@ -42,47 +29,6 @@ describe('generated index action helpers', () => {
       [receiveCoursePricesFailure, RECEIVE_COURSE_PRICES_FAILURE],
       [clearCoursePrices, CLEAR_COURSE_PRICES],
     ].forEach(assertCreatedActionHelper);
-  });
-
-  it('requestDashboard should pass noSpinner in the payload', () => {
-    assert.deepEqual(requestDashboard(true), {
-      type: REQUEST_DASHBOARD,
-      payload: {
-        noSpinner: true
-      }
-    });
-  });
-
-  it('receiveDashboardSuccess should pass a list of programs', () => {
-    assert.deepEqual(receiveDashboardSuccess(DASHBOARD_RESPONSE), {
-      type: RECEIVE_DASHBOARD_SUCCESS,
-      payload: {
-        programs: DASHBOARD_RESPONSE
-      }
-    });
-  });
-
-  it('receiveDashboardFailure should pass an error response', () => {
-    assert.deepEqual(receiveDashboardFailure(ERROR_RESPONSE), {
-      type: RECEIVE_DASHBOARD_FAILURE,
-      payload: {
-        errorInfo: ERROR_RESPONSE
-      }
-    });
-  });
-
-  it('clearDashboard should only have its type', () => {
-    assert.deepEqual(clearDashboard(), { type: CLEAR_DASHBOARD });
-  });
-
-  it('updateCourseStatus has courseId and status in its payload', () => {
-    assert.deepEqual(updateCourseStatus('course_id', 'status'), {
-      type: UPDATE_COURSE_STATUS,
-      payload: {
-        courseId: 'course_id',
-        status: 'status'
-      }
-    });
   });
 
   it('requestCheckout passes a course id', () => {

--- a/static/js/actions/programs.js
+++ b/static/js/actions/programs.js
@@ -7,10 +7,8 @@ import {
   TOAST_SUCCESS,
   TOAST_FAILURE,
 } from '../constants';
-import {
-  fetchCoursePrices,
-  fetchDashboard,
-} from './';
+import { fetchDashboard } from './dashboard';
+import { fetchCoursePrices } from './';
 import { setToastMessage, setEnrollProgramDialogVisibility } from '../actions/ui';
 import type { Dispatcher } from '../flow/reduxTypes';
 import type {

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -1,3 +1,4 @@
+// @flow
 /* global document: false, window: false, SETTINGS: false */
 import '../global_init';
 
@@ -9,6 +10,8 @@ import Navbar from '../components/Navbar';
 import {
   REQUEST_DASHBOARD,
   RECEIVE_DASHBOARD_SUCCESS,
+} from '../actions/dashboard';
+import {
   REQUEST_COURSE_PRICES,
   RECEIVE_COURSE_PRICES_SUCCESS,
 } from '../actions';

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -14,12 +14,14 @@ import { calculatePrices } from '../lib/coupon';
 import {
   FETCH_SUCCESS,
   FETCH_PROCESSING,
-  updateCourseStatus,
-  fetchDashboard,
-  clearDashboard,
   fetchCoursePrices,
   clearCoursePrices,
 } from '../actions';
+import {
+  updateCourseStatus,
+  fetchDashboard,
+  clearDashboard,
+} from '../actions/dashboard';
 import {
   COUPON_CONTENT_TYPE_COURSE,
   COUPON_CONTENT_TYPE_PROGRAM,

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -19,11 +19,13 @@ import IntegrationTestHelper from '../util/integration_test_helper';
 import {
   REQUEST_DASHBOARD,
   UPDATE_COURSE_STATUS,
-  CLEAR_COURSE_PRICES,
   CLEAR_DASHBOARD,
+} from '../actions/dashboard';
+import {
+  CLEAR_COURSE_PRICES,
   FETCH_SUCCESS,
 } from '../actions';
-import * as actions from '../actions';
+import * as dashboardActions from '../actions/dashboard';
 import { CLEAR_COUPONS } from '../actions/coupons';
 import {
   SHOW_DIALOG,
@@ -324,7 +326,7 @@ describe('DashboardPage', () => {
           `/dashboard?status=receipt&course_key=${encodedKey}`,
           SUCCESS_WITH_TIMEOUT_ACTIONS
         ).then(() => {
-          let fetchDashboardStub = helper.sandbox.stub(actions, 'fetchDashboard').returns(() => ({
+          let fetchDashboardStub = helper.sandbox.stub(dashboardActions, 'fetchDashboard').returns(() => ({
             type: 'fake'
           }));
           clock.tick(3501);

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -39,6 +39,8 @@ import {
 import {
   REQUEST_DASHBOARD,
   RECEIVE_DASHBOARD_SUCCESS,
+} from '../actions/dashboard';
+import {
   REQUEST_COURSE_PRICES,
   RECEIVE_COURSE_PRICES_SUCCESS,
 } from '../actions/index';

--- a/static/js/containers/OrderSummaryPage.js
+++ b/static/js/containers/OrderSummaryPage.js
@@ -11,12 +11,14 @@ import type { AvailableProgram } from '../flow/enrollmentTypes';
 import OrderSummary from '../components/OrderSummary';
 import {
   FETCH_PROCESSING,
-  fetchDashboard,
   fetchCoursePrices,
-  clearDashboard,
-  clearCoursePrices,
   checkout,
+  clearCoursePrices,
 } from '../actions';
+import {
+  clearDashboard,
+  fetchDashboard,
+} from '../actions/dashboard';
 import {
   clearCoupons,
   fetchCoupons,

--- a/static/js/containers/OrderSummaryPage_test.js
+++ b/static/js/containers/OrderSummaryPage_test.js
@@ -3,12 +3,8 @@ import '../global_init';
 import { assert } from 'chai';
 
 import IntegrationTestHelper from '../util/integration_test_helper';
-import {
-  REQUEST_DASHBOARD,
-} from '../actions';
-import {
-  STATUS_OFFERED,
-} from '../constants';
+import { REQUEST_DASHBOARD } from '../actions/dashboard';
+import { STATUS_OFFERED } from '../constants';
 import * as actions from '../actions';
 
 import * as util from '../util/util';
@@ -18,9 +14,7 @@ import {
 } from '../test_constants';
 
 import { DASHBOARD_SUCCESS_ACTIONS } from './test_util';
-import {
-  findCourse,
-} from '../util/test_utils';
+import { findCourse } from '../util/test_utils';
 
 describe('OrderSummaryPage', () => {
   let renderComponent, helper,run, url;

--- a/static/js/containers/test_util.js
+++ b/static/js/containers/test_util.js
@@ -2,6 +2,8 @@ import {
   REQUEST_DASHBOARD,
   RECEIVE_DASHBOARD_SUCCESS,
   RECEIVE_DASHBOARD_FAILURE,
+} from '../actions/dashboard';
+import {
   REQUEST_COURSE_PRICES,
   RECEIVE_COURSE_PRICES_SUCCESS,
 } from '../actions';

--- a/static/js/reducers/course_enrollments.js
+++ b/static/js/reducers/course_enrollments.js
@@ -10,9 +10,7 @@ import {
   FETCH_PROCESSING
 } from '../actions';
 import type { Action } from '../flow/reduxTypes';
-import type {
-  CourseEnrollmentsState,
-} from '../flow/enrollmentTypes';
+import type { CourseEnrollmentsState } from '../flow/enrollmentTypes';
 
 export const INITIAL_ENROLLMENTS_STATE: CourseEnrollmentsState = {};
 

--- a/static/js/reducers/course_enrollments_test.js
+++ b/static/js/reducers/course_enrollments_test.js
@@ -15,6 +15,7 @@ import {
 } from '../actions/course_enrollments';
 import * as api from '../lib/api';
 import * as actions from '../actions';
+import * as dashboardActions from '../actions/dashboard';
 import rootReducer from '../reducers';
 
 describe('enrollments', () => {
@@ -37,7 +38,7 @@ describe('enrollments', () => {
 
       fetchCoursePricesStub = sandbox.stub(actions, 'fetchCoursePrices');
       fetchCoursePricesStub.returns({type: "fake"});
-      fetchDashboardStub = sandbox.stub(actions, 'fetchDashboard');
+      fetchDashboardStub = sandbox.stub(dashboardActions, 'fetchDashboard');
       fetchDashboardStub.returns({type: "fake"});
     });
 

--- a/static/js/reducers/dashboard.js
+++ b/static/js/reducers/dashboard.js
@@ -1,0 +1,70 @@
+// @flow
+import _ from 'lodash';
+
+import {
+  REQUEST_DASHBOARD,
+  RECEIVE_DASHBOARD_SUCCESS,
+  RECEIVE_DASHBOARD_FAILURE,
+  CLEAR_DASHBOARD,
+  UPDATE_COURSE_STATUS,
+} from '../actions/dashboard';
+import {
+  FETCH_FAILURE,
+  FETCH_PROCESSING,
+  FETCH_SUCCESS,
+} from '../actions';
+import type { DashboardState } from '../flow/dashboardTypes';
+import type { Action } from '../flow/reduxTypes';
+
+const INITIAL_DASHBOARD_STATE: DashboardState = {
+  programs: []
+};
+
+export const dashboard = (state: DashboardState = INITIAL_DASHBOARD_STATE, action: Action) => {
+  switch (action.type) {
+  case REQUEST_DASHBOARD:
+    if (action.payload.noSpinner) {
+      return state;
+    } else {
+      return {
+        ...state,
+        fetchStatus: FETCH_PROCESSING
+      };
+    }
+  case RECEIVE_DASHBOARD_SUCCESS:
+    return {
+      ...state,
+      fetchStatus: FETCH_SUCCESS,
+      programs: action.payload.programs
+    };
+  case RECEIVE_DASHBOARD_FAILURE:
+    return {
+      ...state,
+      fetchStatus: FETCH_FAILURE,
+      errorInfo: action.payload.errorInfo,
+    };
+  case UPDATE_COURSE_STATUS: {
+    const { courseId, status } = action.payload;
+    let programs = _.cloneDeep(state.programs);
+    for (let program of programs) {
+      for (let course of program.courses) {
+        for (let courseRun of course.runs) {
+          if (courseRun.course_id === courseId) {
+            courseRun.status = status;
+          }
+        }
+      }
+    }
+    return {
+      ...state,
+      programs,
+    };
+  }
+  case CLEAR_DASHBOARD:
+    return INITIAL_DASHBOARD_STATE;
+  default:
+    return state;
+  }
+};
+
+

--- a/static/js/reducers/documents_test.js
+++ b/static/js/reducers/documents_test.js
@@ -18,6 +18,7 @@ import {
   updateDocumentSentDate,
 } from '../actions/documents';
 import * as actions from '../actions';
+import * as dashboardActions from '../actions/dashboard';
 import type { DocumentsState } from '../reducers/documents';
 import rootReducer from '../reducers';
 import * as api from '../lib/api';
@@ -52,7 +53,7 @@ describe('documents reducers', () => {
       updateDocumentSentDateStub = sandbox.stub(api, 'updateDocumentSentDate');
       fetchCoursePricesStub = sandbox.stub(actions, 'fetchCoursePrices');
       fetchCoursePricesStub.returns({type: "fake"});
-      fetchDashboardStub = sandbox.stub(actions, 'fetchDashboard');
+      fetchDashboardStub = sandbox.stub(dashboardActions, 'fetchDashboard');
       fetchDashboardStub.returns({type: "fake"});
     });
 

--- a/static/js/reducers/financial_aid_test.js
+++ b/static/js/reducers/financial_aid_test.js
@@ -29,6 +29,7 @@ import {
   FETCH_SUCCESS,
 } from '../actions';
 import * as actions from '../actions';
+import * as dashboardActions from '../actions/dashboard';
 import { setCurrentProgramEnrollment } from '../actions/programs';
 import { FINANCIAL_AID_EDIT } from './financial_aid';
 import rootReducer from '../reducers';
@@ -46,7 +47,7 @@ describe('financial aid reducers', () => {
     store.dispatch(setCurrentProgramEnrollment(1));
     addFinancialAidStub = sandbox.stub(api, 'addFinancialAid');
     skipFinancialAidStub = sandbox.stub(api, 'skipFinancialAid');
-    fetchDashboardStub = sandbox.stub(actions, 'fetchDashboard');
+    fetchDashboardStub = sandbox.stub(dashboardActions, 'fetchDashboard');
     fetchDashboardStub.returns({type: "fake"});
     fetchCoursePricesStub = sandbox.stub(actions, 'fetchCoursePrices');
     fetchCoursePricesStub.returns({type: "fake"});

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -19,11 +19,6 @@ import {
   UPDATE_VALIDATION_VISIBILITY,
 } from '../actions/profile';
 import {
-  REQUEST_DASHBOARD,
-  RECEIVE_DASHBOARD_SUCCESS,
-  RECEIVE_DASHBOARD_FAILURE,
-  CLEAR_DASHBOARD,
-
   REQUEST_CHECKOUT,
   RECEIVE_CHECKOUT_SUCCESS,
   RECEIVE_CHECKOUT_FAILURE,
@@ -32,7 +27,6 @@ import {
   RECEIVE_COURSE_PRICES_SUCCESS,
   RECEIVE_COURSE_PRICES_FAILURE,
   CLEAR_COURSE_PRICES,
-  UPDATE_COURSE_STATUS,
 
   FETCH_FAILURE,
   FETCH_PROCESSING,
@@ -45,7 +39,7 @@ import {
   programs,
 } from './programs';
 import { courseEnrollments } from './course_enrollments';
-import type { DashboardState, CoursePricesState } from '../flow/dashboardTypes';
+import type { CoursePricesState } from '../flow/dashboardTypes';
 import type { Action } from '../flow/reduxTypes';
 import type {
   ProfileGetResult,
@@ -58,6 +52,7 @@ import { documents } from './documents';
 import { orderReceipt } from './order_receipt';
 import { coupons } from './coupons';
 import { pearson } from './pearson';
+import { dashboard } from './dashboard';
 import { ALL_ERRORS_VISIBLE } from '../constants';
 
 export const INITIAL_PROFILES_STATE = {};
@@ -179,57 +174,6 @@ export const profiles = (state: Profiles = INITIAL_PROFILES_STATE, action: Actio
         }
       });
     }
-  default:
-    return state;
-  }
-};
-
-const INITIAL_DASHBOARD_STATE: DashboardState = {
-  programs: []
-};
-
-export const dashboard = (state: DashboardState = INITIAL_DASHBOARD_STATE, action: Action) => {
-  switch (action.type) {
-  case REQUEST_DASHBOARD:
-    if (action.payload.noSpinner) {
-      return state;
-    } else {
-      return {
-        ...state,
-        fetchStatus: FETCH_PROCESSING
-      };
-    }
-  case RECEIVE_DASHBOARD_SUCCESS:
-    return {
-      ...state,
-      fetchStatus: FETCH_SUCCESS,
-      programs: action.payload.programs
-    };
-  case RECEIVE_DASHBOARD_FAILURE:
-    return {
-      ...state,
-      fetchStatus: FETCH_FAILURE,
-      errorInfo: action.payload.errorInfo,
-    };
-  case UPDATE_COURSE_STATUS: {
-    const { courseId, status } = action.payload;
-    let programs = _.cloneDeep(state.programs);
-    for (let program of programs) {
-      for (let course of program.courses) {
-        for (let courseRun of course.runs) {
-          if (courseRun.course_id === courseId) {
-            courseRun.status = status;
-          }
-        }
-      }
-    }
-    return {
-      ...state,
-      programs,
-    };
-  }
-  case CLEAR_DASHBOARD:
-    return INITIAL_DASHBOARD_STATE;
   default:
     return state;
   }

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -34,7 +34,10 @@ import {
   RECEIVE_DASHBOARD_FAILURE,
   CLEAR_DASHBOARD,
   receiveDashboardSuccess,
-
+  updateCourseStatus,
+  UPDATE_COURSE_STATUS,
+} from '../actions/dashboard';
+import {
   checkout,
   REQUEST_CHECKOUT,
   RECEIVE_CHECKOUT_SUCCESS,
@@ -47,8 +50,6 @@ import {
   RECEIVE_COURSE_PRICES_FAILURE,
   CLEAR_COURSE_PRICES,
 
-  updateCourseStatus,
-  UPDATE_COURSE_STATUS,
 
   FETCH_FAILURE,
   FETCH_SUCCESS

--- a/static/js/reducers/programs_test.js
+++ b/static/js/reducers/programs_test.js
@@ -30,6 +30,7 @@ import {
 } from '../actions/programs';
 import * as api from '../lib/api';
 import * as actions from '../actions';
+import * as dashboardActions from '../actions/dashboard';
 import rootReducer from '../reducers';
 
 describe('enrollments', () => {
@@ -58,7 +59,7 @@ describe('enrollments', () => {
 
       fetchCoursePricesStub = sandbox.stub(actions, 'fetchCoursePrices');
       fetchCoursePricesStub.returns({type: "fake"});
-      fetchDashboardStub = sandbox.stub(actions, 'fetchDashboard');
+      fetchDashboardStub = sandbox.stub(dashboardActions, 'fetchDashboard');
       fetchDashboardStub.returns({type: "fake"});
     });
 


### PR DESCRIPTION
#### What are the relevant tickets?

this is a refactor, doing it as the first part of #2672 

#### What's this PR do?

this moves the dashboard-related actions and the dashboard reducer into separate files.

#### How should this be manually tested?

Just make sure that tests are passing and that the `/dashboard` loads up ok.

