### PR TITLE
Allowed users to expand/hide search facets by clicking facet title

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -200,22 +200,24 @@ export default class LearnerSearch extends SearchkitComponent {
       <Card className="fullwidth" shadow={1}>
         <FilterVisibilityToggle
           {...this.props}
+          title="Course"
           filterName="courses"
         >
           <HierarchicalRefinementFilter
             field={"program.enrollments"}
-            title="Course"
+            title=""
             id="courses"
           />
         </FilterVisibilityToggle>
         <FilterVisibilityToggle
           {...this.props}
           filterName="semester"
+          title="Semester"
         >
           <PatchedMenuFilter
             field="program.semester_enrollments.semester"
             fieldOptions={{ type: 'nested', options: {path: 'program.semester_enrollments'} }}
-            title="Semester"
+            title=""
             id="semester"
             bucketsTransform={sortSemesterBuckets}
           />
@@ -223,6 +225,7 @@ export default class LearnerSearch extends SearchkitComponent {
         <FilterVisibilityToggle
           {...this.props}
           filterName="num-courses-passed"
+          title="# of Courses Passed"
         >
           <RangeFilter
             field="program.num_courses_passed"
@@ -230,11 +233,12 @@ export default class LearnerSearch extends SearchkitComponent {
             min={0}
             max={this.getNumberOfCoursesInProgram()}
             showHistogram={false}
-            title="# of Courses Passed" />
+            title="" />
         </FilterVisibilityToggle>
         <FilterVisibilityToggle
           {...this.props}
           filterName="grade-average"
+          title="Average Grade in Program"
         >
           <RangeFilter
             field="program.grade_average"
@@ -242,16 +246,17 @@ export default class LearnerSearch extends SearchkitComponent {
             min={0}
             max={100}
             showHistogram={true}
-            title="Average Grade in Program"
+            title=""
           />
         </FilterVisibilityToggle>
         <FilterVisibilityToggle
           {...this.props}
           filterName="birth-location"
+          title="Country of Birth"
         >
           <RefinementListFilter
             id="birth_location"
-            title="Country of Birth"
+            title=""
             field="profile.birth_country"
             operator="OR"
             itemComponent={CountryRefinementOption}
@@ -260,22 +265,24 @@ export default class LearnerSearch extends SearchkitComponent {
         </FilterVisibilityToggle>
         <FilterVisibilityToggle
           {...this.props}
+          title="Current Residence"
           filterName="residence-country"
         >
           <HierarchicalMenuFilter
             fields={["profile.country", "profile.state_or_territory"]}
-            title="Current Residence"
+            title=""
             id="country"
             translations={this.countryNameTranslations}
           />
         </FilterVisibilityToggle>
         <FilterVisibilityToggle
           {...this.props}
+          title="Degree"
           filterName="education-level"
         >
           <PatchedMenuFilter
             id="education_level"
-            title="Degree"
+            title=""
             field="profile.education.degree_name"
             fieldOptions={{type: 'nested', options: { path: 'profile.education' } }}
             translations={this.degreeTranslations}
@@ -284,6 +291,7 @@ export default class LearnerSearch extends SearchkitComponent {
         <FilterVisibilityToggle
           {...this.props}
           filterName="company-name"
+          title="Company"
         >
           <WorkHistoryFilter id="company_name" />
         </FilterVisibilityToggle>

--- a/static/js/components/search/FilterVisibilityToggle.js
+++ b/static/js/components/search/FilterVisibilityToggle.js
@@ -13,6 +13,7 @@ export const FILTER_ID_ADJUST = {
 
 export default class FilterVisibilityToggle extends SearchkitComponent {
   props: {
+    title:             string,
     filterName:             string,
     checkFilterVisibility:  (filterName: string) => boolean,
     setFilterVisibility:    (filterName: string, visibility: boolean) => void,
@@ -71,6 +72,20 @@ export default class FilterVisibilityToggle extends SearchkitComponent {
     />;
   };
 
+  renderFilterName = (children: React$Element<*>): React$Element<*>|null => {
+    if (!this.isInResults(children.props.id)) {
+      return null;
+    }
+    const { title } = this.props;
+    return (
+      <div
+        className="sk-hierarchical-refinement-list__header"
+        onClick={this.toggleFilterVisibility}>
+        {title}
+      </div>
+    );
+  };
+
   toggleFilterVisibility = (): void => {
     const {
       filterName,
@@ -87,7 +102,10 @@ export default class FilterVisibilityToggle extends SearchkitComponent {
     const { children } = this.props;
     return (
       <div className={`filter-visibility-toggle ${this.openClass()}`}>
-        { this.openStateIcon(children) }
+        <div className="title-row">
+          { this.openStateIcon(children) }
+          { this.renderFilterName(children) }
+        </div>
         { children }
       </div>
     );

--- a/static/js/components/search/FilterVisibilityToggle.js
+++ b/static/js/components/search/FilterVisibilityToggle.js
@@ -13,7 +13,7 @@ export const FILTER_ID_ADJUST = {
 
 export default class FilterVisibilityToggle extends SearchkitComponent {
   props: {
-    title:             string,
+    title:                  string,
     filterName:             string,
     checkFilterVisibility:  (filterName: string) => boolean,
     setFilterVisibility:    (filterName: string, visibility: boolean) => void,
@@ -60,28 +60,21 @@ export default class FilterVisibilityToggle extends SearchkitComponent {
     return false;
   };
 
-  openStateIcon = (children: React$Element<*>): React$Element<*>|null => {
-    if (!this.isInResults(children.props.id)) {
-      return null;
-    }
-
-    return <Icon
-      name="arrow_drop_down"
-      onClick={this.toggleFilterVisibility}
-      className={this.openClass()}
-    />;
-  };
-
-  renderFilterName = (children: React$Element<*>): React$Element<*>|null => {
+  renderFilterTitle = (children: React$Element<*>): React$Element<*>|null => {
     if (!this.isInResults(children.props.id)) {
       return null;
     }
     const { title } = this.props;
     return (
-      <div
-        className="sk-hierarchical-refinement-list__header"
-        onClick={this.toggleFilterVisibility}>
-        {title}
+      <div className="title-row" onClick={this.toggleFilterVisibility}>
+        <Icon
+          name="arrow_drop_down"
+          onClick={this.toggleFilterVisibility}
+          className={this.openClass()}
+        />
+        <div className="sk-hierarchical-refinement-list__header">
+          {title}
+        </div>
       </div>
     );
   };
@@ -102,10 +95,7 @@ export default class FilterVisibilityToggle extends SearchkitComponent {
     const { children } = this.props;
     return (
       <div className={`filter-visibility-toggle ${this.openClass()}`}>
-        <div className="title-row">
-          { this.openStateIcon(children) }
-          { this.renderFilterName(children) }
-        </div>
+        { this.renderFilterTitle(children) }
         { children }
       </div>
     );

--- a/static/js/components/search/WorkHistoryFilter.js
+++ b/static/js/components/search/WorkHistoryFilter.js
@@ -51,7 +51,7 @@ export default class WorkHistoryFilter extends SearchkitComponent {
     return (
       <RefinementListFilter
         field="profile.work_history.company_name"
-        title="Company"
+        title=""
         id="company_name"
         operator="OR"
         fieldOptions={{type: 'nested', options: { path: 'profile.work_history'}}}

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -64,6 +64,11 @@
       font-size: 14px;
       font-weight: 500;
       color: $font-black;
+      cursor: pointer;
+
+      &:empty {
+        display: none;
+      }
     }
 
     // Search facet content blocks
@@ -127,12 +132,17 @@
 
     .filter-visibility-toggle {
       display: flex;
-      flex-direction: row;
+      flex-direction: column;
       margin-bottom: 10px;
 
       i {
         cursor: pointer;
         padding-top: 12px;
+      }
+
+      .title-row {
+        display: flex;
+        flex-direction: row;
       }
     }
 


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2120

#### What's this PR do?
- Made facets title clickable, user can expand/hide search facets by clicking facet title

#### How should this be manually tested?
- Go to learners page and click the title of any facet.

@pdpinch 
#### Screenshots (if appropriate)
<img width="803" alt="screen shot 2017-03-06 at 6 28 34 pm" src="https://cloud.githubusercontent.com/assets/10431250/23611926/0cfd417e-029b-11e7-8798-adfc562f3f6a.png">

