### PR TITLE
Cleaned up more MMTrack code

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -12,6 +12,7 @@ from backends.exceptions import InvalidCredentialStored
 from courses.models import Program
 from dashboard.api_edx_cache import CachedEdxDataApi, CachedEdxUserData
 from dashboard.utils import MMTrack
+from financialaid.serializers import FinancialAidDashboardSerializer
 from grades import api
 from grades.models import FinalGrade
 from exams.models import ExamAuthorization
@@ -176,14 +177,7 @@ def get_info_for_program(mmtrack):
         "grade_average": mmtrack.calculate_final_grade_average(),
     }
     if mmtrack.financial_aid_available:
-        data["financial_aid_user_info"] = {
-            "id": mmtrack.financial_aid_id,
-            "has_user_applied": mmtrack.financial_aid_applied,
-            "application_status": mmtrack.financial_aid_status,
-            "min_possible_cost": mmtrack.financial_aid_min_price,
-            "max_possible_cost": mmtrack.financial_aid_max_price,
-            "date_documents_sent": mmtrack.financial_aid_date_documents_sent,
-        }
+        data["financial_aid_user_info"] = FinancialAidDashboardSerializer.serialize(mmtrack.user, mmtrack.program)
     for course in mmtrack.program.course_set.all():
         data['courses'].append(
             get_info_for_course(course, mmtrack)

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -172,7 +172,7 @@ def get_info_for_program(mmtrack):
         "title": mmtrack.program.title,
         "financial_aid_availability": mmtrack.financial_aid_available,
         "courses": [],
-        "pearson_exam_status": mmtrack.pearson_exam_status,
+        "pearson_exam_status": mmtrack.get_pearson_exam_status(),
         "grade_average": mmtrack.calculate_final_grade_average(),
     }
     if mmtrack.financial_aid_available:

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1368,7 +1368,7 @@ class InfoProgramTest(MockedESTestCase):
         self.mmtrack.configure_mock(**{
             'program': self.program,
             'financial_aid_available': False,
-            'pearson_exam_status': ExamProfile.PROFILE_SUCCESS,
+            'get_pearson_exam_status.return_value': ExamProfile.PROFILE_SUCCESS,
             'calculate_final_grade_average.return_value': 91,
         })
         mock_info_course.return_value = {'position_in_program': 1}
@@ -1392,7 +1392,7 @@ class InfoProgramTest(MockedESTestCase):
         self.mmtrack.configure_mock(**{
             'program': self.program_no_courses,
             'financial_aid_available': False,
-            'pearson_exam_status': ExamProfile.PROFILE_INVALID,
+            'get_pearson_exam_status.return_value': ExamProfile.PROFILE_INVALID,
             'calculate_final_grade_average.return_value': 91,
         })
         res = api.get_info_for_program(self.mmtrack)
@@ -1403,7 +1403,7 @@ class InfoProgramTest(MockedESTestCase):
             "title": self.program_no_courses.title,
             "courses": [],
             "financial_aid_availability": False,
-            'pearson_exam_status': ExamProfile.PROFILE_INVALID,
+            "pearson_exam_status": ExamProfile.PROFILE_INVALID,
             "grade_average": 91,
         }
         self.assertEqual(res, expected_data)
@@ -1420,7 +1420,7 @@ class InfoProgramTest(MockedESTestCase):
             'financial_aid_min_price': 123,
             'financial_aid_max_price': 456,
             'financial_aid_date_documents_sent': datetime.now(pytz.utc) - timedelta(hours=12),
-            'pearson_exam_status': ExamProfile.PROFILE_IN_PROGRESS,
+            'get_pearson_exam_status.return_value': ExamProfile.PROFILE_IN_PROGRESS,
             'calculate_final_grade_average.return_value': 91,
         }
         self.mmtrack.configure_mock(**kwargs)

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1409,39 +1409,36 @@ class InfoProgramTest(MockedESTestCase):
         self.assertEqual(res, expected_data)
 
     @patch('dashboard.api.get_info_for_course', autospec=True)
