### PR TITLE
Changed course description to show: Auditing or Paid

### DIFF
--- a/static/js/components/dashboard/CourseDescription.js
+++ b/static/js/components/dashboard/CourseDescription.js
@@ -29,17 +29,16 @@ export default class CourseDescription extends React.Component {
     openCourseContactDialog: () => void,
   };
 
-  renderCourseDateMessage(label: string, dateString: string): React$Element<*> {
+  renderCourseDateMessage(label: string, dateString: string): string {
     let date = moment(dateString);
-    let text = ifValidDate('', date => `${label}: ${date.format(DASHBOARD_FORMAT)}`, date);
-    return <span key='1'>{text}</span>;
+    return ifValidDate('', date => `${label}: ${date.format(DASHBOARD_FORMAT)}`, date);
   }
 
-  renderStartDateMessage(run: CourseRun, shouldStartInFuture: boolean): React$Element<*>|null {
+  renderStartDateMessage(run: CourseRun, shouldStartInFuture: boolean): string|null {
     if (run.course_start_date) {
       return this.renderCourseDateMessage('Start date', run.course_start_date);
     } else if (run.fuzzy_start_date && shouldStartInFuture) {
-      return <span key='1'>Coming {run.fuzzy_start_date}</span>;
+      return `Coming ${run.fuzzy_start_date}`;
     } else {
       return null;
     }
@@ -47,29 +46,45 @@ export default class CourseDescription extends React.Component {
 
   renderDetailContents(run: CourseRun) {
     let dateMessage, additionalDetail;
+    let additionalClass = '';
 
-    switch (run.status) {
-    case STATUS_PASSED:
-    case STATUS_NOT_PASSED:
-      dateMessage = this.renderCourseDateMessage('Ended', run.course_end_date);
-      break;
-    case STATUS_CAN_UPGRADE:
-    case STATUS_MISSED_DEADLINE:
-    case STATUS_CURRENTLY_ENROLLED:
-      dateMessage = this.renderStartDateMessage(run, false);
-      break;
-    case STATUS_WILL_ATTEND:
-    case STATUS_OFFERED:
-    case STATUS_PENDING_ENROLLMENT:
-      dateMessage = this.renderStartDateMessage(run, true);
-      break;
+    if (run && !_.isEmpty(run)) {
+      switch (run.status) {
+      case STATUS_PASSED:
+      case STATUS_NOT_PASSED:
+        dateMessage = this.renderCourseDateMessage('Ended', run.course_end_date);
+        break;
+      case STATUS_CAN_UPGRADE:
+      case STATUS_MISSED_DEADLINE:
+      case STATUS_CURRENTLY_ENROLLED:
+        dateMessage = this.renderStartDateMessage(run, false);
+        break;
+      case STATUS_WILL_ATTEND:
+      case STATUS_OFFERED:
+      case STATUS_PENDING_ENROLLMENT:
+        dateMessage = this.renderStartDateMessage(run, true);
+        break;
+      }
+
+      if (run.status === STATUS_CAN_UPGRADE || run.status === STATUS_MISSED_DEADLINE) {
+        additionalDetail = 'Auditing';
+      }
+      if (
+        run.status === STATUS_CURRENTLY_ENROLLED ||
+        run.status === STATUS_PASSED ||
+        run.status === STATUS_NOT_PASSED
+      ) {
+        additionalDetail = 'Paid';
+      }
+    } else {
+      dateMessage = 'No future courses are currently scheduled.';
+      additionalClass = 'no-runs';
     }
 
-    if (run.status === STATUS_CAN_UPGRADE || run.status === STATUS_MISSED_DEADLINE) {
-      additionalDetail = <span key='2'>You are Auditing this Course.</span>;
-    }
-
-    return _.compact([dateMessage, additionalDetail]);
+    return _.compact([
+      <span className={`course-details ${additionalClass}`} key='1'>{dateMessage}</span>,
+      <span className="status" key='2'>{additionalDetail}</span>
+    ]);
   }
 
   isCurrentOrPastEnrolled = (courseRun: CourseRun): boolean => {
@@ -130,19 +145,12 @@ export default class CourseDescription extends React.Component {
   render() {
     const { courseRun, courseTitle } = this.props;
 
-    let detailContents;
-    if (courseRun && !_.isEmpty(courseRun)) {
-      detailContents = this.renderDetailContents(courseRun);
-    } else {
-      detailContents = <span className="no-runs">No future courses are currently scheduled.</span>;
-    }
-
     return <div className="course-description">
       <div className="course-title">
         <span>{courseTitle}</span>
       </div>
       <div className="details">
-        {detailContents}
+        { this.renderDetailContents(courseRun) }
       </div>
       { this.renderCourseLinks() }
     </div>;

--- a/static/js/components/dashboard/CourseDescription.js
+++ b/static/js/components/dashboard/CourseDescription.js
@@ -81,10 +81,10 @@ export default class CourseDescription extends React.Component {
       additionalClass = 'no-runs';
     }
 
-    return _.compact([
+    return [
       <span className={`course-details ${additionalClass}`} key='1'>{dateMessage}</span>,
       <span className="status" key='2'>{additionalDetail}</span>
-    ]);
+    ];
   }
 
   isCurrentOrPastEnrolled = (courseRun: CourseRun): boolean => {

--- a/static/js/components/dashboard/CourseDescription_test.js
+++ b/static/js/components/dashboard/CourseDescription_test.js
@@ -27,7 +27,8 @@ describe('CourseDescription', () => {
     titleText: renderedComponent.find(".course-title").text(),
     edxLink: renderedComponent.find("a.view-edx-link"),
     contactLink: renderedComponent.find("a.contact-link"),
-    detailsText: renderedComponent.find(".details").text()
+    detailsText: renderedComponent.find(".course-details").text(),
+    statusText: renderedComponent.find(".status").text()
   });
 
   let renderCourseDescription = (
@@ -286,7 +287,6 @@ describe('CourseDescription', () => {
     let elements = getElements(wrapper);
     let courseStartDate = moment(firstRun.course_start_date);
     let formattedDate = courseStartDate.format(DASHBOARD_FORMAT);
-
     assert.equal(elements.detailsText, `Start date: ${formattedDate}`);
   });
 
@@ -311,7 +311,6 @@ describe('CourseDescription', () => {
     let elements = getElements(wrapper);
     let courseStartDate = moment(firstRun.course_start_date);
     let formattedDate = courseStartDate.format(DASHBOARD_FORMAT);
-
     assert.include(elements.detailsText, `Start date: ${formattedDate}`);
   });
 
@@ -390,7 +389,21 @@ describe('CourseDescription', () => {
       const wrapper = renderCourseDescription(firstRun, course.title);
       let elements = getElements(wrapper);
 
-      assert.include(elements.detailsText, 'You are Auditing this Course');
+      assert.include(elements.statusText, 'Auditing');
+    });
+  });
+
+  it('shows a status when the user paid for the course', () => {
+    [STATUS_CURRENTLY_ENROLLED, STATUS_PASSED, STATUS_NOT_PASSED].forEach(auditStatus => {
+      let course = findCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === auditStatus
+      ));
+      let firstRun = course.runs[0];
+      const wrapper = renderCourseDescription(firstRun, course.title);
+      let elements = getElements(wrapper);
+
+      assert.include(elements.statusText, 'Paid');
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #2917

#### What's this PR do?
Changed course description to show: Auditing or Paid
for both staff and learner views.

#### How should this be manually tested?
As a learner run management commands to set a course to different states, for example:
```
./manage.py alter_data set_to_enrolled --username=staff --program-title='Analog' --course-title='100' --audit
```

And check the dashboard to the course status (as a learner and as staff viewing learner's page).

![screen shot 2017-03-22 at 3 10 45 pm](https://cloud.githubusercontent.com/assets/7574259/24216178/a4a428b2-0f11-11e7-9a73-b8c0862c87d4.png)
