### PR TITLE
Added feature flag for showing exam card (#2769)

### DIFF
--- a/ui/views.py
+++ b/ui/views.py
@@ -63,7 +63,10 @@ class ReactView(View):  # pylint: disable=unused-argument
             "EXAMS_SSO_CLIENT_CODE": settings.EXAMS_SSO_CLIENT_CODE,
             "EXAMS_SSO_URL": settings.EXAMS_SSO_URL,
             "FEATURES": {
-                "EXAMS": FeatureFlag.EXAMS in getattr(request, 'mm_feature_flags', []),
+                "EXAMS": (
+                    settings.FEATURES.get('EXAMS_CARD_ENABLED', False) or
+                    FeatureFlag.EXAMS in getattr(request, 'mm_feature_flags', [])
+                ),
             },
         }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2769 

#### What's this PR do?
Adds a feature flag to allow the exams card to be shown in 

#### How should this be manually tested?
- Set `MIDDLEWARE_FEATURE_FLAG_QS_PREFIX=MM` in `.env`
- Create an `ExamProfile` record for your user
- Verify that you can't see an exam card on the dashboard
- Go to http://localhost:8079/dashboard/?MM_FEATURE_EXAMS=1
- Verify you can see the card now
- Go to http://localhost:8079/dashboard/?MM_FEATURE_CLEAR
- Verify card is gone again
- Set `FEATURE_EXAMS_CARD_ENABLED=True` in .env
- Reload dash, verify you can see card

#### Where should the reviewer start?
ui/views.py


#### What GIF best describes this PR or how it makes you feel?
https://media4.giphy.com/media/Jk8F8BanWi3Is/200w.gif