### PR TITLE
Add refresh_index to fix race condition with percolate

### DIFF
--- a/search/tasks.py
+++ b/search/tasks.py
@@ -8,12 +8,14 @@ from dashboard.models import ProgramEnrollment
 from mail.api import send_automatic_emails as _send_automatic_emails
 from micromasters.celery import async
 from search.indexing_api import (
+    get_default_alias,
     index_program_enrolled_users as _index_program_enrolled_users,
     remove_program_enrolled_user as _remove_program_enrolled_user,
     index_users as _index_users,
     remove_user as _remove_user,
     index_percolate_queries as _index_percolate_queries,
     delete_percolate_query as _delete_percolate_query,
+    refresh_index,
 )
 from search.models import PercolateQuery
 
@@ -40,6 +42,7 @@ def index_program_enrolled_users(program_enrollments):
     _index_program_enrolled_users(program_enrollments)
 
     # Send email for profiles that newly fit the search query for an automatic email
+    refresh_index(get_default_alias())
     for program_enrollment in program_enrollments:
         _send_automatic_emails(program_enrollment)
 
@@ -55,6 +58,7 @@ def index_users(users):
     _index_users(users)
 
     # Send email for profiles that newly fit the search query for an automatic email
+    refresh_index(get_default_alias())
     for program_enrollment in ProgramEnrollment.objects.filter(user__in=users):
         _send_automatic_emails(program_enrollment)
 

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -15,7 +15,7 @@ from search.indexing_api import (
     remove_user as _remove_user,
     index_percolate_queries as _index_percolate_queries,
     delete_percolate_query as _delete_percolate_query,
-    refresh_index,
+    refresh_index as _refresh_index,
 )
 from search.models import PercolateQuery
 
@@ -42,7 +42,7 @@ def index_program_enrolled_users(program_enrollments):
     _index_program_enrolled_users(program_enrollments)
 
     # Send email for profiles that newly fit the search query for an automatic email
-    refresh_index(get_default_alias())
+    _refresh_index(get_default_alias())
     for program_enrollment in program_enrollments:
         _send_automatic_emails(program_enrollment)
 
@@ -58,7 +58,7 @@ def index_users(users):
     _index_users(users)
 
     # Send email for profiles that newly fit the search query for an automatic email
-    refresh_index(get_default_alias())
+    _refresh_index(get_default_alias())
     for program_enrollment in ProgramEnrollment.objects.filter(user__in=users):
         _send_automatic_emails(program_enrollment)
 

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -1,5 +1,6 @@
 """Tests for search tasks"""
 from dashboard.factories import ProgramEnrollmentFactory
