### PR TITLE
Fixed erroneous logging of ExamProfile.status (#2783)

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -408,10 +408,10 @@ class MMTrack:
         except ExamProfile.DoesNotExist:
             return ExamProfile.PROFILE_ABSENT
 
-        if exam_profile.status in (ExamProfile.PROFILE_PENDING, ExamProfile.PROFILE_IN_PROGRESS):
+        if exam_profile.status in (ExamProfile.PROFILE_PENDING, ExamProfile.PROFILE_IN_PROGRESS,):
             return ExamProfile.PROFILE_IN_PROGRESS
 
-        elif exam_profile.status == ExamProfile.PROFILE_INVALID:
+        elif exam_profile.status in (ExamProfile.PROFILE_INVALID, ExamProfile.PROFILE_FAILED,):
             return ExamProfile.PROFILE_INVALID
 
         elif exam_profile.status == ExamProfile.PROFILE_SUCCESS:

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -925,18 +925,20 @@ class MMTrackTest(MockedESTestCase):
         assert mmtrack.has_paid(key) is True
 
     @ddt.data(
-        ["", "", False, False, False],
-        ["", ExamProfile.PROFILE_ABSENT, True, False, False],
-        [ExamProfile.PROFILE_INVALID, ExamProfile.PROFILE_INVALID, True, True, False],
-        [ExamProfile.PROFILE_FAILED, ExamProfile.PROFILE_INVALID, True, True, False],
-        ["", ExamProfile.PROFILE_INVALID, True, True, False],
-        [ExamProfile.PROFILE_PENDING, ExamProfile.PROFILE_IN_PROGRESS, True, True, False],
-        [ExamProfile.PROFILE_IN_PROGRESS, ExamProfile.PROFILE_IN_PROGRESS, True, True, False],
-        [ExamProfile.PROFILE_SUCCESS, ExamProfile.PROFILE_SUCCESS, True, True, False],
-        [ExamProfile.PROFILE_SUCCESS, ExamProfile.PROFILE_SCHEDULABLE, True, True, True],
+        ["", "", False, False, False, False],
+        ["", ExamProfile.PROFILE_ABSENT, True, False, False, False],
+        [ExamProfile.PROFILE_INVALID, ExamProfile.PROFILE_INVALID, True, True, False, False],
+        [ExamProfile.PROFILE_FAILED, ExamProfile.PROFILE_INVALID, True, True, False, False],
+        ["", ExamProfile.PROFILE_INVALID, True, True, False, True],
+        [ExamProfile.PROFILE_PENDING, ExamProfile.PROFILE_IN_PROGRESS, True, True, False, False],
+        [ExamProfile.PROFILE_IN_PROGRESS, ExamProfile.PROFILE_IN_PROGRESS, True, True, False, False],
+        [ExamProfile.PROFILE_SUCCESS, ExamProfile.PROFILE_SUCCESS, True, True, False, False],
+        [ExamProfile.PROFILE_SUCCESS, ExamProfile.PROFILE_SCHEDULABLE, True, True, True, False],
     )
     @ddt.unpack  # pylint: disable=too-many-arguments
-    def test_get_pearson_exam_status(self, profile_status, expected_status, set_series_code, make_profile, make_auth):
+    @patch('dashboard.utils.log')
+    def test_get_pearson_exam_status(self, profile_status, expected_status, set_series_code,
+                                     make_profile, make_auth, log_error_called, log_mock):
         """
         test get_pearson_exam_status
         """
@@ -968,6 +970,7 @@ class MMTrackTest(MockedESTestCase):
         )
 
         assert mmtrack.get_pearson_exam_status() == expected_status
+        assert log_mock.error.called is log_error_called
 
         if not set_series_code:
             self.program.exam_series_code = exam_series_code


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2783 

#### What's this PR do?
The failed status was falling through to the default status where we log an error and return 'invalid'. 'invalid' is correct, but we don't want the logging. I added an assertion to the test for the log call and fixed the logic.

#### How should this be manually tested?
- Create an `ExamProfile` for yourself with `status='failed'` and load the dashboard. You should see no errors logged.

#### Where should the reviewer start?
dashboard/utils.py

#### What GIF best describes this PR or how it makes you feel?
(Optional)
