### PR TITLE
Use searchkit from props instead of storing it in redux

### DIFF
--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -26,11 +26,19 @@ export default class ProgramFilter extends SearchkitComponent {
     return this._accessor;
   }
 
+  refreshSearchkit = () => {
+    // (╯°□°)╯︵ ┻━┻
+    this.context.searchkit.resetState();
+    this.context.searchkit.reloadSearch();
+  };
+
+  componentDidMount() {
+    this.refreshSearchkit();
+  }
+
   componentDidUpdate(prevProps: Object): void {
     if (!_.isEqual(prevProps.currentProgramEnrollment, this.props.currentProgramEnrollment)) {
-      // (╯°□°)╯︵ ┻━┻
-      this.context.searchkit.resetState();
-      this.context.searchkit.reloadSearch();
+      this.refreshSearchkit();
     }
   }
 

--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -12,7 +12,7 @@ export default class EmailCompositionDialog extends React.Component {
     dialogVisibility:           boolean,
     activeEmail:                EmailState,
     title?:                     string,
-    subheadingRenderer?:        () => React$Element<*>,
+    subheadingRenderer?:        (subheading: ?string) => React$Element<*>,
     closeAndClearEmailComposer: () => void,
     closeEmailComposerAndSend:  () => void,
     updateEmailFieldEdit:       () => void

--- a/static/js/components/email/hoc.js
+++ b/static/js/components/email/hoc.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import R from 'ramda';
 

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -11,7 +11,7 @@ import { EmailConfig } from '../../flow/emailTypes';
 export const COURSE_TEAM_EMAIL_CONFIG: EmailConfig = {
   title: 'Contact the Course Team',
 
-  renderSubheading: (subheading: string) => (
+  renderSubheading: (subheading: ?string) => (
     <div className="subheading-section">
       <Grid noSpacing={true}>
         <Cell col={1} align={"middle"} className="subheading-to">TO:</Cell>
@@ -38,7 +38,7 @@ export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
   title: 'New Email',
 
   emailOpenParams: (searchkit: Object) => ({
-    params: {searchkit: searchkit},
+    params: {},
     subheading: `${searchkit.getHitsCount() || 0} recipients selected`
   }),
 
@@ -46,7 +46,7 @@ export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
     sendSearchResultMail(
       emailState.inputs.subject || '',
       emailState.inputs.body || '',
-      emailState.params.searchkit.buildQuery().query
+      emailState.searchkit.buildQuery().query
     )
   )
 };

--- a/static/js/components/email/test_constants.js
+++ b/static/js/components/email/test_constants.js
@@ -10,7 +10,7 @@ const dummyEmailActionDispatcher = () => (
 export const TEST_EMAIL_TYPE = 'TEST_EMAIL';
 export const TEST_EMAIL_CONFIG = {
   title: 'Test Email Dialog',
-  renderSubheading: (subheading: string) => (
+  renderSubheading: (subheading: ?string) => (
     <div className="test-subheading">{ subheading }</div>
   ),
   emailOpenParams: () => {},

--- a/static/js/components/search/WithSearchkitManager.js
+++ b/static/js/components/search/WithSearchkitManager.js
@@ -1,0 +1,37 @@
+// @flow
+/* global SETTINGS: false */
+import React from 'react';
+import { SearchkitManager, SearchkitProvider } from 'searchkit';
+
+import { getDisplayName } from '../../util/util';
+import { getCookie } from '../../lib/api';
+
+const withSearchkitManager = (WrappedComponent: ReactClass<*>) => {
+  class WithSearchkitManager extends React.Component {
+    searchkit: SearchkitManager;
+
+    constructor(props: Object) {
+      super(props);
+
+      this.searchkit = new SearchkitManager(SETTINGS.search_url, {
+        httpHeaders: {
+          'X-CSRFToken': getCookie('csrftoken')
+        }
+      });
+    }
+
+    render() {
+      return <SearchkitProvider searchkit={this.searchkit}>
+        <WrappedComponent
+          {...this.props}
+          searchkit={this.searchkit}
+        />
+      </SearchkitProvider>;
+    }
+  }
+
+  WithSearchkitManager.displayName = `WithSearchkitManager(${getDisplayName(WrappedComponent)})`;
+  return WithSearchkitManager;
+};
+
+export default withSearchkitManager;

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -122,7 +122,7 @@ class DashboardPage extends React.Component {
     financialAid:             FinancialAidState,
     location:                 Object,
     pearson:                  PearsonAPIState,
-    openEmailComposer:        () => void
+    openEmailComposer:        (emailType: string, emailOpenParams: any) => void
   };
 
   componentDidMount() {

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -29,6 +29,7 @@ import * as dashboardActions from '../actions/dashboard';
 import { CLEAR_COUPONS } from '../actions/coupons';
 import {
   SHOW_DIALOG,
+  HIDE_DIALOG,
   SET_TOAST_MESSAGE,
   CLEAR_UI,
   SET_COUPON_NOTIFICATION_VISIBILITY,
@@ -37,7 +38,13 @@ import {
   SET_ENROLL_SELECTED_COURSE_RUN,
   setToastMessage,
 } from '../actions/ui';
-import { START_EMAIL_EDIT } from '../actions/email';
+import {
+  INITIATE_SEND_EMAIL,
+  START_EMAIL_EDIT,
+  SEND_EMAIL_SUCCESS,
+  CLEAR_EMAIL_EDIT,
+  UPDATE_EMAIL_VALIDATION,
+} from '../actions/email';
 import {
   SET_TIMEOUT_ACTIVE,
   setInitialTime,
@@ -80,7 +87,10 @@ import {
   TOAST_SUCCESS,
 } from '../constants';
 import type { Program } from '../flow/programTypes';
-import { findCourse } from '../util/test_utils';
+import {
+  findCourse,
+  modifyTextField,
+} from '../util/test_utils';
 import { DASHBOARD_SUCCESS_ACTIONS } from './test_util';
 
 describe('DashboardPage', () => {
@@ -483,6 +493,22 @@ describe('DashboardPage', () => {
         }).then((state) => {
           assert.isFalse(state.ui.paymentTeaserDialogVisibility);
           assert.isTrue(state.ui.dialogVisibility[EMAIL_COMPOSITION_DIALOG]);
+
+          modifyTextField(document.querySelector('.email-subject'), 'subject');
+          modifyTextField(document.querySelector('.email-body'), 'body');
+
+          return listenForActions([
+            UPDATE_EMAIL_VALIDATION,
+            INITIATE_SEND_EMAIL,
+            SEND_EMAIL_SUCCESS,
+            CLEAR_EMAIL_EDIT,
+            HIDE_DIALOG,
+          ], () => {
+            document.querySelector('.email-composition-dialog .save-button').click();
+          }).then(state => {
+            assert.isFalse(state.ui.dialogVisibility[EMAIL_COMPOSITION_DIALOG]);
+            assert.isTrue(helper.sendCourseTeamMail.calledWith('subject', 'body', course.id));
+          });
         });
       });
     });

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -29,7 +29,7 @@ export type AllEmailsState = {
 
 export type EmailConfig = {
   title: string,
-  renderSubheading: (subheading: string) => React$Element<*>,
+  renderSubheading: (subheading: ?string) => React$Element<*>,
   emailOpenParams: (args: any) => Object,
   emailSendAction: (emailState: EmailState) => Dispatcher<EmailSendResponse>
 };

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -67,6 +67,10 @@ export default class IntegrationTestHelper {
     this.skipFinancialAidStub.returns(Promise.resolve());
     this.addFinancialAidStub = this.sandbox.stub(api, 'addFinancialAid');
     this.addFinancialAidStub.returns(Promise.resolve());
+    this.sendSearchResultMail = this.sandbox.stub(api, 'sendSearchResultMail');
+    this.sendSearchResultMail.returns(Promise.resolve());
+    this.sendCourseTeamMail = this.sandbox.stub(api, 'sendCourseTeamMail');
+    this.sendCourseTeamMail.returns(Promise.resolve());
     this.scrollIntoViewStub = this.sandbox.stub();
     window.HTMLDivElement.prototype.scrollIntoView = this.scrollIntoViewStub;
     window.HTMLFieldSetElement.prototype.scrollIntoView = this.scrollIntoViewStub;


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2527 

#### What's this PR do?
This passes in searchkit as a prop in the email state so that we don't have to pass it to redux for the dialog to see it. This also refactors the searchkit manager code to live in a higher order class.

#### How should this be manually tested?
Go to the learners page and send an email. Everything should work as it did before.
