### PR TITLE
Small change to size of search box on learner page

### DIFF
--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -252,8 +252,22 @@
       border-radius: 3px;
       margin-right: 4px;
 
+      input.sk-search-box__text {
+        padding: 6px 10px;
+        font-size: 15px;
+      }
+
+      .sk-search-box__action {
+        height: 32px;
+      }
+
       .sk-search-box__icon {
         opacity: 1;
+        margin: 6px 0 0 7px;
+      }
+
+      .sk-search-box__loader {
+        margin: 6px;
       }
 
       .sk-search-box__icon:before {


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/2682

#### What's this PR do?
This is a small PR. 
This was a part of the style changes to the Learner Search that didn't go through because I made the css change in the wrong file. This PR just makes the search box on the learner search smaller, and the font smaller.

#### How should this be manually tested?
Check to see that the layout looks correct.

#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/20047260/23558325/2d5cab86-0001-11e7-9b94-48d70071729b.png)



