### PR TITLE
Removed 'view on edx' link for staff

### DIFF
--- a/static/js/components/dashboard/CourseDescription.js
+++ b/static/js/components/dashboard/CourseDescription.js
@@ -1,5 +1,6 @@
 /* global SETTINGS: false */
 // @flow
+/* global SETTINGS: false */
 import React from 'react';
 import R from 'ramda';
 import _ from 'lodash';
@@ -20,6 +21,7 @@ import {
 } from '../../constants';
 import { renderSeparatedComponents } from '../../util/util';
 import { ifValidDate } from '../../util/date';
+import { hasAnyStaffRole } from '../../lib/roles';
 
 export default class CourseDescription extends React.Component {
   props: {
@@ -98,7 +100,7 @@ export default class CourseDescription extends React.Component {
       url = courseRun.enrollment_url;
     }
 
-    return url ?
+    return url && !hasAnyStaffRole(SETTINGS.roles) ?
       <a key={'view-edx-link'} className={'view-edx-link'} href={url} target="_blank">View on edX</a>
       : null;
   };

--- a/static/js/components/dashboard/CourseDescription_test.js
+++ b/static/js/components/dashboard/CourseDescription_test.js
@@ -1,3 +1,4 @@
+/* global SETTINGS */
 import React from 'react';
 import { shallow } from 'enzyme';
 import moment from 'moment';
@@ -134,6 +135,22 @@ describe('CourseDescription', () => {
     ));
     let firstRun = course.runs[0];
     firstRun.course_id = null;
+    const wrapper = renderCourseDescription(firstRun, course.title);
+    let elements = getElements(wrapper);
+
+    assert.lengthOf(elements.edxLink, 0);
+  });
+
+  it('does not show a link to view the course on edX if the user is staff', () => {
+    SETTINGS.roles = [{
+      "role": "staff",
+      "program": 1
+    }];
+    let course = findAndCloneCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_PASSED
+    ));
+    let firstRun = course.runs[0];
     const wrapper = renderCourseDescription(firstRun, course.title);
     let elements = getElements(wrapper);
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #2916

#### What's this PR do?
Remove 'view on edx' link for courses for staff when viewing learners page.

#### How should this be manually tested?
As staff, go to view learner's page. Make sure there is a course with a valid edx link.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
![screen shot 2017-03-20 at 4 20 05 pm](https://cloud.githubusercontent.com/assets/7574259/24120655/c3050254-0d8b-11e7-9ec7-93a188dbd208.png)


#### What GIF best describes this PR or how it makes you feel?
(Optional)
