### PR TITLE
Fixed EOFError (#2753)

### DIFF
--- a/exams/pearson/download.py
+++ b/exams/pearson/download.py
@@ -93,14 +93,14 @@ class ArchivedResponseProcessor:
                         if self.process_zip(local_path):
                             self.sftp.remove(remote_path)
                         log.debug("Processed remote file: %s", remote_path)
-                    except SSHException:
+                    except (EOFError, SSHException):
                         raise
                     except:  # pylint: disable=bare-except
                         log.exception("Error processing file: %s", remote_path)
                     finally:
                         if os.path.exists(local_path):
                             os.remove(local_path)
-        except SSHException as exc:
+        except (EOFError, SSHException) as exc:
             raise RetryableSFTPException("Exception processing response files") from exc
 
     def process_zip(self, local_path):

--- a/exams/pearson/download.py
+++ b/exams/pearson/download.py
@@ -100,7 +100,7 @@ class ArchivedResponseProcessor:
                     finally:
                         if os.path.exists(local_path):
                             os.remove(local_path)
-        except (EOFError, SSHException) as exc:
+        except (EOFError, SSHException,) as exc:
             raise RetryableSFTPException("Exception processing response files") from exc
 
     def process_zip(self, local_path):

--- a/exams/pearson/download.py
+++ b/exams/pearson/download.py
@@ -93,7 +93,7 @@ class ArchivedResponseProcessor:
                         if self.process_zip(local_path):
                             self.sftp.remove(remote_path)
                         log.debug("Processed remote file: %s", remote_path)
-                    except (EOFError, SSHException):
+                    except (EOFError, SSHException,):
                         raise
                     except:  # pylint: disable=bare-except
                         log.exception("Error processing file: %s", remote_path)

--- a/exams/pearson/download_test.py
+++ b/exams/pearson/download_test.py
@@ -172,6 +172,7 @@ class PearsonDownloadTest(SimpleTestCase):
 
 
 @override_settings(**EXAMS_SFTP_SETTINGS)
+@ddt.ddt
 @patch('os.remove')
 @patch('os.path.exists', return_value=True)
 @patch(
@@ -222,10 +223,14 @@ class ArchivedResponseProcessorProcessTest(SimpleTestCase):
         os_path_exists_mock.assert_called_once_with('/tmp/a.zip')
         os_remove_mock.assert_called_once_with('/tmp/a.zip')
 
+    @ddt.data(
+        SSHException('exception'),
+        EOFError(),
+    )
     def test_process_ssh_exception_remove(
-            self, process_zip_mock, filtered_files_mock, os_path_exists_mock, os_remove_mock):
+            self, exc, process_zip_mock, filtered_files_mock, os_path_exists_mock, os_remove_mock):
         """Test that SSH exceptions bubble up"""
-        self.sftp.remove.side_effect = SSHException('exception')
+        self.sftp.remove.side_effect = exc
 
         processor = download.ArchivedResponseProcessor(self.sftp)
         with self.assertRaises(RetryableSFTPException):

--- a/exams/pearson/upload.py
+++ b/exams/pearson/upload.py
@@ -19,5 +19,5 @@ def upload_tsv(file_path):
         with get_connection() as sftp:
             with sftp.cd(settings.EXAMS_SFTP_UPLOAD_DIR):
                 sftp.put(file_path)
-    except (EOFError, SSHException) as exc:
+    except (EOFError, SSHException,) as exc:
         raise RetryableSFTPException() from exc

--- a/exams/pearson/upload.py
+++ b/exams/pearson/upload.py
@@ -19,5 +19,5 @@ def upload_tsv(file_path):
         with get_connection() as sftp:
             with sftp.cd(settings.EXAMS_SFTP_UPLOAD_DIR):
                 sftp.put(file_path)
-    except SSHException as ex:
-        raise RetryableSFTPException() from ex
+    except (EOFError, SSHException) as exc:
+        raise RetryableSFTPException() from exc

--- a/exams/pearson/upload_test.py
+++ b/exams/pearson/upload_test.py
@@ -37,6 +37,7 @@ class PeasonUploadTest(SimpleTestCase):
 
     @data(
         SSHException(),
+        EOFError(),
         ConnectionException('localhost', 22),
     )
     def test_retryable_exceptions(self, expected_exc, connection_mock):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2753 

#### What's this PR do?
Adds `EOFError` to the set of errors considered retryable for sftp operations.

#### How should this be manually tested?
Not really a way to manually test this, the `EOFError` potentially gets raised by pysftp during operations. The code changes are minimal and covered in tests here. If they pass, we should be good.

#### What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/MNkvHycccpOA8/giphy.gif)