### PR TITLE
Enroll and pay later: Load dashboard page without reloading

### DIFF
--- a/static/js/actions/course_enrollments.js
+++ b/static/js/actions/course_enrollments.js
@@ -7,6 +7,7 @@ import { fetchDashboard } from './dashboard';
 import { fetchCoursePrices } from './course_prices';
 import type { Dispatcher } from '../flow/reduxTypes';
 import * as api from '../lib/api';
+import { showEnrollPayLaterSuccess } from './ui';
 
 export const REQUEST_ADD_COURSE_ENROLLMENT = 'REQUEST_ADD_COURSE_ENROLLMENT';
 export const requestAddCourseEnrollment = createAction(REQUEST_ADD_COURSE_ENROLLMENT);
@@ -22,14 +23,28 @@ export const addCourseEnrollment = (courseId: string): Dispatcher<*> => {
     dispatch(requestAddCourseEnrollment(courseId));
     return api.addCourseEnrollment(courseId).
       then(() => {
-        dispatch(receiveAddCourseEnrollmentSuccess());
-        dispatch(fetchDashboard(SETTINGS.user.username));
-        dispatch(fetchCoursePrices(SETTINGS.user.username));
+        dispatch(receiveAddCourseEnrollmentSuccess(courseId));
+        dispatch(fetchDashboard(SETTINGS.user.username, true));
+        dispatch(fetchCoursePrices(SETTINGS.user.username, true));
+        dispatch(showEnrollPayLaterSuccessMessage(courseId));
         return Promise.resolve();
       }).
       catch(() => {
         dispatch(receiveAddCourseEnrollmentFailure());
         return Promise.reject();
       });
+  };
+};
+
+export const showEnrollPayLaterSuccessMessage = (courseId: string): Dispatcher<*> => {
+  return (dispatch: Dispatch) => {
+    dispatch(showEnrollPayLaterSuccess(courseId));
+    let promise = new Promise(function(resolve) {
+      window.setTimeout(function() {
+        dispatch(showEnrollPayLaterSuccess(null));
+        resolve();
+      }, 9000);
+    });
+    return promise;
   };
 };

--- a/static/js/actions/course_enrollments_test.js
+++ b/static/js/actions/course_enrollments_test.js
@@ -1,14 +1,24 @@
 // @flow
+import { assert } from 'chai';
+import configureTestStore from 'redux-asserts';
+
 import {
   requestAddCourseEnrollment,
   receiveAddCourseEnrollmentSuccess,
   receiveAddCourseEnrollmentFailure,
+  showEnrollPayLaterSuccessMessage,
 
   REQUEST_ADD_COURSE_ENROLLMENT,
   RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS,
   RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
 } from './course_enrollments';
 import { assertCreatedActionHelper } from './test_util';
