### PR TITLE
Enabled learner-to-learner emails

### DIFF
--- a/roles/permissions.py
+++ b/roles/permissions.py
@@ -21,17 +21,6 @@ def can_advance_search(role, user, program):
 
 
 @register_object_checker()
-def can_message_learners(role, user, program):
-    """
-    Determines whether a user can send a message to learners of a specific program.
-    """
-    return (
-        has_permission(user, Permissions.CAN_MESSAGE_LEARNERS) and Role.objects.filter(
-            user=user, role=role.ROLE_ID, program=program).exists()
-    )
-
-
-@register_object_checker()
 def can_edit_financial_aid(role, user, program):
     """
     Determines whether a user can access and edit financial aid requests for a specific program.

--- a/static/js/components/Learner.js
+++ b/static/js/components/Learner.js
@@ -13,22 +13,23 @@ import {
   employmentValidation,
   personalValidation,
 } from '../lib/validation/profile';
+import StaffLearnerInfoCard from './StaffLearnerInfoCard';
 import type { Profile, SaveProfileFunc } from '../flow/profileTypes';
 import type { UIState } from '../reducers/ui';
-import StaffLearnerInfoCard from './StaffLearnerInfoCard';
 import type { DashboardState } from '../flow/dashboardTypes';
 
 export default class Learner extends React.Component {
   props: {
     profile:                                Profile,
     profilePatchStatus:                     ?string,
-    setLearnerPageDialogVisibility:         () => void,
     ui:                                     UIState,
-    clearProfileEdit:                       () => void,
+    dashboard:                              DashboardState,
     saveProfile:                            SaveProfileFunc,
+    clearProfileEdit:                       () => void,
+    setLearnerPageDialogVisibility:         () => void,
     startProfileEdit:                       () => void,
     setLearnerPageAboutMeDialogVisibility:  () => void,
-    dashboard:                              DashboardState,
+    openLearnerEmailComposer:               () => void,
   };
 
   toggleShowPersonalDialog = (): void => {
@@ -65,7 +66,10 @@ export default class Learner extends React.Component {
   };
 
   render() {
-    const { profile } = this.props;
+    const {
+      profile,
+      openLearnerEmailComposer
+    } = this.props;
 
     return <div className="single-column dashboard">
       <LearnerPagePersonalDialog {...this.props} />
@@ -73,7 +77,8 @@ export default class Learner extends React.Component {
       <LearnerInfoCard
         profile={profile}
         toggleShowAboutMeDialog={this.toggleShowAboutMeDialog}
-        toggleShowPersonalDialog={this.toggleShowPersonalDialog} />
+        toggleShowPersonalDialog={this.toggleShowPersonalDialog}
+        openLearnerEmailComposer={openLearnerEmailComposer} />
       { this.showStaffInfo() }
       <EducationForm {...this.props} showSwitch={false} validator={educationValidation} />
       <EmploymentForm {...this.props} showSwitch={false} validator={employmentValidation} />

--- a/static/js/components/LearnerChip.js
+++ b/static/js/components/LearnerChip.js
@@ -11,6 +11,16 @@ import type { Profile } from '../flow/profileTypes';
 const LearnerChip = (props: {profile: Profile, openLearnerEmailComposer: () => void}): React$Element<*> => {
   const { profile, openLearnerEmailComposer } = props;
 
+  let emailLink;
+  if (profile.email_optin) {
+    emailLink = (
+      <button onClick={openLearnerEmailComposer} className="icon-button-link">
+        <Icon name="email" aria-hidden="true" />
+        <span>Send a Message</span>
+      </button>
+    );
+  }
+
   return <Card className="user-chip">
     <div className="profile-info">
       <span className="name">
@@ -19,14 +29,11 @@ const LearnerChip = (props: {profile: Profile, openLearnerEmailComposer: () => v
       <span className="employer">
         { mstr(getEmployer(profile)) }
       </span>
-      <a href={`/learner/${profile.username}`} className="mm-minor-action">
+      <a href={`/learner/${profile.username}`} className="icon-button-link">
         <Icon name="person" aria-hidden="true" />
         <span>View Profile</span>
       </a>
-      <button onClick={openLearnerEmailComposer} className="mm-minor-action">
-        <Icon name="email" aria-hidden="true" />
-        <span>Send a Message</span>
-      </button>
+      { emailLink }
     </div>
     <ProfileImage profile={profile}/>
   </Card>;

--- a/static/js/components/LearnerChip_test.js
+++ b/static/js/components/LearnerChip_test.js
@@ -10,7 +10,7 @@ import { getPreferredName } from '../util/util';
 import ProfileImage from '../containers/ProfileImage';
 
 describe('LearnerChip', () => {
-  let profileClone;
+  let profileClone, sandbox;
 
   const renderChip = (profile, openLearnerEmailComposer) => (
     shallow(<LearnerChip profile={profile} openLearnerEmailComposer={openLearnerEmailComposer} />)
@@ -18,6 +18,11 @@ describe('LearnerChip', () => {
 
   beforeEach(() => {
     profileClone = R.clone(USER_PROFILE_RESPONSE);
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   it('should show the preferred name', () => {
@@ -43,12 +48,19 @@ describe('LearnerChip', () => {
   });
 
   it('should provide a link to email the learner', () => {
-    let sandbox = sinon.sandbox.create();
     let openLearnerEmailComposer = sandbox.stub();
+    profileClone.email_optin = true;
     let chip = renderChip(profileClone, openLearnerEmailComposer);
     let emailLink = chip.find('button').at(0);
     emailLink.simulate('click');
     sinon.assert.calledOnce(openLearnerEmailComposer);
+  });
+
+  it('should hide the email link when the learner is opted out of email', () => {
+    let openLearnerEmailComposer = sandbox.stub();
+    profileClone.email_optin = false;
+    let chip = renderChip(profileClone, openLearnerEmailComposer);
+    assert.lengthOf(chip.find('button'), 0);
   });
 
   it('should include the profile image', () => {

--- a/static/js/components/PrivacyForm.js
+++ b/static/js/components/PrivacyForm.js
@@ -26,11 +26,12 @@ class PrivacyForm extends ProfileFormFields {
       be visible to MIT faculty and staff.` }
   ];
 
+  emailOptions: Array<{value: string, label: string}> = [
+    { value: "true", label: "Faculty, staff, and other learners can send me emails"},
+    { value: "false", label: "I don't want to receive any emails" }
+  ];
+
   render() {
-    const emailOptions = [
-      { value: "true", label: "Faculty and staff can send me emails"},
-      { value: "false", label: "I don't want to receive any emails" }
-    ];
     return (
       <div>
         <Card shadow={1} className="profile-form">
@@ -42,7 +43,7 @@ class PrivacyForm extends ProfileFormFields {
         <Card shadow={1} className="profile-form">
           <h4 className="privacy-form-heading">Email Preferences</h4>
           <div className="profile-form-row">
-            { this.boundRadioGroupField(['email_optin'], '', emailOptions) }
+            { this.boundRadioGroupField(['email_optin'], '', this.emailOptions) }
           </div>
         </Card>
       </div>

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -174,7 +174,7 @@
   background-color: $button-color;
 }
 
-.mm-minor-action {
+.mm-minor-action, .icon-button-link {
   color: $link-text;
   font-size: 15px;
   font-weight: 400;
@@ -185,12 +185,37 @@
 
   &:hover {
     color: $link-hover;
-    text-decoration: underline;
   }
 
   &[disabled] {
     color: $font-gray-disabled;
     text-decoration: none;
+  }
+}
+
+.mm-minor-action:hover {
+  text-decoration: underline;
+}
+
+
+.icon-button-link {
+  display: inline-flex;
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  i.material-icons {
+    margin-right: 6px;
+    font-size: 28px;
+  }
+
+  span {
+    line-height: 28px;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 

--- a/static/scss/profile.scss
+++ b/static/scss/profile.scss
@@ -12,7 +12,7 @@
     margin-left: 15px;
   }
 
-  i.material-icons {
+  .mdl-button i.material-icons {
     color: $mm-brand-bg;
   }
 

--- a/static/scss/user-chip.scss
+++ b/static/scss/user-chip.scss
@@ -37,15 +37,6 @@
     a:hover > span {
       text-decoration: underline;
     }
-
-    .mm-minor-action {
-      i {
-        margin-right: 6px;
-        font-size: 28px;
-        position: relative;
-        top: 6px;
-      }
-    }
   }
 
   .profile-image {


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #2196

#### What's this PR do?

- Adds the back-end functionality that will allow a paid learner to email another learner
- Replaces the email display on the profile page with an email link, which for now will only be seen by staff users

#### How should this be manually tested?
With a staff user, visit the profile of a user that has an email address and `Profile.email_optin=True`. Click the email link and make sure you can send a message. You can also use the learner mail view to send a learner-to-learner message since the link isn't viewable for other learners (yet). I'll post a code snippet to try out that email in the comments

#### Where should the reviewer start?
`mail/permissions.py` and `static/js/components/LearnerInfoCard.js`

#### Any background context you want to provide?
The email link is being hidden from other learners for now. We need to wait on the learner's search for learners issue (https://github.com/mitodl/micromasters/issues/2512) before we can show it. I will create a new issue to cover this work and update this description when that's done

#### Screenshots (if appropriate)
![ss 2017-03-10 at 12 59 35](https://cloud.githubusercontent.com/assets/14932219/23806895/7410f0c4-0591-11e7-8ef6-0a6c64e854fe.png)
