### PR TITLE
refactor course price actions and reducer

### DIFF
--- a/static/js/actions/course_enrollments.js
+++ b/static/js/actions/course_enrollments.js
@@ -4,7 +4,7 @@ import type { Dispatch } from 'redux';
 import { createAction } from 'redux-actions';
 
 import { fetchDashboard } from './dashboard';
-import { fetchCoursePrices } from './';
+import { fetchCoursePrices } from './course_prices';
 import type { Dispatcher } from '../flow/reduxTypes';
 import * as api from '../lib/api';
 
@@ -24,7 +24,7 @@ export const addCourseEnrollment = (courseId: string): Dispatcher<*> => {
       then(() => {
         dispatch(receiveAddCourseEnrollmentSuccess());
         dispatch(fetchDashboard(SETTINGS.user.username));
-        dispatch(fetchCoursePrices());
+        dispatch(fetchCoursePrices(SETTINGS.user.username));
         return Promise.resolve();
       }).
       catch(() => {

--- a/static/js/actions/course_prices.js
+++ b/static/js/actions/course_prices.js
@@ -1,0 +1,31 @@
+// @flow
+import type { Dispatch } from 'redux';
+
+import * as api from '../lib/api';
+import type { Dispatcher } from '../flow/reduxTypes';
+import type { CoursePrices } from '../flow/dashboardTypes';
+import { withUsername } from './util';
+
+export const REQUEST_COURSE_PRICES = 'REQUEST_COURSE_PRICES';
+export const requestCoursePrices = withUsername(REQUEST_COURSE_PRICES);
+
+export const RECEIVE_COURSE_PRICES_SUCCESS = 'RECEIVE_COURSE_PRICES_SUCCESS';
+export const receiveCoursePricesSuccess = withUsername(RECEIVE_COURSE_PRICES_SUCCESS);
+
+export const RECEIVE_COURSE_PRICES_FAILURE = 'RECEIVE_COURSE_PRICES_FAILURE';
+export const receiveCoursePricesFailure = withUsername(RECEIVE_COURSE_PRICES_FAILURE);
+
+export const CLEAR_COURSE_PRICES = 'CLEAR_COURSE_PRICES';
+export const clearCoursePrices = withUsername(CLEAR_COURSE_PRICES);
+
+export function fetchCoursePrices(username: string): Dispatcher<CoursePrices> {
+  return (dispatch: Dispatch) => {
+    dispatch(requestCoursePrices(username));
+    return api.getCoursePrices().
+      then(coursePrices => dispatch(receiveCoursePricesSuccess(username, coursePrices))).
+      catch(error => {
+        dispatch(receiveCoursePricesFailure(username, error));
+        // the exception is assumed handled and will not be propagated
+      });
+  };
+}

--- a/static/js/actions/course_prices_test.js
+++ b/static/js/actions/course_prices_test.js
@@ -1,0 +1,24 @@
+// @flow
+import {
+  requestCoursePrices,
+  receiveCoursePricesSuccess,
+  receiveCoursePricesFailure,
+  clearCoursePrices,
+
+  REQUEST_COURSE_PRICES,
+  RECEIVE_COURSE_PRICES_SUCCESS,
+  RECEIVE_COURSE_PRICES_FAILURE,
+  CLEAR_COURSE_PRICES,
+} from './course_prices';
+import { assertWithUsernameActionHelper } from './test_util';
+
+describe('generated index action helpers', () => {
+  it('should create all action creators', () => {
+    [
+      [requestCoursePrices, REQUEST_COURSE_PRICES],
+      [receiveCoursePricesSuccess, RECEIVE_COURSE_PRICES_SUCCESS],
+      [receiveCoursePricesFailure, RECEIVE_COURSE_PRICES_FAILURE],
+      [clearCoursePrices, CLEAR_COURSE_PRICES],
+    ].forEach(assertWithUsernameActionHelper);
+  });
+});

--- a/static/js/actions/documents.js
+++ b/static/js/actions/documents.js
@@ -4,7 +4,7 @@ import { createAction } from 'redux-actions';
 import type { Dispatch } from 'redux';
 
 import { fetchDashboard } from './dashboard';
-import { fetchCoursePrices } from './';
+import { fetchCoursePrices } from './course_prices';
 import * as api from '../lib/api';
 import type { Dispatcher } from '../flow/reduxTypes';
 
@@ -27,7 +27,7 @@ export const updateDocumentSentDate = (financialAidId: number, dateSent: string)
       () => {
         dispatch(receiveUpdateDocumentSentDateSuccess());
         dispatch(fetchDashboard(SETTINGS.user.username));
-        dispatch(fetchCoursePrices());
+        dispatch(fetchCoursePrices(SETTINGS.user.username));
         return Promise.resolve();
       },
       () => {

--- a/static/js/actions/financial_aid.js
+++ b/static/js/actions/financial_aid.js
@@ -6,7 +6,7 @@ import { createAction } from 'redux-actions';
 import type { Dispatcher } from '../flow/reduxTypes';
 import * as api from '../lib/api';
 import { fetchDashboard } from './dashboard';
-import { fetchCoursePrices } from './';
+import { fetchCoursePrices } from './course_prices';
 
 export const START_CALCULATOR_EDIT = 'START_CALCULATOR_EDIT';
 export const startCalculatorEdit = createAction(START_CALCULATOR_EDIT);
@@ -35,7 +35,7 @@ export const addFinancialAid = (income: number, currency: string, programId: num
     return api.addFinancialAid(income, currency, programId).then(
       () => {
         dispatch(receiveAddFinancialAidSuccess());
-        dispatch(fetchCoursePrices());
+        dispatch(fetchCoursePrices(SETTINGS.user.username));
         dispatch(fetchDashboard(SETTINGS.user.username));
         return Promise.resolve();
       },
@@ -64,7 +64,7 @@ export const skipFinancialAid = (programId: number): Dispatcher<*> => {
     return api.skipFinancialAid(programId).then(
       () => {
         dispatch(receiveSkipFinancialAidSuccess());
-        dispatch(fetchCoursePrices());
+        dispatch(fetchCoursePrices(SETTINGS.user.username));
         dispatch(fetchDashboard(SETTINGS.user.username));
         return Promise.resolve();
       },

--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -7,7 +7,6 @@ import * as api from '../lib/api';
 import type { CheckoutResponse } from '../flow/checkoutTypes';
 import type { APIErrorInfo } from '../flow/generalTypes';
 import type { Dispatcher } from '../flow/reduxTypes';
-import type { CoursePrices } from '../flow/dashboardTypes';
 
 // constants for fetch status (these are not action types)
 export const FETCH_FAILURE = 'FETCH_FAILURE';
@@ -45,28 +44,3 @@ export const RECEIVE_CHECKOUT_FAILURE = 'RECEIVE_CHECKOUT_FAILURE';
 export const receiveCheckoutFailure = createAction(RECEIVE_CHECKOUT_FAILURE,
   (errorInfo: APIErrorInfo) => ({errorInfo })
 );
-
-// course price actions
-export const REQUEST_COURSE_PRICES = 'REQUEST_COURSE_PRICES';
-export const requestCoursePrices = createAction(REQUEST_COURSE_PRICES);
-
-export const RECEIVE_COURSE_PRICES_SUCCESS = 'RECEIVE_COURSE_PRICES_SUCCESS';
-export const receiveCoursePricesSuccess = createAction(RECEIVE_COURSE_PRICES_SUCCESS);
-
-export const RECEIVE_COURSE_PRICES_FAILURE = 'RECEIVE_COURSE_PRICES_FAILURE';
-export const receiveCoursePricesFailure = createAction(RECEIVE_COURSE_PRICES_FAILURE);
-
-export const CLEAR_COURSE_PRICES = 'CLEAR_COURSE_PRICES';
-export const clearCoursePrices = createAction(CLEAR_COURSE_PRICES);
-
-export function fetchCoursePrices(): Dispatcher<CoursePrices> {
-  return (dispatch: Dispatch) => {
-    dispatch(requestCoursePrices());
-    return api.getCoursePrices().
-      then(coursePrices => dispatch(receiveCoursePricesSuccess(coursePrices))).
-      catch(error => {
-        dispatch(receiveCoursePricesFailure(error));
-        // the exception is assumed handled and will not be propagated
-      });
-  };
-}

--- a/static/js/actions/index_test.js
+++ b/static/js/actions/index_test.js
@@ -5,32 +5,14 @@ import {
   requestCheckout,
   receiveCheckoutSuccess,
   receiveCheckoutFailure,
-  requestCoursePrices,
-  receiveCoursePricesSuccess,
-  receiveCoursePricesFailure,
-  clearCoursePrices,
 
   REQUEST_CHECKOUT,
   RECEIVE_CHECKOUT_SUCCESS,
   RECEIVE_CHECKOUT_FAILURE,
-  REQUEST_COURSE_PRICES,
-  RECEIVE_COURSE_PRICES_SUCCESS,
-  RECEIVE_COURSE_PRICES_FAILURE,
-  CLEAR_COURSE_PRICES,
 } from './';
-import { assertCreatedActionHelper } from './test_util';
 import { ERROR_RESPONSE } from '../constants';
 
 describe('generated index action helpers', () => {
-  it('should create all action creators', () => {
-    [
-      [requestCoursePrices, REQUEST_COURSE_PRICES],
-      [receiveCoursePricesSuccess, RECEIVE_COURSE_PRICES_SUCCESS],
-      [receiveCoursePricesFailure, RECEIVE_COURSE_PRICES_FAILURE],
-      [clearCoursePrices, CLEAR_COURSE_PRICES],
-    ].forEach(assertCreatedActionHelper);
-  });
-
   it('requestCheckout passes a course id', () => {
     assert.deepEqual(requestCheckout('course_id'), {
       type: REQUEST_CHECKOUT,

--- a/static/js/actions/programs.js
+++ b/static/js/actions/programs.js
@@ -8,7 +8,7 @@ import {
   TOAST_FAILURE,
 } from '../constants';
 import { fetchDashboard } from './dashboard';
-import { fetchCoursePrices } from './';
+import { fetchCoursePrices } from './course_prices';
 import { setToastMessage, setEnrollProgramDialogVisibility } from '../actions/ui';
 import type { Dispatcher } from '../flow/reduxTypes';
 import type {
@@ -62,7 +62,7 @@ export const addProgramEnrollment = (programId: number): Dispatcher<AvailablePro
         }));
         dispatch(setEnrollProgramDialogVisibility(false));
         dispatch(fetchDashboard(SETTINGS.user.username));
-        dispatch(fetchCoursePrices());
+        dispatch(fetchCoursePrices(SETTINGS.user.username));
       }).
       catch(error => {
         dispatch(receiveAddProgramEnrollmentFailure(error));

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -14,7 +14,7 @@ import {
 import {
   REQUEST_COURSE_PRICES,
   RECEIVE_COURSE_PRICES_SUCCESS,
-} from '../actions';
+} from '../actions/course_prices';
 import {
   REQUEST_FETCH_COUPONS,
   RECEIVE_FETCH_COUPONS_SUCCESS,

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -14,9 +14,11 @@ import { calculatePrices } from '../lib/coupon';
 import {
   FETCH_SUCCESS,
   FETCH_PROCESSING,
+} from '../actions';
+import {
   fetchCoursePrices,
   clearCoursePrices,
-} from '../actions';
+} from '../actions/course_prices';
 import {
   updateCourseStatus,
   fetchDashboard,
@@ -101,7 +103,7 @@ import {
 } from '../actions/pearson';
 import { generateSSOForm } from '../lib/pearson';
 import type { PearsonAPIState } from '../reducers/pearson';
-import { getOwnDashboard } from '../reducers/util';
+import { getOwnDashboard, getOwnCoursePrices } from '../reducers/util';
 
 const isProcessing = R.equals(FETCH_PROCESSING);
 const PEARSON_TOS_DIALOG = "pearsonTOSDialogVisible";
@@ -268,7 +270,7 @@ class DashboardPage extends React.Component {
   fetchCoursePrices() {
     const { prices, dispatch } = this.props;
     if (prices.fetchStatus === undefined) {
-      dispatch(fetchCoursePrices());
+      dispatch(fetchCoursePrices(SETTINGS.user.username));
     }
   }
 
@@ -745,7 +747,7 @@ const mapStateToProps = (state) => {
   return {
     profile: profile,
     dashboard: getOwnDashboard(state),
-    prices: state.prices,
+    prices: getOwnCoursePrices(state),
     programs: state.programs,
     currentProgramEnrollment: state.currentProgramEnrollment,
     ui: state.ui,

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -21,10 +21,8 @@ import {
   UPDATE_COURSE_STATUS,
   CLEAR_DASHBOARD,
 } from '../actions/dashboard';
-import {
-  CLEAR_COURSE_PRICES,
-  FETCH_SUCCESS,
-} from '../actions';
+import { CLEAR_COURSE_PRICES } from '../actions/course_prices';
+import { FETCH_SUCCESS } from '../actions';
 import * as dashboardActions from '../actions/dashboard';
 import { CLEAR_COUPONS } from '../actions/coupons';
 import {

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -43,7 +43,7 @@ import {
 import {
   REQUEST_COURSE_PRICES,
   RECEIVE_COURSE_PRICES_SUCCESS,
-} from '../actions/index';
+} from '../actions/course_prices';
 import { DASHBOARD_SUCCESS_ACTIONS } from './test_util';
 
 describe('FinancialAidCalculator', () => {

--- a/static/js/containers/OrderSummaryPage.js
+++ b/static/js/containers/OrderSummaryPage.js
@@ -9,12 +9,11 @@ import type { Profiles } from '../flow/profileTypes';
 import type { CoursePricesState, DashboardState } from '../flow/dashboardTypes';
 import type { AvailableProgram } from '../flow/enrollmentTypes';
 import OrderSummary from '../components/OrderSummary';
+import { FETCH_PROCESSING, checkout } from '../actions';
 import {
-  FETCH_PROCESSING,
   fetchCoursePrices,
-  checkout,
   clearCoursePrices,
-} from '../actions';
+} from '../actions/course_prices';
 import {
   clearDashboard,
   fetchDashboard,
@@ -27,7 +26,7 @@ import type { CouponsState } from '../reducers/coupons';
 import type { CheckoutState } from '../reducers';
 import { createForm, findCourseRun } from '../util/util';
 import { calculatePrice } from '../lib/coupon';
-import { getOwnDashboard } from '../reducers/util';
+import { getOwnDashboard, getOwnCoursePrices } from '../reducers/util';
 
 class OrderSummaryPage extends React.Component {
   static contextTypes = {
@@ -69,7 +68,7 @@ class OrderSummaryPage extends React.Component {
   fetchCoursePrices() {
     const { prices, dispatch } = this.props;
     if (prices.fetchStatus === undefined) {
-      dispatch(fetchCoursePrices());
+      dispatch(fetchCoursePrices(SETTINGS.user.username));
     }
   }
 
@@ -155,8 +154,8 @@ const mapStateToProps = (state) => {
   return {
     profile: profile,
     dashboard: getOwnDashboard(state),
+    prices: getOwnCoursePrices(state),
     currentProgramEnrollment: state.currentProgramEnrollment,
-    prices: state.prices,
     orderReceipt: state.orderReceipt,
     checkout: state.checkout,
     coupons: state.coupons,

--- a/static/js/containers/test_util.js
+++ b/static/js/containers/test_util.js
@@ -7,7 +7,7 @@ import {
 import {
   REQUEST_COURSE_PRICES,
   RECEIVE_COURSE_PRICES_SUCCESS,
-} from '../actions';
+} from '../actions/course_prices';
 import {
   REQUEST_FETCH_COUPONS,
   RECEIVE_FETCH_COUPONS_SUCCESS,

--- a/static/js/flow/dashboardTypes.js
+++ b/static/js/flow/dashboardTypes.js
@@ -31,3 +31,7 @@ export type CoursePricesState = {
   coursePrices: CoursePrices,
   fetchStatus?: string,
 }
+
+export type CoursePriceReducerState = {
+  [username: string]: CoursePricesState
+};

--- a/static/js/reducers/course_enrollments_test.js
+++ b/static/js/reducers/course_enrollments_test.js
@@ -14,7 +14,7 @@ import {
   RECEIVE_ADD_COURSE_ENROLLMENT_FAILURE,
 } from '../actions/course_enrollments';
 import * as api from '../lib/api';
-import * as actions from '../actions';
+import * as coursePriceActions from '../actions/course_prices';
 import * as dashboardActions from '../actions/dashboard';
 import rootReducer from '../reducers';
 
@@ -36,7 +36,7 @@ describe('enrollments', () => {
     beforeEach(() => {
       dispatchThen = store.createDispatchThen(state => state.courseEnrollments);
 
-      fetchCoursePricesStub = sandbox.stub(actions, 'fetchCoursePrices');
+      fetchCoursePricesStub = sandbox.stub(coursePriceActions, 'fetchCoursePrices');
       fetchCoursePricesStub.returns({type: "fake"});
       fetchDashboardStub = sandbox.stub(dashboardActions, 'fetchDashboard');
       fetchDashboardStub.returns({type: "fake"});

--- a/static/js/reducers/course_prices.js
+++ b/static/js/reducers/course_prices.js
@@ -1,0 +1,51 @@
+// @flow
+import _ from 'lodash';
+import R from 'ramda';
+
+import {
+  REQUEST_COURSE_PRICES,
+  RECEIVE_COURSE_PRICES_SUCCESS,
+  RECEIVE_COURSE_PRICES_FAILURE,
+  CLEAR_COURSE_PRICES,
+} from '../actions/course_prices';
+import {
+  FETCH_FAILURE,
+  FETCH_PROCESSING,
+  FETCH_SUCCESS,
+} from '../actions';
+import type { Action } from '../flow/reduxTypes';
+import type {
+  CoursePricesState,
+  CoursePriceReducerState,
+} from '../flow/dashboardTypes';
+import { updateStateByUsername } from './util';
+
+export const INITIAL_COURSE_PRICES_STATE: CoursePricesState = {
+  coursePrices: []
+};
+
+export const prices = (state: CoursePriceReducerState = {}, action: Action<any, string>) => {
+  const { meta: username } = action;
+  switch (action.type) {
+  case REQUEST_COURSE_PRICES:
+    return updateStateByUsername(
+      R.dissoc(username, state),
+      username,
+      _.merge({}, INITIAL_COURSE_PRICES_STATE, { fetchStatus: FETCH_PROCESSING })
+    );
+  case RECEIVE_COURSE_PRICES_SUCCESS:
+    return updateStateByUsername(state, username, {
+      fetchStatus: FETCH_SUCCESS,
+      coursePrices: action.payload,
+    });
+  case RECEIVE_COURSE_PRICES_FAILURE:
+    return updateStateByUsername(state, username, {
+      fetchStatus: FETCH_FAILURE,
+      errorInfo: action.payload
+    });
+  case CLEAR_COURSE_PRICES:
+    return updateStateByUsername(R.dissoc(username, state), username, INITIAL_COURSE_PRICES_STATE);
+  default:
+    return state;
+  }
+};

--- a/static/js/reducers/course_prices_test.js
+++ b/static/js/reducers/course_prices_test.js
@@ -1,0 +1,71 @@
+import configureTestStore from 'redux-asserts';
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+import rootReducer from '../reducers';
+import * as api from '../lib/api';
+import {
+  fetchCoursePrices,
+  clearCoursePrices,
+  REQUEST_COURSE_PRICES,
+  RECEIVE_COURSE_PRICES_SUCCESS,
+  RECEIVE_COURSE_PRICES_FAILURE,
+  CLEAR_COURSE_PRICES,
+} from '../actions/course_prices';
+import { COURSE_PRICES_RESPONSE } from '../test_constants';
+import {
+  FETCH_FAILURE,
+  FETCH_SUCCESS
+} from '../actions';
+
+describe('prices reducer', () => {
+  let sandbox, store, dispatchThen, pricesStub;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    store = configureTestStore(rootReducer);
+    dispatchThen = store.createDispatchThen(state => state.prices);
+    pricesStub = sandbox.stub(api, 'getCoursePrices');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    store = null;
+    dispatchThen = null;
+  });
+
+  it('should have an empty default state', () => {
+    return dispatchThen({type: 'unknown'}, ['unknown']).then(state => {
+      assert.deepEqual(state, {});
+    });
+  });
+
+  it('should fetch the prices successfully then clear it', () => {
+    pricesStub.returns(Promise.resolve(COURSE_PRICES_RESPONSE));
+
+    return dispatchThen(fetchCoursePrices('username'), [
+      REQUEST_COURSE_PRICES,
+      RECEIVE_COURSE_PRICES_SUCCESS,
+    ]).then(({ username: pricesState }) => {
+      assert.deepEqual(pricesState.coursePrices, COURSE_PRICES_RESPONSE);
+      assert.equal(pricesState.fetchStatus, FETCH_SUCCESS);
+
+      return dispatchThen(clearCoursePrices('username'), [CLEAR_COURSE_PRICES]).then(({ username: pricesState }) => {
+        assert.deepEqual(pricesState, {
+          coursePrices: []
+        });
+      });
+    });
+  });
+
+  it('should fail to fetch the dashboard', () => {
+    pricesStub.returns(Promise.reject());
+
+    return dispatchThen(fetchCoursePrices('username'), [
+      REQUEST_COURSE_PRICES,
+      RECEIVE_COURSE_PRICES_FAILURE,
+    ]).then(({ username: pricesState }) => {
+      assert.equal(pricesState.fetchStatus, FETCH_FAILURE);
+    });
+  });
+});

--- a/static/js/reducers/dashboard.js
+++ b/static/js/reducers/dashboard.js
@@ -19,6 +19,7 @@ import type {
   DashboardState,
 } from '../flow/dashboardTypes';
 import type { Action } from '../flow/reduxTypes';
+import { updateStateByUsername } from './util';
 
 export const INITIAL_DASHBOARD_STATE: DashboardState = {
   programs: [],
@@ -27,32 +28,28 @@ export const INITIAL_DASHBOARD_STATE: DashboardState = {
 
 const INITIAL_DASHBOARDS_STATE: DashboardsState = {};
 
-const updateDashboardState = (state, username, update) => (
-  _.merge({}, state, {[username]: update })
-);
-
 export const dashboard = (state: DashboardsState = INITIAL_DASHBOARDS_STATE, action: Action<any, string>) => {
   const { meta: username } = action;
   switch (action.type) {
   case REQUEST_DASHBOARD: // eslint-disable-line no-case-declarations
     let newBaseState = R.dissoc(username, state);
     if (action.payload === true) {
-      return updateDashboardState(newBaseState, username, INITIAL_DASHBOARD_STATE);
+      return updateStateByUsername(newBaseState, username, INITIAL_DASHBOARD_STATE);
     } else {
-      return updateDashboardState(
+      return updateStateByUsername(
         newBaseState,
         username,
         _.merge({}, INITIAL_DASHBOARD_STATE, { fetchStatus: FETCH_PROCESSING })
       );
     }
   case RECEIVE_DASHBOARD_SUCCESS:
-    return updateDashboardState(state, username, {
+    return updateStateByUsername(state, username, {
       fetchStatus: FETCH_SUCCESS,
       programs: action.payload.programs,
       isEdxDataFresh: action.payload.is_edx_data_fresh
     });
   case RECEIVE_DASHBOARD_FAILURE:
-    return updateDashboardState(state, username, {
+    return updateStateByUsername(state, username, {
       fetchStatus: FETCH_FAILURE,
       errorInfo: action.payload,
     });
@@ -68,10 +65,10 @@ export const dashboard = (state: DashboardsState = INITIAL_DASHBOARDS_STATE, act
         }
       }
     }
-    return updateDashboardState(state, username, { programs });
+    return updateStateByUsername(state, username, { programs });
   }
   case CLEAR_DASHBOARD:
-    return updateDashboardState(
+    return updateStateByUsername(
       R.dissoc(username, state), username, INITIAL_DASHBOARD_STATE
     );
   default:

--- a/static/js/reducers/documents_test.js
+++ b/static/js/reducers/documents_test.js
@@ -17,7 +17,7 @@ import {
   RECEIVE_UPDATE_DOCUMENT_SENT_DATE_FAILURE,
   updateDocumentSentDate,
 } from '../actions/documents';
-import * as actions from '../actions';
+import * as coursePriceActions from '../actions/course_prices';
 import * as dashboardActions from '../actions/dashboard';
 import type { DocumentsState } from '../reducers/documents';
 import rootReducer from '../reducers';
@@ -51,7 +51,7 @@ describe('documents reducers', () => {
 
     beforeEach(() => {
       updateDocumentSentDateStub = sandbox.stub(api, 'updateDocumentSentDate');
-      fetchCoursePricesStub = sandbox.stub(actions, 'fetchCoursePrices');
+      fetchCoursePricesStub = sandbox.stub(coursePriceActions, 'fetchCoursePrices');
       fetchCoursePricesStub.returns({type: "fake"});
       fetchDashboardStub = sandbox.stub(dashboardActions, 'fetchDashboard');
       fetchDashboardStub.returns({type: "fake"});

--- a/static/js/reducers/financial_aid_test.js
+++ b/static/js/reducers/financial_aid_test.js
@@ -28,7 +28,7 @@ import {
   FETCH_PROCESSING,
   FETCH_SUCCESS,
 } from '../actions';
-import * as actions from '../actions';
+import * as coursePriceActions from '../actions/course_prices';
 import * as dashboardActions from '../actions/dashboard';
 import { setCurrentProgramEnrollment } from '../actions/programs';
 import { FINANCIAL_AID_EDIT } from './financial_aid';
@@ -49,7 +49,7 @@ describe('financial aid reducers', () => {
     skipFinancialAidStub = sandbox.stub(api, 'skipFinancialAid');
     fetchDashboardStub = sandbox.stub(dashboardActions, 'fetchDashboard');
     fetchDashboardStub.returns({type: "fake"});
-    fetchCoursePricesStub = sandbox.stub(actions, 'fetchCoursePrices');
+    fetchCoursePricesStub = sandbox.stub(coursePriceActions, 'fetchCoursePrices');
     fetchCoursePricesStub.returns({type: "fake"});
   });
 

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -23,11 +23,6 @@ import {
   RECEIVE_CHECKOUT_SUCCESS,
   RECEIVE_CHECKOUT_FAILURE,
 
-  REQUEST_COURSE_PRICES,
-  RECEIVE_COURSE_PRICES_SUCCESS,
-  RECEIVE_COURSE_PRICES_FAILURE,
-  CLEAR_COURSE_PRICES,
-
   FETCH_FAILURE,
   FETCH_PROCESSING,
   FETCH_SUCCESS,
@@ -39,7 +34,6 @@ import {
   programs,
 } from './programs';
 import { courseEnrollments } from './course_enrollments';
-import type { CoursePricesState } from '../flow/dashboardTypes';
 import type { Action } from '../flow/reduxTypes';
 import type {
   ProfileGetResult,
@@ -53,6 +47,7 @@ import { orderReceipt } from './order_receipt';
 import { coupons } from './coupons';
 import { pearson } from './pearson';
 import { dashboard } from './dashboard';
+import { prices } from './course_prices';
 import { ALL_ERRORS_VISIBLE } from '../constants';
 
 export const INITIAL_PROFILES_STATE = {};
@@ -200,35 +195,6 @@ export const checkout = (state: CheckoutState = INITIAL_CHECKOUT_STATE, action: 
       ...state,
       fetchStatus: FETCH_FAILURE,
     };
-  default:
-    return state;
-  }
-};
-
-const INITIAL_COURSE_PRICES_STATE: CoursePricesState = {
-  coursePrices: []
-};
-export const prices = (state: CoursePricesState = INITIAL_COURSE_PRICES_STATE, action: Action<any, null>) => {
-  switch (action.type) {
-  case REQUEST_COURSE_PRICES:
-    return {
-      ...state,
-      fetchStatus: FETCH_PROCESSING
-    };
-  case RECEIVE_COURSE_PRICES_SUCCESS:
-    return {
-      ...state,
-      fetchStatus: FETCH_SUCCESS,
-      coursePrices: action.payload
-    };
-  case RECEIVE_COURSE_PRICES_FAILURE:
-    return {
-      ...state,
-      fetchStatus: FETCH_FAILURE,
-      errorInfo: action.payload
-    };
-  case CLEAR_COURSE_PRICES:
-    return INITIAL_COURSE_PRICES_STATE;
   default:
     return state;
   }

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -31,21 +31,12 @@ import {
   REQUEST_CHECKOUT,
   RECEIVE_CHECKOUT_SUCCESS,
   RECEIVE_CHECKOUT_FAILURE,
-
-  fetchCoursePrices,
-  clearCoursePrices,
-  REQUEST_COURSE_PRICES,
-  RECEIVE_COURSE_PRICES_SUCCESS,
-  RECEIVE_COURSE_PRICES_FAILURE,
-  CLEAR_COURSE_PRICES,
-
-
   FETCH_FAILURE,
   FETCH_SUCCESS
-} from '../actions/index';
+} from '../actions';
+
 import * as api from '../lib/api';
 import {
-  COURSE_PRICES_RESPONSE,
   USER_PROFILE_RESPONSE,
   CYBERSOURCE_CHECKOUT_RESPONSE,
 } from '../test_constants';
@@ -257,52 +248,6 @@ describe('reducers', () => {
         [UPDATE_PROFILE_VALIDATION]
       ).then(profileState => {
         assert.deepEqual(profileState['jane'], undefined);
-      });
-    });
-  });
-
-  describe('prices reducer', () => {
-    let pricesStub;
-
-    beforeEach(() => {
-      dispatchThen = store.createDispatchThen(state => state.prices);
-      pricesStub = sandbox.stub(api, 'getCoursePrices');
-    });
-
-    it('should have an empty default state', () => {
-      return dispatchThen({type: 'unknown'}, ['unknown']).then(state => {
-        assert.deepEqual(state, {
-          coursePrices: []
-        });
-      });
-    });
-
-    it('should fetch the prices successfully then clear it', () => {
-      pricesStub.returns(Promise.resolve(COURSE_PRICES_RESPONSE));
-
-      return dispatchThen(fetchCoursePrices(), [
-        REQUEST_COURSE_PRICES,
-        RECEIVE_COURSE_PRICES_SUCCESS,
-      ]).then(pricesState => {
-        assert.deepEqual(pricesState.coursePrices, COURSE_PRICES_RESPONSE);
-        assert.equal(pricesState.fetchStatus, FETCH_SUCCESS);
-
-        return dispatchThen(clearCoursePrices(), [CLEAR_COURSE_PRICES]).then(pricesState => {
-          assert.deepEqual(pricesState, {
-            coursePrices: []
-          });
-        });
-      });
-    });
-
-    it('should fail to fetch the dashboard', () => {
-      pricesStub.returns(Promise.reject());
-
-      return dispatchThen(fetchCoursePrices(), [
-        REQUEST_COURSE_PRICES,
-        RECEIVE_COURSE_PRICES_FAILURE,
-      ]).then(pricesState => {
-        assert.equal(pricesState.fetchStatus, FETCH_FAILURE);
       });
     });
   });

--- a/static/js/reducers/programs_test.js
+++ b/static/js/reducers/programs_test.js
@@ -29,7 +29,7 @@ import {
   SET_CURRENT_PROGRAM_ENROLLMENT,
 } from '../actions/programs';
 import * as api from '../lib/api';
-import * as actions from '../actions';
+import * as coursePriceActions from '../actions/course_prices';
 import * as dashboardActions from '../actions/dashboard';
 import rootReducer from '../reducers';
 
@@ -57,7 +57,7 @@ describe('enrollments', () => {
     beforeEach(() => {
       dispatchThen = store.createDispatchThen(state => state.programs);
 
-      fetchCoursePricesStub = sandbox.stub(actions, 'fetchCoursePrices');
+      fetchCoursePricesStub = sandbox.stub(coursePriceActions, 'fetchCoursePrices');
       fetchCoursePricesStub.returns({type: "fake"});
       fetchDashboardStub = sandbox.stub(dashboardActions, 'fetchDashboard');
       fetchDashboardStub.returns({type: "fake"});

--- a/static/js/reducers/util.js
+++ b/static/js/reducers/util.js
@@ -1,9 +1,11 @@
 // @flow
 /* global SETTINGS: false */
 import R from 'ramda';
+import _ from 'lodash';
 import { INITIAL_DASHBOARD_STATE } from './dashboard';
+import { INITIAL_COURSE_PRICES_STATE } from './course_prices';
 import { guard } from '../lib/sanctuary';
-import type { DashboardsState } from '../flow/dashboardTypes';
+import type { DashboardsState, CoursePricesState } from '../flow/dashboardTypes';
 
 export const getInfoByUsername = R.curry((
   reducer,
@@ -14,15 +16,25 @@ export const getInfoByUsername = R.curry((
   R.pathOr(defaultTo, [reducer, username], state)
 ));
 
+const usernameIfPresent = () => SETTINGS.user ? SETTINGS.user.username : "";
+
 export const getOwnDashboard = (state: {dashboard?: DashboardsState}) => (
   getInfoByUsername(
     'dashboard',
     INITIAL_DASHBOARD_STATE,
-    SETTINGS.user ? SETTINGS.user.username : "",
+    usernameIfPresent(),
     state
   )
+);
+
+export const getOwnCoursePrices = (state: {prices?: CoursePricesState}) => (
+  getInfoByUsername('prices', INITIAL_COURSE_PRICES_STATE, usernameIfPresent(), state)
 );
 
 export const getDashboard = guard((username, dashboard) => (
   R.pathOr(INITIAL_DASHBOARD_STATE, [username], dashboard)
 ));
+
+export const updateStateByUsername = (state: Object, username: string, update: Object) => (
+  _.merge({}, state, {[username]: update })
+);


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2923 

#### What's this PR do?

This just refactors the frontend code for the course price API to support namespacing based on username.

To facilitate this I also moved the course price reducer into a separate file.

#### How should this be manually tested?

I think just make sure you can visit the dashboard page and order summary page, and that everything looks normal on them (and no runtime errors). If we get that and the tests are all passing I think we're good.