### PR TITLE
Removed error message if there are no enrollments

### DIFF
--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -144,21 +144,21 @@ describe("ErrorMessage", () => {
         });
       });
 
-      it('shows an error if there are no programs', () => {
+      it('shows nothing if there are no programs', () => {
         helper.dashboardStub.returns(Promise.resolve([]));
 
         return renderComponent("/dashboard", DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
           let message = wrapper.find('.page-content').text();
-          assert(message.includes("Additional info: No program enrollment is available."));
+          assert.equal(message, "");
         });
       });
 
-      it('shows an error if there is no matching current program enrollment', () => {
+      it('shows nothing if there is no matching current program enrollment', () => {
         helper.programsGetStub.returns(Promise.resolve([]));
 
         return renderComponent("/dashboard", DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
           let message = wrapper.find('.page-content').text();
-          assert(message.includes("Additional info: No program enrollment is available."));
+          assert.equal(message, "");
         });
       });
     });
@@ -254,12 +254,12 @@ describe("ErrorMessage", () => {
     });
 
     describe('learners page', () => {
-      it('shows an error if there is no matching current program enrollment', () => {
+      it('shows nothing if there is no matching current program enrollment', () => {
         helper.programsGetStub.returns(Promise.resolve([]));
 
         return renderComponent("/learners").then(([wrapper]) => {
           let message = wrapper.find('.page-content').text();
-          assert(message.includes("Additional info: No program enrollment is available."));
+          assert.equal(message, "");
         });
       });
     });

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -141,7 +141,7 @@ describe('App', function() {
 
   describe('program enrollments', () => {
     it('shows an error message if the enrollments GET fetch fails', () => {
-      helper.programsGetStub.returns(Promise.reject());
+      helper.programsGetStub.returns(Promise.reject("error"));
       let types = [
         REQUEST_DASHBOARD,
         RECEIVE_DASHBOARD_SUCCESS,

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -531,7 +531,7 @@ class DashboardPage extends React.Component {
         return null;
       }
     }
-    return <ErrorMessage errorInfo={{user_message: "No program enrollment is available."}} />;
+    return null;
   };
 
   renderPageContent = (): React$Element<*>|null => {
@@ -628,7 +628,7 @@ class DashboardPage extends React.Component {
 
     const errorMessage = this.renderErrorMessage();
     let pageContent;
-    if (_.isNil(errorMessage)) {
+    if (_.isNil(errorMessage) && this.getCurrentlyEnrolledProgram()) {
       pageContent = this.renderPageContent();
     }
 

--- a/static/js/containers/LearnerSearchPage.js
+++ b/static/js/containers/LearnerSearchPage.js
@@ -6,7 +6,6 @@ import _ from 'lodash';
 import type { Dispatch } from 'redux';
 import R from 'ramda';
 
-import ErrorMessage from '../components/ErrorMessage';
 import LearnerSearch from '../components/LearnerSearch';
 import withSearchkitManager from '../components/search/WithSearchkitManager';
 import { setSearchFilterVisibility } from '../actions/ui';
@@ -44,7 +43,7 @@ class LearnerSearchPage extends React.Component {
     const { currentProgramEnrollment, openEmailComposer } = this.props;
 
     if (_.isNil(currentProgramEnrollment)) {
-      return <ErrorMessage errorInfo={{user_message: "No program enrollment is available."}} />;
+      return null;
     }
 
     return (


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2027 

#### What's this PR do?
Removes the error messages if there is no currently selected enrollment. This can happen:
 - if there are no programs the user is enrolled in
 - when the user first loads the app, before we fetch from the programs API
 - if we fail to fetch programs

The first case should not happen because the user must enroll in a program to complete their profile. The second case happens from time to time but is not an error, so we shouldn't show anything special in this case. For the third case we should show an error message. This PR fixes handling of the second case and leaves the handling of the third case as is.

#### How should this be manually tested?
Go to the dashboard. Clear `localStorage.redux` and refresh the page. You should not see any temporary error message. Repeat for `/learners`
