### PR TITLE
Patch search.tasks instead of search.indexing_api

### DIFF
--- a/search/base.py
+++ b/search/base.py
@@ -45,6 +45,8 @@ class MockedESTestCase(TestCase):
     def setUpClass(cls):
         cls.patchers = []
         for name, val in tasks.__dict__.items():
+            # This looks for functions starting with _ because those are the functions which are imported
+            # from indexing_api. The _ lets it prevent name collisions.
             if callable(val) and name.startswith("_"):
                 cls.patchers.append(patch('search.tasks.{0}'.format(name), autospec=True))
         for patcher in cls.patchers:

--- a/search/base.py
+++ b/search/base.py
@@ -7,7 +7,7 @@ from django.test import (
     TestCase,
 )
 
-from search import indexing_api
+from search import tasks
 from search.indexing_api import recreate_index, delete_index
 
 
@@ -44,9 +44,9 @@ class MockedESTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.patchers = []
-        for name, val in indexing_api.__dict__.items():
-            if callable(val):
-                cls.patchers.append(patch('search.indexing_api.{0}'.format(name), autospec=True))
+        for name, val in tasks.__dict__.items():
+            if callable(val) and name.startswith("_"):
+                cls.patchers.append(patch('search.tasks.{0}'.format(name), autospec=True))
         for patcher in cls.patchers:
             patcher.start()
         try:


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #2705

#### What's this PR do?
Patches search.tasks instead of search.indexing_api because patches should patch the module where it's invoked rather than the one where it's defined. This worked fine before because `search.indexing_api` functions usually just called other functions, but in a future PR this will not work because the percolate indexing work uses a function in `search.api`

#### How should this be manually tested?
This should only affect tests so no manual review is necessary
