### PR TITLE
Add transaction.on_commit on signals

### DIFF
--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -153,7 +153,9 @@ class SearchResultMailViewsTests(MockedESTestCase, APITestCase):
             'mail.views.MailgunClient'
         ) as mock_mailgun_client, patch(
             'search.signals.index_percolate_queries.delay', autospec=True
-        ) as mocked_index_percolate_queries:
+        ) as mocked_index_percolate_queries, patch(
+            'search.signals.transaction', on_commit=lambda callback: callback()
+        ):
             mock_mailgun_client.send_batch.return_value = Response()
             resp_post = self.client.post(self.search_result_mail_url, data=request_data, format='json')
         assert resp_post.status_code == status.HTTP_200_OK

--- a/search/models_test.py
+++ b/search/models_test.py
@@ -8,31 +8,41 @@ from search.models import PercolateQuery
 class SearchModelsTests(MockedESTestCase):
     """Tests for search models"""
 
+    def setUp(self):
+        super().setUp()
+
+        # We can't patch the same method twice, so get the patches we already defined
+        for _mock in self.patcher_mocks:
+            if _mock.name == "_index_percolate_queries":
+                self.mocked_index_percolate_queries = _mock
+            elif _mock.name == "_delete_percolate_query":
+                self.mocked_delete_percolate_query = _mock
+
     def test_index_create_percolate_query(self):
         """When a new PercolateQuery is created we should index it"""
-        with patch('search.tasks._index_percolate_queries') as mocked_index_percolate_queries:
+        with patch('search.signals.transaction', on_commit=lambda callback: callback()):
             percolate_query = PercolateQuery.objects.create(query={})
-        assert mocked_index_percolate_queries.call_count == 1
-        assert len(mocked_index_percolate_queries.call_args[0]) == 1
-        assert list(mocked_index_percolate_queries.call_args[0][0])[0].id == percolate_query.id
+            assert self.mocked_index_percolate_queries.call_count == 1
+            assert len(self.mocked_index_percolate_queries.call_args[0]) == 1
+            assert list(self.mocked_index_percolate_queries.call_args[0][0])[0].id == percolate_query.id
 
     def test_index_update_percolate_query(self):
         """When a PercolateQuery is updated we should index it"""
-        with patch('search.tasks._index_percolate_queries'):
+        with patch('search.signals.transaction', on_commit=lambda callback: callback()):
             percolate_query = PercolateQuery.objects.create(query={})
-        with patch('search.tasks._index_percolate_queries') as mocked_index_percolate_queries:
-            percolate_query.save()
-        assert mocked_index_percolate_queries.call_count == 1
-        assert len(mocked_index_percolate_queries.call_args[0]) == 1
-        assert list(mocked_index_percolate_queries.call_args[0][0])[0].id == percolate_query.id
+            self.mocked_index_percolate_queries.reset_mock()
+            with patch('search.tasks._index_percolate_queries') as mocked_index_percolate_queries:
+                percolate_query.save()
+            assert mocked_index_percolate_queries.call_count == 1
+            assert len(mocked_index_percolate_queries.call_args[0]) == 1
+            assert list(mocked_index_percolate_queries.call_args[0][0])[0].id == percolate_query.id
 
     def test_index_delete_percolate_query(self):
         """When a PercolateQuery is deleted we should delete it from the index too"""
-        with patch('search.tasks._index_percolate_queries'):
+        with patch('search.signals.transaction', on_commit=lambda callback: callback()):
             percolate_query = PercolateQuery.objects.create(query={})
-        percolate_query_id = percolate_query.id
-        with patch('search.tasks._delete_percolate_query') as mocked_delete_percolate_query:
+            percolate_query_id = percolate_query.id
             percolate_query.delete()
-        assert mocked_delete_percolate_query.call_count == 1
-        assert len(mocked_delete_percolate_query.call_args[0]) == 1
-        assert mocked_delete_percolate_query.call_args[0][0] == percolate_query_id
+            assert self.mocked_delete_percolate_query.call_count == 1
+            assert len(self.mocked_delete_percolate_query.call_args[0]) == 1
+            assert self.mocked_delete_percolate_query.call_args[0][0] == percolate_query_id


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #2705

#### What's this PR do?
Uses `transaction.on_commit` to workaround database information not being available to the Celery worker until after the transaction commits. Patches are added in tests to force `on_commit` to execute immediately, since all tests are run in a transaction and `on_commit` would delay action until after the test completes.

#### How should this be manually tested?
Tests should pass
