### PR TITLE
Change VCDC processing to treat warnings as errors

### DIFF
--- a/exams/pearson/download.py
+++ b/exams/pearson/download.py
@@ -193,7 +193,7 @@ class ArchivedResponseProcessor:
                 messages.append(error_message)
                 continue
 
-            if result.status == EAC_SUCCESS_STATUS:
+            if result.status == EAC_SUCCESS_STATUS and 'WARNING' not in result.message:
                 exam_profile.status = ExamProfile.PROFILE_SUCCESS
             else:
                 exam_profile.status = ExamProfile.PROFILE_FAILED

--- a/exams/pearson/download_test.py
+++ b/exams/pearson/download_test.py
@@ -389,6 +389,30 @@ class VCDCDownloadTest(MockedESTestCase):
                 ]
             )
 
+    def test_process_result_vcdc_successful_warning(self):
+        """Tests for the situation where we get a success with a warning"""
+        message = "WARNING: success doesn't come that easy"
+        profile = self.failure_profiles[1].profile
+        results = ([
+            VCDCResult(
+                client_candidate_id=profile.student_id,
+                status=VCDC_SUCCESS_STATUS,
+                date=self.now,
+                message=message,
+            ),
+        ], [])
+
+        with patch('exams.pearson.download.VCDCReader.read', return_value=results):
+            assert self.processor.process_vcdc_file("/tmp/file.ext") == (
+                True,
+                [
+                    "ExamProfile sync failed for user `{username}`. Received error: '{message}'.".format(
+                        username=profile.user.username,
+                        message=message,
+                    )
+                ]
+            )
+
 
 @override_settings(**EXAMS_SFTP_SETTINGS)
 @ddt.ddt


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2803 

#### What's this PR do?
If we get a successful response but it has a warning in it we treat that as a failure so we get alerted and fix it.

#### How should this be manually tested?
This isn't easy to test, I suggest just reading the tests and verifying they pass.