### PR TITLE
Added validation for invalid name chars (#2837)

### DIFF
--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -12,6 +12,8 @@ export const DASHBOARD_FORMAT = 'MMM D, Y';
 export const DASHBOARD_MONTH_FORMAT = 'MM[/]YYYY';
 
 export const CP1252_REGEX = /^[\u0020-\u00FF]*$/;
+// greater-than, comma, quotation-mark
+export const INVALID_NAME_CHARS_REGEX = /[\u003E\u002C\u0022]/;
 
 // NOTE: this is in order of attainment
 export const EDUCATION_LEVELS = [

--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -21,7 +21,8 @@ import {
   PERSONAL_STEP,
   EDUCATION_STEP,
   EMPLOYMENT_STEP,
-  CP1252_REGEX
+  CP1252_REGEX,
+  INVALID_NAME_CHARS_REGEX,
 } from '../../constants';
 import { shouldRenderRomanizedFields } from '../../util/profile_edit';
 
@@ -125,6 +126,15 @@ export const checkLatin = R.curry((key, label, profile) => (
   )
 ));
 
+export const checkInvalidNameChars = R.curry((key, label, profile) => (
+  checkProp(
+    key,
+    `${label} must not contain comma, double quote, or greater than characters`,
+    R.complement(R.test(INVALID_NAME_CHARS_REGEX)),
+    profile
+  )
+));
+
 export const checkDateOfBirth: Validator = (
   checkProp(
     'date_of_birth',
@@ -141,9 +151,11 @@ export const checkRomanizedNames: Validator = (
     shouldRenderRomanizedFields,
     mergeValidations(
       checkLatin('romanized_first_name', 'Latin given name'),
+      checkInvalidNameChars('romanized_first_name', 'Latin given name'),
       checkMaxLength('romanized_first_name', 'Latin given name', 30),
       checkIsNotNilOrEmpty('romanized_first_name', 'Latin given name is required'),
       checkLatin('romanized_last_name', 'Latin family name'),
+      checkInvalidNameChars('romanized_last_name', 'Latin family name'),
       checkMaxLength('romanized_last_name', 'Latin family name', 50),
       checkIsNotNilOrEmpty('romanized_last_name', 'Latin family name is required'),
     ),
@@ -187,9 +199,12 @@ const checkPersonalMessages = R.compose(
 
 // precedence is bottom-to-top
 export const personalValidation: Validator = mergeValidations(
-  // names
+  // first name
   checkMaxLength('first_name', 'Given name', 30),
+  checkInvalidNameChars('first_name', 'Given name'),
+  // last name
   checkMaxLength('last_name', 'Family name', 50),
+  checkInvalidNameChars('last_name', 'Family name'),
   checkRomanizedNames,
   // date of birth
   checkDateOfBirth,

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -202,6 +202,58 @@ describe('Profile validation functions', () => {
       assert.deepEqual(personalValidation(profile), errors);
     });
 
+    const invalidCharErrorSuffix = 'must not contain comma, double quote, or greater than characters';
+
+    for (const invalidChar of ['"', '>', ',']) {
+      it(`should error when first_name contains ${invalidChar}`, () => {
+        let profile = {
+          ...USER_PROFILE_RESPONSE,
+          first_name: invalidChar,
+        };
+        let errors = {
+          first_name: `Given name ${invalidCharErrorSuffix}`,
+        };
+        assert.deepEqual(personalValidation(profile), errors);
+      });
+
+      it(`should error when last_name contains ${invalidChar}`, () => {
+        let profile = {
+          ...USER_PROFILE_RESPONSE,
+          last_name: invalidChar,
+        };
+        let errors = {
+          last_name: `Family name ${invalidCharErrorSuffix}`,
+        };
+        assert.deepEqual(personalValidation(profile), errors);
+      });
+
+      it(`should error when romanized_first_name contains ${invalidChar}`, () => {
+        let profile = {
+          ...USER_PROFILE_RESPONSE,
+          first_name: 'ر',
+          romanized_first_name: invalidChar,
+          romanized_last_name: 'name',
+        };
+        let errors = {
+          romanized_first_name: `Latin given name ${invalidCharErrorSuffix}`,
+        };
+        assert.deepEqual(personalValidation(profile), errors);
+      });
+
+      it(`should error when romanized_last_name contains ${invalidChar}`, () => {
+        let profile = {
+          ...USER_PROFILE_RESPONSE,
+          first_name: 'ر',
+          romanized_first_name: 'name',
+          romanized_last_name: invalidChar,
+        };
+        let errors = {
+          romanized_last_name: `Latin family name ${invalidCharErrorSuffix}`,
+        };
+        assert.deepEqual(personalValidation(profile), errors);
+      });
+    }
+
     it('should error when any name is too long', () => {
       let profile = {
         ...USER_PROFILE_RESPONSE,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2837 

#### What's this PR do?
Adds validation to ensure `<`, `,` and `"` aren't allowed in names.

#### How should this be manually tested?
Try inputting the above chars into the romanized / non-romanized name fields

#### Where should the reviewer start?
`static/js/lib/validation/profile.js`