### PR TITLE
Make Material Design Lite configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "jsdom-global": "^2.1.1",
     "keycode": "2.1.1",
     "lodash": "^4.17.4",
+    "material-design-lite": "^1.3.0",
     "material-ui": "^0.16.3",
     "minimist": "^1.2.0",
     "mocha": "^3.2.0",

--- a/static/js/entry/style.js
+++ b/static/js/entry/style.js
@@ -1,9 +1,11 @@
 __webpack_public_path__ = `${SETTINGS.public_path}`;  // eslint-disable-line no-undef, camelcase
+
+// material design lite (MDL)
+import '../../scss/material-design-lite.scss';
+
 // bootstrap
 import 'style-loader!css-loader!bootstrap/dist/css/bootstrap.min.css';
 
-// react-mdl material-design-lite file
-import 'style-loader!css-loader!react-mdl/extra/material.css';
 // react-virtualized requirement
 import 'style-loader!css-loader!react-virtualized/styles.css';
 import 'style-loader!css-loader!react-virtualized-select/styles.css';

--- a/static/scss/material-design-lite.scss
+++ b/static/scss/material-design-lite.scss
@@ -1,0 +1,5 @@
+// Our overrides
+$color-primary: "27,122,227";
+
+// Core variables and mixins
+@import "~material-design-lite/src/material-design-lite";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4204,6 +4204,10 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+material-design-lite@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/material-design-lite/-/material-design-lite-1.3.0.tgz#d004ce3fee99a1eeb74a78b8a325134a5f1171d3"
+
 material-ui@^0.16.3:
   version "0.16.7"
   resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-0.16.7.tgz#5ec5080d5f227817092c449105df9cbc8807941c"


### PR DESCRIPTION
#### What are the relevant tickets?
This is a utility that future improvements can build upon. It is related to #2732, but doesn't have its own ticket.

#### What's this PR do?
[Material Design Lite](https://github.com/google/material-design-lite) is designed to be very configurable and flexible, by exposing many, well-organized [Sass variables that can be overridden](https://github.com/google/material-design-lite/blob/mdl-1.x/src/_variables.scss). Previously, we were importing a CSS file for MDL, which had already passed through a Sass processor. This pull request changes how we load MDL, so that we can override the variables and configure it to look and work the way we want, _without_ resorting to `!important`.

This pull request overrides one variable (`$color-primary`), just to verify that it does work properly. However, this override is currently hidden by the CSS cascade, so there should be no user-visible changes in this pull request.

#### How should this be manually tested?
On the dashboard, open the course enrollment dialog. Inspect one of the buttons in that dialog. You should see that the `.mdl-button.mdl-button--colored` CSS rule sets the `color` to `rgb(27,122,227)`, which matches the value set in the override file in this pull request. If you want, you can change the `$color-primary` variable to another color, let Sass recompile, and then inspect the element again. The CSS rule should match whatever color you define.

<img width="1344" alt="material-design-lite-override" src="https://cloud.githubusercontent.com/assets/132355/24018921/48f5fd78-0a6c-11e7-9204-674a176349fd.png">
