### PR TITLE
Add/aq/username email search

### DIFF
--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -275,6 +275,7 @@ def program_enrolled_user_mapping():
             'school_state_or_territory': NOT_ANALYZED_STRING_TYPE,
         }},
         'email_optin': BOOL_TYPE,
+        'email': FOLDED_SEARCHABLE_STRING_TYPE,
         'filled_out': BOOL_TYPE,
         'first_name': FOLDED_SEARCHABLE_STRING_TYPE,
         'gender': NOT_ANALYZED_STRING_TYPE,

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -253,7 +253,7 @@ def program_enrolled_user_mapping():
     mapping = Mapping(USER_DOC_TYPE)
     mapping.field("id", "long")
     mapping.field("user_id", "long")
-    mapping.field("email", NOT_ANALYZED_STRING_TYPE)
+    mapping.field("email", FOLDED_SEARCHABLE_STRING_TYPE)
     mapping.field("profile", "object", properties={
         'account_privacy': NOT_ANALYZED_STRING_TYPE,
         'agreed_to_terms_of_service': BOOL_TYPE,
@@ -275,7 +275,6 @@ def program_enrolled_user_mapping():
             'school_state_or_territory': NOT_ANALYZED_STRING_TYPE,
         }},
         'email_optin': BOOL_TYPE,
-        'email': FOLDED_SEARCHABLE_STRING_TYPE,
         'filled_out': BOOL_TYPE,
         'first_name': FOLDED_SEARCHABLE_STRING_TYPE,
         'gender': NOT_ANALYZED_STRING_TYPE,
@@ -283,7 +282,7 @@ def program_enrolled_user_mapping():
         'preferred_language': NOT_ANALYZED_STRING_TYPE,
         'preferred_name': FOLDED_SEARCHABLE_STRING_TYPE,
         'pretty_printed_student_id': NOT_ANALYZED_STRING_TYPE,
