### PR TITLE
Change date format to be globally accessible

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -125,7 +125,7 @@ class Course(models.Model):
 
         if course_run.is_current:
             if course_run.enrollment_end:
-                end_text = 'Enrollment Ends {:%D}'.format(
+                end_text = 'Enrollment Ends {:%b %-d, %Y}'.format(
                     course_run.enrollment_end
                 )
             else:
@@ -140,7 +140,7 @@ class Course(models.Model):
                 )
             else:
                 end_text = ''
-            return "Starts {start:%D}{end}".format(
+            return "Starts {start:%b %-d, %Y}{end}".format(
                 start=course_run.start_date,
                 end=end_text,
             )

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -201,15 +201,15 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
 
     @data(
         # course starts in future, enrollment future
-        [1, 10, 1, 2, 'Starts {:%D} - Enrollment {:%m/%Y}'.format(from_weeks(1), from_weeks(1))],
+        [1, 10, 1, 2, 'Starts {:%b %-d, %Y} - Enrollment {:%m/%Y}'.format(from_weeks(1), from_weeks(1))],
         # course starts in future, enrollment open
-        [1, 10, -1, 10, 'Starts {:%D} - Enrollment Open'.format(from_weeks(1))],
+        [1, 10, -1, 10, 'Starts {:%b %-d, %Y} - Enrollment Open'.format(from_weeks(1))],
         # course starts in future, enrollment open with no end
-        [1, 10, -1, None, 'Starts {:%D} - Enrollment Open'.format(from_weeks(1))],
+        [1, 10, -1, None, 'Starts {:%b %-d, %Y} - Enrollment Open'.format(from_weeks(1))],
         # course starts in future, no enrollment dates
-        [1, 10, None, None, 'Starts {:%D}'.format(from_weeks(1))],
+        [1, 10, None, None, 'Starts {:%b %-d, %Y}'.format(from_weeks(1))],
         # course is currently running, enrollment is open, ending soon
-        [-1, 10, -1, 10, 'Ongoing - Enrollment Ends {:%D}'.format(from_weeks(10))],
+        [-1, 10, -1, 10, 'Ongoing - Enrollment Ends {:%b %-d, %Y}'.format(from_weeks(10))],
         # course is currently running without end, enrollment is open, no end
         [-1, None, -1, None, 'Ongoing - Enrollment Open'],
         # course is currently running, enrollment is closed

--- a/static/js/components/dashboard/FinancialAidCard_test.js
+++ b/static/js/components/dashboard/FinancialAidCard_test.js
@@ -122,7 +122,7 @@ describe("FinancialAidCard", () => {
       program.financial_aid_user_info.has_user_applied = false;
       let wrapper = renderCard({ program });
       wrapper.find('.full-price').simulate('click');
-      sinon.assert.calledWith(setSkipDialogStub, true);
+      assert.ok(setSkipDialogStub.calledWith(true), 'Dialog should get opened');
     });
   });
 
