### PR TITLE
fix profile validation

### DIFF
--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -27,8 +27,8 @@ import { shouldRenderRomanizedFields } from '../../util/profile_edit';
 
 type ErrorMessages = {[key: string]: string};
 
-let isNilOrEmptyString = (val: any): boolean => (
-  val === null || val === undefined || val === ""
+export const isNilOrEmptyString = R.anyPass(
+  [R.isNil, R.test(/^\s*$/)]
 );
 
 const filledOutFields = R.compose(R.keys, R.reject(isNilOrEmptyString));

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import moment from 'moment';
 
 import {
+  isNilOrEmptyString,
   personalValidation,
   educationValidation,
   employmentValidation,
@@ -31,6 +32,25 @@ describe('Profile validation functions', () => {
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  describe('isNilOrEmptyString', () => {
+    it('should match nil values and empty strings, nothing else', () => {
+      [
+        [null, true],
+        [undefined, true],
+        ["", true],
+        [" ", true],
+        ["   ", true],
+        [" \n  ", true],
+        ["\t ", true],
+        ["TEST", false],
+        [" TEST", false],
+        [" TEST ", false],
+      ].forEach(([val, expectation]) => {
+        assert.equal(isNilOrEmptyString(val), expectation);
+      });
+    });
   });
 
   describe('Personal validation', () => {


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #2721

#### What's this PR do?

This ensures that we validate strings composed of just whitespace the same way we do empty strings and null values.

#### How should this be manually tested?

Go to `/profile` and put a whitespace string in any field. You should get a validation error, and it should not make a request to save the profile. You should have to enter a legit value to get it to save.