### PR TITLE
Load CSS URLs through Django template

### DIFF
--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -29,43 +29,26 @@ body.app-media {
         float: left;
       }
 
-      .brand-logo {
+      .brand-logo, .micromasters-logo {
         float: left;
-        margin-right: 15px;
-        background: url(/static/images/mit_logo.svg) no-repeat;
+        /* background image from background-images.css */
+        background-repeat: no-repeat;
         height: 36px;
         width: 51px;
         overflow: visible;
         position: relative;
-        top: 5px;
       }
 
-      .brand-logo:hover {
-        background: url(/static/images/mit_logo_on.svg) no-repeat;
+      .brand-logo {
         height: 36px;
         width: 51px;
-        overflow: visible;
-        position: relative;
         top: 5px;
+        margin-right: 15px;
       }
 
       .micromasters-logo {
-        float: left;
-        background: url(/static/images/micromasters_logo.svg) no-repeat;
         height: 23px;
         width: 155px;
-        overflow: visible;
-        position: relative;
-        top: 13px;
-      }
-
-      .micromasters-logo:hover {
-        float: left;
-        background: url(/static/images/micromasters_logo_on.svg) no-repeat;
-        height: 23px;
-        width: 155px;
-        overflow: visible;
-        position: relative;
         top: 13px;
       }
 
@@ -159,13 +142,16 @@ body.app-media {
 }
 
 .banner-wrapper {
-  background: #222 center center url(/static/images/lp_hero.jpg) no-repeat;
+  /* background image from background-images.css */
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-color: #222;
+  background-size: cover;
+  background-attachment: fixed;
   margin: 0 auto;
   width: 100%;
   min-height: 620px;
   padding: 0;
-  background-size: cover;
-  background-attachment: fixed;
   position: relative;
   height: 94vh;
 
@@ -600,7 +586,7 @@ body.app-media {
   background: #1a1a1a;
 
   .reasons-images-wrap::after {
-    content: url(/static/images/hiw-arrow2.png);
+    /* content from background-images.css */
     position: absolute;
     left: 103%;
     top: 18px;

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -271,7 +271,8 @@
       }
 
       .sk-search-box__icon:before {
-        background: url(/static/images/search-icon.svg) no-repeat top left;
+        /* background-image from background-images.css */
+        background: top left no-repeat;
       }
     }
 

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -272,7 +272,8 @@
 
       .sk-search-box__icon:before {
         /* background-image from background-images.css */
-        background: top left no-repeat;
+        background-position: top left;
+        background-repeat: no-repeat;
       }
     }
 

--- a/ui/templates/background-images.css
+++ b/ui/templates/background-images.css
@@ -1,0 +1,22 @@
+{% load static %}
+.banner-wrapper {
+  background-image: url({% static "images/lp_hero.jpg" %});
+}
+.navbar .navbar-header .brand-logo {
+  background-image: url({% static "images/mit_logo.svg" %});
+}
+.navbar .navbar-header .brand-logo:hover {
+  background-image: url({% static "images/mit_logo_on.svg" %});
+}
+.navbar .navbar-header .micromasters-logo {
+  background-image: url({% static "images/micromasters_logo.svg" %});
+}
+.navbar .navbar-header .micromasters-logo:hover {
+  background-image: url({% static "images/micromasters_logo_on.svg" %});
+}
+.how-it-works-section .reasons-images-wrap::after {
+  content: url({% static "images/hiw-arrow2.png" %});
+}
+.sk-search-box form .sk-search-box__icon:before {
+  background-image: url({% static "images/search-icon.svg" %});
+}

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,400i,500,700" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link rel="stylesheet" href="{% url 'background-images-css' %}" />
     {% load raven %}
     <link rel="icon" href="{% static 'images/favicon.ico' %}" />
     <script type="text/javascript">

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,400i,500,700" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
-    <link rel="stylesheet" href="{% url 'background-images-css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% url 'background-images-css' %}" />
     {% load raven %}
     <link rel="icon" href="{% static 'images/favicon.ico' %}" />
     <script type="text/javascript">

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -14,6 +14,7 @@ from ui.views import (
     terms_of_service,
     page_404,
     page_500,
+    BackgroundImagesCSSView,
 )
 
 dashboard_urlpatterns = [
@@ -27,4 +28,5 @@ urlpatterns = [
     url(r'^500/$', page_500, name='ui-500'),
     url(r'^learner/(?P<user>[-\w.]+)?/?', UsersView.as_view(), name='ui-users'),
     url(r'^{}$'.format(TERMS_OF_SERVICE_URL.lstrip("/")), terms_of_service, name='terms_of_service'),
+    url(r'^background-images\.css$', BackgroundImagesCSSView.as_view(), name='background-images-css'),
 ] + dashboard_urlpatterns

--- a/ui/views.py
+++ b/ui/views.py
@@ -10,7 +10,7 @@ from django.core.urlresolvers import reverse
 from django.shortcuts import Http404, redirect, render
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
-from django.views.generic import View
+from django.views.generic import View, TemplateView
 from raven.contrib.django.raven_compat.models import client as sentry
 from rolepermissions.shortcuts import available_perm_status
 from rolepermissions.verifications import has_role
@@ -180,3 +180,12 @@ def page_500(request, *args, **kwargs):  # pylint: disable=unused-argument
     Overridden handler for the 404 error pages.
     """
     return standard_error_page(request, 500, "500.html")
+
+
+class BackgroundImagesCSSView(TemplateView):
+    """
+    Pass a CSS file through Django's template system, so that we can make
+    the URLs point to a CDN.
+    """
+    template_name = "background-images.css"
+    content_type = "text/css"


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2462

#### What's this PR do?
Moves our URL references out of the Sass files and into a file that is processed through the Django Templates system. This allows us to dynamically rewrite this file to point to whatever CDN we're using, if any.

#### How should this be manually tested?
Development: run the project locally, and ensure that the page still loads normally. All assets should continue to have local references, rather than pointing to CloudFront.

Production: set `CLOUDFRONT_DIST=d3o95baofem9lo` in your `.env` file and run the project. The page should appear the same as in development, but if you inspect the page, background images should be pointing to CloudFront. In particular, check the MIT logo at the top left of the page, the hero image on the home page, and the search spyglass icon to the left of the search input box.

#### Any background context you want to provide?
This pull request was made in response to #2703, where we determined that we can't load the CloudFront URL during build time, only at run time.
