### PR TITLE
Added handling of can-upgrade status for past courses

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -278,6 +278,8 @@ def get_info_for_course(course, mmtrack):
             else:
                 # any other status means that the student never passed the course run
                 _add_run(run_status.course_run, mmtrack, CourseStatus.NOT_PASSED)
+        elif run_status.status == CourseRunStatus.CAN_UPGRADE:
+            _add_run(run_status.course_run, mmtrack, CourseStatus.CAN_UPGRADE)
 
     return course_data
 
@@ -409,6 +411,13 @@ def format_courserun_for_dashboard(course_run, status_for_user, mmtrack, positio
             formatted_run['final_grade'] = mmtrack.get_final_grade(course_run.edx_course_key)
         else:
             formatted_run['final_grade'] = mmtrack.get_current_grade(course_run.edx_course_key)
+    # if the course is can-upgrade, we need to show the current grade if it is in progress
+    # or the final grade if it is final
+    elif status_for_user == CourseStatus.CAN_UPGRADE:
+        if mmtrack.has_frozen_grade(course_run.edx_course_key):
+            formatted_run['final_grade'] = mmtrack.get_final_grade(course_run.edx_course_key)
+        else:
+            formatted_run['current_grade'] = mmtrack.get_current_grade(course_run.edx_course_key)
     # any other status but "offered" should have the current grade
     elif status_for_user != CourseStatus.OFFERED:
         formatted_run['current_grade'] = mmtrack.get_current_grade(course_run.edx_course_key)


### PR DESCRIPTION
#### What are the relevant tickets?
part of #2736 

#### What's this PR do?
Fixes 2 problems:

1. If an user has a frozen final grade for a course run BUT she did not pay for the course and the upgrade deadline is still in the future, the course appears as upgradable in the dashboard but the final grade is returned as well.
2. If the above mentioned course run (with exactly the same characteristics) is an old one and the user is currently enrolled in a newer run, the old run is returned with status `can-upgrade` as an old run.
**NOTE: this currently does not work on the dashboard UI but only in the dashboard REST API**

#### How should this be manually tested?

1. for the first part:
In a non financial aid program (for simplicity) take a course with multiple runs, then take the oldest of the runs. Set the upgrade deadline in the future. Then, using the `grade.factories.FinalGradeFactory` create  a final grade for your user in the course run, paying attention to set `passed=True`, `status='complete'` and  `course_run_paid_on_edx=False`.
Now you should see on the dashboard the Pay button together with the final grade number.
2. for the second part
Given the previous setup, take the newest course run in the same course as point 1 and create an verified cached enrollment for your user in it. Create also a cached current grade for the same course run. Remember to set the `dashboard.UserCacheRefreshTime` for your user in the future for `enrollment` and `current_grade` so the cache will not be updated.
If now you go to `/api/v0/dashboard/<your_username>/` you should see 2 course runs for the course above picked: the first should have status `currently-enrolled` and the second `can-upgrade`. The second should also have a final grade (it should have the same data of the first part).

#### Where should the reviewer start?
`dashboard/api.py`

#### Any background context you want to provide?
The change to the `FormatRunTest ` tests is quite extensive only because I split one single huge test in multiple ones: Feel free to review only `test_format_run_with_can_upgrade_no_frozen_grade` and `test_format_run_with_can_upgrade_and_frozen_grade`
