### PR TITLE
Fixed exam authorization issues when final grade status is pending

### DIFF
--- a/exams/utils.py
+++ b/exams/utils.py
@@ -261,20 +261,16 @@ def authorize_for_latest_passed_course(mmtrack, course_id):
 
     for enrollment in enrollments_qset:
         # only latest passed course_run per course allowed
-        edx_course_key = enrollment.course_run.edx_course_key
-        if _has_passed_course(mmtrack, edx_course_key) and _has_paid_for_exam(mmtrack, edx_course_key):
-            # if user has passed and paid for the course
-            # and not already authorized for exam the create authorizations.
-            try:
-                authorize_for_exam(mmtrack, enrollment.course_run)
-            except ExamAuthorizationException:
-                log.exception(
-                    'Unable to authorize user: %s for exam on course_id: %s',
-                    mmtrack.user.username,
-                    enrollment.course_run.course.id
-                )
-            else:
-                break
+        try:
+            authorize_for_exam(mmtrack, enrollment.course_run)
+        except ExamAuthorizationException:
+            log.exception(
+                'Unable to authorize user: %s for exam on course_id: %s',
+                mmtrack.user.username,
+                enrollment.course_run.course.id
+            )
+        else:
+            break
 
 
 def _match_field(profile, field):

--- a/exams/utils_test.py
+++ b/exams/utils_test.py
@@ -672,11 +672,16 @@ class BulkExamUtilV1Tests(TestCase):
             )
 
         log.exception.assert_called_with(
-            '[Exam authorization] User: %s do not have complete FinalGrade for course %s',
+            'Unable to authorize user: %s for exam on course_id: %s',
             user.username,
-            self.course_run2.edx_course_key
+            course.id
         )
-        assert ExamProfile.objects.filter(profile=user.profile).exists() is False
+
+        mmtrack = get_mmtrack(user, self.program)
+        assert mmtrack.has_paid(self.course_run.edx_course_key) is True
+        assert mmtrack.has_paid(self.course_run2.edx_course_key) is True
+        assert ExamProfile.objects.filter(profile=user.profile).exists() is True
+        # because user has no complete final grade.
         assert ExamAuthorization.objects.filter(user=user, course=course).exists() is False
 
     def test_exam_authorization_no_exam_series_code_set(self):

--- a/exams/utils_test.py
+++ b/exams/utils_test.py
@@ -39,7 +39,9 @@ from ecommerce.factories import (
     LineFactory,
     CoursePriceFactory
 )
+from grades.constants import FinalGradeStatus
 from grades.factories import FinalGradeFactory
+from grades.models import FinalGrade
 from financialaid.api_test import create_program
 from profiles.factories import ProfileFactory
 from search.base import MockedESTestCase
@@ -648,6 +650,34 @@ class BulkExamUtilV1Tests(TestCase):
             user=user,
             course=self.course_run.course
         ).exists() is False
+
+    def test_exam_authorization_pending_final_grade(self):
+        """Test authorization when final grade is pending."""
+        user = self.users[0]
+        course = self.course_run.course
+        # change the final grade status to pending
+        with mute_signals(post_save):
+            # set status=PENDING for both course runs, so that user can not get exam authorization.
+            FinalGrade.objects.filter(course_run=self.course_run, user=user).update(status=FinalGradeStatus.PENDING)
+            FinalGrade.objects.filter(course_run=self.course_run2, user=user).update(status=FinalGradeStatus.PENDING)
+
+        # Neither user has exam profile nor authorization.
+        assert ExamProfile.objects.filter(profile=user.profile).exists() is False
+        assert ExamAuthorization.objects.filter(user=user, course=course).exists() is False
+
+        with patch("exams.utils.log") as log:
+            bulk_authorize_for_exam(
+                username=user.username,
+                program_id=self.program.id
+            )
+
+        log.exception.assert_called_with(
+            '[Exam authorization] User: %s do not have complete FinalGrade for course %s',
+            user.username,
+            self.course_run2.edx_course_key
+        )
+        assert ExamProfile.objects.filter(profile=user.profile).exists() is False
+        assert ExamAuthorization.objects.filter(user=user, course=course).exists() is False
 
     def test_exam_authorization_no_exam_series_code_set(self):
         """Test authorization when `exam_series_code` is not set on program."""


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2796

#### What's this PR do?
Fixed an exception issue which appears when user dont have complete final grade object

#### How should this be manually tested?
- run  command `authorization_user_exam` for a user who has final grade status pending, and see logged exception.

@pdpinch 