### PR TITLE
Fix flaky test

### DIFF
--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -77,6 +77,7 @@ class BasicTests(SeleniumTestsBase):
         # Update for new users and new role
         index_program_enrolled_users(ProgramEnrollment.objects.iterator())
         self.get("{}/learners".format(self.live_server_url))
+        self.wait().until(lambda driver: driver.find_element_by_class_name('learner-result'))
         assert self.num_elements_on_page('.learner-result') == page_size
         self.selenium.find_elements_by_class_name('sk-pagination-option')[1].click()
 


### PR DESCRIPTION
#### What are the relevant tickets?
None
#### What's this PR do?
Fixes a flaky selenium test. It adds a wait for the react components to load on the page. Previously it just waited for the `body` to be available

#### How should this be manually tested?
Test should pass
