### PR TITLE
Refactor MailgunClient for better error handling

### DIFF
--- a/mail/api.py
+++ b/mail/api.py
@@ -225,7 +225,7 @@ class MailgunClient:
         from_address = cls.default_params()['from']
         to_address = financial_aid.user.email
         response = cls.send_individual_email(subject, body, to_address, raise_for_status=raise_for_status)
-        if response.status_code == status.HTTP_200_OK:
+        if response.ok:
             FinancialAidEmailAudit.objects.create(
                 acting_user=acting_user,
                 financial_aid=financial_aid,

--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -12,7 +12,6 @@ from django.db.models.signals import post_save
 from django.test import override_settings
 from factory.django import mute_signals
 from requests import Response
-from requests.exceptions import HTTPError
 from rest_framework.status import (
     HTTP_200_OK,
     HTTP_400_BAD_REQUEST,
@@ -121,21 +120,15 @@ class MailAPITests(MockedESTestCase):
             json=mocked_json()
         )
 
-        exception = None
-        bcc_response = None
-        try:
-            bcc_response = MailgunClient.send_bcc(
-                'email subject',
-                'email body',
-                ['a@example.com', 'b@example.com'],
-                raise_for_status=raise_for_status,
-            )
-        except Exception as _exception:  # pylint: disable=broad-except
-            exception = _exception
-        if raise_for_status:
-            assert isinstance(exception, HTTPError)
-        else:
-            assert bcc_response.status_code == HTTP_400_BAD_REQUEST
+        response = MailgunClient.send_bcc(
+            'email subject',
+            'email body',
+            ['a@example.com', 'b@example.com'],
+            raise_for_status=raise_for_status,
+        )
+
+        assert response.raise_for_status.called is raise_for_status
+        assert response.status_code == HTTP_400_BAD_REQUEST
 
     @override_settings(MAILGUN_RECIPIENT_OVERRIDE=None)
     @data(None, 'Tester')
@@ -291,23 +284,16 @@ class MailAPITests(MockedESTestCase):
             json=mocked_json()
         )
 
-        exception = None
-        response = None
-        try:
-            response = MailgunClient.send_individual_email(
-                subject='email subject',
-                body='email body',
-                recipient='a@example.com',
-                raise_for_status=raise_for_status,
-            )
-        except Exception as _exception:  # pylint: disable=broad-except
-            exception = _exception
+        response = MailgunClient.send_individual_email(
+            subject='email subject',
+            body='email body',
+            recipient='a@example.com',
+            raise_for_status=raise_for_status,
+        )
 
-        if raise_for_status:
-            assert isinstance(exception, HTTPError)
-        else:
-            assert response.status_code == HTTP_400_BAD_REQUEST
-            assert response.json() == {}
+        assert response.raise_for_status.called is raise_for_status
+        assert response.status_code == HTTP_400_BAD_REQUEST
+        assert response.json() == {}
 
     @override_settings(MAILGUN_RECIPIENT_OVERRIDE=None)
     def test_send_with_sender_address(self, mock_post):
@@ -406,24 +392,17 @@ class FinancialAidMailAPITests(MockedESTestCase):
             json=mocked_json(),
         )
 
-        exception = None
-        response = None
-        try:
-            response = MailgunClient.send_financial_aid_email(
-                self.staff_user_profile.user,
-                self.financial_aid,
-                'email subject',
-                'email body',
-                raise_for_status=raise_for_status,
-            )
-        except Exception as _exception:  # pylint: disable=broad-except
-            exception = _exception
+        response = MailgunClient.send_financial_aid_email(
+            self.staff_user_profile.user,
+            self.financial_aid,
+            'email subject',
+            'email body',
+            raise_for_status=raise_for_status,
+        )
 
-        if raise_for_status:
-            assert isinstance(exception, HTTPError)
-        else:
-            assert response.status_code == HTTP_400_BAD_REQUEST
-            assert response.json() == {}
+        assert response.raise_for_status.called is raise_for_status
+        assert response.status_code == HTTP_400_BAD_REQUEST
+        assert response.json() == {}
 
     @override_settings(
         EMAIL_SUPPORT='mailgun_from_email@example.com',
@@ -529,21 +508,13 @@ class CourseTeamMailAPITests(MockedESTestCase):
         )
         course_with_email = CourseFactory.create(title='course with email', contact_email='course@example.com')
 
