### PR TITLE
Add UI to send automatic emails for learner search

### DIFF
--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import Dialog from 'material-ui/Dialog';
+import Checkbox from 'material-ui/Checkbox';
 
 import { FETCH_PROCESSING } from '../../actions';
 import { dialogActions } from '../inputs/util';
@@ -46,13 +47,29 @@ export default class EmailCompositionDialog extends React.Component {
     if (!this.props.activeEmail) return null;
 
     const {
-      activeEmail: { fetchStatus, inputs },
+      activeEmail: { fetchStatus, inputs, supportsAutomaticEmails },
       title,
       dialogVisibility,
       closeAndClearEmailComposer,
       closeEmailComposerAndSend,
       updateEmailFieldEdit
     } = this.props;
+    let automaticCheckbox;
+    if (supportsAutomaticEmails) {
+      automaticCheckbox = <Checkbox
+        label="Automatically send this message in the future, whenever new users join who meet these criteria"
+        className="email-automatic"
+        checked={inputs.sendAutomaticEmails || false}
+        value={true}
+        onCheck={e => {
+          updateEmailFieldEdit('sendAutomaticEmails', {
+            target: {
+              value: e.target.checked
+            }
+          });
+        }}
+      />;
+    }
 
     return <Dialog
       title={title || "New Email"}
@@ -88,6 +105,7 @@ export default class EmailCompositionDialog extends React.Component {
           onChange={updateEmailFieldEdit('body')}
         />
         { this.showValidationError('body') }
+        {automaticCheckbox}
       </div>
     </Dialog>;
   }

--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -43,6 +43,27 @@ export default class EmailCompositionDialog extends React.Component {
     }
   };
 
