### PR TITLE
fix bad searchkit default prop value

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -295,6 +295,7 @@ export default class LearnerSearch extends SearchkitComponent {
             title=""
             id="country"
             translations={this.countryNameTranslations}
+            size={0}
           />
         </FilterVisibilityToggle>
         <FilterVisibilityToggle


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2856

#### What's this PR do?

This just passes a value of 0 for size to HierarchicalMenuFilter, which results in it showing all results (instead of the default, which is just the first? 20).

#### How should this be manually tested?

Go to the learner search page and confirm you can see all of the 'current residence' countries for your users.
