### PR TITLE
Style changes to the Learner Search page

### DIFF
--- a/static/images/search-icon.svg
+++ b/static/images/search-icon.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 20.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#CC223F;}
+</style>
+<path id="magnifier-2-icon" class="st0" d="M460.4,421.6L353.8,315.1c20-27.6,31.9-61.4,31.9-98c0-92.1-74.9-167-167-167
+	c-92.1,0-167,74.9-167,167c0,92.1,74.9,167,167,167c34.9,0,67.4-10.8,94.2-29.2L419.9,462L460.4,421.6z M100.6,217
+	c0-65.1,53-118.1,118.1-118.1c65.1,0,118.1,53,118.1,118.1c0,65.1-53,118.1-118.1,118.1C153.6,335.1,100.6,282.1,100.6,217z"/>
+</svg>

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -147,8 +147,8 @@ export default class LearnerSearch extends SearchkitComponent {
     }
 
     return (
-      <Grid className="search-header">
-        <Cell col={7} className="result-info">
+      <Grid noSpacing={true} className="search-header">
+        <Cell col={6} className="result-info">
           <button
             id="email-selected"
             className="mdl-button minor-action"
@@ -158,7 +158,7 @@ export default class LearnerSearch extends SearchkitComponent {
           </button>
           <HitsStats component={HitsCount} />
         </Cell>
-        <Cell col={5} className="pagination-search">
+        <Cell col={6} className="pagination-search">
           <SearchBox
             queryBuilder={() => ({})}  // we only care about prefix query
             searchOnChange={true}

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -148,7 +148,7 @@ export default class LearnerSearch extends SearchkitComponent {
 
     return (
       <Grid className="search-header">
-        <Cell col={4} className="result-info">
+        <Cell col={7} className="result-info">
           <button
             id="email-selected"
             className="mdl-button minor-action"
@@ -158,7 +158,7 @@ export default class LearnerSearch extends SearchkitComponent {
           </button>
           <HitsStats component={HitsCount} />
         </Cell>
-        <Cell col={8} className="pagination-search">
+        <Cell col={5} className="pagination-search">
           <SearchBox
             queryBuilder={() => ({})}  // we only care about prefix query
             searchOnChange={true}

--- a/static/js/components/search/CustomSortingColumnHeaders.js
+++ b/static/js/components/search/CustomSortingColumnHeaders.js
@@ -69,11 +69,11 @@ export default class CustomSortingColumnHeaders extends React.Component {
     return (
       <Grid className="sorting-row">
         <Cell col={1}/>
-        <Cell col={3} onClick={this.toggleNameSort} className={`name ${this.selectedClass(nameKeys)}`}>
+        <Cell col={5} onClick={this.toggleNameSort} className={`name ${this.selectedClass(nameKeys)}`}>
           Name {this.sortDirection(nameKeys)}
         </Cell>
         <Cell
-          col={4}
+          col={3}
           onClick={this.toggleLocationSort}
           className={`residence ${this.selectedClass(locationKeys)}`}
         >
@@ -86,7 +86,6 @@ export default class CustomSortingColumnHeaders extends React.Component {
         >
           Program grade {this.sortDirection(gradeKeys)}
         </Cell>
-        <Cell col={1}/>
       </Grid>
     );
   }

--- a/static/js/components/search/LearnerResult.js
+++ b/static/js/components/search/LearnerResult.js
@@ -41,7 +41,7 @@ class LearnerResult extends SearchkitComponent {
           <ProfileImage profile={profile} useSmall={true} />
         </Cell>
         <Cell
-          col={3}
+          col={5}
           className="learner-name centered"
           onMouseLeave={() => setLearnerChipVisibility(null)}
           onMouseEnter={() => setLearnerChipVisibility(profile.username)}
@@ -51,7 +51,7 @@ class LearnerResult extends SearchkitComponent {
           </span>
           {profile.username === learnerChipVisibility ? <LearnerChip profile={profile} /> : null}
         </Cell>
-        <Cell col={4} className="centered learner-location">
+        <Cell col={3} className="centered learner-location">
           <span>
             { getLocation(profile, false) }
           </span>
@@ -60,9 +60,7 @@ class LearnerResult extends SearchkitComponent {
           <span className="percent">
             { LearnerResult.hasGrade(program) ? `${program.grade_average}%` : '-' }
           </span>
-          <span className="hint">Program Avg. Grade</span>
         </Cell>
-        <Cell col={1} />
       </Grid>
     );
   }

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -107,11 +107,15 @@
   }
 
   &.minor-action {
-    font-size: 12px;
-    color: #333333;
-    border: 1px solid #d2d2d2;
-    background: linear-gradient(to bottom, #ffffff, #e2e2e2);
+    font-size: 13px;
+    color: #4a4a4a;
+    border: 1px solid #d4d4d4;
+    background: linear-gradient(to bottom, #f7f7f7, #f1f1f1);
     box-shadow: none;
+    padding: 0 12px;
+    height: 33px;
+    line-height: 32px;
+    text-transform: none;
   }
 
   &.minor-action:hover, &.minor-action:focus, &.minor-action:active, &.minor-action:focus:not(:active) {

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -3,7 +3,7 @@
 //font colors
 $font-black: rgba(0,0,0,.87);
 $font-gray: #6f6f6f;
-$font-gray-light: #9c9c9c;
+$font-gray-light: #a0a0a0;
 $font-gray-disabled: rgba(0,0,0,.2);
 $link-text: #0074e1;
 $link-hover: #0074e1;

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -12,7 +12,7 @@ $sidenav-font: #b3b3b3;
 // MIT brand colors palette
 $mm-brand-bg: #a31f34;
 $mm-brand-bg-dark: #90192c;
-$mm-brand-bg-light: #cf3650;
+$mm-brand-bg-light: #f9315b;
 $brand-font: #a31f34;
 $brand-overlay: rgba(0, 0, 0, 0.23);
 $page-background: #e8e8e8;

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -45,6 +45,12 @@
       top: 10px !important;
     }
 
+    .Select-placeholder {
+      top: 1px;
+      padding-left: 10px;
+      font-size: 15px;
+    }
+
     .mdl-card {
       padding: 10px;
       background-color: #ffffff;
@@ -63,7 +69,9 @@
     .sk-hierarchical-menu-list__header,
     .sk-hierarchical-refinement-list__header {
       margin: 15px 5px 10px 0;
-      font-size: 15px;
+      font-size: 14px;
+      font-weight: 500;
+      color: $font-black;
     }
 
     // Search facet content blocks
@@ -183,7 +191,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin: 10px 0 15px 8px !important;
+    margin: 10px 0 0 8px !important;
 
     &:empty {
       display: none;
@@ -191,8 +199,7 @@
   }
 
   .search-header {
-    min-height: 100px;
-    padding: 30px 0 0 5px;
+    padding: 22px 0 0 5px;
     border-bottom: 1px solid $border-color;
     margin: 0;
 
@@ -248,8 +255,8 @@
 
     .sk-search-box form {
       border: 1px solid $border-color;
-      border-radius: 5px;
-      margin-right: 10px;
+      border-radius: 3px;
+      margin-right: 4px;
     }
 
     .sk-selected-filters {
@@ -260,6 +267,7 @@
       background-color: $bg-light-gray;
       padding: 6px 10px;
       font-size: 13px;
+      margin-bottom: 0;
 
       .sk-selected-filters-option__remove-action {
         border-left: none;
@@ -277,8 +285,6 @@
       font-size: 14px;
       font-weight: 300;
       padding: 4px;
-      position: relative;
-      bottom: 5px;
     }
 
     .mdl-cell {
@@ -294,7 +300,7 @@
 
     .result-info > span {
       white-space: nowrap;
-      font-size: 15px;
+      font-size: 13px;
       font-weight: 300;
       padding-left: 15px;
       color: $font-gray;
@@ -320,13 +326,14 @@
 
       .sorting-row {
         width: 100%;
-        padding: 20px 0;
+        padding: 30px 0 9px;
         text-transform: uppercase;
         font-size: 12px;
-        color: $font-gray;
+        color: $font-gray-light;
 
         .selected {
-          color: black;
+          color: $font-black;
+          font-weight: 400;
         }
 
         .mdl-cell {
@@ -363,8 +370,8 @@
       }
 
       .learner-name {
-        font-weight: 500;
-        font-size: 15px;
+        font-weight: 400;
+        font-size: 14px;
       }
 
       .learner-location {
@@ -396,7 +403,7 @@
       }
 
       .mdl-cell .card-image {
-        height: 43px;
+        height: 37px;
       }
     }
 

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -5,14 +5,6 @@
   margin: 0 auto;
   max-width: 1400px;
 
-  .mdl-grid {
-    padding: 0;
-
-    .mdl-cell {
-      margin: 0 8px;
-    }
-  }
-
   .centered {
     display: flex;
     flex-direction: row;
@@ -199,9 +191,9 @@
   }
 
   .search-header {
-    padding: 22px 0 0 5px;
+    padding-top: 22px;
+    padding-bottom: 5px;
     border-bottom: 1px solid $border-color;
-    margin: 0;
 
     > * {
       display: flex;

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -194,6 +194,7 @@
     padding-top: 22px;
     padding-bottom: 5px;
     border-bottom: 1px solid $border-color;
+    width: 100%;
 
     > * {
       display: flex;

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -248,6 +248,7 @@
         .sk-pagination-option * {
           font-size: 21px;
           font-weight: 400;
+
           padding: 0 0 !important;
         }
       }
@@ -257,6 +258,14 @@
       border: 1px solid $border-color;
       border-radius: 3px;
       margin-right: 4px;
+
+      .sk-search-box__icon {
+        opacity: 1;
+      }
+
+      .sk-search-box__icon:before {
+        background: url(/static/images/search-icon.svg) no-repeat top left;
+      }
     }
 
     .sk-selected-filters {


### PR DESCRIPTION
#### What are the relevant tickets?
#2682 

#### What's this PR do?
This fixes a small layout problem on the Learner search page, and makes several small style changes.

#### How should this be manually tested?
Make sure the page looks ok, nothing is broken, css looks correct.

#### Where should the reviewer start?
Here are the changes:
- vertically center the Company facet selector text
- lighten font weight for user name
- fix spacing around column headers
- make search box and text smaller
- make user avatars smaller
- tighten row spacing
- remove the "Program Avg grade" copy in table cells.
- changed the column widths
- changed the font of the facet headers

#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/20047260/23313303/2a200df8-fa8b-11e6-82a2-5cecc5ef73de.png)