-        'username': NOT_ANALYZED_STRING_TYPE,
+        'username': FOLDED_SEARCHABLE_STRING_TYPE,
         'work_history': {'type': 'nested', 'properties': {
             'city': NOT_ANALYZED_STRING_TYPE,
             'company_name': NOT_ANALYZED_STRING_TYPE,

--- a/search/views_test.py
+++ b/search/views_test.py
@@ -212,7 +212,9 @@ class SearchTests(ESTestCase, APITestCase):
                     "fields": [
                         "profile.first_name.folded",
                         "profile.last_name.folded",
-                        "profile.preferred_name.folded"
+                        "profile.preferred_name.folded",
+                        "profile.username",
+                        "profile.email.folded"
                     ],
                     "query": "l",
                     "type": "phrase_prefix"

--- a/search/views_test.py
+++ b/search/views_test.py
@@ -213,8 +213,8 @@ class SearchTests(ESTestCase, APITestCase):
                         "profile.first_name.folded",
                         "profile.last_name.folded",
                         "profile.preferred_name.folded",
-                        "profile.username",
-                        "profile.email.folded"
+                        "profile.username.folded",
+                        "email.folded"
                     ],
                     "query": "l",
                     "type": "phrase_prefix"

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -166,6 +166,8 @@ export default class LearnerSearch extends SearchkitComponent {
               'profile.first_name.folded',
               'profile.last_name.folded',
               'profile.preferred_name.folded',
+              'profile.username',
+              'profile.email.folded'
             ]}
             prefixQueryOptions={{
               analyzer: "folding"

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -166,8 +166,8 @@ export default class LearnerSearch extends SearchkitComponent {
               'profile.first_name.folded',
               'profile.last_name.folded',
               'profile.preferred_name.folded',
-              'profile.username',
-              'profile.email.folded'
+              'profile.username.folded',
+              'email.folded'
             ]}
             prefixQueryOptions={{
               analyzer: "folding"

--- a/static/js/components/search/CustomSortingColumnHeaders.js
+++ b/static/js/components/search/CustomSortingColumnHeaders.js
@@ -69,11 +69,11 @@ export default class CustomSortingColumnHeaders extends React.Component {
     return (
       <Grid className="sorting-row">
         <Cell col={1}/>
-        <Cell col={5} onClick={this.toggleNameSort} className={`name ${this.selectedClass(nameKeys)}`}>
+        <Cell col={4} onClick={this.toggleNameSort} className={`name ${this.selectedClass(nameKeys)}`}>
           Name {this.sortDirection(nameKeys)}
         </Cell>
         <Cell
-          col={3}
+          col={4}
           onClick={this.toggleLocationSort}
           className={`residence ${this.selectedClass(locationKeys)}`}
         >

--- a/static/js/components/search/LearnerResult.js
+++ b/static/js/components/search/LearnerResult.js
@@ -50,7 +50,7 @@ class LearnerResult extends SearchkitComponent {
             { highlight(getUserDisplayName(profile), this.searchkit.state.q) }
           </span>
           <span className="user-name">
-            { profile.username }
+            { highlight(profile.username, this.searchkit.state.q) }
           </span>
           {profile.username === learnerChipVisibility ? <LearnerChip profile={profile} /> : null}
         </Cell>

--- a/static/js/components/search/LearnerResult.js
+++ b/static/js/components/search/LearnerResult.js
@@ -41,17 +41,20 @@ class LearnerResult extends SearchkitComponent {
           <ProfileImage profile={profile} useSmall={true} />
         </Cell>
         <Cell
-          col={5}
-          className="learner-name centered"
+          col={4}
+          className="learner-name"
           onMouseLeave={() => setLearnerChipVisibility(null)}
           onMouseEnter={() => setLearnerChipVisibility(profile.username)}
         >
           <span className="display-name">
             { highlight(getUserDisplayName(profile), this.searchkit.state.q) }
           </span>
+          <span className="user-name">
+            { profile.username }
+          </span>
           {profile.username === learnerChipVisibility ? <LearnerChip profile={profile} /> : null}
         </Cell>
-        <Cell col={3} className="centered learner-location">
+        <Cell col={4} className="centered learner-location">
           <span>
             { getLocation(profile) }
           </span>

--- a/static/js/components/search/LearnerResult_test.js
+++ b/static/js/components/search/LearnerResult_test.js
@@ -179,6 +179,7 @@ describe('LearnerResult', () => {
     profile.first_name = 'queryname';
     profile.last_name = 'qÜeryson';
     profile.preferred_name = 'Querypreferred';
+    profile.username = 'queryfake.username';
     let result = renderElasticSearchResult(
       {
         _source: {
@@ -192,5 +193,6 @@ describe('LearnerResult', () => {
       'qÜery',
       'Query',
     ]);
+    assert.equal(result.find(".user-name .highlight").text(), "query");
   });
 });

--- a/static/js/components/search/LearnerResult_test.js
+++ b/static/js/components/search/LearnerResult_test.js
@@ -71,6 +71,11 @@ describe('LearnerResult', () => {
     assert.equal(result.text(), getUserDisplayName(USER_PROFILE_RESPONSE));
   });
 
+  it("should include the username", () => {
+    let result = renderLearnerResult().find(".learner-name").find(".user-name");
+    assert.equal(result.text(), USER_PROFILE_RESPONSE.username);
+  });
+
   it("should include the user's location for US residence", () => {
     let result = renderLearnerResult().find(".learner-location").find("span");
     assert.include(result.text(), USER_PROFILE_RESPONSE.city);

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -131,8 +131,8 @@ describe('LearnerSearchPage', function () {
           'profile.first_name.folded',
           'profile.last_name.folded',
           'profile.preferred_name.folded',
-          'profile.username',
-          'profile.email.folded'
+          'profile.username.folded',
+          'email.folded'
         ],
         analyzer: 'folding',
         query: 'xyz',

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -131,6 +131,8 @@ describe('LearnerSearchPage', function () {
           'profile.first_name.folded',
           'profile.last_name.folded',
           'profile.preferred_name.folded',
+          'profile.username',
+          'profile.email.folded'
         ],
         analyzer: 'folding',
         query: 'xyz',

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -372,8 +372,18 @@
       }
 
       .learner-name {
-        font-weight: 400;
-        font-size: 14px;
+        display: flex;
+        flex-direction: column;
+
+        .display-name {
+          font-size: 15px;
+          font-weight: 500;
+        }
+
+        .user-name {
+          color: #a0a0a0;
+          font-size: 13px;
+        }
       }
 
       .learner-location {

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -381,7 +381,7 @@
         }
 
         .user-name {
-          color: #a0a0a0;
+          color: $font-gray-light;
           font-size: 13px;
         }
       }


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2668

#### What's this PR do?
Added email and username as search able fields.

#### How should this be manually tested?
**Run:** `docker-compose run web ./manage.py recreate_index`
GO to `http://192.168.99.100:8079/learners/` and in search box add email or user name

@pdpinch 
#### Screenshots (if appropriate)
<img width="643" alt="screen shot 2017-03-01 at 1 29 46 pm" src="https://cloud.githubusercontent.com/assets/10431250/23451768/31402ea0-fe83-11e6-9147-bd48fa39d5e6.png">

<img width="1274" alt="screen shot 2017-03-01 at 1 28 41 pm" src="https://cloud.githubusercontent.com/assets/10431250/23451770/314832ee-fe83-11e6-9aee-729d83e69e7d.png">

<img width="1240" alt="screen shot 2017-03-01 at 1 29 37 pm" src="https://cloud.githubusercontent.com/assets/10431250/23451769/3140e57a-fe83-11e6-9f56-555c3ea72a37.png">