+import {
+  showEnrollPayLaterSuccess,
+
+  SHOW_ENROLL_PAY_LATER_SUCCESS
+} from './ui';
+import rootReducer from '../reducers';
 
 describe('course enrollment actions', () => {
   it('should create all action creators', () => {
@@ -17,5 +27,29 @@ describe('course enrollment actions', () => {
       [receiveAddCourseEnrollmentSuccess, RECEIVE_ADD_COURSE_ENROLLMENT_SUCCESS],
       [receiveAddCourseEnrollmentFailure, RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE],
     ].forEach(assertCreatedActionHelper);
+  });
+});
+
+describe('show and hide enroll pay later success alert', () => {
+  let store, dispatchThen;
+
+  beforeEach(() => {
+    store = configureTestStore(rootReducer);
+    dispatchThen = store.createDispatchThen(state => state.ui);
+  });
+
+  it('should set and reset enroll pay later dialog', () => {
+    return dispatchThen(
+      showEnrollPayLaterSuccessMessage('foo/bar/baz'),
+      [SHOW_ENROLL_PAY_LATER_SUCCESS]
+    ).then((state) => {
+      assert.equal(state.showEnrollPayLaterSuccess, 'foo/bar/baz');
+      return dispatchThen(
+        showEnrollPayLaterSuccess(null),
+        [SHOW_ENROLL_PAY_LATER_SUCCESS]
+      ).then((state) => {
+        assert.deepEqual(state.showEnrollPayLaterSuccess, null);
+      });
+    });
   });
 });

--- a/static/js/actions/course_prices.js
+++ b/static/js/actions/course_prices.js
@@ -18,9 +18,9 @@ export const receiveCoursePricesFailure = withUsername(RECEIVE_COURSE_PRICES_FAI
 export const CLEAR_COURSE_PRICES = 'CLEAR_COURSE_PRICES';
 export const clearCoursePrices = withUsername(CLEAR_COURSE_PRICES);
 
-export function fetchCoursePrices(username: string): Dispatcher<CoursePrices> {
+export function fetchCoursePrices(username: string, noSpinner: boolean = false): Dispatcher<CoursePrices> {
   return (dispatch: Dispatch) => {
-    dispatch(requestCoursePrices(username));
+    dispatch(requestCoursePrices(username, noSpinner));
     return api.getCoursePrices().
       then(coursePrices => dispatch(receiveCoursePricesSuccess(username, coursePrices))).
       catch(error => {

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -128,3 +128,6 @@ export const setNavDrawerOpen = createAction(SET_NAV_DRAWER_OPEN);
 
 export const SET_LEARNER_CHIP_VISIBILITY = 'SET_LEARNER_CHIP_VISIBILITY';
 export const setLearnerChipVisibility = createAction(SET_LEARNER_CHIP_VISIBILITY);
+
+export const SHOW_ENROLL_PAY_LATER_SUCCESS = "SHOW_ENROLL_PAY_LATER_SUCCESS";
+export const showEnrollPayLaterSuccess = createAction(SHOW_ENROLL_PAY_LATER_SUCCESS);

--- a/static/js/actions/ui_test.js
+++ b/static/js/actions/ui_test.js
@@ -32,6 +32,7 @@ import {
   SET_COUPON_NOTIFICATION_VISIBILITY,
   SET_NAV_DRAWER_OPEN,
   SET_LEARNER_CHIP_VISIBILITY,
+  SHOW_ENROLL_PAY_LATER_SUCCESS,
 
   clearUI,
   updateDialogText,
@@ -66,6 +67,7 @@ import {
   setCouponNotificationVisibility,
   setNavDrawerOpen,
   setLearnerChipVisibility,
+  showEnrollPayLaterSuccess,
 } from '../actions/ui';
 import { assertCreatedActionHelper } from './test_util';
 
@@ -105,6 +107,7 @@ describe('generated UI action helpers', () => {
       [setWorkHistoryAnswer, SET_WORK_HISTORY_ANSWER],
       [setNavDrawerOpen, SET_NAV_DRAWER_OPEN],
       [setLearnerChipVisibility, SET_LEARNER_CHIP_VISIBILITY],
+      [showEnrollPayLaterSuccess, SHOW_ENROLL_PAY_LATER_SUCCESS],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -13,6 +13,7 @@ import CourseRow from './CourseRow';
 import FinancialAidCalculator from '../../containers/FinancialAidCalculator';
 import type { CoursePrice } from '../../flow/dashboardTypes';
 import type { CourseRun } from '../../flow/programTypes';
+import type { UIState } from '../../reducers/ui';
 import {
   FA_TERMINAL_STATUSES,
   COUPON_CONTENT_TYPE_PROGRAM,
@@ -40,6 +41,7 @@ export default class CourseListCard extends React.Component {
     openCourseContactDialog:      (course: Course, canContactCourseTeam: boolean) => void,
     setEnrollSelectedCourseRun:   (r: CourseRun) => void,
     setEnrollCourseDialogVisibility: (bool: boolean) => void,
+    ui:                           UIState,
   };
 
   renderFinancialAidPriceMessage(): ?React$Element<*> {
@@ -167,6 +169,7 @@ export default class CourseListCard extends React.Component {
       openCourseContactDialog,
       setEnrollSelectedCourseRun,
       setEnrollCourseDialogVisibility,
+      ui,
     } = this.props;
     const now = this.props.now || moment();
 
@@ -186,6 +189,7 @@ export default class CourseListCard extends React.Component {
         openCourseContactDialog={openCourseContactDialog}
         setEnrollSelectedCourseRun={setEnrollSelectedCourseRun}
         setEnrollCourseDialogVisibility={setEnrollCourseDialogVisibility}
+        ui={ui}
         {...courseRowOptionalProps}
       />
     );

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -12,6 +12,7 @@ import CourseListCard from './CourseListCard';
 import CourseRow from './CourseRow';
 import { DASHBOARD_RESPONSE, COURSE_PRICES_RESPONSE } from '../../test_constants';
 import { INITIAL_EMAIL_STATE } from '../../reducers/email';
+import { INITIAL_UI_STATE } from '../../reducers/ui';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import IntegrationTestHelper from '../../util/integration_test_helper';
@@ -58,6 +59,7 @@ describe('CourseListCard', () => {
             coursePrice={coursePrice}
             addCourseEnrollment={() => Promise.resolve()}
             prices={prices}
+            ui={INITIAL_UI_STATE}
             openCourseContactDialog={() => undefined}
             closeEmailDialog={() => undefined}
             updateEmailEdit={() => undefined}

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import R from 'ramda';
+import Icon from 'react-mdl/lib/Icon';
 
 import CouponMessage from './CouponMessage';
 import CourseAction from './CourseAction';
@@ -9,6 +10,7 @@ import CourseGrade from './CourseGrade';
 import CourseDescription from './CourseDescription';
 import CourseSubRow from './CourseSubRow';
 import type { Course, CourseRun, FinancialAidUserInfo } from '../../flow/programTypes';
+import type { UIState } from '../../reducers/ui';
 import type {
   CalculatedPrices,
   Coupon,
@@ -34,6 +36,7 @@ export default class CourseRow extends React.Component {
     openCourseContactDialog: (course: Course, canContactCourseTeam: boolean) => void,
     setEnrollSelectedCourseRun: (r: CourseRun) => void,
     setEnrollCourseDialogVisibility: (b: boolean) => void,
+    ui: UIState,
   };
 
   shouldDisplayGradeColumn = (run: CourseRun): boolean => (
@@ -183,13 +186,35 @@ export default class CourseRow extends React.Component {
     return null;
   };
 
+  renderEnrollmentSuccess = (): React$Element<*> => {
+    return (
+      <Grid className="course-sub-row enroll-pay-later-success">
+        <Cell col={2} key="1">
+          <Icon name="check" className="tick-icon"/>
+        </Cell>,
+        <Cell col={7} key="2">
+          <p className="enroll-pay-later-heading">You are now auditing this course</p>
+          <span className="enroll-pay-later-txt">But you still need to pay to get credit.</span>
+        </Cell>
+      </Grid>
+    );
+  }
+
+  renderColumns = (firstRun: CourseRun): React$Element<*> => (
+    <Grid className="course-row" key="0">
+      { this.renderRowColumns(firstRun) }
+    </Grid>
+  )
+
   render() {
+    const { ui } = this.props;
     let firstRun = this.getFirstRun();
+    const showEnrollPayLaterSuccess =  (
+      ui.showEnrollPayLaterSuccess && ui.showEnrollPayLaterSuccess === firstRun.course_id
+    );
 
     return <div className="course-container">
-      <Grid className="course-row" key="0">
-        { this.renderRowColumns(firstRun) }
-      </Grid>
+      { showEnrollPayLaterSuccess ? this.renderEnrollmentSuccess() : this.renderColumns(firstRun) }
       {this.renderCouponMessage()}
       { this.renderSubRows() }
     </div>;

--- a/static/js/components/dashboard/CourseRow_test.js
+++ b/static/js/components/dashboard/CourseRow_test.js
@@ -20,6 +20,7 @@ import {
   STATUS_MISSED_DEADLINE,
 } from '../../constants';
 import { generateCourseFromExisting } from '../../util/test_utils';
+import { INITIAL_UI_STATE } from '../../reducers/ui';
 
 describe('CourseRow', () => {
   let sandbox;
@@ -32,6 +33,7 @@ describe('CourseRow', () => {
     addCourseEnrollment: sandbox.stub(),
     course: null,
     openCourseContactDialog: sandbox.stub(),
+    ui: INITIAL_UI_STATE
   });
 
   beforeEach(() => {
@@ -160,5 +162,25 @@ describe('CourseRow', () => {
       );
       assert.equal(wrapper.find('CourseDescription').props().hasContactEmail, hasContactEmail);
     }
+  });
+
+  it('when enroll pay later selected', () => {
+    let props = defaultCourseRowProps();
+    let course = makeCourse();
+    props.ui.showEnrollPayLaterSuccess = course.runs[0].course_id;
+    const wrapper = shallow(
+      <CourseRow
+        {...props}
+        course={course}
+      />
+    );
+    assert.equal(
+      wrapper.find('.enroll-pay-later-heading').text(),
+      "You are now auditing this course"
+    );
+    assert.equal(
+      wrapper.find('.enroll-pay-later-txt').text(),
+      "But you still need to pay to get credit."
+    );
   });
 });

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -262,14 +262,14 @@ class DashboardPage extends React.Component {
 
   fetchDashboard() {
     const { dashboard, dispatch } = this.props;
-    if (dashboard.fetchStatus === undefined && dashboard.noSpinner === false) {
+    if (dashboard.fetchStatus === undefined) {
       dispatch(fetchDashboard(SETTINGS.user.username));
     }
   }
 
   fetchCoursePrices() {
     const { prices, dispatch } = this.props;
-    if (prices.fetchStatus === undefined && prices.noSpinner === false) {
+    if (prices.fetchStatus === undefined) {
       dispatch(fetchCoursePrices(SETTINGS.user.username));
     }
   }
@@ -716,7 +716,10 @@ class DashboardPage extends React.Component {
       dashboard,
       prices
     } = this.props;
-    const loaded = R.none(isProcessing, [dashboard.fetchStatus, prices.fetchStatus]);
+    const loaded = R.or(
+      R.none(isProcessing, [dashboard.fetchStatus, prices.fetchStatus]),
+      R.or(dashboard.noSpinner, prices.noSpinner)
+    );
     const fetchStarted = !_.isNil(prices.fetchStatus) && !_.isNil(dashboard.fetchStatus);
 
     const errorMessage = this.renderErrorMessage();

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -262,14 +262,14 @@ class DashboardPage extends React.Component {
 
   fetchDashboard() {
     const { dashboard, dispatch } = this.props;
-    if (dashboard.fetchStatus === undefined) {
+    if (dashboard.fetchStatus === undefined && dashboard.noSpinner === false) {
       dispatch(fetchDashboard(SETTINGS.user.username));
     }
   }
 
   fetchCoursePrices() {
     const { prices, dispatch } = this.props;
-    if (prices.fetchStatus === undefined) {
+    if (prices.fetchStatus === undefined && prices.noSpinner === false) {
       dispatch(fetchCoursePrices(SETTINGS.user.username));
     }
   }
@@ -694,6 +694,7 @@ class DashboardPage extends React.Component {
               coursePrice={coursePrice}
               prices={calculatedPrices}
               key={program.id}
+              ui={ui}
               openFinancialAidCalculator={this.openFinancialAidCalculator}
               addCourseEnrollment={this.addCourseEnrollment}
               openCourseContactDialog={this.openCourseContactDialog}

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -113,7 +113,7 @@ describe('DashboardPage', () => {
       assert.notOk(div.querySelector(".loader"), "Found spinner but no fetch in progress");
       helper.store.dispatch({
         type: REQUEST_DASHBOARD,
-        payload: { noSpinner: false },
+        payload: false,
         meta: SETTINGS.user.username
       });
 

--- a/static/js/flow/dashboardTypes.js
+++ b/static/js/flow/dashboardTypes.js
@@ -12,6 +12,7 @@ export type DashboardState = {
   programs:       Array<Program>,
   isEdxDataFresh: boolean,
   fetchStatus?:   string,
+  noSpinner:      boolean
 };
 
 export type DashboardsState = {
@@ -30,6 +31,7 @@ export type CoursePrices = Array<CoursePrice>;
 export type CoursePricesState = {
   coursePrices: CoursePrices,
   fetchStatus?: string,
+  noSpinner?:   boolean
 }
 
 export type CoursePriceReducerState = {

--- a/static/js/reducers/course_prices.js
+++ b/static/js/reducers/course_prices.js
@@ -33,7 +33,10 @@ export const prices = (state: CoursePriceReducerState = {}, action: Action<any, 
       return updateStateByUsername(
         R.dissoc(username, state),
         username,
-        _.merge({}, INITIAL_COURSE_PRICES_STATE, { noSpinner: true })
+        _.merge({}, INITIAL_COURSE_PRICES_STATE, {
+          noSpinner: true,
+          fetchStatus: FETCH_PROCESSING
+        })
       );
     } else {
       return updateStateByUsername(

--- a/static/js/reducers/course_prices.js
+++ b/static/js/reducers/course_prices.js
@@ -29,14 +29,17 @@ export const prices = (state: CoursePriceReducerState = {}, action: Action<any, 
   const { meta: username } = action;
   switch (action.type) {
   case REQUEST_COURSE_PRICES:
-    return updateStateByUsername(
-      R.dissoc(username, state),
-      username,
-      _.merge({}, INITIAL_COURSE_PRICES_STATE, {
-        noSpinner: action.payload,
-        fetchStatus: FETCH_PROCESSING
-      })
-    );
+    if (action.payload === true) {
+      return updateStateByUsername(state, username,
+        _.merge({}, state[username] || {}, { fetchStatus: FETCH_PROCESSING, noSpinner: true })
+      );
+    } else {
+      return updateStateByUsername(
+        R.dissoc(username, state),
+        username,
+        _.merge({}, INITIAL_COURSE_PRICES_STATE, { fetchStatus: FETCH_PROCESSING })
+      );
+    }
   case RECEIVE_COURSE_PRICES_SUCCESS:
     return updateStateByUsername(state, username, {
       fetchStatus: FETCH_SUCCESS,

--- a/static/js/reducers/course_prices.js
+++ b/static/js/reducers/course_prices.js
@@ -21,18 +21,27 @@ import type {
 import { updateStateByUsername } from './util';
 
 export const INITIAL_COURSE_PRICES_STATE: CoursePricesState = {
-  coursePrices: []
+  coursePrices: [],
+  noSpinner:    false
 };
 
 export const prices = (state: CoursePriceReducerState = {}, action: Action<any, string>) => {
   const { meta: username } = action;
   switch (action.type) {
   case REQUEST_COURSE_PRICES:
-    return updateStateByUsername(
-      R.dissoc(username, state),
-      username,
-      _.merge({}, INITIAL_COURSE_PRICES_STATE, { fetchStatus: FETCH_PROCESSING })
-    );
+    if (action.payload === true) {
+      return updateStateByUsername(
+        R.dissoc(username, state),
+        username,
+        _.merge({}, INITIAL_COURSE_PRICES_STATE, { noSpinner: true })
+      );
+    } else {
+      return updateStateByUsername(
+        R.dissoc(username, state),
+        username,
+        _.merge({}, INITIAL_COURSE_PRICES_STATE, { fetchStatus: FETCH_PROCESSING })
+      );
+    }
   case RECEIVE_COURSE_PRICES_SUCCESS:
     return updateStateByUsername(state, username, {
       fetchStatus: FETCH_SUCCESS,

--- a/static/js/reducers/course_prices.js
+++ b/static/js/reducers/course_prices.js
@@ -42,13 +42,16 @@ export const prices = (state: CoursePriceReducerState = {}, action: Action<any, 
       return updateStateByUsername(
         R.dissoc(username, state),
         username,
-        _.merge({}, INITIAL_COURSE_PRICES_STATE, { fetchStatus: FETCH_PROCESSING })
+        _.merge({}, INITIAL_COURSE_PRICES_STATE, {
+          fetchStatus: FETCH_PROCESSING
+        })
       );
     }
   case RECEIVE_COURSE_PRICES_SUCCESS:
     return updateStateByUsername(state, username, {
       fetchStatus: FETCH_SUCCESS,
       coursePrices: action.payload,
+      noSpinner: false,
     });
   case RECEIVE_COURSE_PRICES_FAILURE:
     return updateStateByUsername(state, username, {

--- a/static/js/reducers/course_prices.js
+++ b/static/js/reducers/course_prices.js
@@ -29,24 +29,14 @@ export const prices = (state: CoursePriceReducerState = {}, action: Action<any, 
   const { meta: username } = action;
   switch (action.type) {
   case REQUEST_COURSE_PRICES:
-    if (action.payload === true) {
-      return updateStateByUsername(
-        R.dissoc(username, state),
-        username,
-        _.merge({}, INITIAL_COURSE_PRICES_STATE, {
-          noSpinner: true,
-          fetchStatus: FETCH_PROCESSING
-        })
-      );
-    } else {
-      return updateStateByUsername(
-        R.dissoc(username, state),
-        username,
-        _.merge({}, INITIAL_COURSE_PRICES_STATE, {
-          fetchStatus: FETCH_PROCESSING
-        })
-      );
-    }
+    return updateStateByUsername(
+      R.dissoc(username, state),
+      username,
+      _.merge({}, INITIAL_COURSE_PRICES_STATE, {
+        noSpinner: action.payload,
+        fetchStatus: FETCH_PROCESSING
+      })
+    );
   case RECEIVE_COURSE_PRICES_SUCCESS:
     return updateStateByUsername(state, username, {
       fetchStatus: FETCH_SUCCESS,

--- a/static/js/reducers/course_prices_test.js
+++ b/static/js/reducers/course_prices_test.js
@@ -16,7 +16,8 @@ import {
 import { COURSE_PRICES_RESPONSE } from '../test_constants';
 import {
   FETCH_FAILURE,
-  FETCH_SUCCESS
+  FETCH_PROCESSING,
+  FETCH_SUCCESS,
 } from '../actions';
 
 describe('prices reducer', () => {
@@ -98,7 +99,8 @@ describe('prices reducer', () => {
       assert.deepEqual(state, {
         'username': {
           coursePrices: [],
-          noSpinner: true
+          noSpinner: true,
+          fetchStatus: FETCH_PROCESSING
         }
       });
     });

--- a/static/js/reducers/course_prices_test.js
+++ b/static/js/reducers/course_prices_test.js
@@ -7,6 +7,7 @@ import * as api from '../lib/api';
 import {
   fetchCoursePrices,
   clearCoursePrices,
+  requestCoursePrices,
   REQUEST_COURSE_PRICES,
   RECEIVE_COURSE_PRICES_SUCCESS,
   RECEIVE_COURSE_PRICES_FAILURE,
@@ -52,7 +53,8 @@ describe('prices reducer', () => {
 
       return dispatchThen(clearCoursePrices('username'), [CLEAR_COURSE_PRICES]).then(({ username: pricesState }) => {
         assert.deepEqual(pricesState, {
-          coursePrices: []
+          coursePrices: [],
+          noSpinner: false
         });
       });
     });
@@ -66,6 +68,39 @@ describe('prices reducer', () => {
       RECEIVE_COURSE_PRICES_FAILURE,
     ]).then(({ username: pricesState }) => {
       assert.equal(pricesState.fetchStatus, FETCH_FAILURE);
+    });
+  });
+
+  it('should fetch when no spin set', () => {
+    pricesStub.returns(Promise.resolve(COURSE_PRICES_RESPONSE));
+
+    return dispatchThen(fetchCoursePrices('username', true), [
+      REQUEST_COURSE_PRICES,
+      RECEIVE_COURSE_PRICES_SUCCESS,
+    ]).then(({ username: pricesState }) => {
+      assert.deepEqual(pricesState.coursePrices, COURSE_PRICES_RESPONSE);
+      assert.equal(pricesState.fetchStatus, FETCH_SUCCESS);
+
+      return dispatchThen(clearCoursePrices('username'), [CLEAR_COURSE_PRICES]).then(({ username: pricesState }) => {
+        assert.deepEqual(pricesState, {
+          coursePrices: [],
+          noSpinner: false
+        });
+      });
+    });
+  });
+
+  it('should let you set noSpinner true', () => {
+    return dispatchThen(
+      requestCoursePrices('username', true),
+      [REQUEST_COURSE_PRICES]
+    ).then((state) => {
+      assert.deepEqual(state, {
+        'username': {
+          coursePrices: [],
+          noSpinner: true
+        }
+      });
     });
   });
 });

--- a/static/js/reducers/course_prices_test.js
+++ b/static/js/reducers/course_prices_test.js
@@ -98,7 +98,6 @@ describe('prices reducer', () => {
     ).then((state) => {
       assert.deepEqual(state, {
         'username': {
-          coursePrices: [],
           noSpinner: true,
           fetchStatus: FETCH_PROCESSING
         }

--- a/static/js/reducers/dashboard.js
+++ b/static/js/reducers/dashboard.js
@@ -23,7 +23,8 @@ import { updateStateByUsername } from './util';
 
 export const INITIAL_DASHBOARD_STATE: DashboardState = {
   programs: [],
-  isEdxDataFresh: true
+  isEdxDataFresh: true,
+  noSpinner: false
 };
 
 const INITIAL_DASHBOARDS_STATE: DashboardsState = {};
@@ -34,7 +35,11 @@ export const dashboard = (state: DashboardsState = INITIAL_DASHBOARDS_STATE, act
   case REQUEST_DASHBOARD: // eslint-disable-line no-case-declarations
     let newBaseState = R.dissoc(username, state);
     if (action.payload === true) {
-      return updateStateByUsername(newBaseState, username, INITIAL_DASHBOARD_STATE);
+      return updateStateByUsername(
+        newBaseState,
+        username,
+        _.merge({}, INITIAL_DASHBOARD_STATE, { noSpinner: true })
+      );
     } else {
       return updateStateByUsername(
         newBaseState,
@@ -46,7 +51,8 @@ export const dashboard = (state: DashboardsState = INITIAL_DASHBOARDS_STATE, act
     return updateStateByUsername(state, username, {
       fetchStatus: FETCH_SUCCESS,
       programs: action.payload.programs,
-      isEdxDataFresh: action.payload.is_edx_data_fresh
+      isEdxDataFresh: action.payload.is_edx_data_fresh,
+      noSpinner: false
     });
   case RECEIVE_DASHBOARD_FAILURE:
     return updateStateByUsername(state, username, {

--- a/static/js/reducers/dashboard.js
+++ b/static/js/reducers/dashboard.js
@@ -34,22 +34,14 @@ export const dashboard = (state: DashboardsState = INITIAL_DASHBOARDS_STATE, act
   switch (action.type) {
   case REQUEST_DASHBOARD: // eslint-disable-line no-case-declarations
     let newBaseState = R.dissoc(username, state);
-    if (action.payload === true) {
-      return updateStateByUsername(
-        newBaseState,
-        username,
-        _.merge({}, INITIAL_DASHBOARD_STATE, {
-          noSpinner: true,
-          fetchStatus: FETCH_PROCESSING
-        })
-      );
-    } else {
-      return updateStateByUsername(
-        newBaseState,
-        username,
-        _.merge({}, INITIAL_DASHBOARD_STATE, { fetchStatus: FETCH_PROCESSING })
-      );
-    }
+    return updateStateByUsername(
+      newBaseState,
+      username,
+      _.merge({}, INITIAL_DASHBOARD_STATE, {
+        noSpinner: action.payload,
+        fetchStatus: FETCH_PROCESSING
+      })
+    );
   case RECEIVE_DASHBOARD_SUCCESS:
     return updateStateByUsername(state, username, {
       fetchStatus: FETCH_SUCCESS,

--- a/static/js/reducers/dashboard.js
+++ b/static/js/reducers/dashboard.js
@@ -38,7 +38,10 @@ export const dashboard = (state: DashboardsState = INITIAL_DASHBOARDS_STATE, act
       return updateStateByUsername(
         newBaseState,
         username,
-        _.merge({}, INITIAL_DASHBOARD_STATE, { noSpinner: true })
+        _.merge({}, INITIAL_DASHBOARD_STATE, {
+          noSpinner: true,
+          fetchStatus: FETCH_PROCESSING
+        })
       );
     } else {
       return updateStateByUsername(

--- a/static/js/reducers/dashboard.js
+++ b/static/js/reducers/dashboard.js
@@ -33,15 +33,18 @@ export const dashboard = (state: DashboardsState = INITIAL_DASHBOARDS_STATE, act
   const { meta: username } = action;
   switch (action.type) {
   case REQUEST_DASHBOARD: // eslint-disable-line no-case-declarations
-    let newBaseState = R.dissoc(username, state);
-    return updateStateByUsername(
-      newBaseState,
-      username,
-      _.merge({}, INITIAL_DASHBOARD_STATE, {
-        noSpinner: action.payload,
-        fetchStatus: FETCH_PROCESSING
-      })
-    );
+    if (action.payload === true) {
+      return updateStateByUsername(state, username,
+        _.merge({}, state[username] || {}, { fetchStatus: FETCH_PROCESSING, noSpinner: true })
+      );
+    } else {
+      let newBaseState = R.dissoc(username, state);
+      return updateStateByUsername(
+        newBaseState,
+        username,
+        _.merge({}, INITIAL_DASHBOARD_STATE, { fetchStatus: FETCH_PROCESSING })
+      );
+    }
   case RECEIVE_DASHBOARD_SUCCESS:
     return updateStateByUsername(state, username, {
       fetchStatus: FETCH_SUCCESS,

--- a/static/js/reducers/dashboard_test.js
+++ b/static/js/reducers/dashboard_test.js
@@ -178,7 +178,7 @@ describe('dashboard reducers', () => {
           "username": {
             noSpinner: true,
             isEdxDataFresh: true,
-            programs: [],
+            programs: DASHBOARD_RESPONSE.programs,
             fetchStatus: FETCH_PROCESSING
           }
         });

--- a/static/js/reducers/dashboard_test.js
+++ b/static/js/reducers/dashboard_test.js
@@ -20,6 +20,7 @@ import {
 import * as api from '../lib/api';
 import {
   FETCH_FAILURE,
+  FETCH_PROCESSING,
   FETCH_SUCCESS
 } from '../actions/index';
 import { DASHBOARD_RESPONSE } from '../test_constants';
@@ -177,7 +178,8 @@ describe('dashboard reducers', () => {
           "username": {
             noSpinner: true,
             isEdxDataFresh: true,
-            programs: []
+            programs: [],
+            fetchStatus: FETCH_PROCESSING
           }
         });
       });

--- a/static/js/reducers/dashboard_test.js
+++ b/static/js/reducers/dashboard_test.js
@@ -9,6 +9,7 @@ import {
   clearDashboard,
   receiveDashboardSuccess,
   updateCourseStatus,
+  requestDashboard,
 
   UPDATE_COURSE_STATUS,
   REQUEST_DASHBOARD,
@@ -59,7 +60,7 @@ describe('dashboard reducers', () => {
 
       return dispatchThen(clearDashboard(SETTINGS.user.username), [CLEAR_DASHBOARD]).then(state => {
         let dashboardState = state[SETTINGS.user.username];
-        assert.deepEqual(dashboardState, { programs: [], isEdxDataFresh: true });
+        assert.deepEqual(dashboardState, { programs: [], isEdxDataFresh: true, noSpinner: false });
       });
     });
   });
@@ -98,7 +99,8 @@ describe('dashboard reducers', () => {
     let successExpectation = {
       programs: DASHBOARD_RESPONSE.programs,
       isEdxDataFresh: DASHBOARD_RESPONSE.is_edx_data_fresh,
-      fetchStatus: FETCH_SUCCESS
+      fetchStatus: FETCH_SUCCESS,
+      noSpinner: false
     };
 
     beforeEach(() => {
@@ -125,7 +127,7 @@ describe('dashboard reducers', () => {
       ]).then(state => {
         assert.deepEqual(state, {
           [_username]: successExpectation,
-          [username]: { programs: [], isEdxDataFresh: true }
+          [username]: { programs: [], isEdxDataFresh: true,  noSpinner: false }
         });
       });
     });
@@ -142,7 +144,8 @@ describe('dashboard reducers', () => {
             fetchStatus: FETCH_FAILURE,
             errorInfo: 'err',
             programs: [],
-            isEdxDataFresh: true
+            isEdxDataFresh: true,
+            noSpinner: false
           }
         });
       });
@@ -162,6 +165,21 @@ describe('dashboard reducers', () => {
       ).then(state => {
         assert.deepEqual(state[username], successExpectation);
         assert.deepEqual(getRun(state[_username].programs).status, 'new_status');
+      });
+    });
+
+    it('should let you set noSpinner true', () => {
+      return dispatchThen(
+        requestDashboard('username', true),
+        [REQUEST_DASHBOARD]
+      ).then((state) => {
+        assert.deepEqual(state, {
+          "username": {
+            noSpinner: true,
+            isEdxDataFresh: true,
+            programs: []
+          }
+        });
       });
     });
   });

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -41,7 +41,9 @@ import {
   CYBERSOURCE_CHECKOUT_RESPONSE,
 } from '../test_constants';
 import { ALL_ERRORS_VISIBLE } from '../constants';
-import rootReducer, { INITIAL_PROFILES_STATE } from '../reducers';
+import rootReducer, {
+  INITIAL_PROFILES_STATE
+} from '../reducers';
 
 describe('reducers', () => {
   let sandbox, store, dispatchThen;
@@ -228,7 +230,6 @@ describe('reducers', () => {
         assert.deepEqual(profileState['jane'].edit.errors, errors);
       });
     });
-
 
     it("can't edit a profile if we never get it successfully", () => {
       return dispatchThen(startProfileEdit('jane'), [START_PROFILE_EDIT]).then(profileState => {

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -41,9 +41,7 @@ import {
   CYBERSOURCE_CHECKOUT_RESPONSE,
 } from '../test_constants';
 import { ALL_ERRORS_VISIBLE } from '../constants';
-import rootReducer, {
-  INITIAL_PROFILES_STATE
-} from '../reducers';
+import rootReducer, { INITIAL_PROFILES_STATE } from '../reducers';
 
 describe('reducers', () => {
   let sandbox, store, dispatchThen;
@@ -230,6 +228,7 @@ describe('reducers', () => {
         assert.deepEqual(profileState['jane'].edit.errors, errors);
       });
     });
+
 
     it("can't edit a profile if we never get it successfully", () => {
       return dispatchThen(startProfileEdit('jane'), [START_PROFILE_EDIT]).then(profileState => {

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -53,9 +53,7 @@ import {
 import { EMAIL_COMPOSITION_DIALOG } from '../components/email/constants';
 import type { ToastMessage } from '../flow/generalTypes';
 import type { Action } from '../flow/reduxTypes';
-import type {
-  AvailableProgram
-} from '../flow/enrollmentTypes';
+import type { AvailableProgram } from '../flow/enrollmentTypes';
 import type { CourseRun } from '../flow/programTypes';
 
 export type UIDialog = {

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -48,11 +48,14 @@ import {
   SET_NAV_DRAWER_OPEN,
   SET_PROGRAM,
   SET_LEARNER_CHIP_VISIBILITY,
+  SHOW_ENROLL_PAY_LATER_SUCCESS,
 } from '../actions/ui';
 import { EMAIL_COMPOSITION_DIALOG } from '../components/email/constants';
 import type { ToastMessage } from '../flow/generalTypes';
 import type { Action } from '../flow/reduxTypes';
-import type { AvailableProgram } from '../flow/enrollmentTypes';
+import type {
+  AvailableProgram
+} from '../flow/enrollmentTypes';
 import type { CourseRun } from '../flow/programTypes';
 
 export type UIDialog = {
@@ -103,7 +106,8 @@ export type UIState = {
   couponNotificationVisibility:        boolean,
   navDrawerOpen:                       boolean,
   learnerChipVisibility:               ?string,
-  dialogVisibility:                    DialogVisibilityState
+  dialogVisibility:                    DialogVisibilityState,
+  showEnrollPayLaterSuccess:           ?string,
 };
 
 export const INITIAL_UI_STATE: UIState = {
@@ -142,7 +146,8 @@ export const INITIAL_UI_STATE: UIState = {
   couponNotificationVisibility:        false,
   navDrawerOpen:                       false,
   learnerChipVisibility:               null,
-  dialogVisibility:                    INITIAL_DIALOG_VISIBILITY_STATE
+  dialogVisibility:                    INITIAL_DIALOG_VISIBILITY_STATE,
+  showEnrollPayLaterSuccess:           null,
 };
 
 export const ui = (state: UIState = INITIAL_UI_STATE, action: Action<any, null>) => {
@@ -322,6 +327,12 @@ export const ui = (state: UIState = INITIAL_UI_STATE, action: Action<any, null>)
     return {
       ...state,
       enrollCourseDialogVisibility: action.payload
+    };
+  }
+  case SHOW_ENROLL_PAY_LATER_SUCCESS: {
+    return {
+      ...state,
+      showEnrollPayLaterSuccess: action.payload
     };
   }
   case SET_PHOTO_DIALOG_VISIBILITY:

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -34,6 +34,9 @@ import {
   setDocsInstructionsVisibility,
   setNavDrawerOpen,
   setLearnerChipVisibility,
+  showEnrollPayLaterSuccess,
+
+  SHOW_ENROLL_PAY_LATER_SUCCESS,
 } from '../actions/ui';
 import { INITIAL_UI_STATE } from '../reducers/ui';
 import rootReducer from '../reducers';
@@ -215,6 +218,26 @@ describe('ui reducers', () => {
   describe('nav drawer', () => {
     it('should let you set the nav drawer visibility', () => {
       assertReducerResultState(setNavDrawerOpen, ui => ui.navDrawerOpen, false);
+    });
+  });
+
+  describe('show enroll pay later success alert', () => {
+    it('should let you set the pay later success alert', () => {
+      return dispatchThen(
+        showEnrollPayLaterSuccess('foo/bar/baz'),
+        [SHOW_ENROLL_PAY_LATER_SUCCESS]
+      ).then((state) => {
+        assert.equal(state.showEnrollPayLaterSuccess, 'foo/bar/baz');
+      });
+    });
+
+    it('should let you reset the pay later success alert', () => {
+      return dispatchThen(
+        showEnrollPayLaterSuccess(null),
+        [SHOW_ENROLL_PAY_LATER_SUCCESS]
+      ).then((state) => {
+        assert.deepEqual(state.showEnrollPayLaterSuccess, null);
+      });
     });
   });
 

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -286,6 +286,27 @@
       background-color: $fg-gray;
       color: $darkgray;
 
+      &.enroll-pay-later-success {
+        padding: 10px;
+        margin-top: 10px;
+      }
+
+      .enroll-pay-later-heading {
+        color: $font-black;
+        font-weight: 500;
+        font-size: 15px;
+        margin: 0;
+      }
+
+      .enroll-pay-later-txt {
+        font-size: 13px;
+      }
+
+      .tick-icon {
+        font-size: 50px;
+        color: $button-color;
+      }
+
       .course-description,
       .course-grade,
       .course-action  {


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/1445

#### What's this PR do?
- Show inline success message when user press enroll and pay later button,
- It also loads dashboard page without reloading whole page

#### How should this be manually tested?
- Open `http://192.168.99.100:8079/dashboard/` and press enroll and pay later.

#### Screenshots (if appropriate)
<img width="722" alt="screen shot 2017-03-13 at 3 57 59 pm" src="https://cloud.githubusercontent.com/assets/10431250/23851604/e5e3930c-0805-11e7-92db-02e8cdec2a5e.png">
