### PR TITLE
Freeze grade modified to be race condition safe

### DIFF
--- a/grades/api.py
+++ b/grades/api.py
@@ -177,7 +177,9 @@ def freeze_user_final_grade(user, course_run, raise_on_exception=False):
                     course_run.edx_course_key
                 )
             ) from ex
-    return FinalGrade.objects.create(
+    # the final grade at this point should not exists, but putting a `get_or_create`
+    # should solve the problem when the function is called synchronously from the dashboard REST API multiple times
+    final_grade_obj, _ = FinalGrade.objects.get_or_create(
         user=user,
         course_run=course_run,
         grade=final_grade.grade,
@@ -185,3 +187,4 @@ def freeze_user_final_grade(user, course_run, raise_on_exception=False):
         status=FinalGradeStatus.COMPLETE,
         course_run_paid_on_edx=final_grade.payed_on_edx
     )
+    return final_grade_obj

--- a/grades/api_test.py
+++ b/grades/api_test.py
@@ -364,3 +364,23 @@ class GradeAPITests(MockedESTestCase):
         assert fg_status.course_run == self.run_fa
         assert fg_status.grade == final_grade.grade
         assert fg_status.passed == final_grade.passed
+
+    @patch('dashboard.api_edx_cache.CachedEdxDataApi.update_all_cached_grade_data', new_callable=MagicMock)
+    def test_freeze_user_final_grade_multiple_calls(self, mock_refr):
+        """
+        Test for freeze_user_final_grade function in case it is called multiple times
+        """
+        fg_qset = FinalGrade.objects.filter(user=self.user, course_run=self.run_fa)
+        assert fg_qset.count() == 0
+
+        # first call
+        final_grade = api.freeze_user_final_grade(self.user, self.run_fa)
+        assert final_grade is not None
+        mock_refr.assert_called_once_with(self.user)
+        assert fg_qset.count() == 1
+
+        # second call
+        final_grade = api.freeze_user_final_grade(self.user, self.run_fa)
+        assert final_grade is not None
+        assert mock_refr.call_count == 2
+        assert fg_qset.count() == 1


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #2819  (hopefully)

#### What's this PR do?
modifies the function `grades.api.freeze_user_final_grade` to be race condition safe

#### How should this be manually tested?
I have not fully understood how users get in this situation: my guess is that the dashboard rest api is slow enough that they reload the page and trigger another request, but I have no proves for this.
