### PR TITLE
Search: Added states/regions to search results for US learners

### DIFF
--- a/static/js/components/search/LearnerResult.js
+++ b/static/js/components/search/LearnerResult.js
@@ -53,7 +53,7 @@ class LearnerResult extends SearchkitComponent {
         </Cell>
         <Cell col={4} className="centered learner-location">
           <span>
-            { getLocation(profile, false) }
+            { getLocation(profile, true) }
           </span>
         </Cell>
         <Cell col={3} className="learner-grade">

--- a/static/js/components/search/LearnerResult.js
+++ b/static/js/components/search/LearnerResult.js
@@ -53,7 +53,7 @@ class LearnerResult extends SearchkitComponent {
         </Cell>
         <Cell col={4} className="centered learner-location">
           <span>
-            { getLocation(profile, true) }
+            { getLocation(profile) }
           </span>
         </Cell>
         <Cell col={3} className="learner-grade">

--- a/static/js/components/search/LearnerResult_test.js
+++ b/static/js/components/search/LearnerResult_test.js
@@ -73,6 +73,7 @@ describe('LearnerResult', () => {
     let result = renderLearnerResult().find(".learner-location").find("span");
     assert.include(result.text(), USER_PROFILE_RESPONSE.city);
     assert.include(result.text(), USER_PROFILE_RESPONSE.country);
+    assert.include(result.text(), USER_PROFILE_RESPONSE.state_or_territory);
   });
 
   it("should include the user's current program grade when a grade is available", () => {

--- a/static/js/components/search/LearnerResult_test.js
+++ b/static/js/components/search/LearnerResult_test.js
@@ -2,6 +2,7 @@
 /* global SETTINGS: false */
 import _ from 'lodash';
 import React from 'react';
+import R from 'ramda';
 import { Provider } from 'react-redux';
 import { assert } from 'chai';
 import { mount } from 'enzyme';
@@ -27,6 +28,7 @@ import {
   USER_PROGRAM_RESPONSE,
   ELASTICSEARCH_RESPONSE,
 } from '../../test_constants';
+import { codeToCountryName } from '../../lib/location';
 
 describe('LearnerResult', () => {
   let helper;
@@ -69,11 +71,30 @@ describe('LearnerResult', () => {
     assert.equal(result.text(), getUserDisplayName(USER_PROFILE_RESPONSE));
   });
 
-  it("should include the user's location", () => {
+  it("should include the user's location for US residence", () => {
     let result = renderLearnerResult().find(".learner-location").find("span");
     assert.include(result.text(), USER_PROFILE_RESPONSE.city);
     assert.include(result.text(), USER_PROFILE_RESPONSE.country);
     assert.include(result.text(), USER_PROFILE_RESPONSE.state_or_territory);
+  });
+
+
+  it("should include the user's location for non US residence", () => {
+    let profile = R.clone(USER_PROFILE_RESPONSE);
+    profile['country'] = 'PK';
+    let searchResults = renderElasticSearchResult(
+      {
+        _source: {
+          profile: profile,
+          program: USER_PROGRAM_RESPONSE,
+        }
+      },
+      {}
+    );
+    let result = searchResults.find(".learner-location").find("span");
+    assert.include(result.text(), profile.city);
+    assert.include(result.text(), codeToCountryName(profile.country));
+    assert.notInclude(result.text(), profile.state_or_territory);
   });
 
   it("should include the user's current program grade when a grade is available", () => {


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2670

#### What's this PR do?
Added state on search results

#### How should this be manually tested?
Go to `/learners/` and see data in resident field against US users.

@pdpinch 

#### Screenshots (if appropriate)
<img width="898" alt="screen shot 2017-02-28 at 8 15 41 pm" src="https://cloud.githubusercontent.com/assets/10431250/23411067/17076bec-fdf3-11e6-92b8-2e42d55791e2.png">

