### PR TITLE
Update UserProgramSerializer to use current enrollments and existing grades

### DIFF
--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -2,7 +2,6 @@
 Provides functionality for serializing a ProgramEnrollment for the ES index
 """
 from courses.utils import get_year_season_from_course_run
-from dashboard.models import CachedEnrollment
 from dashboard.utils import get_mmtrack
 from roles.api import is_learner
 
@@ -12,20 +11,20 @@ class UserProgramSearchSerializer:
     Provides functions for serializing a ProgramEnrollment for the ES index
     """
     @classmethod
-    def serialize_enrollments(cls, mmtrack, enrollments):
+    def serialize_enrollments(cls, mmtrack):
         """
         Serializes a user's enrollment data for search results
 
         Args:
             mmtrack (MMTrack): An MMTrack object
-            enrollments (iterable): An iterable of CachedEnrollments
         Returns:
             list: Serialized courses
         """
         enrollment_status_map = {}
-        for enrollment in enrollments:
-            course_title = enrollment.course_run.course.title
-            is_verified = mmtrack.is_enrolled_mmtrack(enrollment.course_run.edx_course_key)
+        course_runs = mmtrack.get_all_enrolled_course_runs()
+        for course_run in course_runs:
+            course_title = course_run.course.title
+            is_verified = mmtrack.is_enrolled_mmtrack(course_run.edx_course_key)
             # If any course run for this course was verified/paid, maintain the verified status
             enrollment_status_map[course_title] = enrollment_status_map.get(course_title) or is_verified
         serialized_enrollments = []
@@ -38,36 +37,38 @@ class UserProgramSearchSerializer:
         return serialized_enrollments
 
     @classmethod
-    def serialize_final_grades(cls, mmtrack, enrollments):
+    def serialize_final_grades(cls, mmtrack):
         """
         Serializes a user's final grades
 
         Args:
             mmtrack (MMTrack): An MMTrack object
-            enrollments (iterable): An iterable of CachedEnrollments
         Returns:
             list: Serialized final grades
         """
-        final_grades = []
-        for enrollment in enrollments:
-            final_grade = mmtrack.get_final_grade_percent(enrollment.course_run.edx_course_key)
-            if final_grade:
-                final_grades.append({'title': enrollment.course_run.course.title, 'grade': final_grade})
-        return final_grades
+
+        serialized_final_grades = []
+        final_grades = mmtrack.get_all_final_grades()
+        for final_grade in final_grades.values():
+            serialized_final_grades.append({
+                'title': final_grade.course_run.course.title,
+                'grade': final_grade.grade_percent
+            })
+        return serialized_final_grades
 
     @classmethod
-    def serialize_semester_enrollments(cls, enrollments):
+    def serialize_semester_enrollments(cls, mmtrack):
         """
         Serializes the semesters that a user is enrolled in
 
         Args:
-            enrollments (iterable): An iterable of CachedEnrollments
+            mmtrack (MMTrack): An MMTrack object
         Returns:
             list: Serialized semester enrollments
         """
         semester_values = set()
-        for enrollment in enrollments:
-            year_season_tuple = get_year_season_from_course_run(enrollment.course_run)
+        for course_run in mmtrack.get_all_enrolled_course_runs():
+            year_season_tuple = get_year_season_from_course_run(course_run)
             if year_season_tuple:
                 semester_values.add(
                     '{} - {}'.format(year_season_tuple[0], year_season_tuple[1])
@@ -82,13 +83,12 @@ class UserProgramSearchSerializer:
         user = program_enrollment.user
         program = program_enrollment.program
         mmtrack = get_mmtrack(user, program)
-        enrollments_qset = CachedEnrollment.user_course_qset(user, program=program)
 
         return {
             'id': program.id,
-            'enrollments': cls.serialize_enrollments(mmtrack, enrollments_qset),
-            'final_grades': cls.serialize_final_grades(mmtrack, enrollments_qset),
-            'semester_enrollments': cls.serialize_semester_enrollments(enrollments_qset),
+            'enrollments': cls.serialize_enrollments(mmtrack),
+            'final_grades': cls.serialize_final_grades(mmtrack),
+            'semester_enrollments': cls.serialize_semester_enrollments(mmtrack),
             'grade_average': mmtrack.calculate_final_grade_average(),
             'is_learner': is_learner(user, program),
             'num_courses_passed': mmtrack.count_courses_passed(),

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -124,9 +124,9 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
             )
         non_fa_cached_edx_data = CachedEdxUserData(cls.user, program=program)
         non_fa_mmtrack = MMTrack(cls.user, program, non_fa_cached_edx_data)
-        cls.serialized_enrollments = UserProgramSearchSerializer.serialize_enrollments(non_fa_mmtrack, cls.enrollments)
-        cls.semester_enrollments = UserProgramSearchSerializer.serialize_semester_enrollments(cls.enrollments)
-        cls.final_grades = UserProgramSearchSerializer.serialize_final_grades(non_fa_mmtrack, cls.enrollments)
+        cls.serialized_enrollments = UserProgramSearchSerializer.serialize_enrollments(non_fa_mmtrack)
+        cls.semester_enrollments = UserProgramSearchSerializer.serialize_semester_enrollments(non_fa_mmtrack)
+        cls.final_grades = UserProgramSearchSerializer.serialize_final_grades(non_fa_mmtrack)
         cls.program_enrollment = ProgramEnrollment.objects.create(user=cls.user, program=program)
         # create a financial aid program
         cls.fa_program, _ = create_program()
@@ -156,10 +156,10 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         fa_cached_edx_data = CachedEdxUserData(cls.user, program=cls.fa_program)
         fa_mmtrack = MMTrack(cls.user, cls.fa_program, fa_cached_edx_data)
         cls.fa_serialized_enrollments = (
-            UserProgramSearchSerializer.serialize_enrollments(fa_mmtrack, cls.fa_enrollments)
+            UserProgramSearchSerializer.serialize_enrollments(fa_mmtrack)
         )
-        cls.fa_semester_enrollments = UserProgramSearchSerializer.serialize_semester_enrollments(cls.fa_enrollments)
-        cls.fa_final_grades = UserProgramSearchSerializer.serialize_final_grades(fa_mmtrack, cls.fa_enrollments)
+        cls.fa_semester_enrollments = UserProgramSearchSerializer.serialize_semester_enrollments(fa_mmtrack)
+        cls.fa_final_grades = UserProgramSearchSerializer.serialize_final_grades(fa_mmtrack)
 
     def test_full_program_user_serialization(self):
         """


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #2939

#### What's this PR do?
Change the logic the search serializer for three facets ( courses, final grade, and semester) to use final grades and cached enrollments to identify all current and past enrollments for a user.

#### How should this be manually tested?
Users with no enrollment, but a final grade for a course should appear in the search results.
