### PR TITLE
show average grade on the staff view of learner page

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -174,6 +174,7 @@ def get_info_for_program(mmtrack):
         "financial_aid_availability": mmtrack.financial_aid_available,
         "courses": [],
         "pearson_exam_status": mmtrack.pearson_exam_status,
+        "grade_average": mmtrack.calculate_final_grade_average(),
     }
     if mmtrack.financial_aid_available:
         data["financial_aid_user_info"] = {

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1395,6 +1395,7 @@ class InfoProgramTest(MockedESTestCase):
             'program': self.program,
             'financial_aid_available': False,
             'pearson_exam_status': ExamProfile.PROFILE_SUCCESS,
+            'calculate_final_grade_average.return_value': 91,
         })
         mock_info_course.return_value = {'position_in_program': 1}
         res = api.get_info_for_program(self.mmtrack)
@@ -1407,6 +1408,7 @@ class InfoProgramTest(MockedESTestCase):
             "courses": [{'position_in_program': 1}, {'position_in_program': 1}],
             "financial_aid_availability": False,
             "pearson_exam_status": ExamProfile.PROFILE_SUCCESS,
+            "grade_average": 91,
         }
         self.assertEqual(res, expected_data)
 
@@ -1417,6 +1419,7 @@ class InfoProgramTest(MockedESTestCase):
             'program': self.program_no_courses,
             'financial_aid_available': False,
             'pearson_exam_status': ExamProfile.PROFILE_INVALID,
+            'calculate_final_grade_average.return_value': 91,
         })
         res = api.get_info_for_program(self.mmtrack)
         assert mock_info_course.called is False
@@ -1427,6 +1430,7 @@ class InfoProgramTest(MockedESTestCase):
             "courses": [],
             "financial_aid_availability": False,
             'pearson_exam_status': ExamProfile.PROFILE_INVALID,
+            "grade_average": 91,
         }
         self.assertEqual(res, expected_data)
 
@@ -1443,6 +1447,7 @@ class InfoProgramTest(MockedESTestCase):
             'financial_aid_max_price': 456,
             'financial_aid_date_documents_sent': datetime.now(pytz.utc) - timedelta(hours=12),
             'pearson_exam_status': ExamProfile.PROFILE_IN_PROGRESS,
+            'calculate_final_grade_average.return_value': 91,
         }
         self.mmtrack.configure_mock(**kwargs)
         mock_info_course.return_value = {'position_in_program': 1}
@@ -1464,5 +1469,6 @@ class InfoProgramTest(MockedESTestCase):
                 "date_documents_sent": kwargs['financial_aid_date_documents_sent'],
             },
             "pearson_exam_status": ExamProfile.PROFILE_IN_PROGRESS,
+            "grade_average": 91,
         }
         self.assertEqual(res, expected_data)

--- a/static/js/components/StaffLearnerInfoCard.js
+++ b/static/js/components/StaffLearnerInfoCard.js
@@ -5,11 +5,12 @@ import R from 'ramda';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 
 import { circularProgressWidget } from './ProgressWidget';
-import { programCourseInfo } from '../util/util';
+import { programCourseInfo, classify } from '../util/util';
 import type { Program } from '../flow/programTypes';
 import CourseDescription from '../components/dashboard/CourseDescription';
 import CourseGrade from '../components/dashboard/CourseGrade';
 import { STATUS_OFFERED } from '../constants';
