### PR TITLE
staff learner info card

### DIFF
--- a/static/js/components/Learner.js
+++ b/static/js/components/Learner.js
@@ -1,5 +1,7 @@
 // @flow
+/* global SETTINGS: false */
 import React from 'react';
+import R from 'ramda';
 
 import EmploymentForm from './EmploymentForm';
 import EducationForm from './EducationForm';
@@ -13,6 +15,8 @@ import {
 } from '../lib/validation/profile';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
+import StaffLearnerInfoCard from './StaffLearnerInfoCard';
+import type { DashboardState } from '../flow/dashboardTypes';
 
 export default class Learner extends React.Component {
   props: {
@@ -24,6 +28,7 @@ export default class Learner extends React.Component {
     saveProfile:                            SaveProfileFunc,
     startProfileEdit:                       () => void,
     setLearnerPageAboutMeDialogVisibility:  () => void,
+    dashboard:                              DashboardState,
   };
 
   toggleShowPersonalDialog = (): void => {
@@ -46,6 +51,19 @@ export default class Learner extends React.Component {
     startProfileEdit();
   };
 
+  showStaffInfo = () => {
+    const { dashboard } = this.props;
+    if (! R.isEmpty(dashboard)) {
+      return dashboard.programs.map(program => (
+        <StaffLearnerInfoCard
+          program={program}
+          key={program.title}
+        />
+      ));
+    }
+    return null;
+  };
+
   render() {
     const { profile } = this.props;
 
@@ -56,6 +74,7 @@ export default class Learner extends React.Component {
         profile={profile}
         toggleShowAboutMeDialog={this.toggleShowAboutMeDialog}
         toggleShowPersonalDialog={this.toggleShowPersonalDialog} />
+      { this.showStaffInfo() }
       <EducationForm {...this.props} showSwitch={false} validator={educationValidation} />
       <EmploymentForm {...this.props} showSwitch={false} validator={employmentValidation} />
     </div>;

--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -17,6 +17,7 @@ import UserMenu from '../containers/UserMenu';
 import ProfileImage from '../containers/ProfileImage';
 import { getPreferredName } from '../util/util';
 import type { Profile } from '../flow/profileTypes';
+import { hasAnyStaffRole } from '../lib/roles';
 
 const PROFILE_SETTINGS_REGEX = /^\/profile\/?|settings\/?|learner\/[a-z]?/;
 const PROFILE_REGEX = /^\/profile\/?/;
@@ -157,7 +158,7 @@ export default class Navbar extends React.Component {
     } = this.props;
 
     let link = '/dashboard';
-    if (SETTINGS.roles.find(role => role.role === 'staff' || role.role === 'instructor')) {
+    if (hasAnyStaffRole(SETTINGS.roles)) {
       link = '/learners';
     }
 

--- a/static/js/components/ProgressWidget.js
+++ b/static/js/components/ProgressWidget.js
@@ -8,25 +8,21 @@ import type {
 } from '../flow/programTypes';
 import { programCourseInfo } from '../util/util';
 
-export default class ProgressWidget extends React.Component {
-  props: {
-    program: Program
-  };
+export const circularProgressWidget = (
+  radius: number,
+  strokeWidth: number,
+  totalPassedCourses: number,
+  totalCourses: number
+): React$Element<*> => {
+  const radiusForMeasures = radius - strokeWidth / 2;
+  const width = radius * 2;
+  const height = radius * 2;
+  const viewBox = `0 0 ${width} ${height}`;
+  const dashArray = radiusForMeasures * Math.PI * 2;
+  const dashOffset = dashArray - dashArray * totalPassedCourses / (totalCourses || 1);
 
-  circularProgressWidget = (
-    radius: number,
-    strokeWidth: number,
-    totalPassedCourses: number,
-    totalCourses: number
-  ): React$Element<*> => {
-    const radiusForMeasures = radius - strokeWidth / 2;
-    const width = radius * 2;
-    const height = radius * 2;
-    const viewBox = `0 0 ${width} ${height}`;
-    const dashArray = radiusForMeasures * Math.PI * 2;
-    const dashOffset = dashArray - dashArray * totalPassedCourses / (totalCourses || 1);
-
-    return (
+  return (
+    <div className="circular-progress-widget">
       <svg className="circular-progress-widget"
         width={radius * 2}
         height={radius * 2}
@@ -56,7 +52,14 @@ export default class ProgressWidget extends React.Component {
           {`${totalPassedCourses}/${totalCourses}`}
         </text>
       </svg>
-    );
+      <p className="text-course-complete">Courses complete</p>
+    </div>
+  );
+};
+
+export default class ProgressWidget extends React.Component {
+  props: {
+    program: Program
   };
 
   render() {
@@ -66,10 +69,7 @@ export default class ProgressWidget extends React.Component {
     return (
       <Card className="progress-widget" shadow={0}>
         <CardTitle className="progress-title">Progress</CardTitle>
-        <div className="circular-progress-widget">
-          {this.circularProgressWidget(63, 7, totalPassedCourses, totalCourses)}
-        </div>
-        <p className="text-course-complete">Courses complete</p>
+        {circularProgressWidget(63, 7, totalPassedCourses, totalCourses)}
         <p className="heading-paragraph">
           On completion, you can apply for
           the master’s degree program</p>

--- a/static/js/components/StaffLearnerInfoCard.js
+++ b/static/js/components/StaffLearnerInfoCard.js
@@ -1,0 +1,33 @@
+// @flow
+import React from 'react';
+import { Card, CardTitle } from 'react-mdl/lib/Card';
+
+import { circularProgressWidget } from './ProgressWidget';
+import { programCourseInfo } from '../util/util';
+import type { Program } from '../flow/programTypes';
+
+type StaffLearnerCardProps = {
+  program: Program,
+};
+
+const StaffLearnerInfoCard = (props: StaffLearnerCardProps) => {
+  const { program } = props;
+  const { totalPassedCourses, totalCourses } = programCourseInfo(program);
+
+  return (
+    <Card shadow={1} className="staff-learner-info-card">
+      <CardTitle>
+        { `Progress - ${program.title}` }
+      </CardTitle>
+      <div className="program-info">
+        <div className="row">
+          <div className="progress-widget">
+            { circularProgressWidget(63, 7, totalPassedCourses, totalCourses) }
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default StaffLearnerInfoCard;

--- a/static/js/components/StaffLearnerInfoCard_test.js
+++ b/static/js/components/StaffLearnerInfoCard_test.js
@@ -1,0 +1,51 @@
+// @flow
+/* global SETTINGS: false */
+import React from 'react';
+import { mount } from 'enzyme';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+
+import StaffLearnerInfoCard from './StaffLearnerInfoCard';
+import { DASHBOARD_RESPONSE } from '../test_constants';
+import { stringStrip } from '../util/test_utils';
+
+describe('StaffLearnerInfoCard', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    SETTINGS.roles.push({ role: 'staff' });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  let renderCard = () => (
+    mount(
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <StaffLearnerInfoCard
+          program={DASHBOARD_RESPONSE[0]}
+        />
+      </MuiThemeProvider>
+    )
+  );
+
+  it('should have the program title', () => {
+    let card = renderCard();
+    assert.include(
+      stringStrip(card.text()),
+      `Progress ${DASHBOARD_RESPONSE[0].title}`
+    );
+  });
+
+  it('should render the progress display', () => {
+    let card = renderCard();
+    assert.include(
+      stringStrip(card.text()),
+      "1 4 Courses complete"
+    );
+  });
+});

--- a/static/js/components/dashboard/FinalExamCard_test.js
+++ b/static/js/components/dashboard/FinalExamCard_test.js
@@ -1,6 +1,5 @@
 // @flow
 import _ from 'lodash';
-import R from 'ramda';
 import React from 'react';
 import { mount } from 'enzyme';
 import { assert } from 'chai';
@@ -20,6 +19,7 @@ import {
   PEARSON_PROFILE_SCHEDULABLE
 } from '../../constants';
 import { INITIAL_PEARSON_STATE } from '../../reducers/pearson';
+import { stringStrip } from '../../util/test_utils';
 
 describe('FinalExamCard', () => {
   let sandbox;
@@ -43,8 +43,6 @@ describe('FinalExamCard', () => {
       pearson: { ...INITIAL_PEARSON_STATE },
     };
   });
-
-  let stringStrip = R.compose(R.join(" "), _.words);
 
   let commonText = `You must take a proctored exam for each course. Exams may
 be taken at any authorized Pearson test center. Before you can take an exam, you have to

--- a/static/js/containers/LearnerPage.js
+++ b/static/js/containers/LearnerPage.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import Loader from '../components/Loader';
 import R from 'ramda';
 
-import { FETCH_PROCESSING } from '../actions';
+import { FETCH_PROCESSING, FETCH_SUCCESS } from '../actions';
 import { clearProfile } from '../actions/profile';
 import {
   profileFormContainer,
@@ -14,16 +14,31 @@ import {
 } from './ProfileFormContainer';
 import ErrorMessage from '../components/ErrorMessage';
 import type { ProfileContainerProps } from './ProfileFormContainer';
+import { fetchDashboard } from '../actions/dashboard';
+import { hasAnyStaffRole } from '../lib/roles';
+import { getDashboard } from '../reducers/util';
+import { S } from '../lib/sanctuary';
+import type { DashboardsState } from '../flow/dashboardTypes';
 
-class LearnerPage extends React.Component<*, ProfileContainerProps, *> {
+const notFetchingOrFetched = R.compose(
+  R.not, R.contains(R.__, [FETCH_PROCESSING, FETCH_SUCCESS])
+);
+
+type LearnerPageProps = ProfileContainerProps & {
+  dashboard: DashboardsState,
+};
+
+class LearnerPage extends React.Component<*, LearnerPageProps, *> {
   componentDidMount() {
     const { params: { username }, fetchProfile } = this.props;
     fetchProfile(username);
+    this.fetchDashboard();
   }
 
   componentDidUpdate() {
     const { params: { username }, fetchProfile } = this.props;
     fetchProfile(username);
+    this.fetchDashboard();
   }
 
   componentWillUnmount() {
@@ -32,6 +47,21 @@ class LearnerPage extends React.Component<*, ProfileContainerProps, *> {
       // don't erase the user's own profile from the state
       dispatch(clearProfile(username));
     }
+  }
+
+  getFocusedDashboard() {
+    const { dashboard, params: { username }} = this.props;
+    return getDashboard(username, dashboard).filter(() => (
+      hasAnyStaffRole(SETTINGS.roles)
+    ));
+  }
+
+  fetchDashboard() {
+    const { dispatch, params: { username } } = this.props;
+
+    this.getFocusedDashboard()
+      .filter(R.propSatisfies(notFetchingOrFetched, 'fetchStatus'))
+      .map(() => dispatch(fetchDashboard(username)));
   }
 
   render() {
@@ -48,7 +78,11 @@ class LearnerPage extends React.Component<*, ProfileContainerProps, *> {
     if (profiles[username] !== undefined) {
       profile = profiles[username];
       loaded = profiles[username].getStatus !== FETCH_PROCESSING;
-      toRender = childrenWithProps(children, profileProps(profile));
+      let props = {
+        dashboard: S.maybe({}, R.identity, this.getFocusedDashboard()),
+        ...profileProps(profile)
+      };
+      toRender = childrenWithProps(children, props);
     }
     const { errorInfo } = profile;
     return <Loader loaded={loaded}>
@@ -57,7 +91,14 @@ class LearnerPage extends React.Component<*, ProfileContainerProps, *> {
   }
 }
 
+const mapStateToProps = state => {
+  return {
+    dashboard: state.dashboard,
+    ...mapStateToProfileProps(state),
+  };
+};
+
 export default R.compose(
-  connect(mapStateToProfileProps),
+  connect(mapStateToProps),
   profileFormContainer
 )(LearnerPage);

--- a/static/js/containers/LearnerPage_test.js
+++ b/static/js/containers/LearnerPage_test.js
@@ -41,7 +41,7 @@ import {
   SET_SHOW_WORK_DELETE_DIALOG,
   SET_SHOW_EDUCATION_DELETE_DIALOG,
 } from '../actions/ui';
-import { USER_PROFILE_RESPONSE } from '../test_constants';
+import { USER_PROFILE_RESPONSE, DASHBOARD_RESPONSE } from '../test_constants';
 import { HIGH_SCHOOL, DOCTORATE } from '../constants';
 import {
   generateNewEducation,
@@ -59,6 +59,11 @@ import {
   clearSelectField,
   GoogleMapsStub,
 } from '../util/test_utils';
+import StaffLearnerInfoCard from '../components/StaffLearnerInfoCard';
+import {
+  REQUEST_DASHBOARD,
+  RECEIVE_DASHBOARD_SUCCESS,
+} from '../actions/dashboard';
 
 describe("LearnerPage", function() {
   this.timeout(10000);
@@ -980,6 +985,25 @@ describe("LearnerPage", function() {
       return renderComponent(`/learner/other`, userActions).then(([, div]) => {
         let count = div.getElementsByClassName('mdl-button--icon').length;
         assert.equal(count, 0);
+      });
+    });
+
+    it('should hide the staff learner info card, if the user doesnt have a staff role', () => {
+      const username = SETTINGS.user.username;
+      return renderComponent(`/learner/${username}`, userActions).then(([wrapper, ]) => {
+        assert.equal(wrapper.find(StaffLearnerInfoCard).length, 0);
+      });
+    });
+
+
+    it('should show the staff learner info card, if the user has a staff role', () => {
+      const smallDashboard = DASHBOARD_RESPONSE.slice(0,1);
+      helper.dashboardStub.returns(Promise.resolve(smallDashboard));
+      const username = SETTINGS.user.username;
+      SETTINGS.roles.push({ role: 'staff' });
+      const actions = userActions.concat([REQUEST_DASHBOARD, RECEIVE_DASHBOARD_SUCCESS]);
+      return renderComponent(`/learner/${username}`, actions).then(([wrapper, ]) => {
+        assert.equal(wrapper.find(StaffLearnerInfoCard).length, 1);
       });
     });
   });

--- a/static/js/lib/roles.js
+++ b/static/js/lib/roles.js
@@ -1,0 +1,17 @@
+// @flow
+import R from 'ramda';
+
+const hasStaffRole = R.propSatisfies(
+  R.contains(R.__, ['staff', 'instructor']),
+  'role'
+);
+
+export const hasAnyStaffRole = R.any(hasStaffRole);
+
+const sameProgram = R.curry((program, role) => (
+  R.equals(program.id, R.prop('program', role))
+));
+
+export const hasStaffForProgram = R.curry((program, roles) => (
+  R.any(R.both(sameProgram(program), hasStaffRole), roles)
+));

--- a/static/js/lib/roles_test.js
+++ b/static/js/lib/roles_test.js
@@ -1,0 +1,45 @@
+// @flow
+import { assert } from 'chai';
+
+import {
+  hasAnyStaffRole,
+  hasStaffForProgram,
+} from './roles';
+
+describe('roles library', () => {
+  let roles;
+
+  beforeEach(() => {
+    roles = [
+      {
+        "role": "staff",
+        "program": 1
+      },
+      {
+        "role": "student",
+        "program": 2
+      }
+    ];
+  });
+
+  describe('hasAnyStaffRole', () => {
+    it('should return true if the user has a staff role on any program', () => {
+      assert.isTrue(hasAnyStaffRole(roles));
+    });
+
+    it('should return false if the user does not have a staff role anywhere', () => {
+      roles[0].role = "student";
+      assert.isFalse(hasAnyStaffRole(roles));
+    });
+  });
+
+  describe('hasStaffForProgram', () => {
+    it('should return true if the user is staff on the specified program', () => {
+      assert.isTrue(hasStaffForProgram({id: 1}, roles));
+    });
+
+    it('should return false if the user is not staff on the specified program', () => {
+      assert.isFalse(hasStaffForProgram({id: 2}, roles));
+    });
+  });
+});

--- a/static/js/lib/sanctuary.js
+++ b/static/js/lib/sanctuary.js
@@ -23,3 +23,18 @@ export const mstr = S.maybe("", String);
  * (the third argument to R.ifElse)
  */
 export const ifNil = R.ifElse(R.isNil, () => S.Nothing());
+
+/*
+ * wraps a function in a guard, which will return Nothing
+ * if any of the arguments are null || undefined,
+ * and otherwise will return Just(fn(...args))
+ * 
+ * Similar to S.toMaybe
+ */
+export const guard = (func: Function) => (...args: any) => {
+  if (R.any(R.isNil, args)) {
+    return S.Nothing();
+  } else {
+    return S.Just(func(...args));
+  }
+};

--- a/static/js/reducers/util.js
+++ b/static/js/reducers/util.js
@@ -2,14 +2,19 @@
 /* global SETTINGS: false */
 import R from 'ramda';
 import { INITIAL_DASHBOARD_STATE } from './dashboard';
+import { guard } from '../lib/sanctuary';
 
 export const getInfoByUsername = R.curry((
   reducer,
-  username,
   defaultTo,
+  username,
   state
 ) => (
   R.pathOr(defaultTo, [reducer, username], state)
 ));
 
-export const getOwnDashboard = getInfoByUsername('dashboard', SETTINGS.user.username, INITIAL_DASHBOARD_STATE);
+export const getOwnDashboard = getInfoByUsername('dashboard', INITIAL_DASHBOARD_STATE, SETTINGS.user.username);
+
+export const getDashboard = guard((username, dashboard) => (
+  R.pathOr(INITIAL_DASHBOARD_STATE, [username], dashboard)
+));

--- a/static/js/reducers/util_test.js
+++ b/static/js/reducers/util_test.js
@@ -2,24 +2,43 @@
 /* global SETTINGS: false */
 import { assert } from 'chai';
 
-import { getOwnDashboard } from './util';
+import { getDashboard, getOwnDashboard } from './util';
 import { DASHBOARD_RESPONSE } from '../test_constants';
 import { INITIAL_DASHBOARD_STATE } from './dashboard';
+import { assertIsJust, assertIsNothing } from '../lib/sanctuary_test';
 
 describe('reducer utilities', () => {
   describe('username selectors', () => {
+    let state = {
+      dashboard: {
+        [SETTINGS.user.username]: DASHBOARD_RESPONSE
+      }
+    };
+
     describe('getOwnDashboard', () => {
       it('should return dashboard -> username, if present', () => {
-        let dashboard = {
-          dashboard: {
-            [SETTINGS.user.username]: DASHBOARD_RESPONSE
-          }
-        };
-        assert.deepEqual(getOwnDashboard(dashboard), DASHBOARD_RESPONSE);
+        assert.deepEqual(getOwnDashboard(state), DASHBOARD_RESPONSE);
       });
 
       it('should return INITIAL_DASHBOARD_STATE otherwise', () => {
         assert.deepEqual(getOwnDashboard({}), INITIAL_DASHBOARD_STATE);
+      });
+    });
+
+    describe('getDashboard', () => {
+      it('should return Just(the dashboard for a particular user), if present', () => {
+        assertIsJust(getDashboard(SETTINGS.user.username, state.dashboard), DASHBOARD_RESPONSE);
+      });
+
+      it('should return Just(INITIAL_DASHBOARD_STATE) if not present', () => {
+        assertIsJust(getDashboard('not_present_username', state.dashboard), INITIAL_DASHBOARD_STATE);
+      });
+
+      it('should return Nothing if either argument is nil', () => {
+        [null, undefined].forEach(nilval => {
+          assertIsNothing(getDashboard('potato', nilval));
+          assertIsNothing(getDashboard(nilval, state.dashboard));
+        });
       });
     });
   });

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -6,6 +6,7 @@ import TestUtils from 'react-addons-test-utils';
 import { assert } from 'chai';
 import sinon from 'sinon';
 import _ from 'lodash';
+import R from 'ramda';
 
 import { findCourseRun } from '../util/util';
 import { DASHBOARD_RESPONSE } from '../test_constants';
@@ -276,3 +277,6 @@ export const testRoutes = (
     <Route path="/learners" component={LearnerSearchPage} />
   </Route>
 );
+
+
+export const stringStrip = R.compose(R.join(" "), _.words);

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -34,6 +34,7 @@
 @import "geosuggest";
 @import "order-summary";
 @import "final-exam-card";
+@import "staff-learner-info-card";
 
 .selected {
   font-weight: bold;

--- a/static/scss/progress-widget.scss
+++ b/static/scss/progress-widget.scss
@@ -2,6 +2,9 @@
 .circular-progress-widget {
   margin-bottom: 8px;
   fill: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 
   .circular-progress-widget-bg {
     stroke: $progress-widget-bg-stroke !important;

--- a/static/scss/staff-learner-info-card.scss
+++ b/static/scss/staff-learner-info-card.scss
@@ -1,0 +1,7 @@
+.staff-learner-info-card {
+  .program-info {
+    .row {
+      display: flex;
+    }
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
closes #2530 

#### What's this PR do?

Implements a card to show info about a learner's course stuff to a staff user.

(note: this is just the first part of the card, which incorporates part of the progress widget from the dashboard).

#### How should this be manually tested?

Make yourself a staff user on a program you're enrolled in, and visit your own learner page.