+  automaticCheckbox = () => {
+    const {
+      activeEmail: { inputs },
+      updateEmailFieldEdit,
+    } = this.props;
+
+    return <Checkbox
+      label="Automatically send this message in the future, whenever new users join who meet these criteria"
+      className="email-automatic"
+      checked={inputs.sendAutomaticEmails || false}
+      value={true}
+      onCheck={e => {
+        updateEmailFieldEdit('sendAutomaticEmails', {
+          target: {
+            value: e.target.checked
+          }
+        });
+      }}
+    />;
+  };
+
   render() {
     if (!this.props.activeEmail) return null;
 
@@ -54,22 +75,6 @@ export default class EmailCompositionDialog extends React.Component {
       closeEmailComposerAndSend,
       updateEmailFieldEdit
     } = this.props;
-    let automaticCheckbox;
-    if (supportsAutomaticEmails) {
-      automaticCheckbox = <Checkbox
-        label="Automatically send this message in the future, whenever new users join who meet these criteria"
-        className="email-automatic"
-        checked={inputs.sendAutomaticEmails || false}
-        value={true}
-        onCheck={e => {
-          updateEmailFieldEdit('sendAutomaticEmails', {
-            target: {
-              value: e.target.checked
-            }
-          });
-        }}
-      />;
-    }
 
     return <Dialog
       title={title || "New Email"}
@@ -105,7 +110,7 @@ export default class EmailCompositionDialog extends React.Component {
           onChange={updateEmailFieldEdit('body')}
         />
         { this.showValidationError('body') }
-        {automaticCheckbox}
+        {supportsAutomaticEmails ? this.automaticCheckbox() : null}
       </div>
     </Dialog>;
   }

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -44,7 +44,8 @@ export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
   title: 'New Email',
 
   emailOpenParams: (searchkit: Object) => ({
-    subheading: `${searchkit.getHitsCount() || 0} recipients selected`
+    subheading: `${searchkit.getHitsCount() || 0} recipients selected`,
+    supportsAutomaticEmails: true,
   }),
 
   getEmailSendFunction: () => sendSearchResultMail,
@@ -52,8 +53,9 @@ export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
   emailSendParams: (emailState) => ([
     emailState.inputs.subject || '',
     emailState.inputs.body || '',
-    emailState.searchkit.buildQuery().query
-  ])
+    emailState.searchkit.buildQuery().query,
+    emailState.inputs.sendAutomaticEmails || false,
+ ])
 };
 
 export const LEARNER_EMAIL_CONFIG: EmailConfig = {

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -55,7 +55,7 @@ export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
     emailState.inputs.body || '',
     emailState.searchkit.buildQuery().query,
     emailState.inputs.sendAutomaticEmails || false,
- ])
+  ])
 };
 
 export const LEARNER_EMAIL_CONFIG: EmailConfig = {

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -82,6 +82,7 @@ describe('LearnerSearchPage', function () {
 
         modifyTextField(document.querySelector('.email-subject'), 'subject');
         modifyTextField(document.querySelector('.email-body'), 'body');
+        document.querySelector('.email-automatic input[type=checkbox]').click();
 
         return listenForActions([
           UPDATE_EMAIL_VALIDATION,
@@ -93,7 +94,7 @@ describe('LearnerSearchPage', function () {
           document.querySelector('.email-composition-dialog .save-button').click();
         }).then(state => {
           assert.isFalse(state.ui.dialogVisibility[EMAIL_COMPOSITION_DIALOG]);
-          assert.isTrue(helper.sendSearchResultMail.calledWith('subject', 'body', sinon.match.any));
+          assert.isTrue(helper.sendSearchResultMail.calledWith('subject', 'body', sinon.match.any, true));
           assert.deepEqual(
             Object.keys(helper.sendSearchResultMail.firstCall.args[2]),
             [

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -5,8 +5,9 @@ export type EmailSendResponse = {
 export type EmailSendError = EmailSendResponse;
 
 export type EmailInputs = {
-  subject?:   ?string,
-  body?:      ?string,
+  subject?:             ?string,
+  body?:                ?string,
+  sendAutomaticEmails?: boolean,
 };
 export type EmailValidationErrors = EmailInputs;
 

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -11,12 +11,12 @@ export type EmailInputs = {
 export type EmailValidationErrors = EmailInputs;
 
 export type EmailState = {
-  inputs:                  EmailInputs,
-  subheading:              ?string,
-  params:                  Object,
-  validationErrors:        EmailValidationErrors,
-  sendError:               EmailSendError,
-  fetchStatus?:            ?string,
+  inputs:                   EmailInputs,
+  subheading:               ?string,
+  params:                   Object,
+  validationErrors:         EmailValidationErrors,
+  sendError:                EmailSendError,
+  fetchStatus?:             ?string,
   supportsAutomaticEmails?: boolean,
 };
 

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -11,12 +11,13 @@ export type EmailInputs = {
 export type EmailValidationErrors = EmailInputs;
 
 export type EmailState = {
-  inputs:           EmailInputs,
-  subheading:       ?string,
-  params:           Object,
-  validationErrors: EmailValidationErrors,
-  sendError:        EmailSendError,
-  fetchStatus?:     ?string,
+  inputs:                  EmailInputs,
+  subheading:              ?string,
+  params:                  Object,
+  validationErrors:        EmailValidationErrors,
+  sendError:               EmailSendError,
+  fetchStatus?:            ?string,
+  supportsAutomaticEmail?: boolean,
 };
 
 export type AllEmailsState = {

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -17,7 +17,7 @@ export type EmailState = {
   validationErrors:        EmailValidationErrors,
   sendError:               EmailSendError,
   fetchStatus?:            ?string,
-  supportsAutomaticEmail?: boolean,
+  supportsAutomaticEmails?: boolean,
 };
 
 export type AllEmailsState = {

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -171,13 +171,16 @@ export function checkout(courseId: string): Promise<CheckoutResponse> {
   });
 }
 
-export function sendSearchResultMail(subject: string, body: string, searchRequest: Object): Promise<EmailSendResponse> {
+export function sendSearchResultMail(
+  subject: string, body: string, searchRequest: Object, sendAutomaticEmails: boolean,
+): Promise<EmailSendResponse> {
   return fetchJSONWithCSRF('/api/v0/mail/search/', {
     method: 'POST',
     body: JSON.stringify({
       email_subject: subject,
       email_body: body,
-      search_request: searchRequest
+      search_request: searchRequest,
+      send_automatic_emails: sendAutomaticEmails,
     })
   });
 }

--- a/static/js/reducers/email.js
+++ b/static/js/reducers/email.js
@@ -31,7 +31,8 @@ export const INITIAL_EMAIL_STATE: EmailState = {
   params: {},
   validationErrors: {},
   sendError: {},
-  subheading: undefined
+  subheading: undefined,
+  supportsAutomaticEmails: false,
 };
 
 export const INITIAL_ALL_EMAILS_STATE: AllEmailsState = {
@@ -65,7 +66,8 @@ export const email = (state: AllEmailsState = INITIAL_ALL_EMAILS_STATE, action: 
     newState[emailType] = {
       ...INITIAL_EMAIL_STATE,
       params: action.payload.params || {},
-      subheading: action.payload.subheading
+      subheading: action.payload.subheading,
+      supportsAutomaticEmails: action.payload.supportsAutomaticEmails,
     };
     newState.currentlyActive = emailType;
     return newState;

--- a/static/js/reducers/email_test.js
+++ b/static/js/reducers/email_test.js
@@ -45,7 +45,10 @@ describe('email reducers', () => {
 
   it('should let you start editing an email', () => {
     return dispatchThen(startEmailEdit(emailType), [START_EMAIL_EDIT]).then(state => {
-      assert.deepEqual(state[emailType], initialExpectedEmailState);
+      assert.deepEqual(state[emailType], {
+        ...initialExpectedEmailState,
+        supportsAutomaticEmails: undefined,
+      });
     });
   });
 
@@ -57,7 +60,11 @@ describe('email reducers', () => {
       updateEmailEdit({type: emailType, inputs: updatedInputs}),
       [UPDATE_EMAIL_EDIT]
     ).then(state => {
-      assert.deepEqual(state[emailType], { ...initialExpectedEmailState, inputs: updatedInputs });
+      assert.deepEqual(state[emailType], {
+        ...initialExpectedEmailState,
+        supportsAutomaticEmails: undefined,
+        inputs: updatedInputs,
+      });
     });
   });
 

--- a/static/scss/email-composition-dialog.scss
+++ b/static/scss/email-composition-dialog.scss
@@ -59,5 +59,9 @@
         margin-bottom: 5px;
       }
     }
+
+    .email-automatic {
+      padding: 20px 0;
+    }
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2707 

#### What's this PR do?
Adds the checkbox for sending emails automatically for the learner search page

#### How should this be manually tested?
On the learner search page click the checkbox and send an email. Look in your network tab and verify that `send_automatic_emails: true` was sent. Unclick the checkbox, send another email and verify that `send_automatic_emails: false` was sent.

Also open the other two email dialogs and verify that there is no checkbox at all for these two. One dialog is activated by clicking the 'send a message' link under the user chip, and the other one is the 'contact course team' link on the dashboard.