### PR TITLE
Modified user dashboard to handle 400 and 401 http errors

### DIFF
--- a/backends/exceptions.py
+++ b/backends/exceptions.py
@@ -1,0 +1,10 @@
+"""
+Exceptions for backends app
+"""
+
+
+class InvalidCredentialStored(Exception):
+    """Custom exception to throw in some specific situations"""
+    def __init__(self, message, http_status_code):
+        super(InvalidCredentialStored, self).__init__(message)
+        self.http_status_code = http_status_code

--- a/backends/utils.py
+++ b/backends/utils.py
@@ -7,12 +7,7 @@ import pytz
 from requests.exceptions import HTTPError
 from social.apps.django_app.utils import load_strategy
 
-
-class InvalidCredentialStored(Exception):
-    """Custom exception to throw in some specific situations"""
-    def __init__(self, message, http_status_code):
-        super(InvalidCredentialStored, self).__init__(message)
-        self.http_status_code = http_status_code
+from backends.exceptions import InvalidCredentialStored
 
 
 def _send_refresh_request(user_social):

--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -105,6 +105,18 @@ class DashboardTest(MockedESTestCase, APITestCase):
         self.client.get(self.url)
         assert update_mock.call_count == 0
 
+    @patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cache_if_expired', new_callable=MagicMock)
+    @patch('backends.utils.refresh_user_token', autospec=True)
+    @ddt.data(400, 401,)
+    def test_http_error_propagated_from_back_functions(
+            self, status_code, refr_token, refr_cache):  # pylint: disable=unused-argument
+        """
+        Tests that if an InvalidCredentialStored is raised from the backend,
+        """
+        refr_cache.side_effect = InvalidCredentialStored('foo message', status_code)
+        result = self.client.get(self.url)
+        assert result.status_code == status_code
+
 
 class DashboardTokensTest(MockedESTestCase, APITestCase):
     """


### PR DESCRIPTION
#### What are the relevant tickets?
part of #2132

#### What's this PR do?
Handles 400 and 401 error coming from edX endpoints during cache refresh even if the access and refresh token are supposed to be valid.

#### How should this be manually tested?
From the admin go to `Home › Python Social Auth › User social auths` and open the social auth for your user. Modify the `"refresh_token"` and `"access_token"` and reload the dashboard.
The browser should redirect to the login page and come back. If you reload the user social auth the modified values should be updated.

#### Where should the reviewer start?
`dashboard/api_edx_cache.py`
`dashboard/views.py`