+from django.test import override_settings
 from search.base import MockedESTestCase
 from search.tasks import (
     index_users,
@@ -7,6 +8,10 @@ from search.tasks import (
 )
 
 
+FAKE_INDEX = 'fake'
+
+
+@override_settings(ELASTICSEARCH_INDEX=FAKE_INDEX)
 class SearchTasksTests(MockedESTestCase):
     """
     Tests for search tasks
@@ -29,17 +34,23 @@ class SearchTasksTests(MockedESTestCase):
         """
         enrollment1 = ProgramEnrollmentFactory.create()
         enrollment2 = ProgramEnrollmentFactory.create(user=enrollment1.user)
-        index_users([enrollment1.user])
+        with self.patch('search.tasks.refresh_index', autospec=True) as refresh_index_mock:
+            index_users([enrollment1.user])
         self.index_users_mock.assert_called_with([enrollment1.user])
         for enrollment in [enrollment1, enrollment2]:
             self.send_automatic_emails_mock.assert_any_call(enrollment)
+        assert refresh_index_mock.call_count == 1
+        refresh_index_mock.assert_called_with(FAKE_INDEX)
 
     def test_index_program_enrolled_users(self):
         """
         When we run the index_program_enrolled_users task we should index them and send them automatic emails
         """
         enrollments = [ProgramEnrollmentFactory.create() for _ in range(2)]
-        index_program_enrolled_users(enrollments)
+        with self.patch('search.tasks.refresh_index', autospec=True) as refresh_index_mock:
+            index_program_enrolled_users(enrollments)
         self.index_program_enrolled_users_mock.assert_called_with(enrollments)
         for enrollment in enrollments:
             self.send_automatic_emails_mock.assert_any_call(enrollment)
+        assert refresh_index_mock.call_count == 1
+        refresh_index_mock.assert_called_with(FAKE_INDEX)

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -2,6 +2,7 @@
 from dashboard.factories import ProgramEnrollmentFactory
 from django.test import override_settings
 from search.base import MockedESTestCase
+from search.indexing_api import get_default_alias
 from search.tasks import (
     index_users,
     index_program_enrolled_users,
@@ -40,7 +41,7 @@ class SearchTasksTests(MockedESTestCase):
         for enrollment in [enrollment1, enrollment2]:
             self.send_automatic_emails_mock.assert_any_call(enrollment)
         assert refresh_index_mock.call_count == 1
-        refresh_index_mock.assert_called_with(FAKE_INDEX)
+        refresh_index_mock.assert_called_with(get_default_alias())
 
     def test_index_program_enrolled_users(self):
         """
@@ -53,4 +54,4 @@ class SearchTasksTests(MockedESTestCase):
         for enrollment in enrollments:
             self.send_automatic_emails_mock.assert_any_call(enrollment)
         assert refresh_index_mock.call_count == 1
-        refresh_index_mock.assert_called_with(FAKE_INDEX)
+        refresh_index_mock.assert_called_with(get_default_alias())

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -28,6 +28,8 @@ class SearchTasksTests(MockedESTestCase):
                 self.index_program_enrolled_users_mock = mock
             elif mock.name == "_send_automatic_emails":
                 self.send_automatic_emails_mock = mock
+            elif mock.name == "_refresh_index":
+                self.refresh_index_mock = mock
 
     def test_index_users(self):
         """
@@ -35,23 +37,21 @@ class SearchTasksTests(MockedESTestCase):
         """
         enrollment1 = ProgramEnrollmentFactory.create()
         enrollment2 = ProgramEnrollmentFactory.create(user=enrollment1.user)
-        with self.patch('search.tasks.refresh_index', autospec=True) as refresh_index_mock:
-            index_users([enrollment1.user])
+        index_users([enrollment1.user])
         self.index_users_mock.assert_called_with([enrollment1.user])
         for enrollment in [enrollment1, enrollment2]:
             self.send_automatic_emails_mock.assert_any_call(enrollment)
-        assert refresh_index_mock.call_count == 1
-        refresh_index_mock.assert_called_with(get_default_alias())
+        assert self.refresh_index_mock.call_count == 1
+        self.refresh_index_mock.assert_called_with(get_default_alias())
 
     def test_index_program_enrolled_users(self):
         """
         When we run the index_program_enrolled_users task we should index them and send them automatic emails
         """
         enrollments = [ProgramEnrollmentFactory.create() for _ in range(2)]
-        with self.patch('search.tasks.refresh_index', autospec=True) as refresh_index_mock:
-            index_program_enrolled_users(enrollments)
+        index_program_enrolled_users(enrollments)
         self.index_program_enrolled_users_mock.assert_called_with(enrollments)
         for enrollment in enrollments:
             self.send_automatic_emails_mock.assert_any_call(enrollment)
-        assert refresh_index_mock.call_count == 1
-        refresh_index_mock.assert_called_with(get_default_alias())
+        assert self.refresh_index_mock.call_count == 1
+        self.refresh_index_mock.assert_called_with(get_default_alias())

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -41,7 +41,6 @@ class SearchTasksTests(MockedESTestCase):
         self.index_users_mock.assert_called_with([enrollment1.user])
         for enrollment in [enrollment1, enrollment2]:
             self.send_automatic_emails_mock.assert_any_call(enrollment)
-        assert self.refresh_index_mock.call_count == 1
         self.refresh_index_mock.assert_called_with(get_default_alias())
 
     def test_index_program_enrolled_users(self):
@@ -53,5 +52,4 @@ class SearchTasksTests(MockedESTestCase):
         self.index_program_enrolled_users_mock.assert_called_with(enrollments)
         for enrollment in enrollments:
             self.send_automatic_emails_mock.assert_any_call(enrollment)
-        assert self.refresh_index_mock.call_count == 1
         self.refresh_index_mock.assert_called_with(get_default_alias())


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2959 

#### What's this PR do?
Adds a couple `refresh_index` commands to flush updates to the index before we run percolate. This should make sure the program enrollment exists by the time we run percolate on it.

#### How should this be manually tested?
I don't think it's easy to reproduce. We will just need to keep an eye on sentry.
