### PR TITLE
Show image upload only for logged in user

### DIFF
--- a/static/js/containers/ProfileImage.js
+++ b/static/js/containers/ProfileImage.js
@@ -104,10 +104,12 @@ class ProfileImage extends React.Component {
     return (
       <div className="profile-image">
         <div className="avatar">
-          <ProfileImageUploader
-            {...this.props}
-            updateUserPhoto={this.updateUserPhoto}
-          />
+          {userPrivilegeCheck(profile,
+            <ProfileImageUploader
+              {...this.props}
+              updateUserPhoto={this.updateUserPhoto}
+            />
+          )}
           <img
             src={imageUrl}
             alt={`Profile image for ${getPreferredName(profile, false)}`}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2912

#### What's this PR do?
Only renders `ProfileImageUploader` for the logged in user

#### How should this be manually tested?
Go to `/learners` and make sure there is more than one row in the learner view. Open the nav bar and click 'Edit Photo'. You should be able to upload a new photo.
