### PR TITLE
Improve searchkit query

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -14,6 +14,7 @@ import {
   RangeFilter,
   SearchBox,
   SortingSelector,
+  MultiMatchQuery,
 } from 'searchkit';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Card from 'react-mdl/lib/Card/Card';
@@ -171,17 +172,18 @@ export default class LearnerSearch extends SearchkitComponent {
         </Cell>
         <Cell col={6} className="pagination-search">
           <SearchBox
-            queryBuilder={() => ({})}  // we only care about prefix query
+            queryBuilder={MultiMatchQuery}
             searchOnChange={true}
-            prefixQueryFields={[
+            queryFields={[
               'profile.first_name.folded',
               'profile.last_name.folded',
               'profile.preferred_name.folded',
               'profile.username.folded',
               'email.folded'
             ]}
-            prefixQueryOptions={{
-              analyzer: "folding"
+            queryOptions={{
+              analyzer: "folding",
+              type: "phrase_prefix",
             }}
           />
           <Pagination showText={false} listComponent={CustomPaginationDisplay} />


### PR DESCRIPTION
#### What are the relevant tickets?
This is a code improvement that will take us one step closer to resolving #2742.

#### What's this PR do?
Uses Searchkit's built-in functionality the way the framework expects to be used. There should be no user-visible changes as a result of this pull request.

#### How should this be manually tested?
Use the learner search. Type in prefixes of user first names and last names, and verify that you still get the results you expect. Note that this pull request will not work with combination prefixes. For example, if you have a user named "John Smith", then the queries "Jo" and "Smi" should return the user. However, the query "John Smi" is not expected to work. (That's the end goal of #2742.)
