### PR TITLE
Fixed dashboard UI to correctly display upgradable past course runs

### DIFF
--- a/static/js/components/OrderSummary.js
+++ b/static/js/components/OrderSummary.js
@@ -75,7 +75,7 @@ class OrderSummary extends React.Component {
     return (
       <div>
         <Card shadow={1}>
-          <p className="intro-text">You are about to enroll in <b>{ course.title }</b></p>
+          <p className="intro-text">You are about to pay for <b>{ course.title }</b></p>
           <div className="wrapper-box">
             <Grid className="summary-box">
               {this.showAmount('Cost of course', this.getCoursePrice())}

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -116,6 +116,8 @@ export default class CourseAction extends React.Component {
 
   renderTextDescription = this.renderDescription('description', null);
 
+  renderActionBtnDescription = this.renderDescription('course-action-btn-footer', null);
+
   renderBoxedDescription = this.renderDescription('boxed description', null);
 
   renderStatusDescription = this.renderDescription('boxed description');
@@ -130,7 +132,7 @@ export default class CourseAction extends React.Component {
       <SpinnerButton
         component="button"
         spinning={inFlight}
-        className="mm-minor-action enroll-pay-later"
+        className="mm-minor-action course-action-btn-footer"
         onClick={() => this.handleAddCourseEnrollment(run)}
         key="2"
       >
@@ -167,7 +169,7 @@ export default class CourseAction extends React.Component {
       let date = moment(run.course_upgrade_deadline);
       action = this.renderEnrollButton(run);
       let text = ifValidDate('', date => `Payment due: ${date.format(DASHBOARD_FORMAT)}`, date);
-      description = this.renderTextDescription(text);
+      description = this.renderActionBtnDescription(text);
       break;
     }
     case STATUS_OFFERED: {
@@ -195,14 +197,14 @@ export default class CourseAction extends React.Component {
       break;
     case STATUS_PENDING_ENROLLMENT:
       action = this.renderEnrollButton(run);
-      description = this.renderTextDescription('Processing...');
+      description = this.renderActionBtnDescription('Processing...');
       break;
     case STATUS_PAID_BUT_NOT_ENROLLED: {
       const contactText = 'Contact us for help.';
       const contactHref = `mailto:${SETTINGS.support_email}`;
       const descriptionText = 'Something went wrong. You paid for this course but are not enrolled.';
       description = (
-        <div className='description' key='2'>
+        <div className="description" key="2">
           {descriptionText} <a href={contactHref}>{contactText}</a>
         </div>
       );

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -56,13 +56,17 @@ describe('CourseAction', () => {
     }
     let description = renderedComponent.find(".description");
     let descriptionText = description.length === 1 ? description.text() : undefined;
-    let link = renderedComponent.find("SpinnerButton.enroll-pay-later");
-    let linkText = link.length === 1 ? link.children().text() : undefined;
+    let btnFooter = renderedComponent.find(".course-action-btn-footer");
+    let btnFooterText = btnFooter.length === 1 ? btnFooter.text() : undefined;
+    let payLaterLink = renderedComponent.find("SpinnerButton.course-action-btn-footer");
+    let payLaterLinkText = payLaterLink.length === 1 ? payLaterLink.children().text() : undefined;
     return {
       button: button,
       buttonText: buttonText,
       descriptionText: descriptionText,
-      linkText: linkText
+      btnFooterText: btnFooterText,
+      payLaterLink: payLaterLink,
+      payLaterLinkText: payLaterLinkText
     };
   };
   let assertEnrollNowButton = (button, courseId) => {
@@ -158,10 +162,10 @@ describe('CourseAction', () => {
 
     assert.isUndefined(elements.button.props().disabled);
     assert.include(elements.buttonText, 'Pay Now');
-    assert.equal(elements.linkText, 'Enroll and pay later');
+    assert.equal(elements.payLaterLinkText, 'Enroll and pay later');
     assertEnrollNowButton(elements.button, firstRun.course_id);
 
-    wrapper.find(".enroll-pay-later").simulate('click');
+    elements.payLaterLink.simulate('click');
     assert(addCourseEnrollmentStub.calledWith(firstRun.course_id));
   });
 
@@ -196,7 +200,7 @@ describe('CourseAction', () => {
 
       assert.isUndefined(elements.button.props().disabled);
       assert.include(elements.buttonText, 'Pay Now');
-      assert.equal(elements.linkText, 'Enroll and pay later');
+      assert.equal(elements.payLaterLinkText, 'Enroll and pay later');
       assertEnrollNowButton(elements.button, firstRun.course_id);
     });
   });
@@ -215,7 +219,7 @@ describe('CourseAction', () => {
 
     assert.isUndefined(elements.button.props().disabled);
     assert.include(elements.buttonText, 'Pay Now');
-    assert.equal(elements.descriptionText, `Payment due: ${formattedUpgradeDate}`);
+    assert.equal(elements.btnFooterText, `Payment due: ${formattedUpgradeDate}`);
     assertEnrollNowButton(elements.button, firstRun.course_id);
   });
 
@@ -352,7 +356,7 @@ describe('CourseAction', () => {
       courseRun: firstRun
     });
 
-    assert.equal(wrapper.find(".description").text(), "Processing...");
+    assert.equal(wrapper.find(".course-action-btn-footer").text(), "Processing...");
     let buttonProps = wrapper.find("SpinnerButton").props();
     assert.isTrue(buttonProps.spinning);
   });
@@ -397,7 +401,7 @@ describe('CourseAction', () => {
 
       assert.isUndefined(elements.button.props().disabled);
       assert.equal(elements.buttonText, 'Calculate Cost');
-      assert.equal(elements.linkText, 'Enroll and pay later');
+      assert.equal(elements.payLaterLinkText, 'Enroll and pay later');
     });
 
     it('shows an enroll/pay button if a user has skipped financial aid', () => {
@@ -418,7 +422,7 @@ describe('CourseAction', () => {
 
       assert.isUndefined(elements.button.props().disabled);
       assert.include(elements.buttonText, 'Pay Now');
-      assert.equal(elements.linkText, 'Enroll and pay later');
+      assert.equal(elements.payLaterLinkText, 'Enroll and pay later');
     });
 
     it('shows the price', () => {
@@ -458,7 +462,7 @@ describe('CourseAction', () => {
         // we don't show a spinner in this case, only for API loads or when waiting for Cybersource callback
         assert.isFalse(elements.button.props().spinning);
         assert.include(elements.buttonText, 'Pay Now');
-        assert.equal(elements.linkText, 'Enroll and pay later');
+        assert.equal(elements.payLaterLinkText, 'Enroll and pay later');
       });
     });
 
@@ -472,7 +476,7 @@ describe('CourseAction', () => {
         courseRun: firstRun,
         courseEnrollAddStatus: FETCH_PROCESSING
       });
-      let link = wrapper.find("SpinnerButton.enroll-pay-later");
+      let link = wrapper.find("SpinnerButton.course-action-btn-footer");
       assert.isTrue(link.props().spinning);
     });
 

--- a/static/js/components/dashboard/CourseSubRow_test.js
+++ b/static/js/components/dashboard/CourseSubRow_test.js
@@ -16,6 +16,7 @@ import {
   STATUS_NOT_PASSED,
   STATUS_PASSED,
   STATUS_OFFERED,
+  STATUS_CAN_UPGRADE,
 } from '../../constants';
 
 describe('CourseSubRow', () => {
@@ -86,7 +87,7 @@ describe('CourseSubRow', () => {
     assert.equal(wrapper.find(".course-grade").text().trim(), "");
     let actionCell = wrapper.find(".course-action");
     assert.equal(actionCell.find("button.pay-button").text(), "Calculate Cost");
-    assert.equal(actionCell.find("button.enroll-pay-later").text(), "Enroll and pay later");
+    assert.equal(actionCell.find("button.course-action-btn-footer").text(), "Enroll and pay later");
   });
 
   it('indicates future enrollment and if a future course run is offered', () => {
@@ -193,5 +194,21 @@ describe('CourseSubRow', () => {
       courseRun: courseRun,
     });
     assert.equal(wrapper.find(".course-description").text(), courseRun.fuzzy_start_date);
+  });
+
+  it('shows a final grade and a payment button with a past course run that was passed and still upgradable', () => {
+    Object.assign(courseRun, {
+      status: STATUS_CAN_UPGRADE,
+      course_end_date: moment().add(-1, 'months'),
+      course_upgrade_deadline: moment().add(1, 'months'),
+      final_grade: 75
+    });
+    const wrapper = renderSubRow({
+      courseRun: courseRun,
+    }, false);
+    assert.equal(wrapper.find(".course-grade").text(), "75%");
+    let courseAction = wrapper.find(".course-action");
+    assert.isAbove(courseAction.find(".pay-button").length, 0);
+    assert.include(courseAction.find(".course-action-btn-footer").text(), "Payment due");
   });
 });

--- a/static/js/components/dashboard/util.js
+++ b/static/js/components/dashboard/util.js
@@ -8,6 +8,12 @@ export const isCurrentlyEnrollable = (enrollmentStartDate: ?moment$Moment, now: 
     enrollmentStartDate.isSameOrBefore(now || moment(), 'day')
 );
 
+export const isUpgradable = (upgradeDeadlineDate: ?moment$Moment, now: ?moment$Moment): boolean => (
+  upgradeDeadlineDate !== null &&
+    upgradeDeadlineDate !== undefined &&
+    upgradeDeadlineDate.isSameOrAfter(now || moment(), 'day')
+);
+
 export const formatGrade = (grade: ?number|?string|null): string => {
   if (_.isNil(grade) || grade === '') {
     return '';

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -136,13 +136,13 @@
 
     .course-container {
       border-bottom: 1px solid $lightgrey;
-    }
 
-    .course-row {
-      width: 100%;
-      font-size: 11pt;
-      align-items: center;
-      padding: 14px 20px;
+      .course-row {
+        width: 100%;
+        font-size: 11pt;
+        align-items: center;
+        padding: 14px 20px;
+      }
 
       .course-description {
         .course-title {
@@ -188,16 +188,20 @@
         align-items: center;
         text-align: center;
 
-        a.enroll-pay-later {
-          font-weight: 400;
-          font-size: 14px;
-        }
-
         .mdl-button {
-          margin-bottom: 6px;
           min-width: 120px;
           padding: 0;
           text-align: center;
+        }
+
+        .mdl-button[disabled] {
+          background-color: $lightgrey;
+          color: #ffffff;
+        }
+
+        .course-action-btn-footer {
+          padding: 8px 0 0 0;
+          font-size: 14px;
         }
 
         .description {
@@ -218,11 +222,6 @@
           &.not-passed {
             background-color: #fce4e2;
           }
-        }
-
-        .mdl-button[disabled] {
-          background-color: $lightgrey;
-          color: #ffffff;
         }
 
         .disabled-with-spinner {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2755 

#### What's this PR do?
Fixes the way that course runs are displayed when they are (a) past their end date, (b) passed, and (c) still upgradable (ie: their `upgrade_deadline` is in the future). Users will be able to pay for these courses from the dashboard UI.

#### How should this be manually tested?
For a course with multiple course runs:

1. Set a course run to current and enrolled or enrollable
1. Set another course run to have an `end_date` in the past and a future `upgrade_deadline`
1. Set a `FinalGrade` with a status of 'completed' for the course run in no. 2
1. Load the dashboard and inspect the UI. Click the pay button to make sure it works

#### Where should the reviewer start?

CourseSubRow.js

#### Any background context you want to provide?

@roberthouse54 spotted some layout tweaks that he wanted when I showed him the dashboard changes, so this PR includes those as well

#### Screenshots (if appropriate)

![ss 2017-03-02 at 17 00 58](https://cloud.githubusercontent.com/assets/14932219/23530713/f1d2e552-ff70-11e6-9df3-e7ec02272429.png)
