### PR TITLE
Modified management commands for grades

### DIFF
--- a/grades/admin.py
+++ b/grades/admin.py
@@ -38,5 +38,13 @@ class FinalGradeAuditAdmin(admin.ModelAdmin):
         return False
 
 
+class CourseRunGradingStatusAdmin(admin.ModelAdmin):
+    """Admin for FinalGradeA"""
+    model = models.CourseRunGradingStatus
+    list_display = ('id', 'course_run', 'status')
+    ordering = ('course_run',)
+
+
 admin.site.register(models.FinalGrade, FinalGradeAdmin)
 admin.site.register(models.FinalGradeAudit, FinalGradeAuditAdmin)
+admin.site.register(models.CourseRunGradingStatus, CourseRunGradingStatusAdmin)

--- a/grades/management/commands/complete_course_run_freeze.py
+++ b/grades/management/commands/complete_course_run_freeze.py
@@ -1,0 +1,69 @@
+"""
+Sets the global freeze status for the course run to "complete"
+"""
+from celery.result import GroupResult
+from django.core.cache import caches
+from django.core.management import BaseCommand, CommandError
+
+from courses.models import CourseRun
+from grades.models import CourseRunGradingStatus
+from grades.tasks import CACHE_ID_BASE_STR
+
+
+cache_redis = caches['redis']
+
+
+class Command(BaseCommand):
+    """
+    Sets the global freeze status for the course run to "complete"
+    """
+    help = ('Sets the global freeze status for the course run to "complete". '
+            'This should not be necessary if all the users are processed')
+
+    def add_arguments(self, parser):
+        parser.add_argument("edx_course_key", help="the edx_course_key for the course run")
+
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
+        edx_course_key = kwargs.get('edx_course_key')
+        try:
+            run = CourseRun.objects.get(edx_course_key=edx_course_key)
+        except CourseRun.DoesNotExist:
+            raise CommandError('Course Run for course_id "{0}" does not exist'.format(edx_course_key))
+
+        if not run.can_freeze_grades:
+            self.stdout.write(
+                self.style.ERROR(
+                    'Course Run "{0}" cannot be marked as frozen yet'.format(edx_course_key)
+                )
+            )
+            return
+
+        if CourseRunGradingStatus.is_complete(run):
+            self.stdout.write(
+                self.style.SUCCESS(
+                    'Course Run "{0}" is already marked as complete'.format(edx_course_key)
+                )
+            )
+            return
+
+        # check if there are tasks running
+        group_results_id = CACHE_ID_BASE_STR.format(edx_course_key)
+        if cache_redis.get(group_results_id):
+            results = GroupResult.restore(group_results_id)
+            if results and not results.ready():
+                self.stdout.write(
+                    self.style.WARNING(
+                        'Tasks for Course Run "{0}" are still running. '
+                        'Impossible to set the global "complete" status'.format(edx_course_key)
+                    )
+                )
+                return
+            # if the tasks are done remove the entry in the cache
+            cache_redis.delete(group_results_id)
+
+        CourseRunGradingStatus.set_to_complete(run)
+        self.stdout.write(
+            self.style.SUCCESS(
+                'Course Run "{0}" has been marked as complete'.format(edx_course_key)
+            )
+        )

--- a/grades/management/commands/freeze_final_grades.py
+++ b/grades/management/commands/freeze_final_grades.py
@@ -1,9 +1,11 @@
 """
 Freezes final grades for a course
 """
+from django.core.exceptions import ImproperlyConfigured
 from django.core.management import BaseCommand, CommandError
 
 from courses.models import CourseRun
+from grades.models import CourseRunGradingStatus
 from grades.tasks import freeze_course_run_final_grades
 
 
@@ -14,17 +16,31 @@ class Command(BaseCommand):
     help = "Submits a celery task to freeze the final grades for all the users enrolled in a course run"
 
     def add_arguments(self, parser):
-        parser.add_argument("course_id", help="the edx_course_key for the course run")
+        parser.add_argument("edx_course_key", help="the edx_course_key for the course run")
 
     def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
-        course_id = kwargs.get('course_id')
+        edx_course_key = kwargs.get('edx_course_key')
         try:
-            run = CourseRun.objects.get(edx_course_key=course_id)
+            run = CourseRun.objects.get(edx_course_key=edx_course_key)
         except CourseRun.DoesNotExist:
-            raise CommandError('Course Run for course_id "{}" does not exist'.format(course_id))
+            raise CommandError('Course Run for course_id "{}" does not exist'.format(edx_course_key))
+        try:
+            can_freeze = run.can_freeze_grades
+        except ImproperlyConfigured:
+            raise CommandError('Course Run for course_id "{}" is missing the freeze date'.format(edx_course_key))
+        if not can_freeze:
+            raise CommandError('Course Run for course_id "{}" cannot be frozen yet'.format(edx_course_key))
+        if CourseRunGradingStatus.is_complete(run):
+            self.stdout.write(
+                self.style.SUCCESS(
+                    'Final grades for course "{0}" are already complete'.format(edx_course_key)
+                )
+            )
+            return
+
         freeze_course_run_final_grades.delay(run)
         self.stdout.write(
             self.style.SUCCESS(
-                'Successfully submitted async task to freeze final grades for course "{0}"'.format(course_id)
+                'Successfully submitted async task to freeze final grades for course "{0}"'.format(edx_course_key)
             )
         )

--- a/grades/models.py
+++ b/grades/models.py
@@ -104,6 +104,12 @@ class CourseRunGradingStatus(TimestampedModel):
         max_length=30,
     )
 
+    def __str__(self):
+        return 'Freezing status "{status}" for course "{course_id}"'.format(
+            course_id=self.course_run.edx_course_key,
+            status=self.status
+        )
+
     @classmethod
     def is_complete(cls, course_run):
         """


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Improves the management commands (and adds another one) to better deal with grades freezing.

#### How should this be manually tested?

1. for the `freeze_final_grades` try to freeze a course run with no "freeze grade": you should see a message saying that such date is missing
2. for the `freeze_final_grades` try to freeze a course run with "freeze grade" in the future: you should see a message saying that the grades cannot be frozen
3. for the `freeze_final_grades` try to freeze a course run that has already a "complete" entry in `CourseRunGradingStatus`: you should see again a message saying that the course is already complete.
4. for the `complete_corse_run_freeze`, try to run it for a course with no entry in `CourseRunGradingStatus`: you should see the course set to complete there (you can use the admin view)
5. for the `complete_corse_run_freeze`, try to run it for a course with an entry in `CourseRunGradingStatus` set to pending: you should see the course set to complete there (you can use the admin view)
