### PR TITLE
only show the user a link to the financial aid review page if they have the permission

### DIFF
--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -17,7 +17,11 @@ import ProgramSelector from './ProgramSelector';
 import ProfileImage from '../containers/ProfileImage';
 import { getPreferredName } from '../util/util';
 import type { Profile } from '../flow/profileTypes';
-import { hasAnyStaffRole } from '../lib/roles';
+import {
+  hasAnyStaffRole,
+  firstFinancialAidProgram,
+  hasEditAbility,
+} from '../lib/roles';
 
 const PROFILE_SETTINGS_REGEX = /^\/profile\/?|settings\/?|learner\/[a-z]?/;
 const PROFILE_REGEX = /^\/profile\/?/;
@@ -48,6 +52,10 @@ const adminLink = (...args) => (
 
 const learnerLink = (...args) => (
   hasAnyStaffRole(SETTINGS.roles) ? null : navLink(...args)
+);
+
+const financialAidLink = (...args) => (
+  R.find(hasEditAbility, SETTINGS.roles) ? navLink(...args) : null
 );
 
 export default class Navbar extends React.Component {
@@ -137,7 +145,14 @@ export default class Navbar extends React.Component {
             <div className="links">
               { adminLink(closeDrawer, '/learners', 'Learners', 'people') }
               { adminLink(closeDrawer, '/cms', 'CMS',  'description', true, true) }
-              { adminLink(closeDrawer, '/financial_aid/review/1', 'Personal Price Admin',  'attach_money', true, true) }
+              { financialAidLink(
+                closeDrawer,
+                `/financial_aid/review/${firstFinancialAidProgram(SETTINGS.roles)}`,
+                'Personal Price Admin',
+                'attach_money',
+                true,
+                true
+              )}
               { learnerLink(closeDrawer, '/dashboard', 'Dashboard', 'dashboard') }
               { navLink(closeDrawer, `/learner/${SETTINGS.user.username}`, 'My Profile', 'person')}
               { navLink(

--- a/static/js/components/Navbar_test.js
+++ b/static/js/components/Navbar_test.js
@@ -35,7 +35,7 @@ describe('Navbar', () => {
 
   it('has a link to the learner page if the user is staff or instructor', () => {
     for (let role of ['staff', 'instructor']) {
-      SETTINGS.roles = [{ role }];
+      SETTINGS.roles = [{ role, permissions: [] }];
       let wrapper = renderNavbar();
       let hrefs = wrapper.find(Link).map(link => link.props()['to']);
       assert.deepEqual(hrefs, [
@@ -47,6 +47,16 @@ describe('Navbar', () => {
         '/learners',
       ]);
     }
+  });
+
+  it('should show a link to the financial aid review page, if the user has that permission', () => {
+    SETTINGS.roles = [{
+      role: 'staff',
+      permissions: [ 'can_edit_financial_aid' ],
+      program: 1
+    }];
+    let wrapper = renderNavbar();
+    assert.equal(wrapper.find("a[href='/financial_aid/review/1']").text(), "Personal Price Admin");
   });
 
   it('has a logout link', () => {

--- a/static/js/containers/LearnerPage_test.js
+++ b/static/js/containers/LearnerPage_test.js
@@ -1006,7 +1006,7 @@ describe("LearnerPage", function() {
       const smallDashboard = DASHBOARD_RESPONSE.slice(0,1);
       helper.dashboardStub.returns(Promise.resolve(smallDashboard));
       const username = SETTINGS.user.username;
-      SETTINGS.roles.push({ role: 'staff' });
+      SETTINGS.roles.push({ role: 'staff', permissions: [] });
       const actions = userActions.concat([REQUEST_DASHBOARD, RECEIVE_DASHBOARD_SUCCESS]);
       return renderComponent(`/learner/${username}`, actions).then(([wrapper, ]) => {
         assert.equal(wrapper.find(StaffLearnerInfoCard).length, 1);

--- a/static/js/lib/roles.js
+++ b/static/js/lib/roles.js
@@ -15,3 +15,11 @@ const sameProgram = R.curry((program, role) => (
 export const hasStaffForProgram = R.curry((program, roles) => (
   R.any(R.both(sameProgram(program), hasStaffRole), roles)
 ));
+
+export const hasEditAbility = R.propSatisfies(
+  R.contains('can_edit_financial_aid'), 'permissions'
+);
+
+export const firstFinancialAidProgram = R.compose(
+  R.propOr(null, 'program'), R.find(hasEditAbility)
+);

--- a/static/js/lib/roles_test.js
+++ b/static/js/lib/roles_test.js
@@ -4,6 +4,8 @@ import { assert } from 'chai';
 import {
   hasAnyStaffRole,
   hasStaffForProgram,
+  hasEditAbility,
+  firstFinancialAidProgram,
 } from './roles';
 
 describe('roles library', () => {
@@ -13,11 +15,13 @@ describe('roles library', () => {
     roles = [
       {
         "role": "staff",
-        "program": 1
+        "program": 1,
+        "permissions": [],
       },
       {
         "role": "student",
-        "program": 2
+        "program": 2,
+        "permissions": [],
       }
     ];
   });
@@ -40,6 +44,37 @@ describe('roles library', () => {
 
     it('should return false if the user is not staff on the specified program', () => {
       assert.isFalse(hasStaffForProgram({id: 2}, roles));
+    });
+  });
+
+  describe('hasEditAbility', () => {
+    it('should return false if user does not have the permission', () => {
+      roles.forEach(role => {
+        assert.isFalse(hasEditAbility(role));
+      });
+    });
+
+    it('should return true if user has permission on any program', () => {
+      roles[0].permissions.push("can_edit_financial_aid");
+      assert.isTrue(hasEditAbility(roles[0]));
+    });
+
+    it('should return false if the user only has other permissions', () => {
+      roles[0].permissions.push("can_make_bad_jokes");
+      assert.isFalse(hasEditAbility(roles[0]));
+    });
+  });
+
+  describe('firstFinancialAidProgram', () => {
+    it('should return null if the user doesnt have the right permission', () => {
+      assert.isNull(firstFinancialAidProgram(roles));
+    });
+
+    it('should return the program ID if the user does have the permission', () => {
+      roles[1].permissions.push("can_edit_financial_aid");
+      assert.equal(2, firstFinancialAidProgram(roles));
+      roles[0].permissions.push("can_edit_financial_aid");
+      assert.equal(1, firstFinancialAidProgram(roles));
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2852

#### What's this PR do?

makes it so we only show the financial aid review page link to users with the appropriate permission.

#### How should this be manually tested?

make sure you have permissions for financial aid on a program. go anywhere in the site, and a link to the corresponding financial aid review page should show up.

get rid of that permission (or sign into a different account) and you shouldn't see the link any longer.