### PR TITLE
Fixed lifecycle handling of DashboardPage to reload cleared items

### DIFF
--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -37,6 +37,14 @@ class BasicTests(SeleniumTestsBase):
         # Click the Enroll Now button on dashboard
         self.selenium.find_element_by_class_name("enroll-button").click()
         self.wait().until(lambda driver: driver.find_element_by_class_name("continue-payment"))
+
+        # Click back then click the enroll now button again to assert back button behavior
+        self.selenium.back()
+        self.wait().until(lambda driver: driver.find_element_by_class_name("enroll-button"))
+        self.selenium.find_element_by_class_name("enroll-button").click()
+        self.wait().until(lambda driver: driver.find_element_by_class_name("continue-payment"))
+        self.assert_console_logs()
+
         # Click 'Continue' on the order summary page
         self.selenium.find_element_by_class_name("continue-payment").click()
         self.wait().until(lambda driver: driver.find_element_by_class_name("description"))

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -580,15 +580,6 @@ class DashboardPage extends React.Component {
     if (prices.errorInfo) {
       return <ErrorMessage errorInfo={prices.errorInfo}/>;
     }
-    const program = this.getCurrentlyEnrolledProgram();
-    if (program) {
-      const coursePrice = prices.coursePrices.find(
-        coursePrice => coursePrice.program_id === program.id
-      );
-      if (coursePrice) {
-        return null;
-      }
-    }
     return null;
   };
 
@@ -683,10 +674,11 @@ class DashboardPage extends React.Component {
       prices
     } = this.props;
     const loaded = R.none(isProcessing, [dashboard.fetchStatus, prices.fetchStatus]);
+    const fetchStarted = !_.isNil(prices.fetchStatus) && !_.isNil(dashboard.fetchStatus);
 
     const errorMessage = this.renderErrorMessage();
     let pageContent;
-    if (_.isNil(errorMessage) && this.getCurrentlyEnrolledProgram()) {
+    if (_.isNil(errorMessage) && this.getCurrentlyEnrolledProgram() && loaded && fetchStarted) {
       pageContent = this.renderPageContent();
     }
 

--- a/static/js/dashboard_routes.js
+++ b/static/js/dashboard_routes.js
@@ -13,6 +13,7 @@ import Learner from './components/Learner';
 import OrderSummaryPage from './containers/OrderSummaryPage';
 
 const errorLoading = error => {
+  console.trace(error);
   throw new Error(`Dynamic page loading failed: ${error}`);
 };
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2878 

#### What's this PR do?
Fixes lifecycle handling in DashboardPage so the back button will work as expected

#### How should this be manually tested?
Click 'Pay now' and it should direct you to the order summary page. Press the back button and you should be back at the dashboard without an error.
