### PR TITLE
Fixed phone numbers handling for pearson

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,6 +21,7 @@ html5lib==0.999999999
 ipython
 jsonfield==1.0.3
 newrelic
+phonenumbers==8.3.2
 psycopg2==2.6
 pycountry==16.11.27.1
 pysftp==0.2.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ django-storages-redux==1.3.2
 django-taggit==0.18.3     # via wagtail
 django-treebeard==4.1.0   # via wagtail
 django-webpack-loader==0.4.1
-Django==1.10.5            # via django-role-permissions, django-server-status, django-treebeard, jsonfield, wagtail
+django==1.10.5
 djangorestframework==3.5.2
 edx-api-client==0.3.0
 edx-opaque-keys==0.4
@@ -47,6 +47,7 @@ packaging==16.8           # via setuptools
 paramiko==2.1.1           # via pysftp
 pbr==1.10.0               # via stevedore
 pexpect==4.2.1            # via ipython
+phonenumbers==8.3.2
 pickleshare==0.7.4        # via ipython
 pillow==3.4.2
 prompt-toolkit==1.0.13    # via ipython


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #2766 

#### What's this PR do?
fixes the bug with the splitting of phone numbers in country code and actual number by user a proper library.

#### How should this be manually tested?
There is no real way to manually test it, but the unit test `test_profile_phone_number_functions` has been updated with several types of numbers included the ones of the issue that were causing problems.

#### Where should the reviewer start?
`exams/pearson/writers.py`