### PR TITLE
Fix exam auth eligibility date handlingi (#2814)

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -55,6 +55,7 @@ class MMTrack:
             program (programs.models.Program): program where the user is enrolled
             edx_user_data (dashboard.api_edx_cache.CachedEdxUserData): A CachedEdxUserData object
         """
+        self.now = datetime.now(utc)
         self.user = user
         self.program = program
         self.enrollments = edx_user_data.enrollments
@@ -415,12 +416,11 @@ class MMTrack:
             return ExamProfile.PROFILE_INVALID
 
         elif exam_profile.status == ExamProfile.PROFILE_SUCCESS:
-            now = datetime.now(utc)
             auths = ExamAuthorization.objects.filter(
                 user=user,
                 status=ExamAuthorization.STATUS_SUCCESS,
-                date_first_eligible__lt=now,
-                date_last_eligible__gt=now,
+                date_first_eligible__lte=self.now.date(),
+                date_last_eligible__gte=self.now.date(),
             )
 
             if auths.exists():


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2814 

#### What's this PR do?
Fixes the dashboard UI so that exam authorizations that were created today and are schedule-able show the button to the user.

#### How should this be manually tested?
Create an `ExamProfile` and `ExamAuthorization` record for your user, both with `success` status. Test with setting `date_last_eligible` to today and then test `date_first_eligible` to the same.
