### PR TITLE
Improve disabled UI buttons

### DIFF
--- a/static/js/components/ProgressWidget.js
+++ b/static/js/components/ProgressWidget.js
@@ -73,7 +73,7 @@ export default class ProgressWidget extends React.Component {
         <p className="heading-paragraph">
           On completion, you can apply for
           the master’s degree program</p>
-           <Button className="progress-button disabled">
+           <Button className="progress-button" disabled>
              Apply for Master’s
            </Button>
       </Card>

--- a/static/js/components/ProgressWidget_test.js
+++ b/static/js/components/ProgressWidget_test.js
@@ -138,6 +138,6 @@ describe('ProgressWidget', () => {
       wrapper.find(".heading-paragraph").text(),
       "On completion, you can apply for the master’s degree program"
     );
-    assert.isTrue(wrapper.find(".progress-button").hasClass('disabled'), 'Button is disable');
+    assert.isTrue(wrapper.find(".progress-button").props().disabled, 'Button is disable');
   });
 });

--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -101,16 +101,6 @@
     background: #1d67a7 !important;
   }
 
-  &.progress-button {
-    color: #ffffff !important;
-    background-color: #989898 !important;
-    box-shadow: none;
-  }
-
-  &.progress-button:hover {
-    box-shadow: none;
-  }
-
   &.minor-action {
     font-size: 13px;
     color: #4a4a4a;
@@ -141,6 +131,17 @@
     background: none;
     box-shadow: none;
     background-color: none;
+  }
+
+  &[disabled], &.progress-button[disabled] {
+    color: white;
+    background-color: $medgrey;
+    box-shadow: none;
+
+    &:hover {
+      cursor: not-allowed;
+      box-shadow: none;
+    }
   }
 }
 
@@ -236,11 +237,6 @@
   &[disabled] {
     background-color: adjust-color($button-color, $alpha: -0.5);
   }
-}
-
-.disabled {
-  background-color: $lightgrey;
-  cursor: not-allowed;
 }
 
 a.btn {

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -222,7 +222,7 @@
 
         .mdl-button[disabled] {
           background-color: $medgrey;
-          color: #ffffff;
+          color: white;
           box-shadow: none;
         }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2900 

#### What's this PR do?
Improves consistency and accessibility of disabled buttons in the application. Now all disabled buttons should have `$medgrey` background color, white text, and a "not allowed" cursor on hover.

#### How should this be manually tested?
Go to the dashboard for a financial aid program, before you've calculated your financial aid. Make sure that the disabled "pay now" buttons are consistent, as well as the disabled "Apply for Masters" button on the right side of the page. Check the screenshots to see what I mean.

#### Screenshots (if appropriate)
<img width="362" alt="screen shot 2017-03-17 at 12 49 32 pm" src="https://cloud.githubusercontent.com/assets/132355/24053691/3d93b4bc-0b10-11e7-9d9c-97eb95db6b6c.png">
<img width="643" alt="screen shot 2017-03-17 at 12 49 41 pm" src="https://cloud.githubusercontent.com/assets/132355/24053693/3d9638a4-0b10-11e7-9e06-6967a9764d50.png">
<img width="583" alt="screen shot 2017-03-17 at 12 49 47 pm" src="https://cloud.githubusercontent.com/assets/132355/24053692/3d947500-0b10-11e7-86b7-94d6c9dc8c32.png">