@@ -169,7 +169,7 @@ describe("FinancialAidCard", () => {
         let wrapper = renderCard({ program, setDocsInstructionsVisibility });
         let link = wrapper.find('.financial-aid-box').find('a');
         link.simulate('click');
-        sinon.assert.called(setDocsInstructionsVisibility);
+        assert.ok(setDocsInstructionsVisibility.called, 'should have called onClick handler');
       });
 
       it(`instruction for status ${FA_STATUS_PENDING_DOCS}`, () => {

--- a/static/js/components/dashboard/FinancialAidCard_test.js
+++ b/static/js/components/dashboard/FinancialAidCard_test.js
@@ -83,11 +83,11 @@ describe("FinancialAidCard", () => {
       const program = programWithStatus();
 
       let wrapper = renderCard({program});
-      assert.equal(wrapper.find('.personalized-pricing').length, 0);
+      assert.lengthOf(wrapper.find('.personalized-pricing'), 0);
       program.financial_aid_user_info.has_user_applied = false;
 
       wrapper = renderCard({ program });
-      assert.equal(wrapper.find('.personalized-pricing').length, 1);
+      assert.lengthOf(wrapper.find('.personalized-pricing'), 1);
     });
 
     it('calculates the cost when you click the button', () => {
@@ -97,7 +97,7 @@ describe("FinancialAidCard", () => {
       let button = wrapper.find(".calculate-cost-button");
       assert.equal(button.text(), "Get My Price Now");
       button.simulate('click');
-      assert.ok(openFinancialAidCalculatorStub.calledWith());
+      sinon.assert.calledWith(openFinancialAidCalculatorStub);
     });
 
     it('shows the minimum and maximum price', () => {
@@ -122,7 +122,7 @@ describe("FinancialAidCard", () => {
       program.financial_aid_user_info.has_user_applied = false;
       let wrapper = renderCard({ program });
       wrapper.find('.full-price').simulate('click');
-      assert.ok(setSkipDialogStub.calledWith(true), 'Dialog should get opened');
+      sinon.assert.calledWith(setSkipDialogStub, true);
     });
   });
 
@@ -139,7 +139,7 @@ describe("FinancialAidCard", () => {
       it(`shows a mailing address if the status is ${status}`, () => {
         let program = programWithStatus(status);
         let wrapper = renderCard({ program });
-        assert.ok(wrapper.html().includes("Cambridge, MA 02139"));
+        assert.include(wrapper.html(), "Cambridge, MA 02139");
       });
 
       it(`has a link to skip financial aid for ${status}`, () => {
@@ -147,7 +147,7 @@ describe("FinancialAidCard", () => {
         let setConfirmSkipDialogVisibility = sandbox.stub();
         let wrapper = renderCard({ program, setConfirmSkipDialogVisibility });
         wrapper.find(".full-price").simulate('click');
-        assert(setConfirmSkipDialogVisibility.calledWith(true));
+        sinon.assert.calledWith(setConfirmSkipDialogVisibility, true);
       });
     }
 
@@ -161,7 +161,7 @@ describe("FinancialAidCard", () => {
 
         assert.equal(props.selected.format(ISO_8601_FORMAT), '2011-11-11');
         props.onChange(moment("1999-01-01"));
-        assert.ok(setDocumentSentDate.calledWith("1999-01-01"));
+        sinon.assert.calledWith(setDocumentSentDate, "1999-01-01");
       });
 
       it(`provides a link to open a dialog with complete instruction for status ${FA_STATUS_PENDING_DOCS}`, () => {
@@ -169,7 +169,7 @@ describe("FinancialAidCard", () => {
         let wrapper = renderCard({ program, setDocsInstructionsVisibility });
         let link = wrapper.find('.financial-aid-box').find('a');
         link.simulate('click');
-        assert.ok(setDocsInstructionsVisibility.called, 'should have called onClick handler');
+        sinon.assert.called(setDocsInstructionsVisibility);
       });
 
       it(`instruction for status ${FA_STATUS_PENDING_DOCS}`, () => {
@@ -193,7 +193,7 @@ describe("FinancialAidCard", () => {
         let wrapper = renderCard({ program, updateDocumentSentDate });
 
         wrapper.find(".document-sent-button").simulate('click');
-        assert(updateDocumentSentDate.calledWith(123, '2011-11-11'));
+        sinon.assert.calledWith(updateDocumentSentDate, 123, '2011-11-11');
       });
 
       for (let activity of [true, false]) {
@@ -209,7 +209,7 @@ describe("FinancialAidCard", () => {
           });
 
           let button = wrapper.find("SpinnerButton");
-          assert(button.props().className.includes("document-sent-button"));
+          assert.include(button.props().className, "document-sent-button");
           assert.equal(button.props().spinning, activity);
         });
       }
@@ -218,7 +218,7 @@ describe("FinancialAidCard", () => {
         it(`shows the document sent date for status ${status}`, () => {
           let program = programWithStatus(status);
           let wrapper = renderCard({ program });
-          assert(wrapper.text().includes('Documents mailed on 3/3/2003'));
+          assert.include(wrapper.text(), 'Documents mailed on Mar 3, 2003');
         });
       }
     });
@@ -229,6 +229,6 @@ describe("FinancialAidCard", () => {
     let setConfirmSkipDialogVisibility = sandbox.stub();
     let wrapper = renderCard({ program, setConfirmSkipDialogVisibility });
     wrapper.find("SkipFinancialAidDialog").props().cancel();
-    assert(setConfirmSkipDialogVisibility.calledWith(false));
+    sinon.assert.calledWith(setConfirmSkipDialogVisibility, false);
   });
 });

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -8,7 +8,7 @@ export const MASTERS = 'm';
 export const DOCTORATE = 'p';
 
 export const ISO_8601_FORMAT = 'YYYY-MM-DD';
-export const DASHBOARD_FORMAT = 'M/D/Y';
+export const DASHBOARD_FORMAT = 'MMM D, Y';
 export const DASHBOARD_MONTH_FORMAT = 'MM[/]YYYY';
 
 export const CP1252_REGEX = /^[\u0020-\u00FF]*$/;


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2820

#### What's this PR do?
Changes the dashboard format string for formatting dates. Does _not_ change how months are formatted, e.g. for education and employment.

#### How should this be manually tested?
Verify that dates are formatted in the format described in #2820.

<img width="641" alt="date format" src="https://cloud.githubusercontent.com/assets/132355/23723971/2186e878-0419-11e7-919d-a4bb850adff9.png">

