### PR TITLE
Removed program.email_optin from ES index

### DIFF
--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -72,7 +72,6 @@ class UserProgramSearchSerializer:
             'semester_enrollments': cls.serialize_semester_enrollments(enrollments_qset),
             'grade_average': mmtrack.calculate_final_grade_average(),
             'is_learner': is_learner(user, program),
-            'email_optin': user.profile.email_optin,
             'num_courses_passed': mmtrack.count_courses_passed(),
             'total_courses': program.course_set.count()
         }

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -37,7 +37,6 @@ from profiles.factories import (
     EmploymentFactory,
     ProfileFactory,
 )
-from profiles.models import Profile
 from roles.models import Role
 from roles.roles import Staff
 from search.base import MockedESTestCase
@@ -157,7 +156,6 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         """
         Tests that full ProgramEnrollment serialization works as expected
         """
-        Profile.objects.filter(pk=self.profile.pk).update(email_optin=True)
         self.profile.refresh_from_db()
         program = self.program_enrollment.program
         assert UserProgramSearchSerializer.serialize(self.program_enrollment) == {
@@ -166,26 +164,6 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
             'semester_enrollments': self.semester_enrollments,
             'grade_average': 75,
             'is_learner': True,
-            'email_optin': True,
-            'num_courses_passed': 1,
-            'total_courses': 1
-        }
-
-    @ddt.data(False, True)
-    def test_full_program_user_serialization_email_optin_changes(self, email_optin_flag):
-        """
-        Tests that full ProgramEnrollment serialization works as expected on email_optin changes.
-        """
-        Profile.objects.filter(pk=self.profile.pk).update(email_optin=email_optin_flag)
-        self.profile.refresh_from_db()
-        program = self.program_enrollment.program
-        assert UserProgramSearchSerializer.serialize(self.program_enrollment) == {
-            'id': program.id,
-            'enrollments': self.serialized_enrollments,
-            'semester_enrollments': self.semester_enrollments,
-            'grade_average': 75,
-            'is_learner': True,
-            'email_optin': email_optin_flag,
             'num_courses_passed': 1,
             'total_courses': 1
         }
@@ -197,7 +175,6 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         the difference with test_full_program_user_serialization
         is that the grade is calculated using the current grades
         """
-        Profile.objects.filter(pk=self.profile.pk).update(email_optin=True)
         self.profile.refresh_from_db()
         expected_result = {
             'id': self.fa_program.id,
@@ -205,7 +182,6 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
             'semester_enrollments': self.fa_semester_enrollments,
             'grade_average': 95,
             'is_learner': True,
-            'email_optin': True,
             'num_courses_passed': 1,
             'total_courses': 2
         }
@@ -215,7 +191,6 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         """
         Tests that when user has staff role, the serialization shows that she is not a learner.
         """
-        Profile.objects.filter(pk=self.profile.pk).update(email_optin=True)
         self.profile.refresh_from_db()
         program = self.program_enrollment.program
         Role.objects.create(
@@ -230,7 +205,6 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
             'semester_enrollments': self.semester_enrollments,
             'grade_average': 75,
             'is_learner': False,
-            'email_optin': True,
             'num_courses_passed': 1,
             'total_courses': 1
         }
@@ -241,7 +215,6 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         has no passed courses.
         """
         with patch.object(MMTrack, 'count_courses_passed', return_value=0):
-            Profile.objects.filter(pk=self.profile.pk).update(email_optin=True)
             self.profile.refresh_from_db()
             program = self.program_enrollment.program
             assert UserProgramSearchSerializer.serialize(self.program_enrollment) == {
@@ -250,7 +223,6 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
                 'semester_enrollments': self.semester_enrollments,
                 'grade_average': 75,
                 'is_learner': True,
-                'email_optin': True,
                 'num_courses_passed': 0,
                 'total_courses': 1
             }

--- a/search/api.py
+++ b/search/api.py
@@ -53,7 +53,7 @@ def create_program_limit_query(user, filter_on_email_optin=False):
     ]
 
     if filter_on_email_optin:
-        must.append(Q('term', **{'program.email_optin': True}))
+        must.append(Q('term', **{'profile.email_optin': True}))
 
     # no matter what the query is, limit the programs to the allowed ones
     # if this is a superset of what searchkit sends, this will not impact the result

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -195,7 +195,7 @@ class SearchAPITests(ESTestCase):  # pylint: disable=missing-docstring
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].user_id, self.learner.id)
         self.assertTrue(results[0].program.is_learner)
-        self.assertTrue(results[0].program.email_optin)
+        self.assertTrue(results[0].profile.email_optin)
 
     def test_all_query_matching_emails(self):
         """


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2689

#### What's this PR do?
- Removed `program.email_optin` from search because we are showing it on profile index.

#### How should this be manually tested?
**Run:** `docker-compose run web ./manage.py recreate_index`
- test working of learners page, send emails when some users has email opt-in configure.

@pdpinch @noisecapella 