### PR TITLE
Fixed search filtering involving query parameters

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -83,10 +83,11 @@ def create_search_obj(user, search_param_dict=None, filter_on_email_optin=False)
     """
     search_obj = Search(index=settings.ELASTICSEARCH_INDEX, doc_type=DOC_TYPES)
     # Update from search params first so our server-side filtering will overwrite it if necessary
-    search_obj.update_from_dict(search_param_dict)
-    # Early versions of searchkit use filter which isn't in the DSL but it acts equivalently to post_filter
-    if 'filter' in search_param_dict:
-        search_obj = search_obj.post_filter(search_param_dict['filter'])
+    if search_param_dict is not None:
+        search_obj.update_from_dict(search_param_dict)
+        # Early versions of searchkit use filter which isn't in the DSL but it acts equivalently to post_filter
+        if 'filter' in search_param_dict:
+            search_obj = search_obj.post_filter(search_param_dict['filter'])
 
     # Limit results to one of the programs the user is staff on
     search_obj = search_obj.filter(create_program_limit_query(

--- a/search/api.py
+++ b/search/api.py
@@ -99,7 +99,10 @@ def create_search_obj(user, search_param_dict=None, filter_on_email_optin=False)
         Q('term', **{'profile.filled_out': True})
     )
     # Force size to be the one we set on the server
-    search_obj.update_from_dict({'size': settings.ELASTICSEARCH_DEFAULT_PAGE_SIZE})
+    update_dict = {'size': settings.ELASTICSEARCH_DEFAULT_PAGE_SIZE}
+    if search_param_dict is not None and search_param_dict.get('from') is not None:
+        update_dict['from'] = search_param_dict['from']
+    search_obj.update_from_dict(update_dict)
     return search_obj
 
 

--- a/search/api.py
+++ b/search/api.py
@@ -32,6 +32,13 @@ def execute_search(search_obj):
 def create_program_limit_query(user, filter_on_email_optin=False):
     """
     Constructs and returns a query that limits a user to data for their allowed programs
+
+    Args:
+        user (django.contrib.auth.models.User): A user
+        filter_on_email_optin (bool): If true, filter out profiles where email_optin != true
+
+    Returns:
+        elasticsearch_dsl.query.Q: An elasticsearch query
     """
     users_allowed_programs = get_advance_searchable_programs(user)
     # if the user cannot search any program, raise an exception.
@@ -69,29 +76,29 @@ def create_search_obj(user, search_param_dict=None, filter_on_email_optin=False)
     Args:
         user (User): User object
         search_param_dict (dict): A dict representing the body of an ES query
+        filter_on_email_optin (bool): If true, filter out profiles where email_optin != True
 
     Returns:
         Search: elasticsearch_dsl Search object
     """
     search_obj = Search(index=settings.ELASTICSEARCH_INDEX, doc_type=DOC_TYPES)
-    # the following filter should come first because the sequence matters in applying them
+    # Update from search params first so our server-side filtering will overwrite it if necessary
+    search_obj.update_from_dict(search_param_dict)
+    # Early versions of searchkit use filter which isn't in the DSL but it acts equivalently to post_filter
+    if 'filter' in search_param_dict:
+        search_obj = search_obj.post_filter(search_param_dict['filter'])
+
+    # Limit results to one of the programs the user is staff on
     search_obj = search_obj.filter(create_program_limit_query(
         user,
         filter_on_email_optin=filter_on_email_optin
     ))
     # Filter so that only filled_out profiles are seen
-    search_obj = search_obj.filter(Q(
-        'bool',
-        must=[
-            Q('term', **{'profile.filled_out': True})
-        ]
-    ))
-    if search_param_dict is not None:
-        search_param_dict['size'] = settings.ELASTICSEARCH_DEFAULT_PAGE_SIZE
-    else:
-        search_param_dict = {'size': settings.ELASTICSEARCH_DEFAULT_PAGE_SIZE}
-
-    search_obj.update_from_dict(search_param_dict)
+    search_obj = search_obj.filter(
+        Q('term', **{'profile.filled_out': True})
+    )
+    # Force size to be the one we set on the server
+    search_obj.update_from_dict({'size': settings.ELASTICSEARCH_DEFAULT_PAGE_SIZE})
     return search_obj
 
 

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -106,12 +106,7 @@ class SearchAPITests(ESTestCase):  # pylint: disable=missing-docstring
                 Q('term', **{'program.is_learner': True})
             ]
         )
-        expected_filled_out_query = Q(
-            'bool',
-            must=[
-                Q('term', **{'profile.filled_out': True})
-            ]
-        )
+        expected_filled_out_query = Q('term', **{'profile.filled_out': True})
         assert 'query' in search_query_dict
         assert 'bool' in search_query_dict['query']
         assert 'filter' in search_query_dict['query']['bool']

