### PR TITLE
Use temporary index during recreate_index

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -6,6 +6,7 @@ from elasticsearch_dsl import Search, Q
 
 from roles.api import get_advance_searchable_programs
 from search.connection import (
+    get_default_alias,
     get_conn,
     DOC_TYPES,
 )
@@ -81,7 +82,7 @@ def create_search_obj(user, search_param_dict=None, filter_on_email_optin=False)
     Returns:
         Search: elasticsearch_dsl Search object
     """
-    search_obj = Search(index=settings.ELASTICSEARCH_INDEX, doc_type=DOC_TYPES)
+    search_obj = Search(index=get_default_alias(), doc_type=DOC_TYPES)
     # Update from search params first so our server-side filtering will overwrite it if necessary
     if search_param_dict is not None:
         search_obj.update_from_dict(search_param_dict)

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -9,7 +9,6 @@ from django.test import (
     override_settings,
 )
 from django.db.models.signals import post_save
-from django.conf import settings
 
 from courses.factories import ProgramFactory
 from dashboard.factories import ProgramEnrollmentFactory
@@ -23,7 +22,10 @@ from search.api import (
     get_all_query_matching_emails,
 )
 from search.base import ESTestCase
-from search.connection import DOC_TYPES
+from search.connection import (
+    DOC_TYPES,
+    get_default_alias,
+)
 from search.exceptions import NoProgramAccessException
 
 
@@ -132,7 +134,7 @@ class SearchAPITests(ESTestCase):  # pylint: disable=missing-docstring
         with patch('search.api.Search.update_from_dict', autospec=True) as mock_update_from_dict:
             search_obj = create_search_obj(self.user, search_param_dict=search_param_dict)
         assert search_obj._doc_type == list(DOC_TYPES)  # pylint: disable=protected-access
-        assert search_obj._index == [settings.ELASTICSEARCH_INDEX]  # pylint: disable=protected-access
+        assert search_obj._index == [get_default_alias()]  # pylint: disable=protected-access
         mock_update_from_dict.assert_called_with(search_obj, search_param_dict)
 
     def test_user_with_no_program_access(self):

--- a/search/connection.py
+++ b/search/connection.py
@@ -50,18 +50,44 @@ def get_conn(verify=True, verify_index=None):
 
     # Make sure everything exists.
     if verify_index is None:
-        verify_index = settings.ELASTICSEARCH_INDEX
+        verify_index = get_default_alias()
     if not _CONN.indices.exists(verify_index):
         raise ReindexException("Unable to find index {index_name}".format(
             index_name=verify_index
         ))
 
-    mappings = _CONN.indices.get_mapping()[verify_index]["mappings"]
     for doc_type in DOC_TYPES:
-        if doc_type not in mappings.keys():
+        mapping = _CONN.indices.get_mapping(index=verify_index, doc_type=doc_type)
+        if not mapping:
             raise ReindexException("Mapping {doc_type} not found".format(
                 doc_type=doc_type
             ))
 
     _CONN_VERIFIED = True
     return _CONN
+
+
+def get_temp_alias():
+    """
+    Get name for alias to a the temporary index
+    """
+    return "{}_temp".format(settings.ELASTICSEARCH_INDEX)
+
+
+def get_default_alias():
+    """
+    Get name for the alias to the default index
+    """
+    return "{}_alias".format(settings.ELASTICSEARCH_INDEX)
+
+
+def get_active_aliases():
+    """
+    Get aliases for active indexes.
+    """
+    conn = get_conn(verify=False)
+    aliases = []
+    for alias in (get_default_alias(), get_temp_alias()):
+        if conn.indices.exists(alias):
+            aliases.append(alias)
+    return aliases

--- a/search/connection.py
+++ b/search/connection.py
@@ -15,7 +15,7 @@ USER_DOC_TYPE = 'program_user'
 DOC_TYPES = (USER_DOC_TYPE, )
 
 
-def get_conn(verify=True):
+def get_conn(verify=True, verify_index=None):
     """
     Lazily create the connection.
     """
@@ -49,13 +49,14 @@ def get_conn(verify=True):
         return _CONN
 
     # Make sure everything exists.
-    index_name = settings.ELASTICSEARCH_INDEX
-    if not _CONN.indices.exists(index_name):
+    if verify_index is None:
+        verify_index = settings.ELASTICSEARCH_INDEX
+    if not _CONN.indices.exists(verify_index):
         raise ReindexException("Unable to find index {index_name}".format(
-            index_name=index_name
+            index_name=verify_index
         ))
 
-    mappings = _CONN.indices.get_mapping()[index_name]["mappings"]
+    mappings = _CONN.indices.get_mapping()[verify_index]["mappings"]
     for doc_type in DOC_TYPES:
         if doc_type not in mappings.keys():
             raise ReindexException("Mapping {doc_type} not found".format(

--- a/search/management/commands/clear_index.py
+++ b/search/management/commands/clear_index.py
@@ -3,11 +3,9 @@ Management command to clear the Elasticsearch index
 """
 
 from django.core.management.base import BaseCommand
-from django.conf import settings
 
-from search.indexing_api import (
-    clear_index,
-)
+from search.connection import get_default_alias
+from search.indexing_api import clear_index
 
 
 class Command(BaseCommand):
@@ -20,4 +18,4 @@ class Command(BaseCommand):
         """
         Clear the index
         """
-        clear_index(settings.ELASTICSEARCH_INDEX)
+        clear_index(get_default_alias())

--- a/search/management/commands/clear_index.py
+++ b/search/management/commands/clear_index.py
@@ -3,6 +3,7 @@ Management command to clear the Elasticsearch index
 """
 
 from django.core.management.base import BaseCommand
+from django.conf import settings
 
 from search.indexing_api import (
     clear_index,
@@ -19,4 +20,4 @@ class Command(BaseCommand):
         """
         Clear the index
         """
-        clear_index()
+        clear_index(settings.ELASTICSEARCH_INDEX)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2550

#### What's this PR do?
Does the reindex in a separate Elasticsearch index, then deletes the old one, recreates it with a mapping and replaces it with the temp index's documents. There is still a tiny amount of time where the old index will go away and come back (less than a second for 1400 documents on my computer), and there is still a risk of stale data if documents are modified during the reindex.

This PR also updates the indexing to check if the temp index exists, then update it if it does. This is to prevent stale data in the temp index from overwriting the current one.

#### How should this be manually tested?
Run a reindex and go to `/learners`. The list of learners should not change during the reindex.