### PR TITLE
Configured JS test script to allow for specific test cases to be run

### DIFF
--- a/js_test.sh
+++ b/js_test.sh
@@ -3,17 +3,33 @@ export TMP_FILE=$(mktemp)
 
 if [[ ! -z "$COVERAGE" ]]
 then
-    export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=html mocha "
+    export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=html mocha"
 elif [[ ! -z "$CODECOV" ]]
 then
-    export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=lcovonly -R spec mocha "
+    export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=lcovonly -R spec mocha"
 else
     export CMD="node ./node_modules/mocha/bin/_mocha"
 fi
 
-export FILES=${1:-'static/**/*/*_test.js'}
+export FILE_PATTERN=${1:-'static/**/*/*_test.js'}
+CMD+=" --require ./static/js/babelhook.js static/js/global_init.js $FILE_PATTERN"
 
-$CMD --require ./static/js/babelhook.js static/js/global_init.js "$FILES" 2> >(tee "$TMP_FILE")
+# Second argument (if specified) should be a string that will match specific test case descriptions
+#
+# EXAMPLE:
+#   (./static/js/SomeComponent_test.js)
+#   it('should test basic arithmetic') {
+#     assert.equal(1 + 1, 2);
+#   }
+#
+#   (in command line...)
+#   > ./js_test.sh static/js/SomeComponent_test.js "should test basic arithmetic"
+if [[ ! -z "$2" ]]; then
+    CMD+=" -g \"$2\""
+fi
+
+eval $CMD 2> >(tee "$TMP_FILE")
+
 export TEST_RESULT=$?
 export TRAVIS_BUILD_DIR=$PWD
 if [[ ! -z "$CODECOV" ]]


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket

#### What's this PR do?
Changes the `./js_test.sh` script to let us run test cases that match specific test descriptions (ie: the `it`/`describe` strings). If you only want to run one or several tests in a JS test file, this allows you to do that easily

#### How should this be manually tested?
I used this command to test it: `./js_test.sh static/js/components/dashboard/CourseAction_test.js 'shows a message'`. You can test a few other files/descriptions