-        exception = None
-        response = None
-        try:
-            response = MailgunClient.send_course_team_email(
-                self.user,
-                course_with_email,
-                'email subject',
-                'email body',
-                raise_for_status=raise_for_status,
-            )
-        except Exception as _exception:  # pylint: disable=broad-except
-            exception = _exception
-
-        if raise_for_status:
-            assert isinstance(exception, HTTPError)
-        else:
-            assert response.status_code == HTTP_400_BAD_REQUEST
-            assert response.json() == {}
+        response = MailgunClient.send_course_team_email(
+            self.user,
+            course_with_email,
+            'email subject',
+            'email body',
+            raise_for_status=raise_for_status,
+        )
+        assert response.raise_for_status.called is raise_for_status
+        assert response.status_code == HTTP_400_BAD_REQUEST
+        assert response.json() == {}

--- a/mail/exceptions.py
+++ b/mail/exceptions.py
@@ -1,0 +1,18 @@
+"""Exceptions for mail"""
+
+
+class SendBatchException(Exception):
+    """
+    An exception which occurs when batch processing of email fails. This contains a list of other exceptions and
+    the emails which caused the failure.
+    """
+
+    def __init__(self, exception_pairs):
+        """
+        Creates a SendBatchException
+
+        Args:
+            exception_pairs (list): A list of (list of recipients, exception)
+        """
+        super().__init__(exception_pairs)
+        self.exception_pairs = exception_pairs

--- a/mail/exceptions.py
+++ b/mail/exceptions.py
@@ -1,5 +1,0 @@
-"""Mail exceptions"""
-
-
-class MailException(Exception):
-    """Exceptions related to sending mail"""

--- a/mail/exceptions.py
+++ b/mail/exceptions.py
@@ -1,0 +1,5 @@
+"""Mail exceptions"""
+
+
+class MailException(Exception):
+    """Exceptions related to sending mail"""

--- a/mail/utils.py
+++ b/mail/utils.py
@@ -3,11 +3,7 @@ Utils for mail
 """
 import logging
 
-from django.core.exceptions import (
-    ImproperlyConfigured,
-    ValidationError
-)
-from rest_framework import status
+from django.core.exceptions import ValidationError
 
 from dashboard.models import ProgramEnrollment
 from financialaid.api import get_formatted_course_price
@@ -79,13 +75,10 @@ def generate_mailgun_response_json(response):
 
     Args:
         response (requests.Response): response object
+        exception (Exception): If not None, there was an exception when trying to contact Mailgun
     Returns:
         dict
     """
-    if response.status_code == status.HTTP_401_UNAUTHORIZED:
-        message = "Mailgun API keys not properly configured."
-        log.error(message)
-        raise ImproperlyConfigured(message)
     try:
         response_json = response.json()
     except ValueError:  # Includes JSONDecodeError since it inherits from ValueError

--- a/mail/utils.py
+++ b/mail/utils.py
@@ -75,7 +75,6 @@ def generate_mailgun_response_json(response):
 
     Args:
         response (requests.Response): response object
-        exception (Exception): If not None, there was an exception when trying to contact Mailgun
     Returns:
         dict
     """

--- a/mail/utils_test.py
+++ b/mail/utils_test.py
@@ -3,7 +3,7 @@ Tests for mail utils
 """
 
 from unittest.mock import Mock
-from django.core.exceptions import ValidationError, ImproperlyConfigured
+from django.core.exceptions import ValidationError
 from requests import Response
 from rest_framework import status
 
@@ -110,23 +110,14 @@ class MailUtilsTests(MockedESTestCase):
 
     def test_generate_mailgun_response_json(self):
         """
-        Tests that generate_mailgun_response_json() returns response.json() unless the status code is 401 in which
-        case it should raise ImproperlyConfigured
+        Tests that generate_mailgun_response_json() returns response.json()
         """
-        # Normal Response
         response = Mock(
             spec=Response,
             status_code=status.HTTP_200_OK,
             json=mocked_json()
         )
         assert generate_mailgun_response_json(response) == response.json()
