### PR TITLE
Fix postal code validation

### DIFF
--- a/static/js/flow/profileTypes.js
+++ b/static/js/flow/profileTypes.js
@@ -96,6 +96,7 @@ export type Profile = {
   romanized_first_name:        ?string,
   romanized_last_name:         ?string,
   student_id:                  number,
+  postal_code:                 string,
 };
 
 export type Profiles = {

--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -92,6 +92,14 @@ export const personalValidation = (profile: Profile) => {
     if (profile.postal_code && !CP1252_REGEX.test(profile.postal_code)) {
       errors.postal_code = "Postal code must be in Latin characters";
     }
+    if (R.isNil(errors.postal_code)) {
+      if (profile.country === 'US' && !R.test(/^\d{5}(-\d{4})?$/, profile.postal_code)) {
+        errors.postal_code = "Postal code must be a valid US postal code.";
+      }
+      if (profile.country === 'CA' && !R.test(/^[A-Za-z0-9]{6}$/, profile.postal_code)) {
+        errors.postal_code = "Postal code must be a valid Canadian postal code.";
+      }
+    }
   } else {
     // postal code only shown/required for US and Canada
     delete errors.postal_code;

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -179,6 +179,18 @@ describe('Profile validation functions', () => {
       assert.deepEqual(personalValidation(profile), errors);
     });
 
+    let validPostalCodes = {
+      'US': ['12345', '12345-6789'],
+      'CA': ['123456', '123ABC', '123abc'],
+    };
+    let inValidPostalCodes = {
+      US: ['a', 'asdfb', '12345a', '%$#$%#$%', '12345-asdf', '12345-', 'a12345', '12345-1234a'],
+      CA: ['a', 'asdfb', '12345-asdf', '12345-1', '12345%', '1234512'],
+    };
+    let messages = {
+      US: "Postal code must be a valid US postal code.",
+      CA: "Postal code must be a valid Canadian postal code.",
+    };
     for (const country of ["US", "CA"]) {
       it(`should error when country is ${country} and no postal code`, () => {
         let profile = {
@@ -190,6 +202,31 @@ describe('Profile validation functions', () => {
           postal_code: "Postal code is required",
         };
         assert.deepEqual(personalValidation(profile), errors);
+      });
+
+      it(`should reject invalid postal codes for ${country}`, () => {
+        inValidPostalCodes[country].forEach(badCode => {
+          let profile = {
+            ...USER_PROFILE_RESPONSE,
+            country: country,
+            postal_code: badCode,
+          };
+          assert.deepEqual(
+            personalValidation(profile),
+            { postal_code: messages[country] }
+          );
+        });
+      });
+
+      it(`should accept valid postal codes for ${country}`, () => {
+        validPostalCodes[country].forEach(goodCode => {
+          let profile = {
+            ...USER_PROFILE_RESPONSE,
+            country: country,
+            postal_code: goodCode,
+          };
+          assert.deepEqual(personalValidation(profile), {});
+        });
       });
     }
 


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #2765 

#### What's this PR do?

This ensures that, for CA and US, the postal code entered is valid.

#### How should this be manually tested?

Go to `/profile` or `/learner`. Make your country the US. Add an invalid postal code. You should see an error message. Fix it, it should go away. Same for Canada.

US codes look like `XXXXX(-XXXX)`, where `X` is in `[0-9]` and the group wrapped in `()` is optional.

Canadian codes look like `YYYYYY`, where `Y` is in `[A-Za-z0-9]`.

The validation behavior should be unchanged for other countries.