### PR TITLE
Add logging for recreate_index

### DIFF
--- a/search/management/commands/recreate_index.py
+++ b/search/management/commands/recreate_index.py
@@ -1,11 +1,13 @@
 """
 Management command to recreate the Elasticsearch index
 """
+import logging
 
 from django.core.management.base import BaseCommand
 
 from search.indexing_api import (
     recreate_index,
+    __name__ as indexing_api_name,
 )
 
 
@@ -19,4 +21,10 @@ class Command(BaseCommand):
         """
         Recreates the index
         """
+        log = logging.getLogger(indexing_api_name)
+        console = logging.StreamHandler(self.stderr)
+        console.setLevel(logging.DEBUG)
+        log.addHandler(console)
+        log.level = logging.INFO
+
         recreate_index()


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Logs every chunk which is indexed to provide information on the progress of `recreate_index`

#### How should this be manually tested?
Run `./manage.py recreate_index` and verify that the output looks as expected.
