### PR TITLE
Cleaned up MMTrack final grade code

### DIFF
--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -5,7 +5,6 @@ from courses.utils import get_year_season_from_course_run
 from dashboard.models import CachedEnrollment
 from dashboard.utils import get_mmtrack
 from roles.api import is_learner
-from grades.models import FinalGrade
 
 
 class UserProgramSearchSerializer:
@@ -51,10 +50,7 @@ class UserProgramSearchSerializer:
         """
         final_grades = []
         for enrollment in enrollments:
-            try:
-                final_grade = mmtrack.get_final_grade(enrollment.course_run.edx_course_key)
-            except FinalGrade.DoesNotExist:
-                continue
+            final_grade = mmtrack.get_final_grade_percent(enrollment.course_run.edx_course_key)
             if final_grade:
                 final_grades.append({'title': enrollment.course_run.course.title, 'grade': final_grade})
         return final_grades

--- a/exams/utils.py
+++ b/exams/utils.py
@@ -119,7 +119,7 @@ def authorize_for_exam(mmtrack, course_run):
     # if user passed the course and currently not authorization for that run then give
     # her authorizations.
     ok_for_authorization = (
-        mmtrack.has_passed_course_for_exam(course_run.edx_course_key) and
+        mmtrack.has_passed_course(course_run.edx_course_key) and
         not ExamAuthorization.objects.filter(
             user=mmtrack.user,
             course=course_run.course,

--- a/seed_data/management/commands/alter_data_test.py
+++ b/seed_data/management/commands/alter_data_test.py
@@ -25,7 +25,7 @@ class AlterDataCommandTests(MockedESTestCase):
         set_to_passed(user=self.user, course_run=self.course_run, grade=grade)
         mmtrack = get_mmtrack(self.user, self.course_run.course.program)
         assert mmtrack.has_passed_course(self.course_run.edx_course_key)
-        assert int(mmtrack.get_final_grade(self.course_run.edx_course_key)) == (grade * 100)
+        assert int(mmtrack.get_final_grade_percent(self.course_run.edx_course_key)) == (grade * 100)
 
     def test_set_to_failed(self):
         """set_to_failed should set a CourseRun to failed for a given User"""
@@ -33,4 +33,4 @@ class AlterDataCommandTests(MockedESTestCase):
         set_to_failed(user=self.user, course_run=self.course_run, grade=grade)
         mmtrack = get_mmtrack(self.user, self.course_run.course.program)
         assert not mmtrack.has_passed_course(self.course_run.edx_course_key)
-        assert int(mmtrack.get_final_grade(self.course_run.edx_course_key)) == (grade * 100)
+        assert int(mmtrack.get_final_grade_percent(self.course_run.edx_course_key)) == (grade * 100)


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket. This is being done as part of the larger effort to clean up the dashboard API and MMTrack

#### What's this PR do?

Generally refactors the final grade-related code in `MMTrack`. More specifically:

- Does away with the exception-raising behavior related to fetching a final grade for a user's course run.
- Refactors several methods to use single database queries where they previously looped through course run id's and executed a query for each one.
- Fixes inconsistent function naming.

#### How should this be manually tested?

`alter_data` can be used to set course runs to be passed/failed, and can then be confirmed on the dashboard page

#### Where should the reviewer start?

`dashboard/utils.py`

#### Any background context you want to provide?
While working on #2890, I noticed a few code smells in `dashboard.utils.MMTrack` related to final grades. Some of the issues:

- `extract_final_grade` was using Django's `get`, which throws `DoesNotExist` exceptions, and there was a lot of code for catching those exceptions. This didn't seem like the best approach since a course run not having an associated `FinalGrade` is not exceptional/unexpected. The abundance of code blocks that included `except FinalGrade.DoesNotExist: continue` and the existence of `MMTrack.has_passed_course_for_exam` was evidence of this. Getting rid of the exception-raising behavior eliminated a decent amount of code and is more readable (IMO)
- There were several functions that looped through a list of course run keys and queried `FinalGrade` for each one. The same logic was easily accomplished by defining a simple model manager and using single queries in each case. That got rid of a good amount of code and is obviously more efficient
- Function names/docs were interchangeably referring to grades as 'final' grades and 'frozen' grades. I changed instances of 'frozen' to 'final'

This should also help us move some functionality outside of `MMTrack` where it's appropriate. `mail/permissions.py`, for example, has a couple of permissions where `MMTrack` needs to be  instantiated just to find out if a user has paid for a course run in a given program. Instantiating `MMTrack` does a fair amount of work that isn't necessary for that logic. The `FinalGradeQuerySet` will allow us to create API methods outside off `MMTrack` which can be used in those permission classes (and elsewhere) without the extra overhead

