### PR TITLE
Force logout before login after a 400/401 error from rest API

### DIFF
--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -104,7 +104,8 @@ const _fetchJSONWithCSRF = (input: string, init: Object = {}, loginOnError: bool
     // to force a new login
     if (loginOnError === true && (response.status === 400 || response.status === 401)) {
       const relativePath = window.location.pathname + window.location.search;
-      window.location = `/login/edxorg/?next=${encodeURIComponent(relativePath)}`;
+      const loginRedirect = `/login/edxorg/?next=${encodeURIComponent(relativePath)}`;
+      window.location = `/logout?next=${encodeURIComponent(loginRedirect)}`;
     }
 
     // For non 2xx status codes reject the promise adding the status code

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -668,7 +668,8 @@ describe('api', function() {
           });
 
           return assert.isRejected(fetchJSONWithCSRF('/url', {}, true)).then(() => {
-            assert.include(window.location.toString(), '/login/edxorg/');
+            const redirectUrl = `/logout?next=${encodeURIComponent('/login/edxorg/')}`;
+            assert.include(window.location.toString(), redirectUrl);
           });
         });
       }


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #2776 

#### What's this PR do?
Forces a logout before the login after a 400 or 401 error from a rest api call.

#### How should this be manually tested?

1.  you need 2 users on edx and one of the 2 should not be a micromasters user.
2. login with the first user on micromasters and visit the dashboard
3. open another tab on the admin of micromasters and open the user social object of the logged in user
4. in another tab of the same browser logout from edx and login with the second user
5. on the micromasters admin, remove the content of the `extra_data` and save 
6. reload the dashboard 

what you should see is the login of the second user.

#### Any background context you want to provide?
this is a fix for the issue observed in #2276