### PR TITLE
Various small style tweaks

### DIFF
--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -135,7 +135,7 @@
         </div>
       </section>
       <section class="row current-programs-section">
-        <h3>Current MITx MicroMasters Programs</h3>
+        <h3>MITx MicroMasters Programs</h3>
         <ul class="current-programs-list">
         {% for program, programpage in programs %}
           <li class="col-md-4">
@@ -239,12 +239,12 @@
         <div class="row quote">
           <img class="person" src="{% static 'images/reif1.png' %}" alt="">
           <blockquote class="quote-text">“We will find people who never thought they would be able to apply to MIT. And they will discover that they are much stronger in the global competition than they think.”</blockquote>
-          <p class="quote-author">-- Rafael Reif, MIT President  </p>
+          <p class="quote-author">Rafael Reif, MIT President  </p>
         </div>
         <div class="row quote">
           <img class="person" src="{% static 'images/sanjay1.png' %}" alt="">
           <blockquote class="quote-text">“Inverted admissions has the potential to disrupt traditional modes of access to higher education… We’re democratizing access to a master’s program for learners worldwide.”</blockquote>
-          <p class="quote-author">-- Sanjay Sarma, Vice President of Open Learning, MIT  </p>
+          <p class="quote-author">Sanjay Sarma, Vice President of Open Learning, MIT  </p>
         </div>
       </section>
 

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -401,7 +401,7 @@
   width: 88%;
   max-width: 1000px;
   padding-left: 10px;
-  margin: 10px auto 29px;
+  margin: 18px auto 29px;
   font-weight: 400;
   font-size: 20px;
 }

--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -621,8 +621,8 @@ body.app-media {
     color: rgba(255,255,255,.45);
 
     @include breakpoint(phone) {
-       color: rgba(255,255,255,.7);
-      }
+      color: rgba(255,255,255,.7);
+    }
   }
 }
 

--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -110,21 +110,19 @@ body.app-media {
 
       a.header-dashboard-link {
         display: inline-block;
-        background: rgba(0,0,0, 0.14);
-        margin: 0 15px 0 0;
-        padding: 12px 25px;
+        margin: 0 25px 0 0;
+        padding: 12px 0;
         font-weight: 400;
         font-size: 16px;
         color: #fff;
         text-decoration: none;
         position: relative;
-        top: 2px;
 
         @include breakpoint(phone) {
           text-align: center;
           padding: 13px 0;
           width: 48%;
-          margin-right: 4%;
+          margin-right: 0;
         }
       }
 
@@ -273,7 +271,7 @@ body.app-media {
       }
 
       @include breakpoint(phone) {
-        width: 90%;
+        width: 97%;
       }
 
       h3 {
@@ -383,8 +381,12 @@ body.app-media {
     text-align: left;
     border-bottom: 1px dashed #c5c5c5;
 
-    @include breakpoint(phone) {
-      width: 87%;
+    @include breakpoint(mobile) {
+      width: 95%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
     }
 
     img.person {
@@ -392,7 +394,7 @@ body.app-media {
       width: 170px;
       margin: 0 70px 80px;
 
-      @include breakpoint(phone) {
+      @include breakpoint(mobile) {
         float: none;
         margin: 0 auto;
       }
@@ -410,7 +412,7 @@ body.app-media {
       }
 
 
-      @include breakpoint(phone) {
+      @include breakpoint(mobile) {
         font-size: 19px;
         margin-top: 20px;
       }
@@ -420,6 +422,7 @@ body.app-media {
       color: $font-gray;
       font-size: 22px;
       font-weight: 300;
+      font-style: italic;
 
       @include breakpoint(phone) {
         font-size: 19px;
@@ -461,6 +464,10 @@ body.app-media {
 
     li {
       padding-bottom: 2.5em;
+
+      @include breakpoint(phone) {
+        padding-bottom: 1.5em;
+      }
     }
 
     .program-thumbnail {
@@ -514,11 +521,16 @@ body.app-media {
 
       @include breakpoint(phone) {
         padding: 20px 3px 30px;
+        height: auto;
       }
 
       p.program-description-text {
         max-height: 15em;
         overflow: auto;
+
+        @include breakpoint(phone) {
+          max-height: none;
+        }
       }
 
       p {
@@ -607,6 +619,10 @@ body.app-media {
 
   p {
     color: rgba(255,255,255,.45);
+
+    @include breakpoint(phone) {
+       color: rgba(255,255,255,.7);
+      }
   }
 }
 

--- a/static/scss/navbar.scss
+++ b/static/scss/navbar.scss
@@ -36,9 +36,11 @@
 
         .mdl-button--icon {
           width: 50px;
+          top: -10px;
 
           .material-icons {
-            font-size: 45px;
+            font-size: 40px;
+            opacity: .7;
           }
         }
 

--- a/static/scss/page-layout.scss
+++ b/static/scss/page-layout.scss
@@ -2,7 +2,7 @@ $border-box-sizing: true !global;
 
 .page-content {
   width: 100%;
-  padding: 21px 0 65px;
+  padding: 11px 0 65px;
 
   .single-column {
     max-width: 900px;

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -78,6 +78,11 @@
       margin-right: 10px;
     }
 
+    .sk-hierarchical-refinement-option {
+      line-height: 18px;
+      margin-bottom: 9px;
+    }
+
     // Search facet option text and count
     .sk-panel__content .sk-item-list-option__text,
     .sk-panel__content .sk-item-list-option__count,
@@ -410,8 +415,8 @@
         flex-direction: column;
 
         .display-name {
-          font-size: 15px;
-          font-weight: 500;
+          font-size: 14px;
+          font-weight: 400;
         }
 
         .user-name {
@@ -474,7 +479,7 @@
   &.left-nav {
     margin: 19px 6px 22px 6px;
     font-size: 14px;
-    padding: 0 75px;
+    padding: 0 40px;
   }
 }
 

--- a/ui/templates/header.html
+++ b/ui/templates/header.html
@@ -14,7 +14,7 @@
             {% else %}
               <a class="header-dashboard-link" href="/dashboard">My Dashboard</a>
             {% endif %}
-          <a class="mdl-button button-signup" href="/logout">
+          <a class="header-dashboard-link" href="/logout">
             Sign Out
           </a>
           {% else %}


### PR DESCRIPTION
#### What's this PR do?
This PR fixes some layout issues, and makes several other small style tweaks to the app, and the marketing site (some on mobile only):

- Small change to arrow placement and opacity in the sidebar
- Changes the style of the "Dashboard" and "Sign Out" links to look like links, not buttons.
- Improves the layout of the quote section on the home page for mobile devices (images and text are centered on mobile).
- Slight change to font-size and font-weight for the user name in Learner search results
- Fixes padding in learner search sidenav when there are No hits 
- Slight tweak to .page-content top padding
- Fixed spacing between programs on mobile 
- Changed width (margins) of sub-banner text on mobile

#### How should this be manually tested?
Check the small changes and see that the layout still looks ok.

#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/20047260/23962379/51e165d2-0984-11e7-9bd9-3b606152eb6c.png)

![image](https://cloud.githubusercontent.com/assets/20047260/23962397/60f663ba-0984-11e7-81fa-622d3ec17614.png)

![image](https://cloud.githubusercontent.com/assets/20047260/23962407/694d9dc6-0984-11e7-97ff-2bf0d725b4c5.png)

