### PR TITLE
Fixed ExamProfile lookup query (#2716)

### DIFF
--- a/exams/pearson/download.py
+++ b/exams/pearson/download.py
@@ -168,7 +168,7 @@ class ArchivedResponseProcessor:
         messages = []
         for result in results:
             try:
-                exam_profile = ExamProfile.objects.get(profile_id=result.client_candidate_id)
+                exam_profile = ExamProfile.objects.get(profile__student_id=result.client_candidate_id)
             except ExamProfile.DoesNotExist:
                 error_message = "Unable to find an ExamProfile record for profile_id `{profile_id}`".format(
                     profile_id=result.client_candidate_id

--- a/exams/pearson/download_test.py
+++ b/exams/pearson/download_test.py
@@ -278,7 +278,9 @@ class VCDCDownloadTest(MockedESTestCase):
         cls.now = datetime.now(pytz.utc)
         cls.processor = download.ArchivedResponseProcessor(sftp)
         with mute_signals(post_save):
-            cls.success_profiles = ExamProfileFactory.create_batch(2)
+            cls.success_profiles = ExamProfileFactory.create_batch(2) + [
+                ExamProfileFactory.create(profile__id=999, profile__student_id=1000),  # disjoint id and student_id
+            ]
             cls.failure_profiles = ExamProfileFactory.create_batch(2)
 
         cls.success_results = [VCDCResult(


### PR DESCRIPTION
Fixes #2716 

#### What's this PR do?
We send data to Pearson using the `Profile.student_id`, but we were looking it up by `Profile.id`. Locally this was fine, but in production some early users have those values differ.

#### How should this be manually tested?
Set `FEATURE_EXAM_SYNC=True` in `.env` and run this in a shell:

```python
from django.contrib.auth.models import User
from exams.models import ExamProfile, ExamAuthorization
from courses.models import Course
from exams import tasks

user = User.objects.get(username=<YOU>)

user.profile.student_id = 1000
user.profile.save()

# fudge the records to sync
ep = ExamProfile.objects.create(profile=user.profile)

# sync each object type to the sftp server
tasks.export_exam_profiles()
```

Then run:

`docker-compose run web ./manage.py simulate_sftp_responses --poll`

And in the shell again:

```python
tasks.batch_process_pearson_zip_files()
ep.refresh_from_db()
print(ep.status)
```

Should print the success status.