### PR TITLE
Create thumbnails in Profile.save

### DIFF
--- a/profiles/models.py
+++ b/profiles/models.py
@@ -2,12 +2,16 @@
 Models for user profile
 """
 import re
+from uuid import uuid4
 
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import JSONField
 from django.db import models, transaction
 
 from profiles.util import (
+    IMAGE_SMALL_MAX_DIMENSION,
+    IMAGE_MEDIUM_MAX_DIMENSION,
+    make_thumbnail,
     profile_image_upload_uri,
     profile_image_upload_uri_small,
     profile_image_upload_uri_medium,
@@ -176,9 +180,16 @@ class Profile(models.Model):
     updated_on = models.DateTimeField(blank=True, null=True, auto_now=True)
 
     @transaction.atomic
-    def save(self, *args, **kwargs):
-        """Set the student_id number to the PK number"""
-        # first save the profile
+    def save(self, *args, update_thumbnails=False, **kwargs):
+        """Set the student_id number to the PK number and update thumbnails if necessary"""
+        if update_thumbnails:
+            small_thumbnail = make_thumbnail(self.image.file, IMAGE_SMALL_MAX_DIMENSION)
+            medium_thumbnail = make_thumbnail(self.image.file, IMAGE_MEDIUM_MAX_DIMENSION)
+
+            # name doesn't matter here, we use upload_to to produce that
+            self.image_small.save("{}.jpg".format(uuid4().hex), small_thumbnail)
+            self.image_medium.save("{}.jpg".format(uuid4().hex), medium_thumbnail)
+
         super(Profile, self).save(*args, **kwargs)
         # if there is no student id, assign the same number of the primary key
         if self.student_id is None:

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -1,8 +1,6 @@
 """
 Serializers for user profiles
 """
-from uuid import uuid4
-
 from django.db import transaction
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import (
@@ -16,11 +14,6 @@ from profiles.models import (
     Education,
     Employment,
     Profile,
-)
-from profiles.util import (
-    IMAGE_SMALL_MAX_DIMENSION,
-    IMAGE_MEDIUM_MAX_DIMENSION,
-    make_thumbnail,
 )
 
 
@@ -180,15 +173,8 @@ class ProfileSerializer(ProfileBaseSerializer):
                 else:
                     setattr(instance, attr, value)
 
-            if 'image' in validated_data:
-                small_thumbnail = make_thumbnail(validated_data['image'], IMAGE_SMALL_MAX_DIMENSION)
-                medium_thumbnail = make_thumbnail(validated_data['image'], IMAGE_MEDIUM_MAX_DIMENSION)
-
-                # name doesn't matter here, we use upload_to to produce that
-                instance.image_small.save("{}.jpg".format(uuid4().hex), small_thumbnail)
-                instance.image_medium.save("{}.jpg".format(uuid4().hex), medium_thumbnail)
-
-            instance.save()
+            update_thumbnails = 'image' in validated_data
+            instance.save(update_thumbnails=update_thumbnails)
             if 'work_history' in self.initial_data:
                 update_work_history(validated_data['work_history'], instance.id)
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2750 

#### What's this PR do?
Creates thumbnails in `save()` instead of in serializer. This will allow other code to update the image and create the related thumbnails automatically even when they don't use the serializer.

#### How should this be manually tested?
Upload a new image and verify that the image of your avatar is the new image and a medium sized version of it