+import { S, getm } from '../lib/sanctuary';
 
 type StaffLearnerCardProps = {
   program: Program,
@@ -42,7 +43,7 @@ const renderCourseRuns = R.addIndex(R.map)((props, index) => (
 ));
 
 const programInfoBadge = (title, text) => (
-  <div className="program-info-badge">
+  <div className={`program-info-badge ${classify(title)}`}>
     <div className="program-badge">
       { text }
     </div>
@@ -54,6 +55,16 @@ const programInfoBadge = (title, text) => (
 
 const displayCourseRuns = R.compose(
   renderCourseRuns, R.flatten, R.map(formatCourseRuns), R.prop('courses')
+);
+
+// getProgramProp :: String -> Program -> Either String Number
+const getProgramProp = (prop, program) => (
+  S.maybeToEither('--', getm(prop, program))
+);
+
+// formatCourseGrade :: Program -> String
+const formatCourseGrade = program => (
+  getProgramProp('grade_average', program).map(grade => `${grade}%`).value
 );
 
 const StaffLearnerInfoCard = (props: StaffLearnerCardProps) => {
@@ -70,7 +81,7 @@ const StaffLearnerInfoCard = (props: StaffLearnerCardProps) => {
           <div className="progress-widget">
             { circularProgressWidget(63, 7, totalPassedCourses, totalCourses) }
           </div>
-          { programInfoBadge('Average program grade', '--') }
+          { programInfoBadge('Average program grade', formatCourseGrade(program)) }
           { programInfoBadge('Course Price', '--') }
         </div>
         { displayCourseRuns(program) }

--- a/static/js/components/StaffLearnerInfoCard_test.js
+++ b/static/js/components/StaffLearnerInfoCard_test.js
@@ -26,11 +26,11 @@ describe('StaffLearnerInfoCard', () => {
     sandbox.restore();
   });
 
-  let renderCard = () => (
+  let renderCard = (program = DASHBOARD_RESPONSE.programs[0]) => (
     mount(
       <MuiThemeProvider muiTheme={getMuiTheme()}>
         <StaffLearnerInfoCard
-          program={DASHBOARD_RESPONSE.programs[0]}
+          program={program}
         />
       </MuiThemeProvider>
     )
@@ -62,5 +62,18 @@ describe('StaffLearnerInfoCard', () => {
     let card = renderCard();
     assert.equal(card.find(CourseDescription).length, numRuns);
     assert.equal(card.find(CourseGrade).length, numRuns);
+  });
+
+  it('should show average grade, if present', () => {
+    let program = {...DASHBOARD_RESPONSE.programs[0]};
+    program.grade_average = 62;
+    let badge = renderCard(program)
+      .find('.average-program-grade .program-badge');
+    assert.equal(badge.text(), '62%');
+  });
+
+  it('should show "--" if the grade is not present', () => {
+    let badge = renderCard().find('.average-program-grade .program-badge');
+    assert.equal(badge.text(), '--');
   });
 });

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -113,6 +113,7 @@ export const makeProgram = (): Program => {
     pearson_exam_status: PEARSON_STATUSES[
       Math.floor(Math.random() * PEARSON_STATUSES.length)
     ],
+    grade_average: Math.floor(Math.random() * 100),
   };
 };
 

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -35,6 +35,7 @@ export type Program = {
   financial_aid_availability: boolean,
   financial_aid_user_info: FinancialAidUserInfo,
   pearson_exam_status: string,
+  grade_average: ?number,
 };
 
 export type Course = {

--- a/static/js/lib/sanctuary.js
+++ b/static/js/lib/sanctuary.js
@@ -27,8 +27,10 @@ export const ifNil = R.ifElse(R.isNil, () => S.Nothing());
  * wraps a function in a guard, which will return Nothing
  * if any of the arguments are null || undefined,
  * and otherwise will return Just(fn(...args))
- * 
+ *
  * Similar to S.toMaybe
+ *
+ * guard :: (a -> b) -> (a -> Maybe b)
  */
 export const guard = (func: Function) => (...args: any) => {
   if (R.any(R.isNil, args)) {
@@ -37,3 +39,8 @@ export const guard = (func: Function) => (...args: any) => {
     return S.Just(func(...args));
   }
 };
+
+// getm :: String -> Object -> Maybe a
+export const getm = R.curry((prop, obj) => (
+  S.toMaybe(R.prop(prop, obj))
+));

--- a/static/js/lib/sanctuary_test.js
+++ b/static/js/lib/sanctuary_test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import R from 'ramda';
 
-import { S, allJust, mstr, ifNil, guard } from './sanctuary';
+import { S, allJust, mstr, ifNil, guard, getm } from './sanctuary';
 const { Maybe, Just, Nothing } = S;
 
 export const assertMaybeEquality = (m1: Maybe, m2: Maybe) => {
@@ -91,6 +91,23 @@ describe('sanctuary util functions', () => {
           assertIsNothing(wrappedRestFunc(...R.update(i, nilVal, args)));
         }
       });
+    });
+  });
+
+  describe('getm', () => {
+    it('returns Nothing if a prop is not present', () => {
+      assertIsNothing(getm('prop', {}));
+    });
+
+    [null, undefined].forEach(nil => {
+      // $FlowFixMe
+      it(`returns Nothing if a prop is ${nil}`, () => {
+        assertIsNothing(getm('prop', {'prop': nil}));
+      });
+    });
+
+    it('returns Just(val) if a prop is present', () => {
+      assertIsJust(getm('prop', {prop: 'HI'}), 'HI');
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2853 

#### What's this PR do?

If the user has a program average grade we'll show it on the staff view of the learner page.

#### How should this be manually tested?

Well, if you already have a program average grade it should show up on `/learner`. If you don't you should see `--` instead.

if you don't have a program average grade you can use my API mocking patch, here: https://github.com/aliceriot/mm_patches/blob/master/mock_api.patch

to get a dashboard (for 'Last Program') which includes the `grade_average` property. Or I suppose you could edit the relevant line in `dashboard/api.py` to just return a number.