### PR TITLE
refactor dashboard reducer to support multiple dashboards

### DIFF
--- a/static/js/actions/coupons_test.js
+++ b/static/js/actions/coupons_test.js
@@ -17,7 +17,7 @@ import {
   SET_RECENTLY_ATTACHED_COUPON,
   setRecentlyAttachedCoupon,
 } from './coupons';
-import { assertCreatedActionHelper } from './util';
+import { assertCreatedActionHelper } from './test_util';
 
 describe('coupons actions', () => {
   it('should create all action creators', () => {

--- a/static/js/actions/course_enrollments_test.js
+++ b/static/js/actions/course_enrollments_test.js
@@ -8,7 +8,7 @@ import {
   RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
   RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
 } from './course_enrollments';
-import { assertCreatedActionHelper } from './util';
+import { assertCreatedActionHelper } from './test_util';
 
 describe('course enrollment actions', () => {
   it('should create all action creators', () => {

--- a/static/js/actions/dashboard.js
+++ b/static/js/actions/dashboard.js
@@ -1,40 +1,36 @@
 // @flow
-import { createAction } from 'redux-actions';
 import type { Dispatch } from 'redux';
 
 import * as api from '../lib/api';
 import type { Dispatcher } from '../flow/reduxTypes';
 import type { Dashboard } from '../flow/dashboardTypes';
-import type { APIErrorInfo } from '../flow/generalTypes';
+import { withUsername } from './util';
 
 export const UPDATE_COURSE_STATUS = 'UPDATE_COURSE_STATUS';
-export const updateCourseStatus = createAction(UPDATE_COURSE_STATUS, (courseId, status) => ({
+export const updateCourseStatus = withUsername(UPDATE_COURSE_STATUS, (_, courseId, status) => ({
   courseId, status
 }));
 
 // dashboard list actions
 export const REQUEST_DASHBOARD = 'REQUEST_DASHBOARD';
-export const requestDashboard = createAction(REQUEST_DASHBOARD, (noSpinner: boolean) => ({ noSpinner }));
+export const requestDashboard = withUsername(REQUEST_DASHBOARD);
 
 export const RECEIVE_DASHBOARD_SUCCESS = 'RECEIVE_DASHBOARD_SUCCESS';
-export const receiveDashboardSuccess = createAction(RECEIVE_DASHBOARD_SUCCESS, (programs: Object[]) => ({ programs }));
+export const receiveDashboardSuccess = withUsername(RECEIVE_DASHBOARD_SUCCESS);
 
 export const RECEIVE_DASHBOARD_FAILURE = 'RECEIVE_DASHBOARD_FAILURE';
-export const receiveDashboardFailure = createAction(
-  RECEIVE_DASHBOARD_FAILURE,
-  (errorInfo: APIErrorInfo) => ({ errorInfo })
-);
+export const receiveDashboardFailure = withUsername(RECEIVE_DASHBOARD_FAILURE);
 
 export const CLEAR_DASHBOARD = 'CLEAR_DASHBOARD';
-export const clearDashboard = createAction(CLEAR_DASHBOARD);
+export const clearDashboard = withUsername(CLEAR_DASHBOARD);
 
 export function fetchDashboard(username: string, noSpinner: boolean = false): Dispatcher<Dashboard> {
   return (dispatch: Dispatch) => {
-    dispatch(requestDashboard(noSpinner));
+    dispatch(requestDashboard(username, noSpinner));
     return api.getDashboard(username).
-      then(dashboard => dispatch(receiveDashboardSuccess(dashboard))).
+      then(dashboard => dispatch(receiveDashboardSuccess(username, dashboard))).
       catch(error => {
-        dispatch(receiveDashboardFailure(error));
+        dispatch(receiveDashboardFailure(username, error));
         // the exception is assumed handled and will not be propagated
       });
   };

--- a/static/js/actions/dashboard_test.js
+++ b/static/js/actions/dashboard_test.js
@@ -14,45 +14,21 @@ import {
   CLEAR_DASHBOARD,
   UPDATE_COURSE_STATUS,
 } from './dashboard';
-import {
-  DASHBOARD_RESPONSE,
-  ERROR_RESPONSE,
-} from '../constants';
+import { assertWithUsernameActionHelper } from './test_util';
 
 describe('dashboard actions', () => {
-  it('requestDashboard should pass noSpinner in the payload', () => {
-    assert.deepEqual(requestDashboard(true), {
-      type: REQUEST_DASHBOARD,
-      payload: {
-        noSpinner: true
-      }
-    });
-  });
-
-  it('receiveDashboardSuccess should pass a list of programs', () => {
-    assert.deepEqual(receiveDashboardSuccess(DASHBOARD_RESPONSE), {
-      type: RECEIVE_DASHBOARD_SUCCESS,
-      payload: {
-        programs: DASHBOARD_RESPONSE
-      }
-    });
-  });
-
-  it('receiveDashboardFailure should pass an error response', () => {
-    assert.deepEqual(receiveDashboardFailure(ERROR_RESPONSE), {
-      type: RECEIVE_DASHBOARD_FAILURE,
-      payload: {
-        errorInfo: ERROR_RESPONSE
-      }
-    });
-  });
-
-  it('clearDashboard should only have its type', () => {
-    assert.deepEqual(clearDashboard(), { type: CLEAR_DASHBOARD });
+  it('should have properly created withUsername creators', () => {
+    [
+      [requestDashboard, REQUEST_DASHBOARD],
+      [receiveDashboardSuccess, RECEIVE_DASHBOARD_SUCCESS],
+      [receiveDashboardFailure, RECEIVE_DASHBOARD_FAILURE],
+      [clearDashboard, CLEAR_DASHBOARD],
+    ].forEach(assertWithUsernameActionHelper);
   });
 
   it('updateCourseStatus has courseId and status in its payload', () => {
-    assert.deepEqual(updateCourseStatus('course_id', 'status'), {
+    assert.deepEqual(updateCourseStatus('username', 'course_id', 'status'), {
+      meta: 'username',
       type: UPDATE_COURSE_STATUS,
       payload: {
         courseId: 'course_id',

--- a/static/js/actions/documents_test.js
+++ b/static/js/actions/documents_test.js
@@ -9,7 +9,7 @@ import {
   receiveUpdateDocumentSentDateSuccess,
   receiveUpdateDocumentSentDateFailure,
 } from '../actions/documents';
-import { assertCreatedActionHelper } from './util';
+import { assertCreatedActionHelper } from './test_util';
 
 describe('generated document action helpers', () => {
   it('should create all action creators', () => {

--- a/static/js/actions/email_test.js
+++ b/static/js/actions/email_test.js
@@ -10,7 +10,7 @@ import {
   CLEAR_EMAIL_EDIT,
   UPDATE_EMAIL_VALIDATION,
 } from './email';
-import { assertCreatedActionHelper } from './util';
+import { assertCreatedActionHelper } from './test_util';
 
 describe('generated email action helpers', () => {
   it('should create all action creators', () => {

--- a/static/js/actions/financial_aid_test.js
+++ b/static/js/actions/financial_aid_test.js
@@ -21,7 +21,7 @@ import {
   RECEIVE_SKIP_FINANCIAL_AID_SUCCESS,
   receiveSkipFinancialAidSuccess,
 } from './financial_aid';
-import { assertCreatedActionHelper } from './util';
+import { assertCreatedActionHelper } from './test_util';
 
 describe('financial aid actions', () => {
   it('should create all action creators', () => {

--- a/static/js/actions/image_upload_test.js
+++ b/static/js/actions/image_upload_test.js
@@ -21,7 +21,7 @@ import {
   receivePatchUserPhotoSuccess,
   RECEIVE_PATCH_USER_PHOTO_SUCCESS,
 } from './image_upload';
-import { assertCreatedActionHelper } from './util';
+import { assertCreatedActionHelper } from './test_util';
 
 describe('generated image upload action helpers', () => {
   it('should create all action creators', () => {

--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -6,7 +6,7 @@ import { createAction } from 'redux-actions';
 import * as api from '../lib/api';
 import type { CheckoutResponse } from '../flow/checkoutTypes';
 import type { APIErrorInfo } from '../flow/generalTypes';
-import type { Action, Dispatcher } from '../flow/reduxTypes';
+import type { Dispatcher } from '../flow/reduxTypes';
 import type { CoursePrices } from '../flow/dashboardTypes';
 
 // constants for fetch status (these are not action types)
@@ -36,15 +36,15 @@ export function checkout(courseId: string): Dispatcher<CheckoutResponse> {
 }
 
 export const RECEIVE_CHECKOUT_SUCCESS = 'RECEIVE_CHECKOUT_SUCCESS';
-export const receiveCheckoutSuccess = (url: string, payload: Object): Action => ({
-  type: RECEIVE_CHECKOUT_SUCCESS,
-  payload: { url, payload }
-});
+
+export const receiveCheckoutSuccess = createAction(RECEIVE_CHECKOUT_SUCCESS, (url, payload) => ({
+  url, payload
+}));
+
 export const RECEIVE_CHECKOUT_FAILURE = 'RECEIVE_CHECKOUT_FAILURE';
-export const receiveCheckoutFailure = (errorInfo: APIErrorInfo): Action => ({
-  type: RECEIVE_CHECKOUT_FAILURE,
-  payload: { errorInfo }
-});
+export const receiveCheckoutFailure = createAction(RECEIVE_CHECKOUT_FAILURE,
+  (errorInfo: APIErrorInfo) => ({errorInfo })
+);
 
 // course price actions
 export const REQUEST_COURSE_PRICES = 'REQUEST_COURSE_PRICES';

--- a/static/js/actions/index_test.js
+++ b/static/js/actions/index_test.js
@@ -18,7 +18,7 @@ import {
   RECEIVE_COURSE_PRICES_FAILURE,
   CLEAR_COURSE_PRICES,
 } from './';
-import { assertCreatedActionHelper } from './util';
+import { assertCreatedActionHelper } from './test_util';
 import { ERROR_RESPONSE } from '../constants';
 
 describe('generated index action helpers', () => {

--- a/static/js/actions/order_receipt_test.js
+++ b/static/js/actions/order_receipt_test.js
@@ -6,7 +6,7 @@ import {
   SET_TIMEOUT_ACTIVE,
   SET_INITIAL_TIME,
 } from './order_receipt';
-import { assertCreatedActionHelper } from './util';
+import { assertCreatedActionHelper } from './test_util';
 
 describe('generated order receipt action helpers', () => {
   it('should create all action creators', () => {

--- a/static/js/actions/pearson_test.js
+++ b/static/js/actions/pearson_test.js
@@ -1,5 +1,5 @@
 // @flow
-import { assertCreatedActionHelper } from './util';
+import { assertCreatedActionHelper } from './test_util';
 import {
   REQUEST_GET_PEARSON_SSO_DIGEST,
   requestGetPearsonSSODigest,

--- a/static/js/actions/programs_test.js
+++ b/static/js/actions/programs_test.js
@@ -18,7 +18,7 @@ import {
   CLEAR_ENROLLMENTS,
   SET_CURRENT_PROGRAM_ENROLLMENT,
 } from './programs';
-import { assertCreatedActionHelper } from './util';
+import { assertCreatedActionHelper } from './test_util';
 
 describe('program enrollment actions', () => {
   it('should create all action creators', () => {

--- a/static/js/actions/signup_dialog_test.js
+++ b/static/js/actions/signup_dialog_test.js
@@ -4,7 +4,7 @@ import {
 
   SET_DIALOG_VISIBILITY,
 } from './signup_dialog';
-import { assertCreatedActionHelper } from './util';
+import { assertCreatedActionHelper } from './test_util';
 
 describe('generated signup dialog action helpers', () => {
   it('should create all action creators', () => {

--- a/static/js/actions/test_util.js
+++ b/static/js/actions/test_util.js
@@ -1,0 +1,28 @@
+// @flow
+import { assert } from 'chai';
+
+const payloads = [
+  null,
+  'foo',
+  12,
+  ['a', 'b', 'c'],
+  { foo: 'bar', baz: [1,2,3] }
+];
+
+type ActionHelperManifest = [Function, string];
+export const assertCreatedActionHelper = ([actionHelper, actionType]: ActionHelperManifest) => {
+  assert.deepEqual(actionHelper(), {type: actionType});
+  payloads.forEach(payload => {
+    assert.deepEqual(actionHelper(payload), { type: actionType, payload: payload});
+  });
+};
+
+export const assertWithUsernameActionHelper = ([actionHelper, actionType]: ActionHelperManifest) => {
+  payloads.forEach(payload => {
+    assert.deepEqual(actionHelper('username', payload), {
+      type: actionType,
+      meta: 'username',
+      payload: payload
+    });
+  });
+};

--- a/static/js/actions/ui_test.js
+++ b/static/js/actions/ui_test.js
@@ -65,7 +65,7 @@ import {
   setNavDrawerOpen,
   setLearnerChipVisibility,
 } from '../actions/ui';
-import { assertCreatedActionHelper } from './util';
+import { assertCreatedActionHelper } from './test_util';
 
 describe('generated UI action helpers', () => {
   it('should create all action creators', () => {

--- a/static/js/actions/util.js
+++ b/static/js/actions/util.js
@@ -1,8 +1,17 @@
 // @flow
-import { assert } from 'chai';
+import { createAction } from 'redux-actions';
+import R from 'ramda';
 
-type ActionHelperManifest = [Function, string];
-export const assertCreatedActionHelper = ([actionHelper, actionType]: ActionHelperManifest) => {
-  assert.deepEqual(actionHelper(), {type: actionType});
-  assert.deepEqual(actionHelper({foo: "bar"}), { type: actionType, payload: { foo: "bar" } });
-};
+import type { ActionType } from '../flow/reduxTypes';
+
+// returns an action creator that takes (username, payload) as it's arguments
+// the 'meta' field on the returned action holds the username
+// 
+// type alias Type :: String
+// type alias Username :: String
+// type class Payload a
+// type UsernameAction a = { type :: Type, meta :: Username, payload :: Payload a }
+// withUsername :: Payload a => Type -> (Username -> a -> UsernameAction a)
+export const withUsername = (type: ActionType, payloadFunc: Function = R.nthArg(1)) => (
+  createAction(type, payloadFunc, R.identity)
+);

--- a/static/js/actions/util_test.js
+++ b/static/js/actions/util_test.js
@@ -1,0 +1,24 @@
+// @flow
+import { assert } from 'chai';
+
+import { withUsername } from './util';
+
+describe('action creator utils', () => {
+  describe('withUsername', () => {
+    let TYPE = 'TYPE';
+    it('should return an action creator, given a type', () => {
+      let creator = withUsername(TYPE);
+      assert.isFunction(creator);
+    });
+
+    it('should add a username and a payload', () => {
+      let creator = withUsername(TYPE);
+      let action = creator('username', { my: 'payload' });
+      assert.deepEqual(action, {
+        type: TYPE,
+        payload: { my: 'payload' },
+        meta: 'username'
+      });
+    });
+  });
+});

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -95,6 +95,7 @@ import {
 } from '../actions/pearson';
 import { generateSSOForm } from '../lib/pearson';
 import type { PearsonAPIState } from '../reducers/pearson';
+import { getOwnDashboard } from '../reducers/util';
 
 const isProcessing = R.equals(FETCH_PROCESSING);
 
@@ -137,7 +138,7 @@ class DashboardPage extends React.Component {
 
   componentWillUnmount() {
     const { dispatch } = this.props;
-    dispatch(clearDashboard());
+    dispatch(clearDashboard(SETTINGS.user.username));
     dispatch(clearCoursePrices());
     dispatch(clearCoupons());
   }
@@ -222,7 +223,7 @@ class DashboardPage extends React.Component {
 
   handleOrderPending = (run: CourseRun): void => {
     const { dispatch } = this.props;
-    dispatch(updateCourseStatus(run.course_id, STATUS_PENDING_ENROLLMENT));
+    dispatch(updateCourseStatus(SETTINGS.user.username, run.course_id, STATUS_PENDING_ENROLLMENT));
 
     if (!this.props.orderReceipt.timeoutActive) {
       setTimeout(() => {
@@ -653,7 +654,7 @@ const mapStateToProps = (state) => {
 
   return {
     profile: profile,
-    dashboard: state.dashboard,
+    dashboard: getOwnDashboard(state),
     prices: state.prices,
     programs: state.programs,
     currentProgramEnrollment: state.currentProgramEnrollment,

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -99,7 +99,11 @@ describe('DashboardPage', () => {
   it('shows a spinner when dashboard get is processing', () => {
     return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([, div]) => {
       assert.notOk(div.querySelector(".loader"), "Found spinner but no fetch in progress");
-      helper.store.dispatch({ type: REQUEST_DASHBOARD, payload: { noSpinner: false } });
+      helper.store.dispatch({
+        type: REQUEST_DASHBOARD,
+        payload: { noSpinner: false },
+        meta: SETTINGS.user.username
+      });
 
       assert(div.querySelector(".loader"), "Unable to find spinner");
     });
@@ -210,7 +214,7 @@ describe('DashboardPage', () => {
         SUCCESS_WITH_TIMEOUT_ACTIONS
       ).then(() => {
         let [ courseRun ] = findCourseRun(
-          helper.store.getState().dashboard.programs,
+          helper.store.getState().dashboard[SETTINGS.user.username].programs,
           _run => _run.course_id === run.course_id
         );
         assert.equal(run.course_id, courseRun.course_id);

--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -32,6 +32,7 @@ import type {
 import type { Program } from '../flow/programTypes';
 import { formatPrice } from '../util/util';
 import { dialogActions } from '../components/inputs/util';
+import { getOwnDashboard } from '../reducers/util';
 
 const updateCurrency = R.curry((update, financialAid, selection) => {
   let _financialAid = R.clone(financialAid);
@@ -304,8 +305,8 @@ const mapStateToProps = state => {
     ui: { calculatorDialogVisibility, confirmIncomeDialogVisibility },
     financialAid,
     currentProgramEnrollment,
-    dashboard: { programs },
   } = state;
+  const { programs } = getOwnDashboard(state);
 
   return {
     calculatorDialogVisibility,

--- a/static/js/containers/OrderSummaryPage.js
+++ b/static/js/containers/OrderSummaryPage.js
@@ -27,6 +27,7 @@ import type { CouponsState } from '../reducers/coupons';
 import type { CheckoutState } from '../reducers';
 import { createForm, findCourseRun } from '../util/util';
 import { calculatePrice } from '../lib/coupon';
+import { getOwnDashboard } from '../reducers/util';
 
 class OrderSummaryPage extends React.Component {
   static contextTypes = {
@@ -153,7 +154,7 @@ const mapStateToProps = (state) => {
   }
   return {
     profile: profile,
-    dashboard: state.dashboard,
+    dashboard: getOwnDashboard(state),
     currentProgramEnrollment: state.currentProgramEnrollment,
     prices: state.prices,
     orderReceipt: state.orderReceipt,

--- a/static/js/containers/OrderSummaryPage_test.js
+++ b/static/js/containers/OrderSummaryPage_test.js
@@ -1,3 +1,4 @@
+/* global SETTINGS: false */
 import '../global_init';
 
 import { assert } from 'chai';
@@ -6,13 +7,11 @@ import IntegrationTestHelper from '../util/integration_test_helper';
 import { REQUEST_DASHBOARD } from '../actions/dashboard';
 import { STATUS_OFFERED } from '../constants';
 import * as actions from '../actions';
-
 import * as util from '../util/util';
 import {
   CYBERSOURCE_CHECKOUT_RESPONSE,
   EDX_CHECKOUT_RESPONSE,
 } from '../test_constants';
-
 import { DASHBOARD_SUCCESS_ACTIONS } from './test_util';
 import { findCourse } from '../util/test_utils';
 
@@ -39,7 +38,7 @@ describe('OrderSummaryPage', () => {
     return renderComponent(url, DASHBOARD_SUCCESS_ACTIONS).then(([, div]) => {
 
       assert.notOk(div.querySelector(".loader"), "Found spinner but no fetch in progress");
-      helper.store.dispatch({type: REQUEST_DASHBOARD, payload: {noSpinner: false}});
+      helper.store.dispatch({type: REQUEST_DASHBOARD, payload: false, meta: SETTINGS.user.username});
 
       assert(div.querySelector(".loader"), "Unable to find spinner");
     });

--- a/static/js/containers/test_util.js
+++ b/static/js/containers/test_util.js
@@ -1,3 +1,4 @@
+// @flow
 import {
   REQUEST_DASHBOARD,
   RECEIVE_DASHBOARD_SUCCESS,
@@ -19,8 +20,9 @@ import {
   REQUEST_GET_USER_PROFILE,
   RECEIVE_GET_USER_PROFILE_SUCCESS,
 } from '../actions/profile';
+import type { ActionType } from '../flow/reduxTypes';
 
-export const SUCCESS_ACTIONS = [
+export const SUCCESS_ACTIONS: Array<ActionType> = [
   REQUEST_GET_PROGRAM_ENROLLMENTS,
   RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
   REQUEST_GET_USER_PROFILE,
@@ -44,4 +46,3 @@ export const DASHBOARD_ERROR_ACTIONS = SUCCESS_ACTIONS.concat([
   REQUEST_FETCH_COUPONS,
   RECEIVE_FETCH_COUPONS_SUCCESS,
 ]);
-

--- a/static/js/flow/dashboardTypes.js
+++ b/static/js/flow/dashboardTypes.js
@@ -1,11 +1,17 @@
 // @flow
 import Decimal from 'decimal.js-light';
 import type { Program } from './programTypes';
+
 // likely to change in very near future
 export type Dashboard = Array<Program>;
+
 export type DashboardState = {
   programs:     Dashboard,
   fetchStatus?: string,
+};
+
+export type DashboardsState = {
+  [username: string]: DashboardState
 };
 
 export type CoursePrice = {
@@ -14,7 +20,9 @@ export type CoursePrice = {
   financial_aid_availability: boolean,
   has_financial_aid_request: boolean
 };
+
 export type CoursePrices = Array<CoursePrice>;
+
 export type CoursePricesState = {
   coursePrices: CoursePrices,
   fetchStatus?: string,

--- a/static/js/flow/reduxTypes.js
+++ b/static/js/flow/reduxTypes.js
@@ -6,21 +6,23 @@ import type {
 } from 'redux';
 
 export type ActionType = string;
-export type Action = {
+
+export type Action<payload, meta> = {
   type: ActionType,
-  payload: any
+  payload: payload,
+  meta: meta,
 };
 
 export type Dispatcher<T> = (d: Dispatch) => Promise<T>;
 
 export type AsyncActionHelper = (...a: any) => Promise<*>;
 
-export type ActionCreator = (...a: any) => Action;
+export type ActionCreator = (...a: any) => Action<*, null>;
 
 export type AsyncActionCreator<T> = (...a: any) => Dispatcher<T>;
 
 export type AssertReducerResultState<T> = (
-  actionFunc: () => Action, stateFunc: ((reducerState: State) => T), defaultValue: any
+  actionFunc: () => Action<*,*>, stateFunc: ((reducerState: State) => T), defaultValue: any
 ) => void;
 
 export type TestStore = {

--- a/static/js/lib/redux_test.js
+++ b/static/js/lib/redux_test.js
@@ -12,7 +12,7 @@ describe('redux helpers', () => {
   const MY_ACTION = 'MY_ACTION';
   let dispatch = sinon.spy();
   let actionCreator = (arg) => ({
-    type: MY_ACTION, payload: arg
+    type: MY_ACTION, payload: arg, meta: null
   });
 
   describe('createActionHelper', () => {
@@ -33,7 +33,7 @@ describe('redux helpers', () => {
     it('should return a function that passes arguments to dispatch', () => {
       helper(3);
       assert(dispatch.calledWith({
-        type: MY_ACTION, payload: 3
+        type: MY_ACTION, payload: 3, meta: null,
       }));
     });
   });
@@ -58,7 +58,7 @@ describe('redux helpers', () => {
       let actionCreator = actions.actionCreator;
       actionCreator(3);
       assert(dispatch.calledWith({
-        type: MY_ACTION, payload: 3
+        type: MY_ACTION, payload: 3, meta: null
       }));
     });
   });

--- a/static/js/reducers/coupons.js
+++ b/static/js/reducers/coupons.js
@@ -29,7 +29,7 @@ export const INITIAL_COUPONS_STATE: CouponsState = {
   recentlyAttachedCoupon: null,
 };
 
-export const coupons = (state: CouponsState = INITIAL_COUPONS_STATE, action: Action) => {
+export const coupons = (state: CouponsState = INITIAL_COUPONS_STATE, action: Action<any, null>) => {
   switch (action.type) {
   case REQUEST_ATTACH_COUPON:
     return { ...state, fetchPostStatus: FETCH_PROCESSING };

--- a/static/js/reducers/course_enrollments.js
+++ b/static/js/reducers/course_enrollments.js
@@ -14,7 +14,10 @@ import type { CourseEnrollmentsState } from '../flow/enrollmentTypes';
 
 export const INITIAL_ENROLLMENTS_STATE: CourseEnrollmentsState = {};
 
-export const courseEnrollments = (state: CourseEnrollmentsState = INITIAL_ENROLLMENTS_STATE, action: Action) => {
+export const courseEnrollments = (
+  state: CourseEnrollmentsState = INITIAL_ENROLLMENTS_STATE,
+  action: Action<null, null>
+) => {
   switch (action.type) {
   case REQUEST_ADD_COURSE_ENROLLMENT:
     return { ...state, courseEnrollAddStatus: FETCH_PROCESSING };

--- a/static/js/reducers/dashboard_test.js
+++ b/static/js/reducers/dashboard_test.js
@@ -1,0 +1,165 @@
+/* global SETTINGS: false */
+import configureTestStore from 'redux-asserts';
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+import rootReducer from '../reducers';
+import {
+  fetchDashboard,
+  clearDashboard,
+  receiveDashboardSuccess,
+  updateCourseStatus,
+
+  UPDATE_COURSE_STATUS,
+  REQUEST_DASHBOARD,
+  RECEIVE_DASHBOARD_SUCCESS,
+  RECEIVE_DASHBOARD_FAILURE,
+  CLEAR_DASHBOARD,
+} from '../actions/dashboard';
+import * as api from '../lib/api';
+import {
+  FETCH_FAILURE,
+  FETCH_SUCCESS
+} from '../actions/index';
+import { DASHBOARD_RESPONSE } from '../test_constants';
+
+describe('dashboard reducers', () => {
+  let sandbox, store, dispatchThen, dashboardStub;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    store = configureTestStore(rootReducer);
+    dispatchThen = store.createDispatchThen(state => state.dashboard);
+    dashboardStub = sandbox.stub(api, 'getDashboard');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    store = null;
+    dispatchThen = null;
+  });
+
+  it('should have an empty default state', () => {
+    return dispatchThen({type: 'unknown'}, ['unknown']).then(state => {
+      assert.deepEqual(state, {});
+    });
+  });
+
+  it('should fetch the dashboard successfully then clear it', () => {
+    dashboardStub.returns(Promise.resolve(DASHBOARD_RESPONSE));
+
+    return dispatchThen(fetchDashboard(SETTINGS.user.username), [
+      REQUEST_DASHBOARD,
+      RECEIVE_DASHBOARD_SUCCESS
+    ]).then(state => {
+      let dashboardState = state[SETTINGS.user.username];
+      assert.deepEqual(dashboardState.programs, DASHBOARD_RESPONSE);
+      assert.equal(dashboardState.fetchStatus, FETCH_SUCCESS);
+
+      return dispatchThen(clearDashboard(SETTINGS.user.username), [CLEAR_DASHBOARD]).then(state => {
+        let dashboardState = state[SETTINGS.user.username];
+        assert.deepEqual(dashboardState, { programs: [] });
+      });
+    });
+  });
+
+  it('should fail to fetch the dashboard', () => {
+    dashboardStub.returns(Promise.reject());
+    return dispatchThen(fetchDashboard(SETTINGS.user.username), [
+      REQUEST_DASHBOARD,
+      RECEIVE_DASHBOARD_FAILURE,
+    ]).then(state => {
+      let dashboardState = state[SETTINGS.user.username];
+      assert.equal(dashboardState.fetchStatus, FETCH_FAILURE);
+    });
+  });
+
+  it("should update a course run's status", () => {
+    store.dispatch(receiveDashboardSuccess(SETTINGS.user.username, DASHBOARD_RESPONSE));
+
+    let getRun = programs => programs[1].courses[0].runs[0];
+
+    let run = getRun(DASHBOARD_RESPONSE);
+    assert.notEqual(run.status, 'new_status');
+    return dispatchThen(
+      updateCourseStatus(SETTINGS.user.username, run.course_id, 'new_status'),
+      [UPDATE_COURSE_STATUS]
+    ).then(state => {
+      let dashboardState = state[SETTINGS.user.username];
+      assert.equal(getRun(dashboardState.programs).status, 'new_status');
+    });
+  });
+
+  describe('support for multiple dashboards', () => {
+    let username = 'username';
+    let _username = '_username';
+
+    let successExpectation = {
+      programs: DASHBOARD_RESPONSE,
+      fetchStatus: FETCH_SUCCESS
+    };
+
+    beforeEach(() => {
+      dashboardStub.returns(Promise.resolve(DASHBOARD_RESPONSE));
+      store.dispatch(receiveDashboardSuccess(username, DASHBOARD_RESPONSE));
+    });
+
+    it('should let you fetch two different dashboards', () => {
+      return dispatchThen(fetchDashboard(_username), [
+        REQUEST_DASHBOARD,
+        RECEIVE_DASHBOARD_SUCCESS
+      ]).then(state => {
+        assert.deepEqual(state, {
+          [username]: successExpectation,
+          [_username]: successExpectation,
+        });
+      });
+    });
+
+    it('should let you clear just one dashboard', () => {
+      store.dispatch(receiveDashboardSuccess(_username, DASHBOARD_RESPONSE));
+      return dispatchThen(clearDashboard(username), [
+        CLEAR_DASHBOARD
+      ]).then(state => {
+        assert.deepEqual(state, {
+          [_username]: successExpectation,
+          [username]: { programs: [] }
+        });
+      });
+    });
+
+    it('should let you fail to fetch just one dashboard', () => {
+      dashboardStub.returns(Promise.reject('err'));
+      return dispatchThen(fetchDashboard(_username), [
+        REQUEST_DASHBOARD,
+        RECEIVE_DASHBOARD_FAILURE,
+      ]).then(state => {
+        assert.deepEqual(state, {
+          [username]: successExpectation,
+          [_username]: {
+            fetchStatus: FETCH_FAILURE,
+            errorInfo: 'err',
+            programs: []
+          }
+        });
+      });
+    });
+
+    it('should let you update a course runs status', () => {
+      store.dispatch(receiveDashboardSuccess(_username, DASHBOARD_RESPONSE));
+
+      let getRun = programs => programs[1].courses[0].runs[0];
+
+      let run = getRun(DASHBOARD_RESPONSE);
+      assert.notEqual(run.status, 'new_status');
+
+      return dispatchThen(
+        updateCourseStatus(_username, run.course_id, 'new_status'),
+        [UPDATE_COURSE_STATUS]
+      ).then(state => {
+        assert.deepEqual(state[username], successExpectation);
+        assert.deepEqual(getRun(state[_username].programs).status, 'new_status');
+      });
+    });
+  });
+});

--- a/static/js/reducers/documents.js
+++ b/static/js/reducers/documents.js
@@ -27,7 +27,7 @@ export const INITIAL_DOCUMENTS_STATE: DocumentsState = {
   documentSentDate: moment().format(ISO_8601_FORMAT)
 };
 
-export const documents = (state: DocumentsState = INITIAL_DOCUMENTS_STATE, action: Action) => {
+export const documents = (state: DocumentsState = INITIAL_DOCUMENTS_STATE, action: Action<?string, null>) => {
   switch (action.type) {
   case SET_DOCUMENT_SENT_DATE:
     return { ...state, documentSentDate: action.payload };

--- a/static/js/reducers/email.js
+++ b/static/js/reducers/email.js
@@ -56,7 +56,7 @@ function resetState(state: AllEmailsState, emailType: string) {
   return clonedState;
 }
 
-export const email = (state: AllEmailsState = INITIAL_ALL_EMAILS_STATE, action: Action) => {
+export const email = (state: AllEmailsState = INITIAL_ALL_EMAILS_STATE, action: Action<any, null>) => {
   let emailType = getEmailType(action.payload);
 
   switch (action.type) {

--- a/static/js/reducers/financial_aid.js
+++ b/static/js/reducers/financial_aid.js
@@ -54,7 +54,7 @@ export type FinancialAidState = {
   fetchError?:      FetchError,
 };
 
-export const financialAid = (state: FinancialAidState = INITIAL_FINANCIAL_AID_STATE, action: Action) => {
+export const financialAid = (state: FinancialAidState = INITIAL_FINANCIAL_AID_STATE, action: Action<any, null>) => {
   switch (action.type) {
   case START_CALCULATOR_EDIT:
     return {

--- a/static/js/reducers/image_upload.js
+++ b/static/js/reducers/image_upload.js
@@ -29,7 +29,7 @@ export type ImageUploadState = {
   patchStatus: ?string
 }
 
-export const imageUpload = (state: ImageUploadState = INITIAL_IMAGE_UPLOAD_STATE, action: Action) => {
+export const imageUpload = (state: ImageUploadState = INITIAL_IMAGE_UPLOAD_STATE, action: Action<any, null>) => {
   switch (action.type) {
   case START_PHOTO_EDIT: {
     if (state.patchStatus === FETCH_PROCESSING) {

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -56,7 +56,7 @@ import { dashboard } from './dashboard';
 import { ALL_ERRORS_VISIBLE } from '../constants';
 
 export const INITIAL_PROFILES_STATE = {};
-export const profiles = (state: Profiles = INITIAL_PROFILES_STATE, action: Action) => {
+export const profiles = (state: Profiles = INITIAL_PROFILES_STATE, action: Action<any, null>) => {
   let patchProfile = newProfile => {
     let username = action.payload.username;
     return {
@@ -183,7 +183,7 @@ export type CheckoutState = {
   fetchStatus?: string,
 };
 const INITIAL_CHECKOUT_STATE = {};
-export const checkout = (state: CheckoutState = INITIAL_CHECKOUT_STATE, action: Action) => {
+export const checkout = (state: CheckoutState = INITIAL_CHECKOUT_STATE, action: Action<null, null>) => {
   switch (action.type) {
   case REQUEST_CHECKOUT:
     return {
@@ -208,7 +208,7 @@ export const checkout = (state: CheckoutState = INITIAL_CHECKOUT_STATE, action: 
 const INITIAL_COURSE_PRICES_STATE: CoursePricesState = {
   coursePrices: []
 };
-export const prices = (state: CoursePricesState = INITIAL_COURSE_PRICES_STATE, action: Action) => {
+export const prices = (state: CoursePricesState = INITIAL_COURSE_PRICES_STATE, action: Action<any, null>) => {
   switch (action.type) {
   case REQUEST_COURSE_PRICES:
     return {

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -27,17 +27,6 @@ import {
   RECEIVE_PATCH_USER_PROFILE_FAILURE,
 } from '../actions/profile';
 import {
-  fetchDashboard,
-  clearDashboard,
-  REQUEST_DASHBOARD,
-  RECEIVE_DASHBOARD_SUCCESS,
-  RECEIVE_DASHBOARD_FAILURE,
-  CLEAR_DASHBOARD,
-  receiveDashboardSuccess,
-  updateCourseStatus,
-  UPDATE_COURSE_STATUS,
-} from '../actions/dashboard';
-import {
   checkout,
   REQUEST_CHECKOUT,
   RECEIVE_CHECKOUT_SUCCESS,
@@ -57,7 +46,6 @@ import {
 import * as api from '../lib/api';
 import {
   COURSE_PRICES_RESPONSE,
-  DASHBOARD_RESPONSE,
   USER_PROFILE_RESPONSE,
   CYBERSOURCE_CHECKOUT_RESPONSE,
 } from '../test_constants';
@@ -95,16 +83,16 @@ describe('reducers', () => {
       getUserProfileStub.withArgs(SETTINGS.user.username).returns(Promise.resolve(USER_PROFILE_RESPONSE));
 
       return dispatchThen(fetchUserProfile('jane'), [REQUEST_GET_USER_PROFILE, RECEIVE_GET_USER_PROFILE_SUCCESS]).
-      then(profileState => {
-        assert.deepEqual(profileState['jane'].profile, USER_PROFILE_RESPONSE);
-        assert.equal(profileState['jane'].getStatus, FETCH_SUCCESS);
+        then(profileState => {
+          assert.deepEqual(profileState['jane'].profile, USER_PROFILE_RESPONSE);
+          assert.equal(profileState['jane'].getStatus, FETCH_SUCCESS);
 
-        assert.ok(getUserProfileStub.calledWith('jane'));
+          assert.ok(getUserProfileStub.calledWith('jane'));
 
-        return dispatchThen(clearProfile('jane'), [CLEAR_PROFILE]).then(state => {
-          assert.deepEqual(state, INITIAL_PROFILES_STATE);
+          return dispatchThen(clearProfile('jane'), [CLEAR_PROFILE]).then(state => {
+            assert.deepEqual(state, INITIAL_PROFILES_STATE);
+          });
         });
-      });
     });
 
     it('should fail to fetch user profile', () => {
@@ -115,11 +103,11 @@ describe('reducers', () => {
       getUserProfileStub.withArgs(SETTINGS.user.username).returns(Promise.reject(errorInfo));
 
       return dispatchThen(fetchUserProfile('jane'), [REQUEST_GET_USER_PROFILE, RECEIVE_GET_USER_PROFILE_FAILURE]).
-      then(profileState => {
-        assert.equal(profileState['jane'].getStatus, FETCH_FAILURE);
-        assert.deepEqual(profileState['jane'].errorInfo, errorInfo);
-        assert.ok(getUserProfileStub.calledWith('jane'));
-      });
+        then(profileState => {
+          assert.equal(profileState['jane'].getStatus, FETCH_FAILURE);
+          assert.deepEqual(profileState['jane'].errorInfo, errorInfo);
+          assert.ok(getUserProfileStub.calledWith('jane'));
+        });
     });
 
     it("should patch the profile successfully", () => {
@@ -269,58 +257,6 @@ describe('reducers', () => {
         [UPDATE_PROFILE_VALIDATION]
       ).then(profileState => {
         assert.deepEqual(profileState['jane'], undefined);
-      });
-    });
-  });
-
-  describe('dashboard reducers', () => {
-    let dashboardStub;
-
-    beforeEach(() => {
-      dispatchThen = store.createDispatchThen(state => state.dashboard);
-      dashboardStub = sandbox.stub(api, 'getDashboard');
-    });
-
-    it('should have an empty default state', () => {
-      return dispatchThen({type: 'unknown'}, ['unknown']).then(state => {
-        assert.deepEqual(state, {
-          programs: []
-        });
-      });
-    });
-
-    it('should fetch the dashboard successfully then clear it', () => {
-      dashboardStub.returns(Promise.resolve(DASHBOARD_RESPONSE));
-
-      return dispatchThen(fetchDashboard(), [REQUEST_DASHBOARD, RECEIVE_DASHBOARD_SUCCESS]).then(dashboardState => {
-        assert.deepEqual(dashboardState.programs, DASHBOARD_RESPONSE);
-        assert.equal(dashboardState.fetchStatus, FETCH_SUCCESS);
-
-        return dispatchThen(clearDashboard(), [CLEAR_DASHBOARD]).then(dashboardState => {
-          assert.deepEqual(dashboardState, {
-            programs: []
-          });
-        });
-      });
-    });
-
-    it('should fail to fetch the dashboard', () => {
-      dashboardStub.returns(Promise.reject());
-
-      return dispatchThen(fetchDashboard(), [REQUEST_DASHBOARD, RECEIVE_DASHBOARD_FAILURE]).then(dashboardState => {
-        assert.equal(dashboardState.fetchStatus, FETCH_FAILURE);
-      });
-    });
-
-    it("should update a course run's status", () => {
-      store.dispatch(receiveDashboardSuccess(DASHBOARD_RESPONSE));
-
-      let getRun = programs => programs[1].courses[0].runs[0];
-
-      let run = getRun(DASHBOARD_RESPONSE);
-      assert.notEqual(run.status, 'new_status');
-      return dispatchThen(updateCourseStatus(run.course_id, 'new_status'), [UPDATE_COURSE_STATUS]).then(state => {
-        assert.equal(getRun(state.programs).status, 'new_status');
       });
     });
   });

--- a/static/js/reducers/order_receipt.js
+++ b/static/js/reducers/order_receipt.js
@@ -17,7 +17,7 @@ export const INITIAL_ORDER_RECEIPT_STATE = {
   initialTime: moment().toISOString()
 };
 
-export const orderReceipt = (state: OrderReceiptState = INITIAL_ORDER_RECEIPT_STATE, action: Action) => {
+export const orderReceipt = (state: OrderReceiptState = INITIAL_ORDER_RECEIPT_STATE, action: Action<any, null>) => {
   switch (action.type) {
   case SET_TIMEOUT_ACTIVE:
     return { ...state, timeoutActive: action.payload };

--- a/static/js/reducers/pearson.js
+++ b/static/js/reducers/pearson.js
@@ -24,7 +24,7 @@ export type PearsonAPIState = {
   error: ?string,
 };
 
-export const pearson = (state: PearsonAPIState = INITIAL_PEARSON_STATE, action: Action) => {
+export const pearson = (state: PearsonAPIState = INITIAL_PEARSON_STATE, action: Action<any, null>) => {
   switch (action.type) {
   case REQUEST_GET_PEARSON_SSO_DIGEST:
     return { ...state, getStatus: FETCH_PROCESSING };

--- a/static/js/reducers/programs.js
+++ b/static/js/reducers/programs.js
@@ -25,7 +25,7 @@ export const INITIAL_PROGRAMS_STATE: AvailableProgramsState = {
   availablePrograms: []
 };
 
-export const programs = (state: AvailableProgramsState = INITIAL_PROGRAMS_STATE, action: Action) => {
+export const programs = (state: AvailableProgramsState = INITIAL_PROGRAMS_STATE, action: Action<any, null>) => {
   switch (action.type) {
   case REQUEST_GET_PROGRAM_ENROLLMENTS:
     return { ...state, getStatus: FETCH_PROCESSING };
@@ -54,7 +54,7 @@ export const programs = (state: AvailableProgramsState = INITIAL_PROGRAMS_STATE,
 };
 
 // state is of type ProgramEnrollment but I can't convince flow that we do all necessary null checks
-export const currentProgramEnrollment = (state: any = null, action: Action) => {
+export const currentProgramEnrollment = (state: any = null, action: Action<any, null>) => {
   switch (action.type) {
   case SET_CURRENT_PROGRAM_ENROLLMENT:
     return action.payload;

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -141,7 +141,7 @@ export const INITIAL_UI_STATE: UIState = {
   dialogVisibility:                    INITIAL_DIALOG_VISIBILITY_STATE
 };
 
-export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
+export const ui = (state: UIState = INITIAL_UI_STATE, action: Action<any, null>) => {
   switch (action.type) {
   case SHOW_DIALOG:
     return {

--- a/static/js/reducers/util.js
+++ b/static/js/reducers/util.js
@@ -1,0 +1,15 @@
+// @flow
+/* global SETTINGS: false */
+import R from 'ramda';
+import { INITIAL_DASHBOARD_STATE } from './dashboard';
+
+export const getInfoByUsername = R.curry((
+  reducer,
+  username,
+  defaultTo,
+  state
+) => (
+  R.pathOr(defaultTo, [reducer, username], state)
+));
+
+export const getOwnDashboard = getInfoByUsername('dashboard', SETTINGS.user.username, INITIAL_DASHBOARD_STATE);

--- a/static/js/reducers/util_test.js
+++ b/static/js/reducers/util_test.js
@@ -1,0 +1,26 @@
+// @flow
+/* global SETTINGS: false */
+import { assert } from 'chai';
+
+import { getOwnDashboard } from './util';
+import { DASHBOARD_RESPONSE } from '../test_constants';
+import { INITIAL_DASHBOARD_STATE } from './dashboard';
+
+describe('reducer utilities', () => {
+  describe('username selectors', () => {
+    describe('getOwnDashboard', () => {
+      it('should return dashboard -> username, if present', () => {
+        let dashboard = {
+          dashboard: {
+            [SETTINGS.user.username]: DASHBOARD_RESPONSE
+          }
+        };
+        assert.deepEqual(getOwnDashboard(dashboard), DASHBOARD_RESPONSE);
+      });
+
+      it('should return INITIAL_DASHBOARD_STATE otherwise', () => {
+        assert.deepEqual(getOwnDashboard({}), INITIAL_DASHBOARD_STATE);
+      });
+    });
+  });
+});

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -244,7 +244,7 @@ export class GoogleMapsStub {
 
 export function createAssertReducerResultState<State>(store: Store, getReducerState: (x: any) => State) {
   return (
-    action: () => Action, stateLookup: (state: State) => any, defaultValue: any
+    action: () => Action<*,*>, stateLookup: (state: State) => any, defaultValue: any
   ): void => {
     const getState = () => stateLookup(getReducerState(store.getState()));
 


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2672 

#### What's this PR do?

This refactors the dashboard reducer to handle multiple users, like so:

```js
dashboard = {
  first_user_username: DashboardForFirstUser,
  second_user_username: DashboardForSecondUser,
};
```

I had to fix a bunch of tests and make some changes to the container components which use the dashboard as well.

#### How should this be manually tested?

Do a functional test of the dashboard! Things should work as normal.