### PR TITLE
Fix parameter in attach_avatars

### DIFF
--- a/profiles/models_test.py
+++ b/profiles/models_test.py
@@ -203,17 +203,19 @@ class ProfileImageTests(MockedESTestCase):
         self.profile.image_small = None
         self.profile.image_medium = None
         self.profile.save()
+        assert not self.profile.image_small
+        assert not self.profile.image_medium
 
         self.profile.save(update_image=True)
-        assert self.profile.image_small is not None
-        assert self.profile.image_medium is not None
+        assert self.profile.image_small
+        assert self.profile.image_medium
 
     def test_resized_images_updated(self):
         """
         thumbnails should be updated if image is already present and updated when update_image=True
         """
-        assert self.profile.image_small is not None
-        assert self.profile.image_medium is not None
+        assert self.profile.image_small
+        assert self.profile.image_medium
 
         # create a dummy image file in memory for upload
         image_file = BytesIO()

--- a/seed_data/management/commands/attach_avatars.py
+++ b/seed_data/management/commands/attach_avatars.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
                 robohash.img.save(f, format='jpeg')
                 f.seek(0)
                 profile.image.save(name, f)
-            profile.save(update_thumbnails=True)
+            profile.save(update_image=True)
 
             if count % 10 == 0:
                 self.stdout.write("Updated {} profiles...".format(count))

--- a/seed_data/management/commands/attach_avatars_test.py
+++ b/seed_data/management/commands/attach_avatars_test.py
@@ -1,0 +1,41 @@
+"""Tests for attach_avatars"""
+from django.db.models.signals import post_save
+from factory.django import mute_signals
+
+from profiles.factories import ProfileFactory
+from profiles.models import Profile
+from search.base import MockedESTestCase
+from seed_data.management.commands.attach_avatars import Command
+
+
+class AttachAvatarsTest(MockedESTestCase):
+    """
+    Tests for attach_avatars
+    """
+    def setUp(self):
+        super().setUp()
+        self.command = Command()
+
+    def test_attach_avatars(self):
+        """
+        It should attach robotic avatars given a username prefix
+        """
+        with mute_signals(post_save):
+            for i in range(3):
+                ProfileFactory.create(user__username="user_{}".format(i))
+            for i in range(3):
+                ProfileFactory.create(user__username="fake_{}".format(i))
+
+        # clear all images
+        for profile in Profile.objects.all():
+            profile.image = None
+            profile.image_medium = None
+            profile.image_small = None
+            profile.save()
+
+        self.command.handle("attach_avatars", username_prefix="fake")
+        for profile in Profile.objects.all():
+            has_image = profile.user.username.startswith("fake")
+            assert bool(profile.image) == has_image
+            assert bool(profile.image_medium) == has_image
+            assert bool(profile.image_small) == has_image


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes the parameter used for `attach_avatars` and adds a test for the command

#### How should this be manually tested?
Run `./manage.py attach_avatars --username-prefix fake` to use robotic avatars on your fake users