--- a/search/views_test.py
+++ b/search/views_test.py
@@ -224,6 +224,29 @@ class SearchTests(ESTestCase, APITestCase):
         user_ids_in_hits = self.get_user_ids_in_hits(resp.data['hits']['hits'])
         assert len(user_ids_in_hits) == 0
 
+    def test_from(self):
+        """
+        Test that we don't filter out the from part of the query
+        """
+        data = {
+            "filter": {
+                "term": {
+                    "program.id": self.program1.id
+                }
+            },
+            "from": 0,
+            "size": 50,
+        }
+        resp = self.assert_status_code(json=data)
+        user_ids_in_hits = self.get_user_ids_in_hits(resp.data['hits']['hits'])
+        assert len(user_ids_in_hits) == 10
+
+        # Look at second page. There should be zero hits here
+        data['from'] = 50
+        resp = self.assert_status_code(json=data)
+        user_ids_in_hits = self.get_user_ids_in_hits(resp.data['hits']['hits'])
+        assert len(user_ids_in_hits) == 0
+
     @override_settings(ELASTICSEARCH_DEFAULT_PAGE_SIZE=1000)
     def test_filled_out(self):
         """

--- a/search/views_test.py
+++ b/search/views_test.py
@@ -15,6 +15,7 @@ from dashboard.factories import ProgramEnrollmentFactory
 from dashboard.models import ProgramEnrollment
 from micromasters.factories import UserFactory
 from profiles.factories import ProfileFactory
+from profiles.models import Profile
 from roles.models import Role
 from roles.roles import (
     Instructor,
@@ -173,28 +174,55 @@ class SearchTests(ESTestCase, APITestCase):
 
         filter_params = {
             "filter": {
-                "bool": {
-                    "should": [
-                        {"term": {"program.id": wanted_program_id}}
-                    ]
-                }
+                "term": {"program.id": wanted_program_id}
             }
         }
-        query_params = {
-            "query": {
-                "bool": {
-                    "should": [
-                        {"term": {"program.id": wanted_program_id}}
-                    ]
-                }
+        post_filter_params = {
+            "post_filter": {
+                "term": {"program.id": wanted_program_id}
             }
         }
-        for params in [filter_params, query_params]:
+        for params in [filter_params, post_filter_params]:
             # verify that only the wanted program is in the hits
             resp = self.assert_status_code(json=params)
             program_ids_in_hits = self.get_program_ids_in_hits(resp.data['hits']['hits'])
             assert len(program_ids_in_hits) == 1
             assert program_ids_in_hits[0] == wanted_program_id
+
+    def test_query_filters(self):
+        """
+        Test that if the user sends a query, it doesn't negatively affect other filters we add.
+        """
+        # Change every users names so the prefix match will hit every result
+        for profile in Profile.objects.all():
+            profile.first_name = "laura"
+            profile.last_name = "laurasia"
+            profile.preferred_name = "lexovisaurus"
+            profile.save()
+
+        data = {
+            "filter": {
+                "term": {
+                    "program.id": self.program2.id
+                }
+            },
+            "query": {
+                "multi_match": {
+                    "analyzer": "folding",
+                    "fields": [
+                        "profile.first_name.folded",
+                        "profile.last_name.folded",
+                        "profile.preferred_name.folded"
+                    ],
+                    "query": "l",
+                    "type": "phrase_prefix"
+                }
+            }
+        }
+        resp = self.assert_status_code(json=data)
+        # User does not have a role in program2 and therefore should not see any results
+        user_ids_in_hits = self.get_user_ids_in_hits(resp.data['hits']['hits'])
+        assert len(user_ids_in_hits) == 0
 
     @override_settings(ELASTICSEARCH_DEFAULT_PAGE_SIZE=1000)
     def test_filled_out(self):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2685 

#### What's this PR do?
Fixes filtering of elasticsearch queries to deal with some quirks in searchkit. Basically:
 - The `update_from_dict` is moved to happen first so that server side filtering will overwrite it if necessary
 - The root level filter element should actually be post_filter, so one is copied over the other. They seem to have equivalent functionality AFAIK. Searchkit is not using `post_filter` in `0.10.0` but it will switch in the next release to `post_filter` so the code should handle both cases.

#### How should this be manually tested?
Have two programs with users and only have a staff role in one of them. Log in as the staff user. You should see all users when you view the learners page for the program you are staff for, and no users or facets for the other program.

After this, try typing in a common letter in the text box. It should match some user in the program you are staff on, but it should not match anything on the other program.
