### PR TITLE
Load SCSS-referenced URLs via Cloudfront on production

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "node-sass": "^4.3.0",
     "nyc": "^10.1.2",
     "object.entries": "^1.0.4",
+    "postcss-assets": "^4.1.0",
     "postcss-loader": "^1.2.2",
     "ramda": "^0.23.0",
     "raven-js": "^3.8.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,20 @@
+const autoprefixer = require('autoprefixer');
+const assets = require('postcss-assets');
+
+const CF_DIST = process.env.CLOUDFRONT_DIST;
+let baseUrl = '/';
+if (CF_DIST) {
+  baseUrl = `https://${CF_DIST}.cloudfront.net/`;
+}
+
 module.exports = {
   plugins: [
-    require('autoprefixer')({
+    autoprefixer({
       browsers: ['> 1%']
+    }),
+    assets({
+      baseUrl: baseUrl,
+      loadPaths: ['static']
     })
   ]
 }

--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -32,7 +32,7 @@ body.app-media {
       .brand-logo {
         float: left;
         margin-right: 15px;
-        background: url(/static/images/mit_logo.svg) no-repeat;
+        background: resolve('images/mit_logo.svg') no-repeat;
         height: 36px;
         width: 51px;
         overflow: visible;
@@ -41,7 +41,7 @@ body.app-media {
       }
 
       .brand-logo:hover {
-        background: url(/static/images/mit_logo_on.svg) no-repeat;
+        background: resolve('images/mit_logo_on.svg') no-repeat;
         height: 36px;
         width: 51px;
         overflow: visible;
@@ -51,7 +51,7 @@ body.app-media {
 
       .micromasters-logo {
         float: left;
-        background: url(/static/images/micromasters_logo.svg) no-repeat;
+        background: resolve('images/micromasters_logo.svg') no-repeat;
         height: 23px;
         width: 155px;
         overflow: visible;
@@ -61,7 +61,7 @@ body.app-media {
 
       .micromasters-logo:hover {
         float: left;
-        background: url(/static/images/micromasters_logo_on.svg) no-repeat;
+        background: resolve('images/micromasters_logo_on.svg') no-repeat;
         height: 23px;
         width: 155px;
         overflow: visible;
@@ -159,7 +159,7 @@ body.app-media {
 }
 
 .banner-wrapper {
-  background: #222 center center url(/static/images/lp_hero.jpg) no-repeat;
+  background: #222 center center resolve('images/lp_hero.jpg') no-repeat;
   margin: 0 auto;
   width: 100%;
   min-height: 620px;
@@ -600,7 +600,7 @@ body.app-media {
   background: #1a1a1a;
 
   .reasons-images-wrap::after {
-    content: url(/static/images/hiw-arrow2.png);
+    content: resolve('images/hiw-arrow2.png');
     position: absolute;
     left: 103%;
     top: 18px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -233,6 +233,22 @@ assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
 
+assets@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/assets/-/assets-2.1.0.tgz#bfae98717974d66636eed26b18eb7120608816f5"
+  dependencies:
+    async "^1.5.0"
+    bluebird "^3.0.6"
+    calipers "^2.0.0"
+    calipers-gif "^2.0.0"
+    calipers-jpeg "^2.0.0"
+    calipers-png "^2.0.0"
+    calipers-svg "^2.0.0"
+    calipers-webp "^2.0.0"
+    glob "^6.0.4"
+    lodash "^3.10.1"
+    mime "^1.3.4"
+
 ast-types@0.9.5:
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.5.tgz#1a660a09945dbceb1f9c9cbb715002617424e04a"
@@ -245,7 +261,7 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
 
-async@^1.4.0, async@^1.4.2:
+async@^1.4.0, async@^1.4.2, async@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
@@ -1042,6 +1058,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird@3.x.x, bluebird@^3.0.6:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
+
 blueimp-canvas-to-blob@^3.6.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-3.7.0.tgz#6e985b935c0223410c3a2ad96c0ba3ea214c2b13"
@@ -1193,6 +1213,42 @@ caching-transform@^1.0.0:
     md5-hex "^1.2.0"
     mkdirp "^0.5.1"
     write-file-atomic "^1.1.4"
+
+calipers-gif@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/calipers-gif/-/calipers-gif-2.0.0.tgz#b5eefec3064a77c6dcdbd5bdc51735a01bafdc37"
+  dependencies:
+    bluebird "3.x.x"
+
+calipers-jpeg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/calipers-jpeg/-/calipers-jpeg-2.0.0.tgz#06d56a53f62717dd809cb956cf64423ce693465b"
+  dependencies:
+    bluebird "3.x.x"
+
+calipers-png@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/calipers-png/-/calipers-png-2.0.0.tgz#1d0d20e5c1ae5f79b74d5286a2e97f59bb70b658"
+  dependencies:
+    bluebird "3.x.x"
+
+calipers-svg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/calipers-svg/-/calipers-svg-2.0.0.tgz#666254d5f1ea66d2052ed82d6d79b8bf10acbb71"
+  dependencies:
+    bluebird "3.x.x"
+
+calipers-webp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/calipers-webp/-/calipers-webp-2.0.0.tgz#e126ece2f84cd71779612bfa2b2653cd95cea77a"
+  dependencies:
+    bluebird "3.x.x"
+
+calipers@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/calipers/-/calipers-2.0.0.tgz#bdf221c6a62f603b8ddd9340cacd9c79c1a03fce"
+  dependencies:
+    bluebird "3.x.x"
 
 caller-id@^0.1.0:
   version "0.1.0"
@@ -2931,6 +2987,16 @@ glob@7.0.5:
 glob@^5.0.15, glob@^5.0.3:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
   dependencies:
     inflight "^1.0.4"
     inherits "2"
@@ -4815,6 +4881,14 @@ pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
+postcss-assets@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-assets/-/postcss-assets-4.1.0.tgz#341f30d6ac0fbb314d82a28cc1ea753a986ffed7"
+  dependencies:
+    assets "^2.0.0"
+    postcss "^5.0.12"
+    postcss-functions "^2.1.0"
+
 postcss-calc@^5.2.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-5.3.1.tgz#77bae7ca928ad85716e2fda42f261bf7c1d65b5e"
@@ -4875,6 +4949,15 @@ postcss-filter-plugins@^2.0.0:
   dependencies:
     postcss "^5.0.4"
     uniqid "^4.0.0"
+
+postcss-functions@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-functions/-/postcss-functions-2.1.1.tgz#f9b64d3b5690f6795fe42a180496805375b7a840"
+  dependencies:
+    glob "^5.0.15"
+    object-assign "^4.0.1"
+    postcss "^5.0.10"
+    postcss-value-parser "^3.1.3"
 
 postcss-load-config@^1.2.0:
   version "1.2.0"
@@ -5064,7 +5147,7 @@ postcss-unique-selectors@^2.0.2:
     postcss "^5.0.4"
     uniqs "^2.0.0"
 
-postcss-value-parser@^3.0.1, postcss-value-parser@^3.0.2, postcss-value-parser@^3.1.1, postcss-value-parser@^3.1.2, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
+postcss-value-parser@^3.0.1, postcss-value-parser@^3.0.2, postcss-value-parser@^3.1.1, postcss-value-parser@^3.1.2, postcss-value-parser@^3.1.3, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2462

#### What's this PR do?
Rewrites URL references in our CSS files to point to Cloudfront on production.

#### How should this be manually tested?
The easy way: wait until this is on the release candidate server, and then verify that the hero image on the landing page (`/static/images/lp_hero.jpg`) is loaded via Cloudfront.

The hard way: first, checkout this branch locally and run `node node_modules/webpack/bin/webpack.js --config webpack.config.prod.js --bail` to compile all the assets via webpack. The compiled versions will end up in the `static/bundles` directory. Open the `style-[hash].js` file, search for `lp_hero.jpg`, and verify that the URL will be _locally_ resolved (and does _not_ reference Cloudfront). This is important to verify, so that local development continues to work without relying on Cloudfront.

Then, set the `CLOUDFRONT_DIST` environment variable to some value, and run the same command again. Open the new `style-[hash].js` file, search for `lp_hero.jpg`, and verify that the URL will be resolved from the Cloudfront distribution you set. For example, if you set `CLOUDFRONT_DIST=abc`, the file should contain `https://abc.cloudfront.net/static/images/lp_hero.jpg`.

#### Additional notes
With this change, we can also use the `resolve()` function in CSS to load files from arbitrary locations, like we do with templates. We can also use `width()`, `height()`, and `size()` functions to get information about images. See the [PostCSS-Assets](https://github.com/borodean/postcss-assets) project for more information.
