### PR TITLE
Final Grade Facet for Selected Course

### DIFF
--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -245,6 +245,10 @@ def program_enrolled_user_mapping():
         'num_courses_passed': LONG_TYPE,
         'total_courses': LONG_TYPE,
         'is_learner': BOOL_TYPE,
+        'final_grades': {'type': 'nested', 'properties': {
+            'title':  NOT_ANALYZED_STRING_TYPE,
+            'grade': LONG_TYPE
+        }},
         'enrollments': {'type': 'nested', 'properties': {
             'level': LONG_TYPE,
             'ancestors': NOT_ANALYZED_STRING_TYPE,

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -4,9 +4,9 @@ import React from 'react';
 import {
   SearchkitComponent,
   HierarchicalMenuFilter,
-  HierarchicalRefinementFilter,
   Hits,
   SelectedFilters,
+  HierarchicalRefinementFilter,
   RefinementListFilter,
   HitsStats,
   Pagination,
@@ -38,6 +38,7 @@ import type { Option } from '../flow/generalTypes';
 import type { AvailableProgram } from '../flow/enrollmentTypes';
 import type { SearchSortItem } from '../flow/searchTypes';
 import type { Profile } from '../flow/profileTypes';
+import FinalGradeRangeFilter  from './search/FinalGradeRangeFilter';
 
 const makeCountryNameTranslations: () => Object = () => {
   let translations = {};
@@ -219,6 +220,16 @@ export default class LearnerSearch extends SearchkitComponent {
             id="courses"
           />
         </FilterVisibilityToggle>
+        <div className="final-grade-wrapper">
+          <FinalGradeRangeFilter
+            field="program.final_grades.grade"
+            id="final-grade"
+            min={0}
+            max={100}
+            showHistogram={true}
+            title="Final Grade in Selected Course"
+          />
+        </div>
         <FilterVisibilityToggle
           {...this.props}
           filterName="semester"

--- a/static/js/components/search/FinalGradeRangeAccessor.js
+++ b/static/js/components/search/FinalGradeRangeAccessor.js
@@ -1,0 +1,102 @@
+import {
+  RangeAccessor, RangeQuery,
+  BoolMust, HistogramBucket, FilterBucket,
+  NestedBucket, NestedQuery, TermQuery,
+  CardinalityMetric
+} from "searchkit";
+import _ from 'lodash';
+
+export default class FinalGradeRangeAccessor extends RangeAccessor {
+  /**
+   * Overriding buildSharedQuery in RangeAccessor
+   * When User changes Final Grade range, need to construct
+   * a nested range filter, that will apply to all other facets
+   * */
+  buildSharedQuery(query) {
+    if (this.state.hasValue()) {
+      const val: any = this.state.getValue();
+      const rangeFilter = this.fieldContext.wrapFilter(RangeQuery(this.options.field, {
+        gte: val.min, lte: val.max
+      }));
+      const selectedFilter = {
+        name: this.translate(this.options.title),
+        value: `${val.min} - ${val.max}`,
+        id: this.options.id,
+        remove: ()=> {
+          this.state = this.state.clear();
+        }
+      };
+      const nestedQuery = NestedQuery('program.final_grades', rangeFilter);
+
+      return query
+        .addFilter(this.key, nestedQuery)
+        .addSelectedFilter(selectedFilter);
+    }
+    return query;
+  }
+
+  /**
+   * Overriding buildOwnQuery in RangeAccessor
+   * Adding a nested bucket, with additional filtering
+   * on the selected course in Course facet
+   */
+  buildOwnQuery(query) {
+    let otherFilters = query.getFiltersWithoutKeys(this.key);
+    let rangeFilter = RangeQuery(this.options.field, {
+      gte: this.options.min, lte: this.options.max
+    });
+    /* Nesting range filter with path: "program.final_grades" */
+    let nestedQuery = NestedQuery('program.final_grades', rangeFilter);
+    /* Combining filters from all facets */
+    let filters = BoolMust([otherFilters, nestedQuery]);
+
+    const courseTitle = this.getSelectedCourse(query);
+    let metric = this.buildHistogramAggregation();
+    /* Match final grades for selected course title */
+    let termQuery = TermQuery('program.final_grades.title', courseTitle);
+    /* filter histogram aggregations by the selected course title */
+    let filterBucket = FilterBucket(this.key, termQuery, ...this.fieldContext.wrapAggregations(metric));
+    let nestedBucket = NestedBucket(this.key, 'program.final_grades', filterBucket);
+
+    return query.setAggs(FilterBucket('final-grade', filters, nestedBucket));
+  }
+
+  buildHistogramAggregation() {
+    let metric ;
+    if (this.options.loadHistogram) {
+      metric = HistogramBucket(this.key, this.options.field, {
+        "interval": this.getInterval(),
+        "min_doc_count": 0,
+        "extended_bounds": {
+          "min": this.options.min,
+          "max": this.options.max
+        }
+      });
+    } else {
+      metric = CardinalityMetric(this.key, this.options.field);
+    }
+    return metric;
+  }
+
+  /**
+   * Looks for selected course in Courses facet
+   */
+  getSelectedCourse(query) {
+    let courseFilters = query.getJSON()['post_filter'];
+    let courseTitle = "";
+    if (_.has(courseFilters, 'bool')) {
+      courseFilters = _.get(courseFilters, ['bool', 'must']);
+      let nestedFilter = _.find(courseFilters, (filter)=>(_.has(filter, 'nested')));
+      courseTitle = _.get(nestedFilter, ['nested', 'filter', 'term', 'program.enrollments.value'], "");
+    }
+    return courseTitle;
+  }
+
+  getBuckets() {
+    return this.getAggregations([
+      this.key,
+      this.fieldContext.getAggregationPath(),
+      this.key, this.key,
+      this.key, "buckets"], []);
+  }
+}

--- a/static/js/components/search/FinalGradeRangeFilter.js
+++ b/static/js/components/search/FinalGradeRangeFilter.js
@@ -1,0 +1,16 @@
+import {RangeFilter} from "searchkit";
+import FinalGradeRangeAccessor from './FinalGradeRangeAccessor';
+
+export default class FinalGradeRangeFilter extends RangeFilter {
+
+  defineAccessor() {
+    const {
+      id, title, min, max, field, fieldOptions,
+      interval, showHistogram
+    } = this.props;
+    return new FinalGradeRangeAccessor(id, {
+      id, min, max, title, field,
+      interval, loadHistogram: showHistogram, fieldOptions
+    });
+  }
+}

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -125,7 +125,7 @@
       }
     }
 
-    .filter-visibility-toggle {
+    .filter-visibility-toggle, .final-grade-wrapper {
       display: flex;
       flex-direction: row;
       margin-bottom: 10px;
@@ -147,7 +147,15 @@
       }
     }
 
-    .filter--grade-average {
+    .filter--final-grade {
+      margin-left: 30px;
+    }
+
+    .sk-panel.filter--final-grade {
+      padding-left: 0;
+    }
+
+    .filter--grade-average, .filter--final-grade {
       .sk-panel__content {
         padding-right: 25px;
       }


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #1711
#### What's this PR do?
Add 'Final Grade' rangefilter to the 'Courses' filter.

#### How should this be manually tested?
Play with the Search filters. The FinalGrade range histogram will appear only if a course is selected and that course has 'paid' learners with final grades.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
![screen shot 2017-03-08 at 6 05 45 pm](https://cloud.githubusercontent.com/assets/7574259/23728248/d2258b02-0429-11e7-8200-e55402943f57.png)


#### What GIF best describes this PR or how it makes you feel?
(Optional)
