### PR TITLE
Fixed authorization_user_exam to authorize and not error (#2796)

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -251,6 +251,9 @@ class MMTrack:
         Args:
             course_id (str): an edX course run id
 
+        Raises:
+            FinalGrade.DoesNotExist: raised if a FinalGrade record was not found
+
         Returns:
             bool: whether the user has passed the course
         """
@@ -280,6 +283,23 @@ class MMTrack:
                 log.error('Missing "end_date" for course run %s', course_id)
                 raise ImproperlyConfigured('Missing "end_date" for course run {}'.format(course_id))
             return cur_grade.passed and course_run.is_past
+
+    def has_passed_course_for_exam(self, course_id):
+        """
+        Returns whether the user has passed a course run for an exam.
+        This method is present because of the need to have a version that doesn't raise FinalGrade.DoesNotExist.
+        In those cases, we treat it as False.
+
+        Args:
+            course_id (str): an edX course run id
+
+        Returns:
+            bool: whether the user has passed the course
+        """
+        try:
+            return self.has_passed_course(course_id)
+        except FinalGrade.DoesNotExist:
+            return False
 
     def get_final_grade(self, course_id):
         """

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -424,6 +424,35 @@ class MMTrackTest(MockedESTestCase):
             mmtrack.has_passed_course(course_id)
         extr_grade_mock.assert_called_once_with(mmtrack, course_id)
 
+    @ddt.data(True, False)
+    @patch('dashboard.utils.MMTrack.has_passed_course', autospec=True)
+    def test_has_passed_course_for_exam(self, has_passed_course_value, has_passed_course_mock):
+        """Test that has_passed_course_for_exam return value of has_passed_course"""
+        course_id = "course-v1:odl+FOO101+CR-FALL15"
+        has_passed_course_mock.return_value = has_passed_course_value
+
+        mmtrack = MMTrack(
+            user=self.user,
+            program=self.program,
+            edx_user_data=self.cached_edx_user_data
+        )
+
+        assert mmtrack.has_passed_course_for_exam(course_id) is has_passed_course_value
+
+    @patch('dashboard.utils.MMTrack.has_passed_course', autospec=True)
+    def test_has_passed_course_for_exam_no_final_grade(self, has_passed_course_mock):
+        """Test that has_passed_course_for_exam returns False if no FinalGrade"""
+        course_id = "course-v1:odl+FOO101+CR-FALL15"
+        has_passed_course_mock.side_effect = FinalGrade.DoesNotExist
+
+        mmtrack = MMTrack(
+            user=self.user,
+            program=self.program,
+            edx_user_data=self.cached_edx_user_data
+        )
+
+        assert mmtrack.has_passed_course_for_exam(course_id) is False
+
     @override_settings(FEATURES={"FINAL_GRADE_ALGORITHM": "v1"})
     @patch('dashboard.utils.MMTrack.extract_final_grade', autospec=True)
     def test_get_final_grade(self, extr_grade_mock):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2796 

#### What's this PR do?
Removes extraneous checks for pass/paid and handles `FinalGrade.DoesNotExist` for exam authorization command.

#### How should this be manually tested?
Setup a course for exams (set `Program.exam_series_code` and `Course.exam_module` to some arbitrary string), enroll in a `CourseRun` for that course. Verify you have no `FinalGrade` in that `Course`. Run `./manage.py authorization_user_exam --program-id=?`

#### Where should the reviewer start?
dashboard/utils.py