-    def test_program_financial_aid(self, mock_info_course):
+    @patch('financialaid.serializers.FinancialAidDashboardSerializer.serialize', new_callable=MagicMock)
+    def test_program_financial_aid(self, mock_fin_aid_serialize, mock_info_course):
         """Test happy path"""
-        kwargs = {
-            'financial_aid_id': 1122334455,
+        self.mmtrack.configure_mock(**{
             'program': self.program,
-            'financial_aid_available': True,
-            'financial_aid_applied': True,
-            'financial_aid_status': 'WHO-KNOWS',
-            'financial_aid_min_price': 123,
-            'financial_aid_max_price': 456,
-            'financial_aid_date_documents_sent': datetime.now(pytz.utc) - timedelta(hours=12),
             'get_pearson_exam_status.return_value': ExamProfile.PROFILE_IN_PROGRESS,
             'calculate_final_grade_average.return_value': 91,
+            'financial_aid_available': True,
+        })
+        serialized_fin_aid = {
+            "id": 123,
+            "has_user_applied": True,
+            "application_status": "WHO-KNOWS",
+            "min_possible_cost": 100,
+            "max_possible_cost": 200,
+            "date_documents_sent": datetime.now(pytz.utc) - timedelta(hours=12)
         }
-        self.mmtrack.configure_mock(**kwargs)
+        mock_fin_aid_serialize.return_value = serialized_fin_aid
         mock_info_course.return_value = {'position_in_program': 1}
         res = api.get_info_for_program(self.mmtrack)
         for course in self.courses:
             mock_info_course.assert_any_call(course, self.mmtrack)
+
         expected_data = {
             "id": self.program.pk,
             "description": self.program.description,
             "title": self.program.title,
             "courses": [{'position_in_program': 1}, {'position_in_program': 1}],
-            "financial_aid_availability": kwargs['financial_aid_available'],
-            "financial_aid_user_info": {
-                "id": kwargs['financial_aid_id'],
-                "has_user_applied": kwargs['financial_aid_applied'],
-                "application_status": kwargs['financial_aid_status'],
-                "min_possible_cost": kwargs['financial_aid_min_price'],
-                "max_possible_cost": kwargs['financial_aid_max_price'],
-                "date_documents_sent": kwargs['financial_aid_date_documents_sent'],
-            },
+            "financial_aid_availability": True,
+            "financial_aid_user_info": serialized_fin_aid,
             "pearson_exam_status": ExamProfile.PROFILE_IN_PROGRESS,
             "grade_average": 91,
         }

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -216,7 +216,7 @@ class MMTrack:
         Returns:
             bool: whether a frozen final grade exists
         """
-        return self.final_grade_qset.paid_on_edx().for_course_run_key(course_id).exists()
+        return self.final_grade_qset.paid_on_edx().for_course_run_key(edx_course_key).exists()
 
     def has_passed_course(self, edx_course_key):
         """

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -70,7 +70,6 @@ class MMTrack:
                 ).values_list("edx_course_key", "course__id")
             )
             self.course_ids = self.edx_key_course_map.keys()
-            self.pearson_exam_status = self.get_pearson_exam_status()
 
             if self.financial_aid_available:
                 self.paid_course_ids = set(Line.objects.filter(

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -11,7 +11,7 @@ from pytz import utc
 
 from courses.models import CourseRun
 from dashboard.api_edx_cache import CachedEdxUserData
-from ecommerce.models import Line
+from ecommerce.models import Order, Line
 from grades.constants import FinalGradeStatus
 from grades.models import FinalGrade
 from exams.models import ExamProfile, ExamAuthorization
@@ -63,7 +63,7 @@ class MMTrack:
 
             if self.financial_aid_available:
                 self.paid_course_keys = set(Line.objects.filter(
-                    order__status='fulfilled', course_key__in=self.edx_course_keys, order__user=user
+                    order__status=Order.FULFILLED, course_key__in=self.edx_course_keys, order__user=user
                 ).values_list("course_key", flat=True))
 
     def __str__(self):

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -33,8 +33,8 @@ class MMTrack:
     enrollments = None
     current_grades = None
     certificates = None
-    course_ids = set()
-    paid_course_ids = set()  # financial aid course ids for paid with the MM app
+    edx_course_keys = set()
+    paid_course_keys = set()  # Course keys for course runs that were paid for via financial aid
     pearson_exam_status = None
 
     def __init__(self, user, program, edx_user_data):
@@ -59,11 +59,11 @@ class MMTrack:
                     Q(edx_course_key__isnull=True) | Q(edx_course_key__exact='')
                 ).values_list("edx_course_key", "course__id")
             )
