### PR TITLE
refactor course price API to take a 'username' url parameter

### DIFF
--- a/financialaid/urls.py
+++ b/financialaid/urls.py
@@ -7,7 +7,6 @@ from django.conf.urls import url
 
 from financialaid.views import (
     CoursePriceListView,
-    CoursePriceDetailView,
     FinancialAidActionView,
     FinancialAidDetailView,
     FinancialAidRequestView,
@@ -16,9 +15,7 @@ from financialaid.views import (
 )
 
 urlpatterns = [
-    url(r'^api/v0/course_prices/$', CoursePriceListView.as_view(), name='course_price_list'),
-    url(r'^api/v0/course_prices/(?P<program_id>[\d]+)/$',
-        CoursePriceDetailView.as_view(), name='course_price_detail'),
+    url(r'^api/v0/course_prices/(?P<username>[-\w.]+)/$', CoursePriceListView.as_view(), name='course_price_list'),
     url(
         r'^financial_aid/review/(?P<program_id>[\d]+)/?$',
         ReviewFinancialAidView.as_view(),

--- a/micromasters/urls_test.py
+++ b/micromasters/urls_test.py
@@ -31,6 +31,5 @@ class URLTests(TestCase):
         ) == '/financial_aid/review/5/xyz'
         assert reverse('financial_aid_skip', kwargs={'program_id': 3}) == '/api/v0/financial_aid_skip/3/'
         assert reverse('financial_aid', kwargs={'financial_aid_id': 123}) == '/api/v0/financial_aid/123/'
-        assert reverse('course_price_list') == '/api/v0/course_prices/'
-        assert reverse('course_price_detail', kwargs={'program_id': 4}) == '/api/v0/course_prices/4/'
+        assert reverse('course_price_list', args=['username']) == '/api/v0/course_prices/username/'
         assert reverse('order-fulfillment') == '/api/v0/order_fulfillment/'

--- a/static/js/actions/course_prices.js
+++ b/static/js/actions/course_prices.js
@@ -21,7 +21,7 @@ export const clearCoursePrices = withUsername(CLEAR_COURSE_PRICES);
 export function fetchCoursePrices(username: string, noSpinner: boolean = false): Dispatcher<CoursePrices> {
   return (dispatch: Dispatch) => {
     dispatch(requestCoursePrices(username, noSpinner));
-    return api.getCoursePrices().
+    return api.getCoursePrices(username).
       then(coursePrices => dispatch(receiveCoursePricesSuccess(username, coursePrices))).
       catch(error => {
         dispatch(receiveCoursePricesFailure(username, error));

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -246,8 +246,8 @@ export function addFinancialAid(income: number, currency: string, programId: num
   });
 }
 
-export function getCoursePrices(): Promise<CoursePrices> {
-  return fetchJSONWithCSRF('/api/v0/course_prices/', {}).then(coursePrices => {
+export function getCoursePrices(username: string): Promise<CoursePrices> {
+  return fetchJSONWithCSRF(`/api/v0/course_prices/${username}/`, {}).then(coursePrices => {
     // turn `price` from string into decimal
     return R.map(R.evolve({price: Decimal}), coursePrices);
   });

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -155,8 +155,8 @@ describe('api', function() {
 
     it('gets course prices', () => {
       fetchJSONStub.returns(Promise.resolve(COURSE_PRICES_RESPONSE));
-      return getCoursePrices().then(coursePrices => {
-        assert.ok(fetchJSONStub.calledWith(`/api/v0/course_prices/`, {}));
+      return getCoursePrices('username').then(coursePrices => {
+        assert.ok(fetchJSONStub.calledWith('/api/v0/course_prices/username/', {}));
         assert.deepEqual(coursePrices, COURSE_PRICES_RESPONSE);
       });
     });


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2933

#### What's this PR do?

this refactors the the course price API so that it isn't limited to just fetching information for the currently logged in user.

#### How should this be manually tested?

The dashboard and so on should work as normal.