### PR TITLE
Refactor ProfileFormContainer into a HOC

### DIFF
--- a/static/js/containers/LearnerPage.js
+++ b/static/js/containers/LearnerPage.js
@@ -3,21 +3,27 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Loader from '../components/Loader';
+import R from 'ramda';
 
 import { FETCH_PROCESSING } from '../actions';
 import { clearProfile } from '../actions/profile';
-import ProfileFormContainer from './ProfileFormContainer';
+import {
+  profileFormContainer,
+  mapStateToProfileProps,
+  childrenWithProps,
+} from './ProfileFormContainer';
 import ErrorMessage from '../components/ErrorMessage';
+import type { ProfileContainerProps } from './ProfileFormContainer';
 
-class LearnerPage extends ProfileFormContainer {
+class LearnerPage extends React.Component<*, ProfileContainerProps, *> {
   componentDidMount() {
-    const { params: { username } } = this.props;
-    this.fetchProfile(username);
+    const { params: { username }, fetchProfile } = this.props;
+    fetchProfile(username);
   }
 
   componentDidUpdate() {
-    const { params: { username } } = this.props;
-    this.fetchProfile(username);
+    const { params: { username }, fetchProfile } = this.props;
+    fetchProfile(username);
   }
 
   componentWillUnmount() {
@@ -29,21 +35,29 @@ class LearnerPage extends ProfileFormContainer {
   }
 
   render() {
-    const { params: { username }, profiles } = this.props;
+    const {
+      params: { username },
+      profiles,
+      children,
+      profileProps,
+    } = this.props;
 
     let profile = {};
-    let children = null;
+    let toRender = null;
     let loaded = false;
     if (profiles[username] !== undefined) {
       profile = profiles[username];
       loaded = profiles[username].getStatus !== FETCH_PROCESSING;
-      children = this.childrenWithProps(profile);
+      toRender = childrenWithProps(children, profileProps(profile));
     }
     const { errorInfo } = profile;
     return <Loader loaded={loaded}>
-      {errorInfo && loaded ? <ErrorMessage errorInfo={errorInfo} /> : children }
+      {errorInfo && loaded ? <ErrorMessage errorInfo={errorInfo} /> : toRender }
     </Loader>;
   }
 }
 
-export default connect(ProfileFormContainer.mapStateToProps)(LearnerPage);
+export default R.compose(
+  connect(mapStateToProfileProps),
+  profileFormContainer
+)(LearnerPage);

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -42,202 +42,212 @@ import type {
 import type { Program } from '../flow/programTypes';
 import { addProgramEnrollment } from '../actions/programs';
 import { ALL_ERRORS_VISIBLE } from '../constants';
+import { getDisplayName } from '../util/util';
 
 type UpdateProfile = (isEdit: boolean, profile: Profile, validator: Validator|UIValidator) => void;
 
-class ProfileFormContainer extends React.Component {
-  props: {
-    profiles:                  Profiles,
-    children:                  React$Element<*>[],
-    dispatch:                  Dispatch,
-    history:                   Object,
-    ui:                        UIState,
-    params:                    {[k: string]: string},
-    programs:                  AvailableProgramsState,
-    currentProgramEnrollment:  AvailableProgram,
-  };
+export const mapStateToProfileProps = R.pick(['profiles', 'ui', 'programs', 'currentProgramEnrollment']);
 
-  static contextTypes = {
-    router: React.PropTypes.object.isRequired
-  };
+type ProfileContainerParentProps = {
+  profiles:                  Profiles,
+  children:                  React$Element<*>[],
+  dispatch:                  Dispatch,
+  history:                   Object,
+  ui:                        UIState,
+  params:                    {[k: string]: string},
+  programs:                  AvailableProgramsState,
+  currentProgramEnrollment:  AvailableProgram,
+};
 
-  static mapStateToProps = state => {
-    return {
-      profiles: state.profiles,
-      ui: state.ui,
-      programs: state.programs,
-      currentProgramEnrollment: state.currentProgramEnrollment
-    };
-  };
-
-  fetchProfile = (username: string): void => {
-    const { dispatch, profiles } = this.props;
-    if (profiles[username] === undefined || profiles[username].getStatus === undefined) {
-      dispatch(fetchUserProfile(username));
-    }
-  };
-
-  updateProfileValidation = (profile: Profile, validator: Validator|UIValidator): void => {
-    const username = SETTINGS.user.username;
-    const { dispatch, ui } = this.props;
-    let errors = validator(profile, ui);
-    dispatch(updateProfileValidation(username, errors));
-  }
-
-  updateProfile: UpdateProfile = (isEdit, profile, validator, skipValidation = false) => {
-    const { dispatch } = this.props;
-    const username = SETTINGS.user.username;
-
-    if (!isEdit) {
-      dispatch(startProfileEdit(username));
-    }
-    dispatch(updateProfile(username, profile));
-    if (!skipValidation) {
-      this.updateProfileValidation(profile, validator);
-    }
-  };
-
-  updateValidationVisibility = (keySet: Array<string>) => {
-    const { dispatch, profiles } = this.props;
-    const username = SETTINGS.user.username;
-    if (!profiles[username].edit) {
-      dispatch(updateValidationVisibility(username, keySet));
-    } else if (!R.contains(keySet, profiles[username].edit.visibility)) {
-      dispatch(updateValidationVisibility(username, keySet));
-    }
-  };
-
-  startProfileEdit = () => {
-    const { dispatch } = this.props;
-    const username = SETTINGS.user.username;
-    dispatch(startProfileEdit(username));
-  };
-
-  saveProfile(isEdit: boolean, validator: Validator|UIValidator, profile: Profile, ui: UIState) {
-    const { dispatch } = this.props;
-    const username = SETTINGS.user.username;
-
-    if (!isEdit) {
-      // Validation errors will only show up if we start the edit
-      dispatch(startProfileEdit(username));
-    }
-    let errors = validator(profile, ui);
-    this.updateValidationVisibility(ALL_ERRORS_VISIBLE);
-    dispatch(updateProfileValidation(username, errors));
-    if (_.isEmpty(errors)) {
-      return dispatch(saveProfile(username, profile)).then(() => {
-        dispatch(clearProfileEdit(username));
-      });
-    } else {
-      this.scrollToError();
-      return Promise.reject(errors);
-    }
-  }
-
-  scrollToError () {
-    // `setState` is being called here because we want to guarantee that
-    // the callback executes on the next re-render. A callback
-    // passed to `setState` executes when the component next re-renders.
-    this.setState({}, () => {
-      let invalidField = document.querySelector('.invalid-input');
-      if (invalidField !== null) {
-        invalidField.scrollIntoView();
-      }
-    });
-  }
-
-  addProgramEnrollment = (programId: number): void => {
-    const { dispatch } = this.props;
-    dispatch(addProgramEnrollment(programId));
-  };
-
-  setProgram = (program: Program): void => {
-    const { dispatch } = this.props;
-    dispatch(setProgram(program));
-  };
-
-  simpleActionHelpers = (): ActionHelpers => {
-    const { dispatch } = this.props;
-    return createSimpleActionHelpers(dispatch, [
-      ['clearProfileEdit', clearProfileEdit],
-      ['setDeletionIndex', setDeletionIndex],
-      ['setEducationDegreeLevel', setEducationDegreeLevel],
-      ['setEducationDialogIndex', setEducationDialogIndex],
-      ['setEducationDialogVisibility', setEducationDialogVisibility],
-      ['setEducationLevelAnswers', setEducationLevelAnswers],
-      ['setShowEducationDeleteDialog', setShowEducationDeleteDialog],
-      ['setShowWorkDeleteDialog', setShowWorkDeleteDialog],
-      ['setLearnerPageDialogVisibility', setLearnerPageDialogVisibility],
-      ['setLearnerPageAboutMeDialogVisibility', setLearnerPageAboutMeDialogVisibility],
-      ['setWorkDialogIndex', setWorkDialogIndex],
-      ['setWorkDialogVisibility', setWorkDialogVisibility],
-      ['setWorkHistoryAnswer', setWorkHistoryAnswer],
-    ]);
-  };
-
-  asyncActionHelpers = (): AsyncActionHelpers => {
-    const { dispatch } = this.props;
-    return createAsyncActionHelpers(dispatch, [
-      ['setWorkHistoryEdit', setWorkHistoryEdit],
-    ]);
-  };
-
-  profileProps: Function = (profileFromStore: ProfileGetResult) => {
-    let {
-      ui,
-      programs,
-      dispatch,
-      currentProgramEnrollment
-    } = this.props;
-    let errors, isEdit, profile, uneditedProfile, patchStatus;
-
-    if (profileFromStore === undefined) {
-      profile = {};
-      uneditedProfile = {};
-      errors = {};
-      isEdit = false;
-    } else {
-      patchStatus = profileFromStore.patchStatus;
-      if (profileFromStore.edit !== undefined) {
-        errors = profileFromStore.edit.errors;
-        profile = profileFromStore.edit.profile;
-        uneditedProfile = profileFromStore.profile;
-        isEdit = true;
-      } else {
-        profile = profileFromStore.profile;
-        uneditedProfile = profileFromStore.profile;
-        errors = {};
-        isEdit = false;
-      }
-    }
-
-    return {
-      addProgramEnrollment: this.addProgramEnrollment,
-      dispatch: dispatch,
-      errors: errors,
-      fetchProfile: this.fetchProfile,
-      profile: profile,
-      profilePatchStatus: patchStatus,
-      uneditedProfile: uneditedProfile,
-      programs: programs.availablePrograms,
-      saveProfile: this.saveProfile.bind(this, isEdit),
-      currentProgramEnrollment: currentProgramEnrollment,
-      setProgram: this.setProgram,
-      startProfileEdit: this.startProfileEdit,
-      ui: ui,
-      updateProfile: this.updateProfile.bind(this, isEdit),
-      updateProfileValidation: this.updateProfileValidation,
-      updateValidationVisibility: this.updateValidationVisibility,
-      ...this.simpleActionHelpers(),
-      ...this.asyncActionHelpers()
-    };
-  };
-
-  childrenWithProps = (profileFromStore: ProfileGetResult) => {
-    return React.Children.map(this.props.children, (child) => (
-      React.cloneElement(child, this.profileProps(profileFromStore))
-    ));
-  }
+export type ProfileContainerProps = ProfileContainerParentProps & {
+  profileProps: Function,
+  scrollToError: () => void,
+  fetchProfile: () => void,
 }
 
-export default ProfileFormContainer;
+export const childrenWithProps = (children: any, props: Object) => {
+  return React.Children.map(children, child => (
+    React.cloneElement(child, props)
+  ));
+};
+
+export const profileFormContainer = (WrappedComponent: ReactClass<*>) => {
+  class ProfileFormContainer extends React.Component<*, ProfileContainerParentProps, *> {
+    fetchProfile = (username: string): void => {
+      const { dispatch, profiles } = this.props;
+      if (profiles[username] === undefined || profiles[username].getStatus === undefined) {
+        dispatch(fetchUserProfile(username));
+      }
+    };
+
+    updateProfileValidation = (profile: Profile, validator: Validator|UIValidator): void => {
+      const username = SETTINGS.user.username;
+      const { dispatch, ui } = this.props;
+      let errors = validator(profile, ui);
+      dispatch(updateProfileValidation(username, errors));
+    }
+
+    updateProfile: UpdateProfile = (isEdit, profile, validator, skipValidation = false) => {
+      const { dispatch } = this.props;
+      const username = SETTINGS.user.username;
+
+      if (!isEdit) {
+        dispatch(startProfileEdit(username));
+      }
+      dispatch(updateProfile(username, profile));
+      if (!skipValidation) {
+        this.updateProfileValidation(profile, validator);
+      }
+    };
+
+    updateValidationVisibility = (keySet: Array<string>) => {
+      const { dispatch, profiles } = this.props;
+      const username = SETTINGS.user.username;
+      if (!profiles[username].edit) {
+        dispatch(updateValidationVisibility(username, keySet));
+      } else if (!R.contains(keySet, profiles[username].edit.visibility)) {
+        dispatch(updateValidationVisibility(username, keySet));
+      }
+    };
+
+    startProfileEdit = () => {
+      const { dispatch } = this.props;
+      const username = SETTINGS.user.username;
+      dispatch(startProfileEdit(username));
+    };
+
+    saveProfile(isEdit: boolean, validator: Validator|UIValidator, profile: Profile, ui: UIState) {
+      const { dispatch } = this.props;
+      const username = SETTINGS.user.username;
+
+      if (!isEdit) {
+        // Validation errors will only show up if we start the edit
+        dispatch(startProfileEdit(username));
+      }
+      let errors = validator(profile, ui);
+      this.updateValidationVisibility(ALL_ERRORS_VISIBLE);
+      dispatch(updateProfileValidation(username, errors));
+      if (_.isEmpty(errors)) {
+        return dispatch(saveProfile(username, profile)).then(() => {
+          dispatch(clearProfileEdit(username));
+        });
+      } else {
+        this.scrollToError();
+        return Promise.reject(errors);
+      }
+    }
+
+    scrollToError () {
+      // `setState` is being called here because we want to guarantee that
+      // the callback executes on the next re-render. A callback
+      // passed to `setState` executes when the component next re-renders.
+      this.setState({}, () => {
+        let invalidField = document.querySelector('.invalid-input');
+        if (invalidField !== null) {
+          invalidField.scrollIntoView();
+        }
+      });
+    }
+
+    addProgramEnrollment = (programId: number): void => {
+      const { dispatch } = this.props;
+      dispatch(addProgramEnrollment(programId));
+    };
+
+    setProgram = (program: Program): void => {
+      const { dispatch } = this.props;
+      dispatch(setProgram(program));
+    };
+
+    simpleActionHelpers = (): ActionHelpers => {
+      const { dispatch } = this.props;
+      return createSimpleActionHelpers(dispatch, [
+        ['clearProfileEdit', clearProfileEdit],
+        ['setDeletionIndex', setDeletionIndex],
+        ['setEducationDegreeLevel', setEducationDegreeLevel],
+        ['setEducationDialogIndex', setEducationDialogIndex],
+        ['setEducationDialogVisibility', setEducationDialogVisibility],
+        ['setEducationLevelAnswers', setEducationLevelAnswers],
+        ['setShowEducationDeleteDialog', setShowEducationDeleteDialog],
+        ['setShowWorkDeleteDialog', setShowWorkDeleteDialog],
+        ['setLearnerPageDialogVisibility', setLearnerPageDialogVisibility],
+        ['setLearnerPageAboutMeDialogVisibility', setLearnerPageAboutMeDialogVisibility],
+        ['setWorkDialogIndex', setWorkDialogIndex],
+        ['setWorkDialogVisibility', setWorkDialogVisibility],
+        ['setWorkHistoryAnswer', setWorkHistoryAnswer],
+      ]);
+    };
+
+    asyncActionHelpers = (): AsyncActionHelpers => {
+      const { dispatch } = this.props;
+      return createAsyncActionHelpers(dispatch, [
+        ['setWorkHistoryEdit', setWorkHistoryEdit],
+      ]);
+    };
+
+    profileProps: Function = (profileFromStore: ProfileGetResult) => {
+      let {
+        ui,
+        programs,
+        dispatch,
+        currentProgramEnrollment
+      } = this.props;
+      let errors, isEdit, profile, uneditedProfile, patchStatus;
+
+      if (profileFromStore === undefined) {
+        profile = {};
+        uneditedProfile = {};
+        errors = {};
+        isEdit = false;
+      } else {
+        patchStatus = profileFromStore.patchStatus;
+        if (profileFromStore.edit !== undefined) {
+          errors = profileFromStore.edit.errors;
+          profile = profileFromStore.edit.profile;
+          uneditedProfile = profileFromStore.profile;
+          isEdit = true;
+        } else {
+          profile = profileFromStore.profile;
+          uneditedProfile = profileFromStore.profile;
+          errors = {};
+          isEdit = false;
+        }
+      }
+
+      return {
+        addProgramEnrollment: this.addProgramEnrollment,
+        dispatch: dispatch,
+        errors: errors,
+        fetchProfile: this.fetchProfile,
+        profile: profile,
+        profilePatchStatus: patchStatus,
+        uneditedProfile: uneditedProfile,
+        programs: programs.availablePrograms,
+        saveProfile: this.saveProfile.bind(this, isEdit),
+        currentProgramEnrollment: currentProgramEnrollment,
+        setProgram: this.setProgram,
+        startProfileEdit: this.startProfileEdit,
+        ui: ui,
+        updateProfile: this.updateProfile.bind(this, isEdit),
+        updateProfileValidation: this.updateProfileValidation,
+        updateValidationVisibility: this.updateValidationVisibility,
+        ...this.simpleActionHelpers(),
+        ...this.asyncActionHelpers()
+      };
+    };
+
+    render () {
+      return (
+        <WrappedComponent
+          {...this.props}
+          profileProps={this.profileProps}
+          fetchProfile={this.fetchProfile}
+          scrollToError={this.scrollToError}
+        />
+      );
+    }
+  }
+
+  ProfileFormContainer.displayName = `ProfileFormContainer(${getDisplayName(WrappedComponent)})`;
+  return ProfileFormContainer;
+};

--- a/static/js/containers/SettingsPage.js
+++ b/static/js/containers/SettingsPage.js
@@ -3,15 +3,17 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Loader from '../components/Loader';
+import R from 'ramda';
 
 import { startProfileEdit } from '../actions/profile';
 import { FETCH_PROCESSING } from '../actions/index';
-import ProfileFormContainer from './ProfileFormContainer';
+import { profileFormContainer, mapStateToProfileProps } from './ProfileFormContainer';
 import PrivacyForm from '../components/PrivacyForm';
 import ProfileProgressControls from '../components/ProfileProgressControls';
 import { privacyValidation } from '../lib/validation/profile';
+import type { ProfileContainerProps } from './ProfileFormContainer';
 
-class SettingsPage extends ProfileFormContainer {
+class SettingsPage extends React.Component<*, ProfileContainerProps, *> {
   componentWillMount() {
     this.startSettingsEdit();
   }
@@ -22,8 +24,8 @@ class SettingsPage extends ProfileFormContainer {
   }
 
   render() {
-    const { profiles } = this.props;
-    let props = this.profileProps(profiles[SETTINGS.user.username]);
+    const { profiles, profileProps } = this.props;
+    let props = profileProps(profiles[SETTINGS.user.username]);
     let loaded = false;
     const username = SETTINGS.user.username;
 
@@ -49,5 +51,7 @@ class SettingsPage extends ProfileFormContainer {
     );
   }
 }
-
-export default connect(ProfileFormContainer.mapStateToProps)(SettingsPage);
+export default R.compose(
+  connect(mapStateToProfileProps),
+  profileFormContainer
+)(SettingsPage);


### PR DESCRIPTION
#### What are the relevant tickets?

part of #2456

came up as part of #2530

#### What's this PR do?

This refactors `ProfileFormContainer` to be a HOC instead of a class (which we sub-class elsewhere). I decided to go ahead and do this because, as I was working on #2530, I noticed that the `ProfileFormContainer` subclassing made the sub-classes very hard to change and hard to reason about. We had some very confusing indirection, including a method on the parent class which injected props relevant to the profile into the children of the subclass...yeah.

Anyway, this should make things much easier to read and should also clear the way for making the changes I'll need to make for #2530.

#### How should this be manually tested?

We just need to make sure that there are no regressions relating to profile code. I think it would be good to go through the profile flow and the `/learner` page, trying to edit things and so on. Make sure that validation, redirect behavior, etc is all as it should be.