-            self.course_ids = self.edx_key_course_map.keys()
+            self.edx_course_keys = set(self.edx_key_course_map.keys())
 
             if self.financial_aid_available:
-                self.paid_course_ids = set(Line.objects.filter(
-                    Q(order__status='fulfilled') & Q(course_key__in=self.course_ids) & Q(order__user=user)
+                self.paid_course_keys = set(Line.objects.filter(
+                    order__status='fulfilled', course_key__in=self.edx_course_keys, order__user=user
                 ).values_list("course_key", flat=True))
 
     def __str__(self):
@@ -72,83 +72,92 @@ class MMTrack:
             self.program.title
         )
 
-    def _is_course_in_program(self, course_id):
+    def _is_course_in_program(self, edx_course_key):
         """
-        Returns whether the course id belongs to the program
+        Returns whether the edx_course_key id belongs to the program
         """
-        return course_id in self.course_ids
+        return edx_course_key in self.edx_course_keys
 
-    def is_enrolled(self, course_id):
+    def get_course_ids(self):
+        """
+        Returns a set of valid Course id's in the given program
+
+        Returns:
+            set: Course id integers
+        """
+        return set(self.edx_key_course_map.values())
+
+    def is_enrolled(self, edx_course_key):
         """
         Returns whether the user is enrolled at least audit in a course run.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
 
         Returns:
-            bool: whether the user is enrolled audit in the course
+            bool: whether the user is enrolled audit in the course run
         """
-        return self._is_course_in_program(course_id) and self.enrollments.is_enrolled_in(course_id)
+        return self._is_course_in_program(edx_course_key) and self.enrollments.is_enrolled_in(edx_course_key)
 
-    def is_enrolled_mmtrack(self, course_id):
+    def is_enrolled_mmtrack(self, edx_course_key):
         """
         Returns whether an used is enrolled mmtrack in a course run.
         This means if the user is enrolled verified for normal programs
         or enrolled and paid on micromasters for financial aid ones.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
 
         Returns:
-            bool: whether the user is enrolled mmtrack in the course
+            bool: whether the user is enrolled mmtrack in the course run
         """
-        return self.is_enrolled(course_id) and self.has_paid(course_id)
+        return self.is_enrolled(edx_course_key) and self.has_paid(edx_course_key)
 
-    def has_paid(self, course_id):
+    def has_paid(self, edx_course_key):
         """
-        Returns true if user paid for a course.
+        Returns true if user paid for a course run.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
 
         Returns:
             bool: whether the user is paid
         """
-        if self.has_paid_final_grade(course_id):
+        if self.has_paid_final_grade(edx_course_key):
             return True
 
         # financial aid programs need to have an audit enrollment and a paid entry for the course
         if self.financial_aid_available:
-            return course_id in self.paid_course_ids
+            return edx_course_key in self.paid_course_keys
 
         # normal programs need to have a verified enrollment
-        return self.has_verified_enrollment(course_id)
+        return self.has_verified_enrollment(edx_course_key)
 
-    def has_verified_enrollment(self, course_id):
+    def has_verified_enrollment(self, edx_course_key):
         """
         Returns true if user has a verified enrollment
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
 
         Returns:
             bool: whether the user has a verified enrollment
         """
-        enrollment = self.enrollments.get_enrollment_for_course(course_id)
+        enrollment = self.enrollments.get_enrollment_for_course(edx_course_key)
         return bool(enrollment and enrollment.is_verified)
 
-    def has_passing_certificate(self, course_id):
+    def has_passing_certificate(self, edx_course_key):
         """
         Returns whether the user has a passing certificate.
 
         Args:
-            course_id (str): An edX course key
+            edx_course_key (str): An edX course key
         Returns:
             bool: whether the user has a passing certificate meaning that the user passed the course on edX
         """
-        if not self.certificates.has_verified_cert(course_id):
+        if not self.certificates.has_verified_cert(edx_course_key):
             return False
-        certificate = self.certificates.get_verified_cert(course_id)
+        certificate = self.certificates.get_verified_cert(edx_course_key)
         return certificate.status == 'downloadable'
 
     @property
@@ -156,100 +165,100 @@ class MMTrack:
         """Base queryset for the MMTrack User's completed FinalGrades"""
         return FinalGrade.objects.filter(user=self.user, status=FinalGradeStatus.COMPLETE)
 
-    def get_final_grade(self, course_id):
+    def get_final_grade(self, edx_course_key):
         """
         Gets a user's FinalGrade for a CourseRun matching a course run key
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Returns:
             FinalGrade: a Final Grade object or None
         """
-        return self.final_grade_qset.for_course_run_key(course_id).first()
+        return self.final_grade_qset.for_course_run_key(edx_course_key).first()
 
-    def get_required_final_grade(self, course_id):
+    def get_required_final_grade(self, edx_course_key):
         """
         Gets a user's FinalGrade for a CourseRun matching a course run key. This should be used
         in cases where a user is expected to have a FinalGrade for the given CourseRun.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Raises:
             FinalGrade.DoesNotExist: raised if a FinalGrade record was not found
         Returns:
             FinalGrade: a Final Grade object
         """
-        return self.final_grade_qset.for_course_run_key(course_id).get()
+        return self.final_grade_qset.for_course_run_key(edx_course_key).get()
 
-    def has_final_grade(self, course_id):
+    def has_final_grade(self, edx_course_key):
         """
         Checks if there is a final grade for the course run
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Returns:
             bool: whether a frozen final grade exists
         """
-        return self.final_grade_qset.for_course_run_key(course_id).exists()
+        return self.final_grade_qset.for_course_run_key(edx_course_key).exists()
 
-    def has_paid_final_grade(self, course_id):
+    def has_paid_final_grade(self, edx_course_key):
         """
         Checks if there is a a frozen final grade and the user paid for it.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Returns:
             bool: whether a frozen final grade exists
         """
         return self.final_grade_qset.paid_on_edx().for_course_run_key(course_id).exists()
 
-    def has_passed_course(self, course_id):
+    def has_passed_course(self, edx_course_key):
         """
         Returns whether the user has passed a course run.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Returns:
             bool: whether the user has passed the course
         """
-        final_grade = self.get_final_grade(course_id)
+        final_grade = self.get_final_grade(edx_course_key)
         return final_grade.passed if final_grade else False
 
-    def get_final_grade_percent(self, course_id):
+    def get_final_grade_percent(self, edx_course_key):
         """
         Returns the course final grade number for the user if she passed.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Returns:
             float: the final grade of the user in the course
         """
-        final_grade = self.get_final_grade(course_id)
+        final_grade = self.get_final_grade(edx_course_key)
         return final_grade.grade_percent if final_grade else None
 
     def calculate_final_grade_average(self):
         """
         Calculates an average grade (integer) from the program final grades
         """
-        final_grades = self.final_grade_qset.for_course_run_keys(self.course_ids)
+        final_grades = self.final_grade_qset.for_course_run_keys(self.edx_course_keys)
         if final_grades:
             return round(
                 sum(Decimal(final_grade.grade_percent) for final_grade in final_grades) /
                 len(final_grades)
             )
 
-    def get_current_grade(self, course_id):
+    def get_current_grade(self, edx_course_key):
         """
-        Returns the current grade number for the user in the course if enrolled.
+        Returns the current grade number for the user in the course run if enrolled.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Returns:
-            float: the current grade of the user in the course
+            float: the current grade of the user in the course run
         """
-        if not self.is_enrolled(course_id):
+        if not self.is_enrolled(edx_course_key):
             return
-        current_grade = self.current_grades.get_current_grade(course_id)
+        current_grade = self.current_grades.get_current_grade(edx_course_key)
         if current_grade is None:
             return
         return float(current_grade.percent) * 100
@@ -262,7 +271,7 @@ class MMTrack:
             int: A number of passed courses.
         """
         return (
-            self.final_grade_qset.for_course_run_keys(self.course_ids).passed()
+            self.final_grade_qset.for_course_run_keys(self.edx_course_keys).passed()
             .values_list('course_run__course__id', flat=True)
             .distinct().count()
         )

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -133,6 +133,12 @@ class MMTrack:
         # normal programs need to have a verified enrollment
         return self.has_verified_enrollment(edx_course_key)
 
+    def has_paid_for_any_in_program(self):
+        """
+        Returns true if a user has paid for any course run in the program
+        """
+        return any(self.has_paid(edx_course_key) for edx_course_key in self.edx_course_keys)
+
     def has_verified_enrollment(self, edx_course_key):
         """
         Returns true if user has a verified enrollment

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -513,6 +513,25 @@ class MMTrackTest(MockedESTestCase):
         final_grade.save()
         assert mmtrack.has_paid(key) is False
 
+    def test_has_paid_for_any_in_program(self):
+        """
+        Assert that has_paid_for_any_in_program returns True if any CourseRun associated with a Program has been
+        paid for.
+        """
+        new_program = ProgramFactory.create()
+        new_course_runs = CourseRunFactory.create_batch(2, course__program=new_program)
+        mmtrack = MMTrack(
+            user=self.user,
+            program=new_program,
+            edx_user_data=self.cached_edx_user_data
+        )
+        assert mmtrack.has_paid_for_any_in_program() is False
+        fg = FinalGradeFactory.create(user=self.user, course_run=new_course_runs[0], course_run_paid_on_edx=True)
+        assert mmtrack.has_paid_for_any_in_program() is True
+        fg.delete()
+        FinalGradeFactory.create(user=self.user, course_run=new_course_runs[1], course_run_paid_on_edx=True)
+        assert mmtrack.has_paid_for_any_in_program() is True
+
     @ddt.data(
         ("verified", "downloadable", True),
         ("audit", "downloadable", False),

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -119,12 +119,12 @@ class MMTrackTest(MockedESTestCase):
         assert mmtrack.current_grades == self.cached_edx_user_data.current_grades
         assert mmtrack.certificates == self.cached_edx_user_data.certificates
         assert mmtrack.financial_aid_available == self.program.financial_aid_availability
-        assert mmtrack.course_ids == {
+        assert mmtrack.edx_course_keys == {
             "course-v1:edX+DemoX+Demo_Course",
             "course-v1:MITx+8.MechCX+2014_T1",
             "course-v1:odl+FOO102+CR-FALL16"
         }
-        assert mmtrack.paid_course_ids == set()
+        assert mmtrack.paid_course_keys == set()
 
     def test_init_financial_aid_track(self):
         """
@@ -142,8 +142,8 @@ class MMTrackTest(MockedESTestCase):
         assert mmtrack.current_grades == self.cached_edx_user_data.current_grades
         assert mmtrack.certificates == self.cached_edx_user_data.certificates
         assert mmtrack.financial_aid_available == self.program_financial_aid.financial_aid_availability
-        assert mmtrack.course_ids == {"course-v1:odl+FOO101+CR-FALL15"}
-        assert mmtrack.paid_course_ids == set()
+        assert mmtrack.edx_course_keys == {"course-v1:odl+FOO101+CR-FALL15"}
+        assert mmtrack.paid_course_keys == set()
 
     def test_fa_paid(self):
         """
@@ -157,14 +157,14 @@ class MMTrackTest(MockedESTestCase):
             program=self.program_financial_aid,
             edx_user_data=self.cached_edx_user_data
         )
-        assert mmtrack_paid.paid_course_ids == {key}
+        assert mmtrack_paid.paid_course_keys == {key}
 
         mmtrack = MMTrack(
             user=UserFactory.create(),
             program=self.program_financial_aid,
             edx_user_data=self.cached_edx_user_data
         )
-        assert mmtrack.paid_course_ids == set()
+        assert mmtrack.paid_course_keys == set()
 
     def test_is_course_in_program(self):
         """

--- a/exams/utils.py
+++ b/exams/utils.py
@@ -205,7 +205,7 @@ def authorize_for_exam_given_program(program, username=None):
             program_enrollment.user,
             program_enrollment.program
         )
-        course_ids = set(mmtrack.edx_key_course_map.values())
+        course_ids = mmtrack.get_course_ids()
 
         # get latest course_run from given course
         for course_id in course_ids:

--- a/financialaid/serializers.py
+++ b/financialaid/serializers.py
@@ -214,6 +214,9 @@ class FormattedCoursePriceSerializer(serializers.Serializer):
 
 
 class FinancialAidDashboardSerializer:
+    """
+    Serializer of financial aid information for the dashboard API
+    """
     default_serialized = {
         "id": None,
         "has_user_applied": None,
@@ -230,7 +233,6 @@ class FinancialAidDashboardSerializer:
         """
         if not program.financial_aid_availability:
             return {}
-        # TODO:
         serialized = copy.copy(cls.default_serialized)
         financial_aid_qset = FinancialAid.objects.filter(
             Q(user=user) & Q(tier_program__program=program)
@@ -253,7 +255,7 @@ class FinancialAidDashboardSerializer:
     @classmethod
     def get_program_price_range(cls, program):
         """
-        Returns the financial aid possible cost range.
+        Returns the financial aid possible cost range
         """
         course_max_price = program.get_course_price()
         # get all the possible discounts for the program

--- a/financialaid/serializers.py
+++ b/financialaid/serializers.py
@@ -3,6 +3,7 @@ Serializers from financial aid
 """
 import logging
 import datetime
+import copy
 
 from django.db.models import Max, Min, Q
 from django.core.exceptions import ImproperlyConfigured
@@ -213,7 +214,7 @@ class FormattedCoursePriceSerializer(serializers.Serializer):
 
 
 class FinancialAidDashboardSerializer:
-    initial_serialized = {
+    default_serialized = {
         "id": None,
         "has_user_applied": None,
         "application_status": None,
@@ -230,7 +231,7 @@ class FinancialAidDashboardSerializer:
         if not program.financial_aid_availability:
             return {}
         # TODO:
-        serialized = {k: v for k, v in cls.initial_serialized.items()}
+        serialized = copy.copy(cls.default_serialized)
         financial_aid_qset = FinancialAid.objects.filter(
             Q(user=user) & Q(tier_program__program=program)
         ).exclude(status=FinancialAidStatus.RESET)

--- a/financialaid/serializers.py
+++ b/financialaid/serializers.py
@@ -1,8 +1,11 @@
 """
 Serializers from financial aid
 """
+import logging
 import datetime
 
+from django.db.models import Max, Min, Q
+from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import get_object_or_404
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -33,6 +36,9 @@ from financialaid.models import (
 )
 from mail.api import MailgunClient
 from mail.utils import generate_financial_aid_email
+
+
+log = logging.getLogger(__name__)
 
 
 class FinancialAidRequestSerializer(serializers.Serializer):
@@ -204,3 +210,60 @@ class FormattedCoursePriceSerializer(serializers.Serializer):
     price = DecimalField(max_digits=None, decimal_places=2)
     financial_aid_availability = BooleanField()
     has_financial_aid_request = BooleanField()
+
+
+class FinancialAidDashboardSerializer:
+    initial_serialized = {
+        "id": None,
+        "has_user_applied": None,
+        "application_status": None,
+        "min_possible_cost": None,
+        "max_possible_cost": None,
+        "date_documents_sent": None,
+    }
+
+    @classmethod
+    def serialize(cls, user, program):
+        """
+        Serializes financial aid info for a user in a program
+        """
+        if not program.financial_aid_availability:
+            return {}
+        # TODO:
+        serialized = {k: v for k, v in cls.initial_serialized.items()}
+        financial_aid_qset = FinancialAid.objects.filter(
+            Q(user=user) & Q(tier_program__program=program)
+        ).exclude(status=FinancialAidStatus.RESET)
+        serialized["has_user_applied"] = financial_aid_qset.exists()
+        if serialized["has_user_applied"]:
+            financial_aid = financial_aid_qset.first()
+            serialized.update({
+                "application_status": financial_aid.status,
+                "date_documents_sent": financial_aid.date_documents_sent,
+                "id": financial_aid.id
+            })
+        financial_aid_min_price, financial_aid_max_price = cls.get_program_price_range(program)
+        serialized.update({
+            "min_possible_cost": financial_aid_min_price,
+            "max_possible_cost": financial_aid_max_price
+        })
+        return serialized
+
+    @classmethod
+    def get_program_price_range(cls, program):
+        """
+        Returns the financial aid possible cost range.
+        """
+        course_max_price = program.get_course_price()
+        # get all the possible discounts for the program
+        program_tiers_qset = TierProgram.objects.filter(
+            Q(program=program) & Q(current=True)).order_by('discount_amount')
+        if not program_tiers_qset.exists():
+            log.error('The program "%s" needs at least one tier configured', program.title)
+            raise ImproperlyConfigured(
+                'The program "{}" needs at least one tier configured'.format(program.title))
+        min_discount = program_tiers_qset.aggregate(
+            Min('discount_amount')).get('discount_amount__min', 0)
+        max_discount = program_tiers_qset.aggregate(
+            Max('discount_amount')).get('discount_amount__max', 0)
+        return course_max_price - max_discount, course_max_price - min_discount

--- a/financialaid/serializers_test.py
+++ b/financialaid/serializers_test.py
@@ -15,12 +15,14 @@ from ecommerce.factories import CoursePriceFactory
 
 
 class FinancialAidDashboardSerializerTests(MockedESTestCase):
+    """
+    Tests for FinancialAidDashboardSerializer
+    """
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
         cls.user = UserFactory.create()
         cls.program = ProgramFactory.create(live=True, financial_aid_availability=True)
-        # create price for the financial aid course
         CoursePriceFactory.create(
             course_run__course__program=cls.program,
             is_valid=True,

--- a/financialaid/serializers_test.py
+++ b/financialaid/serializers_test.py
@@ -1,0 +1,134 @@
+"""
+Tests for financial aid serializers
+"""
+from datetime import datetime
+from pytz import utc
+from django.core.exceptions import ImproperlyConfigured
+
+from search.base import MockedESTestCase
+from financialaid.factories import TierProgramFactory, FinancialAidFactory
+from financialaid.constants import FinancialAidStatus
+from financialaid.serializers import FinancialAidDashboardSerializer
+from micromasters.factories import UserFactory
+from courses.factories import ProgramFactory
+from ecommerce.factories import CoursePriceFactory
+
+
+class FinancialAidDashboardSerializerTests(MockedESTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = UserFactory.create()
+        cls.program = ProgramFactory.create(live=True, financial_aid_availability=True)
+        # create price for the financial aid course
+        CoursePriceFactory.create(
+            course_run__course__program=cls.program,
+            is_valid=True,
+            price=1000
+        )
+        cls.min_tier_program = TierProgramFactory.create(
+            program=cls.program,
+            discount_amount=750,
+            current=True
+        )
+        cls.max_tier_program = TierProgramFactory.create(
+            program=cls.program,
+            discount_amount=0,
+            current=True
+        )
+
+    def test_financial_aid_with_application(self):
+        """
+        Test that a user that has a FinancialAid record with a non-reset status will have serialized financial aid
+        information that indicates that they have applied
+        """
+        fin_aid = FinancialAidFactory.create(
+            user=self.user,
+            tier_program=self.min_tier_program,
+            date_documents_sent=None,
+        )
+        serialized = FinancialAidDashboardSerializer.serialize(self.user, self.program)
+        assert serialized == {
+            "id": fin_aid.id,
+            "has_user_applied": True,
+            "application_status": fin_aid.status,
+            "min_possible_cost": 250,
+            "max_possible_cost": 1000,
+            "date_documents_sent": None,
+        }
+
+    def test_financial_aid_with_application_in_reset(self):
+        """
+        Test that a user that has a FinancialAid record with the reset status will have serialized financial aid
+        information that indicates that they have not applied
+        """
+        FinancialAidFactory.create(
+            user=self.user,
+            tier_program=self.min_tier_program,
+            date_documents_sent=None,
+            status=FinancialAidStatus.RESET
+        )
+        serialized = FinancialAidDashboardSerializer.serialize(self.user, self.program)
+        assert serialized == {
+            "id": None,
+            "has_user_applied": False,
+            "application_status": None,
+            "min_possible_cost": 250,
+            "max_possible_cost": 1000,
+            "date_documents_sent": None,
+        }
+
+    def test_financial_aid_with_documents_sent(self):
+        """
+        Test that a user that has a FinancialAid record and has sent documents will have serialized financial aid
+        information that indicates the date that documents were sent
+        """
+        now = datetime.now(tz=utc)
+        fin_aid = FinancialAidFactory.create(
+            user=self.user,
+            tier_program=self.min_tier_program,
+            date_documents_sent=now,
+        )
+        serialized = FinancialAidDashboardSerializer.serialize(self.user, self.program)
+        assert serialized == {
+            "id": fin_aid.id,
+            "has_user_applied": True,
+            "application_status": fin_aid.status,
+            "min_possible_cost": 250,
+            "max_possible_cost": 1000,
+            "date_documents_sent": now.date(),
+        }
+
+    def test_course_price_mandatory(self):
+        """
+        Test that an attempt to serialize financial aid information will raise an exception if no course prices
+        are available.
+        """
+        new_program = ProgramFactory.create(live=True, financial_aid_availability=True)
+        TierProgramFactory.create(
+            program=new_program,
+            discount_amount=750,
+            current=True
+        )
+        with self.assertRaises(ImproperlyConfigured):
+            FinancialAidDashboardSerializer.serialize(self.user, new_program)
+
+    def test_course_tier_mandatory(self):
+        """
+        Test that an attempt to serialize financial aid information will raise an exception if no tiers are created.
+        """
+        new_program = ProgramFactory.create(live=True, financial_aid_availability=True)
+        CoursePriceFactory.create(
+            course_run__course__program=new_program,
+            is_valid=True,
+            price=1000
+        )
+        with self.assertRaises(ImproperlyConfigured):
+            FinancialAidDashboardSerializer.serialize(self.user, new_program)
+
+    def test_with_non_financial_aid_program(self):
+        """
+        Test that a non-financial aid program will serialize to an empty dict
+        """
+        non_fa_program = ProgramFactory.create(live=True, financial_aid_availability=False)
+        assert FinancialAidDashboardSerializer.serialize(self.user, non_fa_program) == {}

--- a/mail/permissions.py
+++ b/mail/permissions.py
@@ -5,7 +5,6 @@ Permission classes for mail views
 from rolepermissions.verifications import has_permission
 from rest_framework.permissions import BasePermission
 
-from courses.models import CourseRun
 from roles.roles import Permissions, Staff, Instructor
 from dashboard.models import ProgramEnrollment
 from dashboard.utils import MMTrack
@@ -67,12 +66,7 @@ class UserCanMessageSpecificLearnerPermission(BasePermission):
                 program_enrollment.program,
                 edx_user_data
             )
-            course_run_keys = (
-                CourseRun.objects
-                .filter(course__program=program_enrollment.program)
-                .values_list('edx_course_key', flat=True)
-            )
-            if any(mmtrack.has_paid(course_run_key) for course_run_key in course_run_keys):
+            if mmtrack.has_paid_for_any_in_program():
                 return True
 
         return False


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #2929
~~⚠️ Rebased on #2909 ⚠️~~

#### What's this PR do?
Cleans up more `dashboard.utils.MMTrack` code, building off of the work in #2909. The details about the fixes are in the #2929 issue description.

#### How should this be manually tested?
Test that changes to user course data result in the expected changes to the dashboard output. The `alter_data` management command can be used to this end (`manage.py alter_data examples`).

#### Where should the reviewer start?
`dashboard/utils.py`

