### PR TITLE
Added setting for Django Storage to use Cloudfront for S3 files

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -283,6 +283,8 @@ STATIC_URL = '/static/'
 CLOUDFRONT_DIST = get_var('CLOUDFRONT_DIST', None)
 if CLOUDFRONT_DIST:
     STATIC_URL = urljoin('https://{dist}.cloudfront.net'.format(dist=CLOUDFRONT_DIST), STATIC_URL)
+    # Configure Django Storages to use Cloudfront distribution for S3 assets
+    AWS_S3_CUSTOM_DOMAIN = '{dist}.cloudfront.net'.format(dist=CLOUDFRONT_DIST)
 
 STATIC_ROOT = 'staticfiles'
 STATICFILES_DIRS = (


### PR DESCRIPTION
Added the `AWS_S3_CUSTOM_DOMAIN` setting in order for S3 assets
managed via Django Storages library to be served via CloudFront.

#### What are the relevant tickets?
Fixed #1922 

#### What's this PR do?
Configures Django Storages to use the Cloudfront dist instead of the S3 domain for S3 assets.

#### How should this be manually tested?
Set the `CLOUDFRONT_DIST` environment variable and verify that the links to e.g. profile images are pointed at Cloudfront instead of S3.

#### Where should the reviewer start?
`micromasters/settings.py`

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
