### PR TITLE
Fixed bug with gdm_grade_task_fail_bug management command

### DIFF
--- a/grades/management/commands/check_final_grade_freeze_status.py
+++ b/grades/management/commands/check_final_grade_freeze_status.py
@@ -37,8 +37,9 @@ class Command(BaseCommand):
                 )
             )
         elif CourseRunGradingStatus.is_pending(run):
-            group_results_id = CACHE_ID_BASE_STR.format(edx_course_key)
-            if cache_redis.get(group_results_id):
+            cache_id = CACHE_ID_BASE_STR.format(edx_course_key)
+            group_results_id = cache_redis.get(cache_id)
+            if group_results_id is not None:
                 results = GroupResult.restore(group_results_id)
                 if not results.ready():
                     self.stdout.write(

--- a/grades/management/commands/complete_course_run_freeze.py
+++ b/grades/management/commands/complete_course_run_freeze.py
@@ -47,8 +47,9 @@ class Command(BaseCommand):
             return
 
         # check if there are tasks running
-        group_results_id = CACHE_ID_BASE_STR.format(edx_course_key)
-        if cache_redis.get(group_results_id):
+        cache_id = CACHE_ID_BASE_STR.format(edx_course_key)
+        group_results_id = cache_redis.get(cache_id)
+        if group_results_id is not None:
             results = GroupResult.restore(group_results_id)
             if results and not results.ready():
                 self.stdout.write(


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #2930

#### What's this PR do?
fixes a bug with the `gdm_grade_task_fail_bug` management command.

#### How should this be manually tested?
Submit a freeze task for a course run using the `freeze_final_grades`, then check the status with `gdm_grade_task_fail_bug`: it should not raise any more.
