### PR TITLE
Fix refresh loop on learner page

### DIFF
--- a/static/js/containers/LearnerPage.js
+++ b/static/js/containers/LearnerPage.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import Loader from '../components/Loader';
 import R from 'ramda';
 
-import { FETCH_PROCESSING, FETCH_SUCCESS } from '../actions';
+import { FETCH_PROCESSING, FETCH_SUCCESS, FETCH_FAILURE } from '../actions';
 import { clearProfile } from '../actions/profile';
 import {
   profileFormContainer,
@@ -25,7 +25,7 @@ import type { DashboardsState } from '../flow/dashboardTypes';
 import type { AllEmailsState } from '../flow/emailTypes';
 
 const notFetchingOrFetched = R.compose(
-  R.not, R.contains(R.__, [FETCH_PROCESSING, FETCH_SUCCESS])
+  R.not, R.contains(R.__, [FETCH_PROCESSING, FETCH_SUCCESS, FETCH_FAILURE])
 );
 
 type LearnerPageProps = ProfileContainerProps & {

--- a/static/js/containers/LearnerPage_test.js
+++ b/static/js/containers/LearnerPage_test.js
@@ -63,6 +63,7 @@ import StaffLearnerInfoCard from '../components/StaffLearnerInfoCard';
 import {
   REQUEST_DASHBOARD,
   RECEIVE_DASHBOARD_SUCCESS,
+  RECEIVE_DASHBOARD_FAILURE,
 } from '../actions/dashboard';
 
 describe("LearnerPage", function() {
@@ -1010,6 +1011,16 @@ describe("LearnerPage", function() {
       const actions = userActions.concat([REQUEST_DASHBOARD, RECEIVE_DASHBOARD_SUCCESS]);
       return renderComponent(`/learner/${username}`, actions).then(([wrapper, ]) => {
         assert.equal(wrapper.find(StaffLearnerInfoCard).length, 1);
+      });
+    });
+
+    it('should only load dashboard API once if loading failed', () => {
+      helper.dashboardStub.returns(Promise.reject());
+      const username = SETTINGS.user.username;
+      SETTINGS.roles.push({ role: 'staff', permissions: [] });
+      const actions = userActions.concat([REQUEST_DASHBOARD, RECEIVE_DASHBOARD_FAILURE]);
+      return renderComponent(`/learner/${username}`, actions).then(([wrapper, ]) => {
+        assert.equal(wrapper.find(StaffLearnerInfoCard).length, 0);
       });
     });
   });


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2905 
Fixes #2907

#### What's this PR do?
Fixes handling of `FETCH_FAILURE` to prevent a refresh loop on dashboard error

#### How should this be manually tested?
On master, in `lib/api.js` have `getDashboard` return `Promise.reject()` then load the learner page. It should cause the loop. Switch to this branch and repeat the change to `lib/api.js` and the failure should only happen once.