-        # 401 error
-        response_401 = Mock(
-            spec=Response,
-            status_code=status.HTTP_401_UNAUTHORIZED
-        )
-        with self.assertRaises(ImproperlyConfigured):
-            generate_mailgun_response_json(response_401)
 
     def test_generate_mailgun_response_json_with_failed_json_call(self):
         """

--- a/mail/views.py
+++ b/mail/views.py
@@ -93,7 +93,7 @@ def _make_batch_status(responses):
     """
     has_error = any(
         exception is not None or
-        response.status_code != status.HTTP_500_INTERNAL_SERVER_ERROR
+        response.status_code != status.HTTP_200_OK
         for _, response, exception in responses
     )
     if has_error:

--- a/mail/views.py
+++ b/mail/views.py
@@ -142,11 +142,7 @@ class SearchResultMailView(APIView):
             sender_name=sender_name,
         )
         return Response(
-            status=_make_batch_status(mailgun_responses),
-            data={
-                "batch_{}".format(batch_num): _make_batch_response_dict(resp, exception)
-                for batch_num, (_, resp, exception) in enumerate(mailgun_responses)
-            }
+            status=_make_batch_status(mailgun_responses)
         )
 
 

--- a/mail/views.py
+++ b/mail/views.py
@@ -64,7 +64,7 @@ class LearnerMailView(GenericAPIView):
             recipient=recipient_user.email,
             sender_address=sender_user.email,
             sender_name=sender_user.profile.display_name,
-            raise_on_error=False,
+            raise_for_status=False,
         )
         return Response(
             status=mailgun_response.status_code,

--- a/mail/views.py
+++ b/mail/views.py
@@ -91,12 +91,15 @@ def _make_batch_status(responses):
     Helper function to figure out a status code to return. In summary, 200 unless any error, then 500.
     The user can inspect the contents for more info.
     """
-    for _, response, exception in responses:
-        if exception is not None:
-            return status.HTTP_500_INTERNAL_SERVER_ERROR
-        if response.status_code != status.HTTP_200_OK:
-            return status.HTTP_500_INTERNAL_SERVER_ERROR
-    return status.HTTP_200_OK
+    has_error = any(
+        exception is not None or
+        response.status_code != status.HTTP_500_INTERNAL_SERVER_ERROR
+        for _, response, exception in responses
+    )
+    if has_error:
+        return status.HTTP_500_INTERNAL_SERVER_ERROR
+    else:
+        return status.HTTP_200_OK
 
 
 class SearchResultMailView(APIView):

--- a/mail/views.py
+++ b/mail/views.py
@@ -86,22 +86,6 @@ def _make_batch_response_dict(response, exception):
     }
 
 
-def _make_batch_status(responses):
-    """
-    Helper function to figure out a status code to return. In summary, 200 unless any error, then 500.
-    The user can inspect the contents for more info.
-    """
-    has_error = any(
-        exception is not None or
-        response.status_code != status.HTTP_200_OK
-        for _, response, exception in responses
-    )
-    if has_error:
-        return status.HTTP_500_INTERNAL_SERVER_ERROR
-    else:
-        return status.HTTP_200_OK
-
-
 class SearchResultMailView(APIView):
     """
     View class that handles HTTP requests to search results mail API
@@ -135,15 +119,13 @@ class SearchResultMailView(APIView):
                     email_body=email_body,
                     sender_name=sender_name,
                 )
