### PR TITLE
Moved Elasticsearch connection management to own module

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from elasticsearch_dsl import Search, Q
 
 from roles.api import get_advance_searchable_programs
-from search.indexing_api import (
+from search.connection import (
     get_conn,
     DOC_TYPES,
 )

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -23,9 +23,7 @@ from search.api import (
     get_all_query_matching_emails,
 )
 from search.base import ESTestCase
-from search.indexing_api import (
-    DOC_TYPES,
-)
+from search.connection import DOC_TYPES
 from search.exceptions import NoProgramAccessException
 
 

--- a/search/connection.py
+++ b/search/connection.py
@@ -1,0 +1,66 @@
+"""Manages the Elasticsearch connection"""
+from django.conf import settings
+from elasticsearch_dsl.connections import connections
+
+from search.exceptions import ReindexException
+
+
+_CONN = None
+# When we create the connection, check to make sure all appropriate mappings exist
+_CONN_VERIFIED = False
+# This is a builtin type
+PERCOLATE_DOC_TYPE = '.percolator'
+
+USER_DOC_TYPE = 'program_user'
+DOC_TYPES = (USER_DOC_TYPE, )
+
+
+def get_conn(verify=True):
+    """
+    Lazily create the connection.
+    """
+    # pylint: disable=global-statement
+    global _CONN
+    global _CONN_VERIFIED
+
+    do_verify = False
+    if _CONN is None:
+        http_auth = settings.ELASTICSEARCH_HTTP_AUTH
+        use_ssl = http_auth is not None
+        _CONN = connections.create_connection(
+            hosts=[settings.ELASTICSEARCH_URL],
+            http_auth=http_auth,
+            use_ssl=use_ssl,
+            # make sure we verify SSL certificates (off by default)
+            verify_certs=use_ssl
+        )
+        # Verify connection on first connect if verify=True.
+        do_verify = verify
+
+    if verify and not _CONN_VERIFIED:
+        # If we have a connection but haven't verified before, do it now.
+        do_verify = True
+
+    if not do_verify:
+        if not verify:
+            # We only skip verification if we're reindexing or
+            # deleting the index. Make sure we verify next time we connect.
+            _CONN_VERIFIED = False
+        return _CONN
+
+    # Make sure everything exists.
+    index_name = settings.ELASTICSEARCH_INDEX
+    if not _CONN.indices.exists(index_name):
+        raise ReindexException("Unable to find index {index_name}".format(
+            index_name=index_name
+        ))
+
+    mappings = _CONN.indices.get_mapping()[index_name]["mappings"]
+    for doc_type in DOC_TYPES:
+        if doc_type not in mappings.keys():
+            raise ReindexException("Mapping {doc_type} not found".format(
+                doc_type=doc_type
+            ))
+
+    _CONN_VERIFIED = True
+    return _CONN

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -8,25 +8,21 @@ from django.conf import settings
 from elasticsearch.helpers import bulk
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch_dsl import Mapping
-from elasticsearch_dsl.connections import connections
 
 from profiles.models import Profile
 from profiles.serializers import ProfileSerializer
 from dashboard.models import ProgramEnrollment
 from dashboard.serializers import UserProgramSearchSerializer
+from search.connection import (
+    get_conn,
+    USER_DOC_TYPE,
+    PERCOLATE_DOC_TYPE,
+)
 from search.exceptions import ReindexException
 from search.models import PercolateQuery
 
 log = logging.getLogger(__name__)
 
-# This is a builtin type
-PERCOLATE_DOC_TYPE = '.percolator'
-
-USER_DOC_TYPE = 'program_user'
-DOC_TYPES = (USER_DOC_TYPE, )
-_CONN = None
-# When we create the connection, check to make sure all appropriate mappings exist
-_CONN_VERIFIED = False
 # A string which must be indexed exactly as is and not stemmed for full text search (the default)
 NOT_ANALYZED_STRING_TYPE = {
     'type': 'string',
@@ -46,57 +42,6 @@ FOLDED_SEARCHABLE_STRING_TYPE = {
 BOOL_TYPE = {'type': 'boolean'}
 DATE_TYPE = {'type': 'date', 'format': 'date'}
 LONG_TYPE = {'type': 'long'}
-
-
-def get_conn(verify=True):
-    """
-    Lazily create the connection.
-    """
-    # pylint: disable=global-statement
-    global _CONN
-    global _CONN_VERIFIED
-
-    do_verify = False
-    if _CONN is None:
-        http_auth = settings.ELASTICSEARCH_HTTP_AUTH
-        use_ssl = http_auth is not None
-        _CONN = connections.create_connection(
-            hosts=[settings.ELASTICSEARCH_URL],
-            http_auth=http_auth,
-            use_ssl=use_ssl,
-            # make sure we verify SSL certificates (off by default)
-            verify_certs=use_ssl
-        )
-        # Verify connection on first connect if verify=True.
-        do_verify = verify
-
-    if verify and not _CONN_VERIFIED:
-        # If we have a connection but haven't verified before, do it now.
-        do_verify = True
-
-    if not do_verify:
-        if not verify:
-            # We only skip verification if we're reindexing or
-            # deleting the index. Make sure we verify next time we connect.
-            _CONN_VERIFIED = False
-        return _CONN
-
-    # Make sure everything exists.
-    index_name = settings.ELASTICSEARCH_INDEX
-    if not _CONN.indices.exists(index_name):
-        raise ReindexException("Unable to find index {index_name}".format(
-            index_name=index_name
-        ))
-
-    mappings = _CONN.indices.get_mapping()[index_name]["mappings"]
-    for doc_type in DOC_TYPES:
-        if doc_type not in mappings.keys():
-            raise ReindexException("Mapping {doc_type} not found".format(
-                doc_type=doc_type
-            ))
-
-    _CONN_VERIFIED = True
-    return _CONN
 
 
 def _index_chunk(chunk, doc_type):


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Moves Elasticsearch connection logic to its own module, which will prevent circular imports in a future PR

#### How should this be manually tested?
Learner search page should still work, `./manage.py recreate_index` should work fine
