### PR TITLE
Fixes layout issue with the Grade Histogram on the Search page

### DIFF
--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -160,6 +160,10 @@
         background-color: $mm-brand-bg-light;
       }
 
+      .sk-range-slider {
+        margin-top: -5px;
+      }
+
       .is-out-of-bounds {
         background-color: $medgrey;
       }


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/2833

#### What's this PR do?
Fixes a gap between the histogram and slider in the grade facet. This was introduced by a searchkit upgrade.

#### How should this be manually tested?
See that there is no gap anymore.

#### Any background context you want to provide?
This is a one-line fix.

#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/20047260/23770165/032f43a8-04e0-11e7-8932-257b4b221c3e.png)