-        mailgun_responses = MailgunClient.send_batch(
+        MailgunClient.send_batch(
             subject=email_subject,
             body=email_body,
             recipients=emails,
             sender_name=sender_name,
         )
-        return Response(
-            status=_make_batch_status(mailgun_responses)
-        )
+        return Response(status=status.HTTP_200_OK)
 
 
 class CourseTeamMailView(GenericAPIView):

--- a/mail/views.py
+++ b/mail/views.py
@@ -64,7 +64,6 @@ class LearnerMailView(GenericAPIView):
             recipient=recipient_user.email,
             sender_address=sender_user.email,
             sender_name=sender_user.profile.display_name,
-            raise_for_status=False,
         )
         return Response(
             status=mailgun_response.status_code,

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -41,22 +41,31 @@ def mocked_json(return_data=None):
     return json
 
 
-def mocked_batch_result(status_codes=None):
-    """Mocked version of the send_batch return value"""
-    if status_codes is None:
-        status_codes = [status.HTTP_200_OK]
+def mocked_batch_result(inputs=None):
+    """
+    Provides some fake return values for send_batch based on the inputs.
 
-    def _is_response(_status_code):
-        """Helper function to figure out whether to generate a response or an exception"""
-        return isinstance(_status_code, int)
-    return [
-        (
-            ['recipient@example.com'],
-            Mock(spec=Response, status_code=status_code, json=mocked_json())
-            if _is_response(status_code) else None,
-            None if _is_response(status_code) else HTTPError(),
-        ) for status_code in status_codes
-    ]
+    Args:
+        inputs (list):
+            A list containing either status codes or exceptions, or a mix of both.
+    Returns:
+        list:
+            A list of tuples (recipients, response, exception) based on the values of inputs
+    """
+    if inputs is None:
+        inputs = [status.HTTP_200_OK]
+
+    responses = []
+    for i, _input in enumerate(inputs):
+        is_status_code = isinstance(_input, int)
+
+        recipients = ['recipient_{}@example.com'.format(i)]
+        if is_status_code:
+            responses.append((recipients, Mock(spec=Response, status_code=_input, json=mocked_json()), None))
+        else:
+            responses.append((recipients, None, HTTPError()))
+
+    return responses
 
 
 class SearchResultMailViewsTests(MockedESTestCase, APITestCase):

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -136,15 +136,6 @@ class SearchResultMailViewsTests(MockedESTestCase, APITestCase):
             resp_post = self.client.post(self.search_result_mail_url, data=self.request_data, format='json')
         assert resp_post.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
-        for num, (_, resp, exception) in enumerate(batch_results):
-            batch = 'batch_{0}'.format(num)
-            batch_result = resp_post.data[batch]
-            if exception is not None:
-                assert batch_result['data'] == str(exception)
-            else:
-                assert batch_result['status_code'] == resp.status_code
-                assert batch_result['data'] == generate_mailgun_response_json(resp)
-
     def test_view_response_error(self):
         """
         If there's at least one non-zero status code from Mailgun, we should return a 500 status code in our response.

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -22,7 +22,6 @@ from financialaid.api_test import (
 )
 from financialaid.factories import FinancialAidFactory, TierProgramFactory
 from mail.models import AutomaticEmail
-from mail.utils import generate_mailgun_response_json
 from profiles.factories import ProfileFactory
 from profiles.util import full_name
 from roles.models import Role

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.db.models.signals import post_save
+from requests.exceptions import HTTPError
 from rest_framework import status
 from rest_framework.test import APITestCase
 from rest_framework.response import Response
@@ -20,7 +21,6 @@ from financialaid.api_test import (
     create_enrolled_profile,
 )
 from financialaid.factories import FinancialAidFactory, TierProgramFactory
-from mail.exceptions import MailException
 from mail.models import AutomaticEmail
 from mail.utils import generate_mailgun_response_json
 from profiles.factories import ProfileFactory
@@ -54,7 +54,7 @@ def mocked_batch_result(status_codes=None):
             ['recipient@example.com'],
             Mock(spec=Response, status_code=status_code, json=mocked_json())
             if _is_response(status_code) else None,
-            None if _is_response(status_code) else MailException("error"),
+            None if _is_response(status_code) else HTTPError(),
         ) for status_code in status_codes
     ]
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2749 

#### What's this PR do?
 - adds tests for error handling for all MailgunClient functions
 - adds a `raise_for_status` flag for a few of the functions, which defaults to **True**. This will cause an exception to be raised if the Mailgun response is not in the 2xx range.
 - Changes `send_batch` to raise an exception if any of the batch calls raised an exception. There is also `raise_for_status` for this function which defaults to true. The exception is `SendBatchException` which contains a list of the failed email addresses so that we can make use of it later.

#### How should this be manually tested?
Send an email in all the ways that are available in the UI
