### PR TITLE
Fix exam card name display

### DIFF
--- a/static/js/components/dashboard/FinalExamCard.js
+++ b/static/js/components/dashboard/FinalExamCard.js
@@ -18,7 +18,7 @@ import {
   PEARSON_PROFILE_SCHEDULABLE
 } from '../../constants';
 import { FETCH_PROCESSING } from '../../actions';
-import { getPreferredName, getLocation } from '../../util/util';
+import { getFullName, getLocation } from '../../util/util';
 import type { PearsonAPIState } from '../../reducers/pearson';
 
 const cardWrapper = (...children) => (
@@ -61,7 +61,7 @@ const accountCreated = (profile, navigateToProfile) => (
       <div className="address-info">
         <div className="address">
           <span className="name">
-            { getPreferredName(profile) }
+            { getFullName(profile) }
           </span>
           <span>
             { _.get(profile, ['address']) }

--- a/static/js/components/dashboard/FinalExamCard_test.js
+++ b/static/js/components/dashboard/FinalExamCard_test.js
@@ -26,6 +26,8 @@ describe('FinalExamCard', () => {
   let navigateToProfileStub, submitPearsonSSOStub;
   let props;
 
+  let profile = { ...USER_PROFILE_RESPONSE, preferred_name: 'Preferred Name' };
+
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     navigateToProfileStub = sandbox.stub();
@@ -34,7 +36,7 @@ describe('FinalExamCard', () => {
       program.pearson_exam_status !== undefined
     )));
     props = {
-      profile: USER_PROFILE_RESPONSE,
+      profile: profile,
       program: program,
       navigateToProfile: navigateToProfileStub,
       submitPearsonSSO: submitPearsonSSOStub,
@@ -75,10 +77,12 @@ pay for the course and pass the online work.`;
     it(`should include profile info if the profile is ${status}`, () => {
       props.program.pearson_exam_status = status;
       let cardText = stringStrip(renderCard(props).text());
-      assert.include(cardText, USER_PROFILE_RESPONSE.address);
-      assert.include(cardText, USER_PROFILE_RESPONSE.first_name);
-      assert.include(cardText, stringStrip(USER_PROFILE_RESPONSE.phone_number));
-      assert.include(cardText, USER_PROFILE_RESPONSE.state_or_territory);
+      assert.include(cardText, profile.address);
+      assert.include(cardText, profile.first_name);
+      assert.include(cardText, profile.last_name);
+      assert.notInclude(cardText, profile.preferred_name);
+      assert.include(cardText, stringStrip(profile.phone_number));
+      assert.include(cardText, profile.state_or_territory);
     });
 
     it(`should show a button to edit if the profile is ${status}`, () => {

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -269,6 +269,10 @@ export function getPreferredName(profile: Profile, last: boolean = true): string
   return last && profile.last_name && !profile.preferred_name ? `${first} ${profile.last_name}` : first;
 }
 
+export const getFullName = (profile: Profile): string => (
+  `${profile.first_name} ${profile.last_name}`
+);
+
 /**
  * returns the users location
  */

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -13,6 +13,7 @@ import {
   generateNewEducation,
   generateNewWorkHistory,
   getPreferredName,
+  getFullName,
   makeProfileProgressDisplay,
   userPrivilegeCheck,
   calculateDegreeInclusions,
@@ -162,6 +163,21 @@ describe('utility functions', () => {
       it(`shows just the first name if 'last === ${bool}' and 'profile.last_name === undefined'`, () => {
         assert.equal('First', getPreferredName({preferred_name: 'First'}, bool));
       });
+    });
+  });
+
+
+  describe('getFullName', () => {
+    let profile;
+    beforeEach(() => {
+      profile = {
+        first_name: 'jane',
+        last_name: 'doe',
+      };
+    });
+
+    it('returns First Last', () => {
+      assert.equal('jane doe', getFullName(profile));
     });
   });
 


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2735

#### What's this PR do?

We don't want the preferred name in this situation, we want the full name.

#### How should this be manually tested?

Oh gosh. Get the final exam card to appear, and then confirm that you can see your first and last names, and not your preferred name.

You can use the `mock_api.patch` here: https://github.com/aliceriot/mm_patches

This will set things up so that the 'Last Program' program is set up for showing the exam card.

Then you also need to enable the exam feature flag. You can do this by setting this environment variable:

```
MIDDLEWARE_FEATURE_FLAG_QS_PREFIX=MM
```

and then visiting `/dashboard/?MM_FEATURE_EXAMS=1`

that should do it?