### PR TITLE
Refactor MailgunClient.send_batch to return list of emails with response

### DIFF
--- a/mail/views.py
+++ b/mail/views.py
@@ -64,7 +64,6 @@ class SearchResultMailView(APIView):
                     email_body=email_body,
                     sender_name=sender_name,
                 )
-
         mailgun_responses = MailgunClient.send_batch(
             subject=email_subject,
             body=email_body,
@@ -77,7 +76,7 @@ class SearchResultMailView(APIView):
                 "batch_{}".format(batch_num): {
                     "status_code": resp.status_code,
                     "data": generate_mailgun_response_json(resp)
-                } for batch_num, resp in enumerate(mailgun_responses)
+                } for batch_num, (_, resp) in enumerate(mailgun_responses)
             }
         )
 


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #2749

#### What's this PR do?
Adds tests for responses from mailgun functions, and changes the return value of `send_batch` from list of response to list of `(recipients, response)`. This isn't used now but it will help future error handling code identify which recipients we couldn't send an email to.

#### How should this be manually tested?
Send an email from the learner search page. It should behave like it did before.
