### PR TITLE
Fixed intermittent JS errors

### DIFF
--- a/js_test.sh
+++ b/js_test.sh
@@ -48,6 +48,7 @@ fi
 if [[ $(
     cat "$TMP_FILE" |
     grep -v 'ignored, nothing could be mapped' |
+    grep -v "This browser doesn't support the \`onScroll\` event" |
     wc -l |
     awk '{print $1}'
     ) -ne 0 ]]  # is file empty?

--- a/static/js/containers/LearnerPage.js
+++ b/static/js/containers/LearnerPage.js
@@ -43,7 +43,7 @@ class LearnerPage extends React.Component<*, LearnerPageProps, *> {
 
   componentWillUnmount() {
     const { dispatch, params: { username } } = this.props;
-    if (SETTINGS.user.username !== username) {
+    if (!SETTINGS.user || SETTINGS.user.username !== username) {
       // don't erase the user's own profile from the state
       dispatch(clearProfile(username));
     }

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -1,4 +1,6 @@
 // Define globals we would usually get from Django
+import ReactDOM from 'react-dom';
+
 const _createSettings = () => ({
   user: {
     username: "jane",
@@ -51,6 +53,10 @@ beforeEach(() => { // eslint-disable-line mocha/no-top-level-hooks
 
 // cleanup after each test run
 afterEach(function () { // eslint-disable-line mocha/no-top-level-hooks
+  let node = document.querySelector("#integration_test_div");
+  if (node) {
+    ReactDOM.unmountComponentAtNode(node);
+  }
   document.body.innerHTML = '';
   global.SETTINGS = _createSettings();
   window.localStorage.reset();

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -110,6 +110,8 @@ export default class IntegrationTestHelper {
     return this.listenForActions(expectedTypes, () => {
       this.browserHistory.push(url);
       div = document.createElement("div");
+      div.setAttribute("id", "integration_test_div");
+      document.body.appendChild(div);
       wrapper = mount(
         <div>
           <DashboardRouter


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2801 

#### What's this PR do?
The root cause of the intermittent errors was that the react component tree wasn't properly unmounted. This affected some creative use of the DOM by material-ui. To fix we check if the IntegrationTestHelper was used to create a DOM, then unmounts that div specifically in the global `afterEach` function.

#### How should this be manually tested?
To reproduce, check out master. Then go to `DashboardPage_test` and look for the test `without a race condition`. Go to `setTimeout` and comment out `resolve([coupon1])`. Run `npm test` and you should see the single test fail with a stack trace similar to the one in the issue.

Then checkout this branch but make sure that the `resolve([coupon1])` line is still commented out. Run the tests and you should see the test fail with a timeout error instead of the large stack trace. Uncomment the test and run again and every test should pass.