### PR TITLE
Load the edX logo from CloudFront on the program page

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -130,7 +130,7 @@
           <p>
             Courses delivered on
           </p>
-          <img src="/static/images/edx_logo.png" alt="edX" />
+          <img src="{% static 'images/edx_logo.png' %}" alt="edX" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #2462.

#### What's this PR do?
I found an image reference in our HTML template that wasn't being loaded from CloudFront. This pull request changes that template to load the image from CloudFront. There should be no user-visible impact to this pull request.

#### How should this be manually tested?
View the program page, and inspect the edX logo on the right sidebar, below the "More Info" box. It should load from CloudFront on the RC server, and on production.
