### PR TITLE
Added message for failed edx cache refresh

### DIFF
--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import R from 'ramda';
 import Dialog from 'material-ui/Dialog';
+import Alert from 'react-bootstrap/lib/Alert';
 
 import Loader from '../components/Loader';
 import { calculatePrices } from '../lib/coupon';
@@ -569,6 +570,30 @@ class DashboardPage extends React.Component {
     />;
   }
 
+  renderEdxCacheRefreshErrorMessage() {
+    const { dashboard } = this.props;
+    if (dashboard.isEdxDataFresh) {
+      return null;
+    }
+    const email = SETTINGS.support_email;
+
+    return (
+      <div className="alert-message alert-message-inline">
+        <Alert bsStyle="danger">
+          <p>
+            Sorry, edx.org is not responding as expected, so some of the information
+            on this page may not be up to date. <br />
+            Please refresh the browser, or check back later.
+          </p>
+          <p>
+            If the error persists, contact <a href={`mailto:${email}`}>
+            {email}</a> for help.
+          </p>
+        </Alert>
+      </div>
+    );
+  }
+
   renderErrorMessage = (): React$Element<*>|null => {
     const {
       dashboard,
@@ -629,6 +654,7 @@ class DashboardPage extends React.Component {
 
     return (
       <div>
+        {this.renderEdxCacheRefreshErrorMessage()}
         <h5 className="program-title-dashboard">{program.title}</h5>
         <div className="double-column">
           <DocsInstructionsDialog

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -73,6 +73,7 @@ import { findCourseRun } from '../util/util';
 import {
   COUPON,
   DASHBOARD_RESPONSE,
+  ERROR_RESPONSE,
 } from '../test_constants';
 import {
   FA_ALL_STATUSES,
@@ -91,7 +92,10 @@ import {
   findCourse,
   modifyTextField,
 } from '../util/test_utils';
-import { DASHBOARD_SUCCESS_ACTIONS } from './test_util';
+import {
+  DASHBOARD_SUCCESS_ACTIONS,
+  DASHBOARD_ERROR_ACTIONS,
+} from './test_util';
 
 describe('DashboardPage', () => {
   let renderComponent, helper, listenForActions;
@@ -562,6 +566,37 @@ describe('DashboardPage', () => {
           assert.isTrue(state.ui.enrollCourseDialogVisibility);
           assert.deepEqual(state.ui.enrollSelectedCourseRun, course.runs[0]);
         });
+      });
+    });
+  });
+
+  describe('edx cache refresh error message', () => {
+    let dashboardResponse;
+    const ERROR_MESSAGE_SELECTOR = '.alert-message-inline';
+
+    beforeEach(() => {
+      dashboardResponse = R.clone(DASHBOARD_RESPONSE);
+    });
+
+    it('if the edx is fresh there is no error box', () => {
+      helper.dashboardStub.returns(Promise.resolve(dashboardResponse));
+      return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
+        assert.lengthOf(wrapper.find(ERROR_MESSAGE_SELECTOR), 0);
+      });
+    });
+
+    it('if the edx is not fresh there is the error box', () => {
+      dashboardResponse.is_edx_data_fresh = false;
+      helper.dashboardStub.returns(Promise.resolve(dashboardResponse));
+      return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
+        assert.lengthOf(wrapper.find(ERROR_MESSAGE_SELECTOR), 1);
+      });
+    });
+
+    it('if the dashboard does not load there is no error box for edx cache', () => {
+      helper.dashboardStub.returns(Promise.reject(ERROR_RESPONSE));
+      return renderComponent("/dashboard", DASHBOARD_ERROR_ACTIONS).then(([wrapper]) => {
+        assert.lengthOf(wrapper.find(ERROR_MESSAGE_SELECTOR), 0);
       });
     });
   });

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -401,7 +401,14 @@
   width: 88%;
   max-width: 1000px;
   padding-left: 10px;
-  margin: 18px auto 29px;
+  margin: 10px auto 29px;
   font-weight: 400;
   font-size: 20px;
+}
+
+.alert-message-inline {
+  width: 88%;
+  max-width: 1000px;
+  padding: 0 10px;
+  margin: 10px auto 29px;
 }


### PR DESCRIPTION
#### What are the relevant tickets?
closes #2181 

#### What's this PR do?
adds an error message box in case the dashboard rest API returns that the edX cache is not fresh

#### How should this be manually tested?
stop the backend edX instance and refresh the dashboard (wait 6 minutes to be sure that the cache is not fresh any more)

#### Where should the reviewer start?
`static/js/containers/DashboardPage.js`
