### PR TITLE
Filter out zendesk errors

### DIFF
--- a/selenium_tests/base.py
+++ b/selenium_tests/base.py
@@ -264,6 +264,8 @@ FROM pg_stat_activity WHERE pid <> pg_backend_pid()""")
                 continue
             if "'webkitURL' is deprecated. Please use 'URL' instead" in message:
                 continue
+            if "zendesk" in message.lower():
+                continue
 
             # warnings (e.g. deprecations) should not fail the tests
             if entry['level'] in ["WARNING"]:


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2799 

#### What's this PR do?
Filters out zendesk errors from the console assert for selenium tests. Zendesk is failing to load periodically on its own unfortunately, so this is not a good test of our Zendesk-related JS

#### How should this be manually tested?
None
