### PR TITLE
Modified Dashboard REST API to include edx data freshness status

### DIFF
--- a/dashboard/api_edx_cache.py
+++ b/dashboard/api_edx_cache.py
@@ -145,6 +145,18 @@ class CachedEdxDataApi:
         )
 
     @classmethod
+    def are_all_caches_fresh(cls, user):
+        """
+        Checks if all cache types are fresh.
+
+        Args:
+            user (django.contrib.auth.models.User): A user
+        Returns:
+            bool
+        """
+        return all(cls.is_cache_fresh(user, cache_type) for cache_type in cls.SUPPORTED_CACHES)
+
+    @classmethod
     def update_cached_enrollment(cls, user, enrollment, course_id, index_user=False):
         """
         Updates the cached enrollment based on an Enrollment object

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -61,6 +61,8 @@ class UserDashboard(APIView):
                     status=exc.http_status_code,
                     data={'error': str(exc)}
                 )
+            except:  # pylint: disable=bare-except
+                log.exception('Impossible to refresh user credentials in dashboard view')
             # create an instance of the client to query edX
             edx_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL)
 

--- a/static/js/components/ProgramEnrollmentDialog_test.js
+++ b/static/js/components/ProgramEnrollmentDialog_test.js
@@ -144,7 +144,7 @@ describe("ProgramEnrollmentDialog", () => {
 
   it("only shows programs which the user is not already enrolled in", () => {
     let enrollmentLookup = new Map(PROGRAMS.map(enrollment => [enrollment.id, null]));
-    let unenrolledPrograms = DASHBOARD_RESPONSE.filter(program => !enrollmentLookup.has(program.id));
+    let unenrolledPrograms = DASHBOARD_RESPONSE.programs.filter(program => !enrollmentLookup.has(program.id));
     unenrolledPrograms = _.sortBy(unenrolledPrograms, 'title');
     unenrolledPrograms = unenrolledPrograms.map(program => ({
       title: program.title,

--- a/static/js/components/StaffLearnerInfoCard_test.js
+++ b/static/js/components/StaffLearnerInfoCard_test.js
@@ -30,7 +30,7 @@ describe('StaffLearnerInfoCard', () => {
     mount(
       <MuiThemeProvider muiTheme={getMuiTheme()}>
         <StaffLearnerInfoCard
-          program={DASHBOARD_RESPONSE[0]}
+          program={DASHBOARD_RESPONSE.programs[0]}
         />
       </MuiThemeProvider>
     )
@@ -40,7 +40,7 @@ describe('StaffLearnerInfoCard', () => {
     let card = renderCard();
     assert.include(
       stringStrip(card.text()),
-      `Progress ${DASHBOARD_RESPONSE[0].title}`
+      `Progress ${DASHBOARD_RESPONSE.programs[0].title}`
     );
   });
 
@@ -53,7 +53,7 @@ describe('StaffLearnerInfoCard', () => {
   });
 
   it('should show information for course runs the user is enrolled in', () => {
-    let numRuns = DASHBOARD_RESPONSE[0]
+    let numRuns = DASHBOARD_RESPONSE.programs[0]
       .courses
       .reduce((acc, course) => acc.concat(course.runs), [])
       .filter(run => run.status !== STATUS_OFFERED)

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -91,7 +91,7 @@ describe('CourseAction', () => {
   };
 
   let renderCourseAction = (props = {}) => {
-    let prices = calculatePrices(DASHBOARD_RESPONSE, COURSE_PRICES_RESPONSE, []);
+    let prices = calculatePrices(DASHBOARD_RESPONSE.programs, COURSE_PRICES_RESPONSE, []);
     return shallow(
       <CourseAction
         hasFinancialAid={false}

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -30,7 +30,7 @@ import { makeCoupon } from '../../factories/dashboard';
 describe('CourseListCard', () => {
   let program, sandbox, helper, routerPushStub;
   beforeEach(() => {
-    program = _.cloneDeep(DASHBOARD_RESPONSE[1]);
+    program = _.cloneDeep(DASHBOARD_RESPONSE.programs[1]);
     assert.isAbove(program.courses.length, 0);
     sandbox = sinon.sandbox.create();
     routerPushStub = sandbox.stub();
@@ -43,7 +43,7 @@ describe('CourseListCard', () => {
   });
 
   let renderCourseListCard = (props = {}) => {
-    helper.store.dispatch(receiveGetProgramEnrollmentsSuccess(DASHBOARD_RESPONSE));
+    helper.store.dispatch(receiveGetProgramEnrollmentsSuccess(DASHBOARD_RESPONSE.programs));
     helper.store.dispatch(setCurrentProgramEnrollment(program));
     let coursePrice = COURSE_PRICES_RESPONSE.find(
       coursePrice => coursePrice.program_id === program.id

--- a/static/js/components/dashboard/CourseRow_test.js
+++ b/static/js/components/dashboard/CourseRow_test.js
@@ -60,7 +60,7 @@ describe('CourseRow', () => {
   };
 
   it('forwards the appropriate props', () => {
-    const programs = makeDashboard();
+    const { programs } = makeDashboard();
     const course = programs[0].courses[0];
     // change this so there's something to show in CourseSubRow
     course.runs[1].status = STATUS_NOT_PASSED;
@@ -91,7 +91,7 @@ describe('CourseRow', () => {
   });
 
   describe('with failed/missed-upgrade-deadline runs', () => {
-    let courseToClone = DASHBOARD_RESPONSE[1].courses[0];
+    let courseToClone = DASHBOARD_RESPONSE.programs[1].courses[0];
 
     it('shows two-column view when the upgrade deadline was missed', () => {
       let pastCourseRunCount = 1;

--- a/static/js/components/dashboard/CourseSubRow_test.js
+++ b/static/js/components/dashboard/CourseSubRow_test.js
@@ -27,7 +27,7 @@ describe('CourseSubRow', () => {
     now = moment();
     openFinancialAidCalculator = sandbox.stub();
     addCourseEnrollment = sandbox.stub();
-    courseRun = _.cloneDeep(DASHBOARD_RESPONSE[1].courses[0]);
+    courseRun = _.cloneDeep(DASHBOARD_RESPONSE.programs[1].courses[0]);
   });
 
   afterEach(() => {

--- a/static/js/components/dashboard/DashboardUserCard_test.js
+++ b/static/js/components/dashboard/DashboardUserCard_test.js
@@ -11,7 +11,7 @@ import DashboardUserCard from './DashboardUserCard';
 
 describe('DashboardUserCard', () => {
   it('renders a user card', () => {
-    const program = DASHBOARD_RESPONSE[1];
+    const program = DASHBOARD_RESPONSE.programs[1];
     const profile = USER_PROFILE_RESPONSE;
     let wrapper = shallow(<DashboardUserCard profile={profile} program={program} />);
     assert.equal(wrapper.find(".dashboard-user-card-image").find(ProfileImage).props().profile, profile);

--- a/static/js/components/dashboard/FinalExamCard_test.js
+++ b/static/js/components/dashboard/FinalExamCard_test.js
@@ -32,7 +32,7 @@ describe('FinalExamCard', () => {
     sandbox = sinon.sandbox.create();
     navigateToProfileStub = sandbox.stub();
     submitPearsonSSOStub = sandbox.stub();
-    let program = _.cloneDeep(DASHBOARD_RESPONSE.find(program => (
+    let program = _.cloneDeep(DASHBOARD_RESPONSE.programs.find(program => (
       program.pearson_exam_status !== undefined
     )));
     props = {

--- a/static/js/components/dashboard/FinancialAidCard_test.js
+++ b/static/js/components/dashboard/FinancialAidCard_test.js
@@ -44,7 +44,7 @@ describe("FinancialAidCard", () => {
     return mount(
       <MuiThemeProvider muiTheme={getMuiTheme()}>
         <FinancialAidCard
-          program={DASHBOARD_RESPONSE[1]}
+          program={DASHBOARD_RESPONSE.programs[1]}
           coursePrice={COURSE_PRICES_RESPONSE[0]}
           updateDocumentSentDate={sandbox.stub()}
           documents={{
@@ -65,7 +65,7 @@ describe("FinancialAidCard", () => {
   };
 
   let programWithStatus = (status = null) => {
-    const program = _.cloneDeep(DASHBOARD_RESPONSE[1]);
+    const program = _.cloneDeep(DASHBOARD_RESPONSE.programs[1]);
     program.financial_aid_availability = true;
     program.financial_aid_user_info = {
       application_status: status,

--- a/static/js/constants_test.js
+++ b/static/js/constants_test.js
@@ -45,11 +45,12 @@ describe('constants', () => {
 
   describe("doesn't duplicate any id numbers within the same type of information", () => {
     it('for DASHBOARD_RESPONSE', () => {
-      assertResponse(DASHBOARD_RESPONSE);
+      assertResponse(DASHBOARD_RESPONSE.programs);
     });
 
     it('for a response from a factory', () => {
-      assertResponse(makeDashboard());
+      const dashboard = makeDashboard();
+      assertResponse(dashboard.programs);
     });
   });
 });

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -246,7 +246,7 @@ describe('DashboardPage', () => {
       beforeEach(() => {
         calculatePricesStub = helper.sandbox.stub(libCoupon, 'calculatePrices');
         dashboard = makeDashboard();
-        program = dashboard[0];
+        program = dashboard.programs[0];
         run = program.courses[0].runs[0];
         run.enrollment_start_date = '2016-01-01';
         availablePrograms = makeAvailablePrograms(dashboard);
@@ -262,7 +262,7 @@ describe('DashboardPage', () => {
 
         return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
           assert.include(wrapper.text(), 'Enroll Now');
-          sinon.assert.calledWith(calculatePricesStub, dashboard, coursePrices, []);
+          sinon.assert.calledWith(calculatePricesStub, dashboard.programs, coursePrices, []);
         });
       });
 
@@ -309,9 +309,9 @@ describe('DashboardPage', () => {
         });
 
         it('should not care about coupons for other programs', () => {
-          coupon.program_id = dashboard[1].id;
-          coupon.object_id = dashboard[1].id;
-          dashboard[1].financial_aid_user_info = {
+          coupon.program_id = dashboard.programs[1].id;
+          coupon.object_id = dashboard.programs[1].id;
+          dashboard.programs[1].financial_aid_user_info = {
             application_status: FA_STATUS_APPROVED,
           };
 
@@ -434,7 +434,7 @@ describe('DashboardPage', () => {
     });
 
     it('without a race condition', () => {  // eslint-disable-line mocha/no-skipped-tests
-      let program = DASHBOARD_RESPONSE[1];
+      let program = DASHBOARD_RESPONSE.programs[1];
       let coupon1 = makeCoupon(program);
       let coupon2 = makeCoupon(program);
       coupon2.coupon_code = 'second-coupon';
@@ -475,14 +475,14 @@ describe('DashboardPage', () => {
 
     beforeEach(() => {
       // Limit the dashboard response to 1 program
-      dashboardResponse = [R.clone(DASHBOARD_RESPONSE[0])];
+      dashboardResponse = {"programs": [R.clone(DASHBOARD_RESPONSE.programs[0])]};
     });
 
     it('shows the email composition dialog when a user has permission to contact a course team', () => {
       let course = makeCourse();
       course.has_contact_email = true;
       course.runs[0].has_paid = true;
-      dashboardResponse[0].courses = [course];
+      dashboardResponse.programs[0].courses = [course];
       helper.dashboardStub.returns(Promise.resolve(dashboardResponse));
 
       return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
@@ -518,7 +518,7 @@ describe('DashboardPage', () => {
       course.has_contact_email = true;
       // Set all course runs to unpaid
       course.runs = R.chain(R.set(R.lensProp('has_paid'), false), course.runs);
-      dashboardResponse[0].courses = [course];
+      dashboardResponse.programs[0].courses = [course];
       helper.dashboardStub.returns(Promise.resolve(dashboardResponse));
 
       return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
@@ -544,13 +544,13 @@ describe('DashboardPage', () => {
 
     beforeEach(() => {
       // Limit the dashboard response to 1 program
-      dashboardResponse = [R.clone(DASHBOARD_RESPONSE[0])];
+      dashboardResponse = {"programs": [R.clone(DASHBOARD_RESPONSE.programs[0])]};
     });
 
     it('renders correctly', () => {
       let course = makeCourse();
       course.runs[0].enrollment_start_date = moment().subtract(2, 'days');
-      dashboardResponse[0].courses = [course];
+      dashboardResponse.programs[0].courses = [course];
       helper.dashboardStub.returns(Promise.resolve(dashboardResponse));
 
       return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -11,7 +11,7 @@ import * as inputUtil from '../components/inputs/util';
 import FinancialAidCalculator from '../containers/FinancialAidCalculator';
 import IntegrationTestHelper from '../util/integration_test_helper';
 import { modifyTextField, modifySelectField, clearSelectField } from '../util/test_utils';
-import { DASHBOARD_RESPONSE, FINANCIAL_AID_PARTIAL_RESPONSE } from '../test_constants';
+import { DASHBOARD_RESPONSE, FINANCIAL_AID_PARTIAL_RESPONSE, PROGRAMS } from '../test_constants';
 import {
   requestAddFinancialAid,
   requestSkipFinancialAid,
@@ -49,7 +49,7 @@ import { DASHBOARD_SUCCESS_ACTIONS } from './test_util';
 describe('FinancialAidCalculator', () => {
   let listenForActions, renderComponent, helper;
   let financialAidDashboard = _.cloneDeep(DASHBOARD_RESPONSE);
-  let program = financialAidDashboard.find(program => (
+  let program = financialAidDashboard.programs.find(program => (
     program.title === "Not passed program"
   ));
   program.financial_aid_availability = true;
@@ -375,7 +375,7 @@ if you continue to have problems.`
   });
 
   it('should show nothing if there is no program found', () => {
-    helper.store.dispatch(receiveGetProgramEnrollmentsSuccess(DASHBOARD_RESPONSE));
+    helper.store.dispatch(receiveGetProgramEnrollmentsSuccess(PROGRAMS));
     helper.store.dispatch(setCurrentProgramEnrollment({
       id: 123456
     }));

--- a/static/js/containers/LearnerPage_test.js
+++ b/static/js/containers/LearnerPage_test.js
@@ -1003,7 +1003,7 @@ describe("LearnerPage", function() {
 
 
     it('should show the staff learner info card, if the user has a staff role', () => {
-      const smallDashboard = DASHBOARD_RESPONSE.slice(0,1);
+      const smallDashboard = {"programs": DASHBOARD_RESPONSE.programs.slice(0,1), "isEdxDataFresh": true};
       helper.dashboardStub.returns(Promise.resolve(smallDashboard));
       const username = SETTINGS.user.username;
       SETTINGS.roles.push({ role: 'staff' });

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -48,11 +48,12 @@ const newRunId = makeCounter();
 const newFinancialAidId = makeCounter();
 
 export const makeDashboard = (): Dashboard => {
-  return R.range(1, 3).map(makeProgram);
+  const programs = R.range(1, 3).map(makeProgram);
+  return { "programs": programs, "is_edx_data_fresh": true};
 };
 
 export const makeAvailablePrograms = (dashboard: Dashboard): AvailablePrograms => {
-  return dashboard.map(program => ({
+  return dashboard.programs.map(program => ({
     enrolled: true,
     id: program.id,
     programpage_url: `/page/${program.id}`,
@@ -125,8 +126,8 @@ export const makeCoupon = (program: Program): Coupon => ({
   object_id: program.id,
 });
 
-export const makeCoupons = (programs: Dashboard): Coupons => (
-  programs.map(makeCoupon)
+export const makeCoupons = (dashboard: Dashboard): Coupons => (
+  dashboard.programs.map(makeCoupon)
 );
 
 export const makeCoursePrice = (program: Program): CoursePrice => ({
@@ -136,6 +137,6 @@ export const makeCoursePrice = (program: Program): CoursePrice => ({
   has_financial_aid_request: true
 });
 
-export const makeCoursePrices = (programs: Dashboard): CoursePrices => (
-  programs.map(makeCoursePrice)
+export const makeCoursePrices = (dashboard: Dashboard): CoursePrices => (
+  dashboard.programs.map(makeCoursePrice)
 );

--- a/static/js/flow/dashboardTypes.js
+++ b/static/js/flow/dashboardTypes.js
@@ -3,11 +3,15 @@ import Decimal from 'decimal.js-light';
 import type { Program } from './programTypes';
 
 // likely to change in very near future
-export type Dashboard = Array<Program>;
+export type Dashboard = {
+  programs:   Array<Program>,
+  is_edx_data_fresh: boolean
+};
 
 export type DashboardState = {
-  programs:     Dashboard,
-  fetchStatus?: string,
+  programs:       Array<Program>,
+  isEdxDataFresh: boolean,
+  fetchStatus?:   string,
 };
 
 export type DashboardsState = {

--- a/static/js/lib/coupon.js
+++ b/static/js/lib/coupon.js
@@ -17,8 +17,10 @@ import type {
 import type {
   CoursePrice,
   CoursePrices,
-  Dashboard,
 } from '../flow/dashboardTypes';
+import type {
+  Program
+} from '../flow/programTypes';
 
 // For objects that have a program id, make a lookup for it
 type HasProgramId = {
@@ -28,7 +30,7 @@ function makeProgramIdLookup<T: HasProgramId>(arr: Array<T>): Map<number, T> {
   return new Map(arr.map((value: T) => [value.program_id, value]));
 }
 
-function* genPrices(programs: Dashboard, prices: CoursePrices, coupons: Coupons) {
+function* genPrices(programs: Array<Program>, prices: CoursePrices, coupons: Coupons) {
   const couponLookup: Map<number, Coupon> = makeProgramIdLookup(coupons);
   const priceLookup: Map<number, CoursePrice> = makeProgramIdLookup(prices);
 
@@ -54,7 +56,7 @@ export const calculatePrice = (
   return [coupon, calculateRunPrice(runId, courseId, price.program_id, price, coupon)];
 };
 
-export const calculatePrices = (programs: Dashboard, prices: CoursePrices, coupons: Coupons): CalculatedPrices => {
+export const calculatePrices = (programs: Array<Program>, prices: CoursePrices, coupons: Coupons): CalculatedPrices => {
   return new Map(genPrices(programs, prices, coupons));
 };
 

--- a/static/js/lib/coupon_test.js
+++ b/static/js/lib/coupon_test.js
@@ -42,7 +42,7 @@ describe('coupon utility functions', () => {
   describe('calculatePrice', () => {
     it('uses calculateRunPrice to figure out price', () => {
       let program = makeProgram();
-      let coupons = makeCoupons([program]);
+      let coupons = makeCoupons({"programs": [program]});
       let price = makeCoursePrice(program);
       let course = program.courses[0];
       let run = course.runs[0];
@@ -66,9 +66,10 @@ describe('coupon utility functions', () => {
     });
 
     it('uses calculateRunPrice to figure out prices', () => {
-      let programs = makeDashboard();
-      let prices = makeCoursePrices(programs);
-      let coupons = makeCoupons(programs);
+      let dashboard = makeDashboard();
+      let programs = dashboard.programs;
+      let prices = makeCoursePrices(dashboard);
+      let coupons = makeCoupons(dashboard);
 
       let stubPrice = 5;
       let calculateRunPriceStub = sandbox.stub(couponFuncs, 'calculateRunPrice');

--- a/static/js/reducers/dashboard.js
+++ b/static/js/reducers/dashboard.js
@@ -21,7 +21,8 @@ import type {
 import type { Action } from '../flow/reduxTypes';
 
 export const INITIAL_DASHBOARD_STATE: DashboardState = {
-  programs: []
+  programs: [],
+  isEdxDataFresh: true
 };
 
 const INITIAL_DASHBOARDS_STATE: DashboardsState = {};
@@ -47,7 +48,8 @@ export const dashboard = (state: DashboardsState = INITIAL_DASHBOARDS_STATE, act
   case RECEIVE_DASHBOARD_SUCCESS:
     return updateDashboardState(state, username, {
       fetchStatus: FETCH_SUCCESS,
-      programs: action.payload
+      programs: action.payload.programs,
+      isEdxDataFresh: action.payload.is_edx_data_fresh
     });
   case RECEIVE_DASHBOARD_FAILURE:
     return updateDashboardState(state, username, {

--- a/static/js/reducers/dashboard_test.js
+++ b/static/js/reducers/dashboard_test.js
@@ -53,12 +53,13 @@ describe('dashboard reducers', () => {
       RECEIVE_DASHBOARD_SUCCESS
     ]).then(state => {
       let dashboardState = state[SETTINGS.user.username];
-      assert.deepEqual(dashboardState.programs, DASHBOARD_RESPONSE);
+      assert.deepEqual(dashboardState.programs, DASHBOARD_RESPONSE.programs);
+      assert.equal(dashboardState.isEdxDataFresh, DASHBOARD_RESPONSE.is_edx_data_fresh);
       assert.equal(dashboardState.fetchStatus, FETCH_SUCCESS);
 
       return dispatchThen(clearDashboard(SETTINGS.user.username), [CLEAR_DASHBOARD]).then(state => {
         let dashboardState = state[SETTINGS.user.username];
-        assert.deepEqual(dashboardState, { programs: [] });
+        assert.deepEqual(dashboardState, { programs: [], isEdxDataFresh: true });
       });
     });
   });
@@ -79,7 +80,7 @@ describe('dashboard reducers', () => {
 
     let getRun = programs => programs[1].courses[0].runs[0];
 
-    let run = getRun(DASHBOARD_RESPONSE);
+    let run = getRun(DASHBOARD_RESPONSE.programs);
     assert.notEqual(run.status, 'new_status');
     return dispatchThen(
       updateCourseStatus(SETTINGS.user.username, run.course_id, 'new_status'),
@@ -95,7 +96,8 @@ describe('dashboard reducers', () => {
     let _username = '_username';
 
     let successExpectation = {
-      programs: DASHBOARD_RESPONSE,
+      programs: DASHBOARD_RESPONSE.programs,
+      isEdxDataFresh: DASHBOARD_RESPONSE.is_edx_data_fresh,
       fetchStatus: FETCH_SUCCESS
     };
 
@@ -123,7 +125,7 @@ describe('dashboard reducers', () => {
       ]).then(state => {
         assert.deepEqual(state, {
           [_username]: successExpectation,
-          [username]: { programs: [] }
+          [username]: { programs: [], isEdxDataFresh: true }
         });
       });
     });
@@ -139,7 +141,8 @@ describe('dashboard reducers', () => {
           [_username]: {
             fetchStatus: FETCH_FAILURE,
             errorInfo: 'err',
-            programs: []
+            programs: [],
+            isEdxDataFresh: true
           }
         });
       });
@@ -150,7 +153,7 @@ describe('dashboard reducers', () => {
 
       let getRun = programs => programs[1].courses[0].runs[0];
 
-      let run = getRun(DASHBOARD_RESPONSE);
+      let run = getRun(DASHBOARD_RESPONSE.programs);
       assert.notEqual(run.status, 'new_status');
 
       return dispatchThen(

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -292,406 +292,409 @@ export const USER_PROGRAM_RESPONSE = deepFreeze({
   "grade_average": 83
 });
 
-export const DASHBOARD_RESPONSE: Dashboard = deepFreeze([
-  {
-    "description": "Not passed program",
-    "title": "Not passed program",
-    "courses": [
-      {
-        "prerequisites": "",
-        "runs": [
-          {
-            "position": 1,
-            "title": "Gio Test Course #15",
-            "course_id": "course-v1:odl+GIO101+CR-FALL15",
-            "status": STATUS_NOT_PASSED,
-            "id": 1,
-            "course_start_date": "2016-09-22T11:48:27Z",
-            "fuzzy_start_date": "Fall 2016",
-            "course_end_date": "2016-09-09T10:20:10Z"
-          },
-          {
-            "position": 2,
-            "title": "Gio Test Course #14",
-            "course_id": "course-v1:odl+GIO101+FALL14",
-            "status": STATUS_NOT_PASSED,
-            "final_grade": "33",
-            "id": 2,
-            "course_start_date": "2016-08-22T11:48:27Z",
-            "fuzzy_start_date": "Fall 2017",
-            "course_end_date": "2016-09-09T10:20:10Z",
-          },
-          {
-            "certificate_url": "www.google.com",
-            "title": "Gio Test Course #13",
-            "status": STATUS_PASSED,
-            "position": 3,
-            "final_grade": "66",
-            "course_id": "course-v1:odl+GIO101+FALL13",
-            "id": 3,
-            "course_start_date": "2016-08-22T11:48:27Z",
-            "fuzzy_start_date": "Fall 2017",
-            "course_end_date": "2016-09-09T10:20:10Z",
-          }
-        ],
+export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
+  "is_edx_data_fresh": true,
+  "programs": [
+    {
+      "description": "Not passed program",
+      "title": "Not passed program",
+      "courses": [
+        {
+          "prerequisites": "",
+          "runs": [
+            {
+              "position": 1,
+              "title": "Gio Test Course #15",
+              "course_id": "course-v1:odl+GIO101+CR-FALL15",
+              "status": STATUS_NOT_PASSED,
+              "id": 1,
+              "course_start_date": "2016-09-22T11:48:27Z",
+              "fuzzy_start_date": "Fall 2016",
+              "course_end_date": "2016-09-09T10:20:10Z"
+            },
+            {
+              "position": 2,
+              "title": "Gio Test Course #14",
+              "course_id": "course-v1:odl+GIO101+FALL14",
+              "status": STATUS_NOT_PASSED,
+              "final_grade": "33",
+              "id": 2,
+              "course_start_date": "2016-08-22T11:48:27Z",
+              "fuzzy_start_date": "Fall 2017",
+              "course_end_date": "2016-09-09T10:20:10Z",
+            },
+            {
+              "certificate_url": "www.google.com",
+              "title": "Gio Test Course #13",
+              "status": STATUS_PASSED,
+              "position": 3,
+              "final_grade": "66",
+              "course_id": "course-v1:odl+GIO101+FALL13",
+              "id": 3,
+              "course_start_date": "2016-08-22T11:48:27Z",
+              "fuzzy_start_date": "Fall 2017",
+              "course_end_date": "2016-09-09T10:20:10Z",
+            }
+          ],
+          "position_in_program": 0,
+          "title": "Gio Course - failed, no grade",
+          "description": "",
+          "id": 1
+        },
+        {
+          "prerequisites": "",
+          "runs": [],
+          "position_in_program": 1,
+          "title": "8.MechCx Advanced Introductory Classical Mechanics",
+          "description": "",
+          "id": 2
+        },
+        {
+          "prerequisites": "",
+          "runs": [],
+          "position_in_program": 2,
+          "title": "EDX Demo course",
+          "description": "",
+          "id": 3
+        },
+        {
+          "prerequisites": "",
+          "runs": [],
+          "position_in_program": 3,
+          "title": "Peter Course",
+          "description": "",
+          "id": 4
+        }
+      ],
+      "financial_aid_availability": false,
+      "id": 3
+    },
+    {
+      "courses": [
+        {
+          "id": 5,
+          "position_in_program": 1,
+          "title": "Supply Chain and Logistics Fundamentals - enroll button",
+          "runs": [
+            {
+              "course_id": "course-v1:supply+chain",
+              "id": 4,
+              "status": STATUS_OFFERED,
+              "fuzzy_enrollment_start_date": null,
+              "title": "Supply Chain Design",
+              "enrollment_start_date": "2016-03-04T01:00:00Z",
+              "position": 0,
+              "price": 50.00,
+              "course_start_date": "2016-08-22T11:48:27Z",
+              "fuzzy_start_date": "Fall 2017",
+              "course_end_date": "2016-09-09T10:20:10Z",
+            }
+          ],
+          "description": null,
+          "prerequisites": null
+        },
+        {
+          "id": 6,
+          "position_in_program": 5,
+          "title": "Passed course - check mark, grade is 88%",
+          "runs": [
+            {
+              "certificate_url": "www.google.com",
+              "course_id": "course-v1:edX+DemoX+Demo_Course",
+              "id": 5,
+              "status": STATUS_PASSED,
+              "title": "Demo course",
+              "final_grade": "88",
+              "position": 0,
+              "course_start_date": "2016-08-22T11:48:27Z",
+              "fuzzy_start_date": "Fall 2017",
+              "course_end_date": "2016-09-09T10:20:10Z",
+            }
+          ],
+          "description": "The demo course",
+          "prerequisites": ""
+        },
+        {
+          "id": 7,
+          "position_in_program": 2,
+          "title": "Empty course - no status text",
+          "runs": [
+          ],
+          "description": null,
+          "prerequisites": null
+        },
+        {
+          "id": 6789,
+          "position_in_program": 11,
+          "title": "Current verified course - grade is 88%",
+          "runs": [
+            {
+              "certificate_url": "www.google.com",
+              "course_id": "course-v1:current",
+              "id": 5678,
+              "status": STATUS_CURRENTLY_ENROLLED,
+              "title": "Current course run",
+              "current_grade": "23",
+              "position": 0,
+              "course_start_date": "2016-08-22T11:48:27Z",
+              "fuzzy_start_date": "Fall 2017",
+              "course_end_date": "2016-09-09T10:20:10Z",
+            }
+          ],
+          "description": "The demo course",
+          "prerequisites": ""
+        },
+        {
+          "id": 8,
+          "position_in_program": 3,
+          "title": "Not verified course - upgrade button",
+          "runs": [
+            {
+              "id": 7,
+              "status": STATUS_CAN_UPGRADE,
+              "title": "Not verified run",
+              "course_id": "not-verified",
+              "position": 0,
+              "price": 50.00,
+              "course_start_date": "2016-08-22T11:48:27Z",
+              "fuzzy_start_date": "Fall 2017",
+              "course_end_date": "2016-09-09T10:20:10Z",
+              "course_upgrade_deadline": "2016-08-20T11:48:27Z",
+            }
+          ],
+          "description": null,
+          "prerequisites": null
+        },
+        {
+          "id": 10,
+          "position_in_program": 4,
+          "title": "Enrollment starting course - disabled enroll button, text says Enrollment begins 3/3/2106",
+          "runs": [
+            {
+              "course_id": "course-v1:supply+chain2",
+              "id": 8,
+              "status": STATUS_OFFERED,
+              "fuzzy_enrollment_start_date": null,
+              "title": "Enrollment starting run",
+              "enrollment_start_date": "2106-03-04T01:00:00Z",
+              "position": 0,
+              "price": 30.00,
+              "course_start_date": "2016-08-22T11:48:27Z",
+              "fuzzy_start_date": "Fall 2017",
+              "course_end_date": "2016-09-09T10:20:10Z",
+            }
+          ],
+          "description": null,
+          "prerequisites": null
+        },
+        {
+          "id": 1278,
+          "title": "Passed course, most recent run non-passed, older passed",
+          "position_in_program": 7,
+          "runs": [
+            {
+              "certificate_url": "www.google.com",
+              "title": "Passed run missing grade",
+              "status": STATUS_PASSED,
+              "position": 2,
+              "course_id": "course_id_one",
+              "id": 100,
+              "course_start_date": "2015-08-22T11:48:27Z",
+              "fuzzy_start_date": "Fall 2015",
+              "course_end_date": "2015-09-09T10:20:10Z",
+            },
+            {
+              "certificate_url": "www.google.com",
+              "title": "Passed run missing grade",
+              "status": STATUS_PASSED,
+              "position": 1,
+              "course_id": "course_id_two",
+              "final_grade": "88",
+              "id": 102,
+              "course_start_date": "2015-08-22T11:48:27Z",
+              "fuzzy_start_date": "Fall 2015",
+              "course_end_date": "2015-09-09T10:20:10Z",
+            },
+            {
+              "certificate_url": "www.google.com",
+              "title": "Passed run missing grade",
+              "status": STATUS_NOT_PASSED,
+              "position": 0,
+              "course_id": "course_id_three",
+              "final_grade": "43",
+              "id": 101,
+              "course_start_date": "2016-08-22T11:48:27Z",
+              "fuzzy_start_date": "Fall 2017",
+              "course_end_date": "2016-09-09T10:20:10Z",
+            }
+          ]
+        },
+        {
+          "id": 17,
+          "title": "Passed course missing grade - check mark, no grade",
+          "position_in_program": 6,
+          "runs": [
+            {
+              "certificate_url": "www.google.com",
+              "title": "Passed run missing grade",
+              "status": STATUS_PASSED,
+              "position": 0,
+              "course_id": "course_id",
+              "id": 10,
+              "course_start_date": "2016-08-22T11:48:27Z",
+              "fuzzy_start_date": "Fall 2017",
+              "course_end_date": "2016-09-09T10:20:10Z",
+            }
+          ]
+        },
+        {
+          "id": 15,
+          "position_in_program": 9,
+          "title": "verified not completed, course starts in future - action text is Course starting",
+          "runs": [
+            {
+              "id": 13,
+              "status": STATUS_WILL_ATTEND,
+              "course_start_date": "8765-03-21",
+              "title": "First run",
+              "position": 0,
+              "fuzzy_start_date": "Fall 2017",
+              "course_end_date": "2016-09-09T10:20:10Z",
+              "course_id": "verified",
+            }
+          ]
+        },
+        {
+          "id": 11,
+          "position_in_program": 0,
+          "title": "Fuzzy enrollment starting course - First in program, action text is enrollment begins soonish",
+          "runs": [
+            {
+              "course_id": "course-v1:supply+chain3",
+              "id": 9,
+              "status": STATUS_OFFERED,
+              "fuzzy_enrollment_start_date": "soonish",
+              "title": "Fuzzy enrollment starting run",
+              "position": 0,
+              "price": 40.00,
+              "course_start_date": "2016-08-22T11:48:27Z",
+              "fuzzy_start_date": "Fall 2017",
+              "course_end_date": "2016-09-09T10:20:10Z",
+            }
+          ],
+          "description": null,
+          "prerequisites": null
+        },
+        {
+          "id": 16,
+          "position_in_program": 10,
+          "title": "Pending enrollment course",
+          "runs": [
+            {
+              "course_id": "course-v1:pending",
+              "id": 47,
+              "title": "Pending enrollment course run",
+              "position": 0,
+              "status": STATUS_PENDING_ENROLLMENT,
+              "course_start_date": "2018-08-22T11:48:27Z",
+              "course_end_date": "2018-09-09T10:20:10Z",
+              "enrollment_start_date": "2016-03-04T01:00:00Z",
+            }
+          ]
+        }
+      ],
+      "title": "Master Program",
+      "description": null,
+      "financial_aid_availability": false,
+      "id": 4
+    },
+    {
+      "financial_aid_availability": false,
+      "title": "Missed deadline program",
+      "description": "Missed deadline program",
+      "courses": [{
+        "id": 9,
         "position_in_program": 0,
-        "title": "Gio Course - failed, no grade",
-        "description": "",
-        "id": 1
-      },
-      {
+        "title": "Course for the missed deadline program",
+        "description": "Course for the missed deadline program",
         "prerequisites": "",
-        "runs": [],
+        "runs": [{
+          "course_id": "course-v1:edX+missed+deadline",
+          "id": 12,
+          "status": STATUS_MISSED_DEADLINE,
+          "title": "Course run for the missed deadline program",
+          "position": 0,
+          "course_start_date": "2016-01-01",
+          "course_end_date": "2016-09-09T10:20:10Z",
+        }]
+      }],
+      "id": 5
+    },
+    {
+      "financial_aid_availability": false,
+      "title": "Empty program",
+      "description": "The empty program",
+      "courses": [
+      ],
+      "id": 2
+    },
+    {
+      "title": "Last program",
+      "description": "The last program",
+      "pearson_exam_status": "",
+      "courses": [
+        {
+          "id": 13,
+          "position_in_program": 0,
+          "title": "Course for last program in progress - no grade, action or description",
+          "runs": [
+            {
+              "course_id": "course-v1:edX+DemoX+Demo_Course2",
+              "id": 11,
+              "status": STATUS_CURRENTLY_ENROLLED,
+              "title": "Course run for last program",
+              "position": 0,
+              "course_start_date": "2016-01-01",
+              "fuzzy_start_date": "Fall 2017",
+              "course_end_date": "2016-09-09T10:20:10Z",
+            }
+          ],
+          "description": "Course for Last program",
+          "prerequisites": ""
+        },
+      ],
+      "financial_aid_availability": false,
+      "id": 6
+    },
+    {
+      "title": "Paid but not enrolled",
+      "description": "Paid but not enrolled",
+      "courses": [{
+        "id": 24,
         "position_in_program": 1,
-        "title": "8.MechCx Advanced Introductory Classical Mechanics",
-        "description": "",
-        "id": 2
-      },
-      {
+        "title": "Course for paid but not enrolled program",
+        "description": "Course for paid but not enrolled program",
         "prerequisites": "",
-        "runs": [],
-        "position_in_program": 2,
-        "title": "EDX Demo course",
-        "description": "",
-        "id": 3
-      },
-      {
-        "prerequisites": "",
-        "runs": [],
-        "position_in_program": 3,
-        "title": "Peter Course",
-        "description": "",
-        "id": 4
-      }
-    ],
-    "financial_aid_availability": false,
-    "id": 3
-  },
-  {
-    "courses": [
-      {
-        "id": 5,
-        "position_in_program": 1,
-        "title": "Supply Chain and Logistics Fundamentals - enroll button",
-        "runs": [
-          {
-            "course_id": "course-v1:supply+chain",
-            "id": 4,
-            "status": STATUS_OFFERED,
-            "fuzzy_enrollment_start_date": null,
-            "title": "Supply Chain Design",
-            "enrollment_start_date": "2016-03-04T01:00:00Z",
-            "position": 0,
-            "price": 50.00,
-            "course_start_date": "2016-08-22T11:48:27Z",
-            "fuzzy_start_date": "Fall 2017",
-            "course_end_date": "2016-09-09T10:20:10Z",
-          }
-        ],
-        "description": null,
-        "prerequisites": null
-      },
-      {
-        "id": 6,
-        "position_in_program": 5,
-        "title": "Passed course - check mark, grade is 88%",
-        "runs": [
-          {
-            "certificate_url": "www.google.com",
-            "course_id": "course-v1:edX+DemoX+Demo_Course",
-            "id": 5,
-            "status": STATUS_PASSED,
-            "title": "Demo course",
-            "final_grade": "88",
-            "position": 0,
-            "course_start_date": "2016-08-22T11:48:27Z",
-            "fuzzy_start_date": "Fall 2017",
-            "course_end_date": "2016-09-09T10:20:10Z",
-          }
-        ],
-        "description": "The demo course",
-        "prerequisites": ""
-      },
-      {
-        "id": 7,
-        "position_in_program": 2,
-        "title": "Empty course - no status text",
-        "runs": [
-        ],
-        "description": null,
-        "prerequisites": null
-      },
-      {
-        "id": 6789,
-        "position_in_program": 11,
-        "title": "Current verified course - grade is 88%",
-        "runs": [
-          {
-            "certificate_url": "www.google.com",
-            "course_id": "course-v1:current",
-            "id": 5678,
-            "status": STATUS_CURRENTLY_ENROLLED,
-            "title": "Current course run",
-            "current_grade": "23",
-            "position": 0,
-            "course_start_date": "2016-08-22T11:48:27Z",
-            "fuzzy_start_date": "Fall 2017",
-            "course_end_date": "2016-09-09T10:20:10Z",
-          }
-        ],
-        "description": "The demo course",
-        "prerequisites": ""
-      },
-      {
-        "id": 8,
-        "position_in_program": 3,
-        "title": "Not verified course - upgrade button",
-        "runs": [
-          {
-            "id": 7,
-            "status": STATUS_CAN_UPGRADE,
-            "title": "Not verified run",
-            "course_id": "not-verified",
-            "position": 0,
-            "price": 50.00,
-            "course_start_date": "2016-08-22T11:48:27Z",
-            "fuzzy_start_date": "Fall 2017",
-            "course_end_date": "2016-09-09T10:20:10Z",
-            "course_upgrade_deadline": "2016-08-20T11:48:27Z",
-          }
-        ],
-        "description": null,
-        "prerequisites": null
-      },
-      {
-        "id": 10,
-        "position_in_program": 4,
-        "title": "Enrollment starting course - disabled enroll button, text says Enrollment begins 3/3/2106",
-        "runs": [
-          {
-            "course_id": "course-v1:supply+chain2",
-            "id": 8,
-            "status": STATUS_OFFERED,
-            "fuzzy_enrollment_start_date": null,
-            "title": "Enrollment starting run",
-            "enrollment_start_date": "2106-03-04T01:00:00Z",
-            "position": 0,
-            "price": 30.00,
-            "course_start_date": "2016-08-22T11:48:27Z",
-            "fuzzy_start_date": "Fall 2017",
-            "course_end_date": "2016-09-09T10:20:10Z",
-          }
-        ],
-        "description": null,
-        "prerequisites": null
-      },
-      {
-        "id": 1278,
-        "title": "Passed course, most recent run non-passed, older passed",
-        "position_in_program": 7,
-        "runs": [
-          {
-            "certificate_url": "www.google.com",
-            "title": "Passed run missing grade",
-            "status": STATUS_PASSED,
-            "position": 2,
-            "course_id": "course_id_one",
-            "id": 100,
-            "course_start_date": "2015-08-22T11:48:27Z",
-            "fuzzy_start_date": "Fall 2015",
-            "course_end_date": "2015-09-09T10:20:10Z",
-          },
-          {
-            "certificate_url": "www.google.com",
-            "title": "Passed run missing grade",
-            "status": STATUS_PASSED,
-            "position": 1,
-            "course_id": "course_id_two",
-            "final_grade": "88",
-            "id": 102,
-            "course_start_date": "2015-08-22T11:48:27Z",
-            "fuzzy_start_date": "Fall 2015",
-            "course_end_date": "2015-09-09T10:20:10Z",
-          },
-          {
-            "certificate_url": "www.google.com",
-            "title": "Passed run missing grade",
-            "status": STATUS_NOT_PASSED,
-            "position": 0,
-            "course_id": "course_id_three",
-            "final_grade": "43",
-            "id": 101,
-            "course_start_date": "2016-08-22T11:48:27Z",
-            "fuzzy_start_date": "Fall 2017",
-            "course_end_date": "2016-09-09T10:20:10Z",
-          }
-        ]
-      },
-      {
-        "id": 17,
-        "title": "Passed course missing grade - check mark, no grade",
-        "position_in_program": 6,
-        "runs": [
-          {
-            "certificate_url": "www.google.com",
-            "title": "Passed run missing grade",
-            "status": STATUS_PASSED,
-            "position": 0,
-            "course_id": "course_id",
-            "id": 10,
-            "course_start_date": "2016-08-22T11:48:27Z",
-            "fuzzy_start_date": "Fall 2017",
-            "course_end_date": "2016-09-09T10:20:10Z",
-          }
-        ]
-      },
-      {
-        "id": 15,
-        "position_in_program": 9,
-        "title": "verified not completed, course starts in future - action text is Course starting",
-        "runs": [
-          {
-            "id": 13,
-            "status": STATUS_WILL_ATTEND,
-            "course_start_date": "8765-03-21",
-            "title": "First run",
-            "position": 0,
-            "fuzzy_start_date": "Fall 2017",
-            "course_end_date": "2016-09-09T10:20:10Z",
-            "course_id": "verified",
-          }
-        ]
-      },
-      {
-        "id": 11,
-        "position_in_program": 0,
-        "title": "Fuzzy enrollment starting course - First in program, action text is enrollment begins soonish",
-        "runs": [
-          {
-            "course_id": "course-v1:supply+chain3",
-            "id": 9,
-            "status": STATUS_OFFERED,
-            "fuzzy_enrollment_start_date": "soonish",
-            "title": "Fuzzy enrollment starting run",
-            "position": 0,
-            "price": 40.00,
-            "course_start_date": "2016-08-22T11:48:27Z",
-            "fuzzy_start_date": "Fall 2017",
-            "course_end_date": "2016-09-09T10:20:10Z",
-          }
-        ],
-        "description": null,
-        "prerequisites": null
-      },
-      {
-        "id": 16,
-        "position_in_program": 10,
-        "title": "Pending enrollment course",
-        "runs": [
-          {
-            "course_id": "course-v1:pending",
-            "id": 47,
-            "title": "Pending enrollment course run",
-            "position": 0,
-            "status": STATUS_PENDING_ENROLLMENT,
-            "course_start_date": "2018-08-22T11:48:27Z",
-            "course_end_date": "2018-09-09T10:20:10Z",
-            "enrollment_start_date": "2016-03-04T01:00:00Z",
-          }
-        ]
-      }
-    ],
-    "title": "Master Program",
-    "description": null,
-    "financial_aid_availability": false,
-    "id": 4
-  },
-  {
-    "financial_aid_availability": false,
-    "title": "Missed deadline program",
-    "description": "Missed deadline program",
-    "courses": [{
-      "id": 9,
-      "position_in_program": 0,
-      "title": "Course for the missed deadline program",
-      "description": "Course for the missed deadline program",
-      "prerequisites": "",
-      "runs": [{
-        "course_id": "course-v1:edX+missed+deadline",
-        "id": 12,
-        "status": STATUS_MISSED_DEADLINE,
-        "title": "Course run for the missed deadline program",
-        "position": 0,
-        "course_start_date": "2016-01-01",
-        "course_end_date": "2016-09-09T10:20:10Z",
-      }]
-    }],
-    "id": 5
-  },
-  {
-    "financial_aid_availability": false,
-    "title": "Empty program",
-    "description": "The empty program",
-    "courses": [
-    ],
-    "id": 2
-  },
-  {
-    "title": "Last program",
-    "description": "The last program",
-    "pearson_exam_status": "",
-    "courses": [
-      {
-        "id": 13,
-        "position_in_program": 0,
-        "title": "Course for last program in progress - no grade, action or description",
-        "runs": [
-          {
-            "course_id": "course-v1:edX+DemoX+Demo_Course2",
-            "id": 11,
-            "status": STATUS_CURRENTLY_ENROLLED,
-            "title": "Course run for last program",
-            "position": 0,
-            "course_start_date": "2016-01-01",
-            "fuzzy_start_date": "Fall 2017",
-            "course_end_date": "2016-09-09T10:20:10Z",
-          }
-        ],
-        "description": "Course for Last program",
-        "prerequisites": ""
-      },
-    ],
-    "financial_aid_availability": false,
-    "id": 6
-  },
-  {
-    "title": "Paid but not enrolled",
-    "description": "Paid but not enrolled",
-    "courses": [{
-      "id": 24,
-      "position_in_program": 1,
-      "title": "Course for paid but not enrolled program",
-      "description": "Course for paid but not enrolled program",
-      "prerequisites": "",
-      "runs": [{
-        "position": 1,
-        "course_id": "course-v1:MITx+paid+not+enrolled+100+Jan_2015",
-        "id": 66,
-        "course_start_date": "2016-12-20T00:00:00Z",
-        "course_end_date": "2018-05-15T00:00:00Z",
-        "enrollment_url": "",
-        "fuzzy_start_date": "",
-        "current_grade": null,
-        "title": "Digital Learning 100 - January 2015",
-        "status": STATUS_PAID_BUT_NOT_ENROLLED
-      }]
-    }],
-    "financial_aid_availability": true,
-    "id": 7
-  },
-]);
+        "runs": [{
+          "position": 1,
+          "course_id": "course-v1:MITx+paid+not+enrolled+100+Jan_2015",
+          "id": 66,
+          "course_start_date": "2016-12-20T00:00:00Z",
+          "course_end_date": "2018-05-15T00:00:00Z",
+          "enrollment_url": "",
+          "fuzzy_start_date": "",
+          "current_grade": null,
+          "title": "Digital Learning 100 - January 2015",
+          "status": STATUS_PAID_BUT_NOT_ENROLLED
+        }]
+      }],
+      "financial_aid_availability": true,
+      "id": 7
+    },
+  ]
+});
 
-export const PROGRAMS: AvailablePrograms = deepFreeze(DASHBOARD_RESPONSE.map(program => ({
+export const PROGRAMS: AvailablePrograms = deepFreeze(DASHBOARD_RESPONSE.programs.map(program => ({
   id: program.id,
   title: program.title,
   programpage_url: `/program${program.id}/`,
@@ -705,7 +708,7 @@ export const FINANCIAL_AID_PARTIAL_RESPONSE: FinancialAidUserInfo = deepFreeze({
   min_possible_cost: 1000
 });
 
-export const COURSE_PRICES_RESPONSE: CoursePrices = deepFreeze(DASHBOARD_RESPONSE.map(program => ({
+export const COURSE_PRICES_RESPONSE: CoursePrices = deepFreeze(DASHBOARD_RESPONSE.programs.map(program => ({
   program_id: program.id,
   price: Decimal(program.id * 1000),
   financial_aid_availability: false,

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -32,7 +32,7 @@ import LearnerSearchPage from '../containers/LearnerSearchPage';
 
 export function findCourse(courseSelector: (course: ?Course, program: ?Program) => boolean): Course {
   let [, course, ] = findCourseRun(
-    DASHBOARD_RESPONSE,
+    DASHBOARD_RESPONSE.programs,
     (courseRun, _course, program) => courseSelector(_course, program)
   );
   if (course !== null && course !== undefined) {

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -606,7 +606,7 @@ describe('utility functions', () => {
 
     it('returns an empty object for each if selector never matches', () => {
       assert.deepEqual(
-        findCourseRun(DASHBOARD_RESPONSE, () => false),
+        findCourseRun(DASHBOARD_RESPONSE.programs, () => false),
         [null, null, null],
       );
     });


### PR DESCRIPTION
#### What are the relevant tickets?
first part of #2181 

#### What's this PR do?
Changes tha data structure of the dashboard rest api and the JS code that uses it.
It also adds an extra key to the dashboard rest api response to specify if the edX cached data is fresh.
The dashboard REST API should not fail even if the backend edX instance is not available.
This is necessary to implement the message in the dashboard to specify if the cache has not been refreshed.

#### How should this be manually tested?
The dashboard should work as usual.
if you shut down the edX backend instance, the dashboard should still load.

#### Where should the reviewer start?
`dashboard/views.py`
`dashboard/api.py`
`static/js/reducers/ashboard.js`

#### Any background context you want to provide?
Most of the changes are in the JS tests because of the change in the structure of the response JSON coming from the REST API
