### PR TITLE
Optimized the exam status query in MMTrack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ webpack-stats.json
 
 # Celery Beat
 celerybeat-schedule
+
+# profiling
+recreate_index_*.profile

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -398,14 +398,14 @@ class MMTrack:
 
         course_runs_for_program = CourseRun.objects.filter(
             course__program=self.program
-        )
+        ).select_related('course__program').only('course', 'edx_course_key')
 
         if not any(course_run.has_exam for course_run in course_runs_for_program):
             return ""
 
         user = self.user
         try:
-            exam_profile = ExamProfile.objects.get(profile=user.profile)
+            exam_profile = ExamProfile.objects.only('status').get(profile=user.profile)
         except ExamProfile.DoesNotExist:
             return ExamProfile.PROFILE_ABSENT
 

--- a/search/management/commands/recreate_index.py
+++ b/search/management/commands/recreate_index.py
@@ -17,6 +17,15 @@ class Command(BaseCommand):
     """
     help = "Clears existing Elasticsearch indices and creates a new index and mapping."
 
+    def add_arguments(self, parser):  # pylint: disable=no-self-use
+        """Configure command args"""
+        parser.add_argument(
+            '--profile',
+            action='store_true',
+            dest='profile',
+            default=False,
+        )
+
     def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
         """
         Recreates the index
@@ -27,4 +36,15 @@ class Command(BaseCommand):
         log.addHandler(console)
         log.level = logging.INFO
 
-        recreate_index()
+        if kwargs['profile']:
+            import cProfile
+            import uuid
+            profile = cProfile.Profile()
+            profile.enable()
+            recreate_index()
+            profile.disable()
+            filename = 'recreate_index_{}.profile'.format(uuid.uuid4())
+            profile.dump_stats(filename)
+            self.stdout.write('Output profiling data to: {}'.format(filename))
+        else:
+            recreate_index()


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2893

#### What's this PR do?
Optimizes two `QuerySet`s in `get_pearson_exam_status` that could be done in less queries and by fetching less data overall. Locally I found this to reduce time spent in that method by ~80% (1.6s -> 0.3s). This should regain some performance that was lost in reindexing and the dashboard api, although it was probably only noticeable in aggregate.

#### How should this be manually tested?
Be sure you can load the dashboard and run `./manage.py recreate_index`. Also run `./manage.py recreate_index --profile` and be sure that outputs a `.profile` file for you. `python -m pstats <filename>` if you want to interact with the results.

#### Where should the reviewer start?
dashboard/utils.py
