### PR TITLE
Release 0.53.5

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,19 @@
 Release Notes
 =============
 
+Version 0.53.5
+--------------
+
+- PR fix
+- merge fix
+- Added helper method for determining if user paid for any course run in a program
+- Renamed &#39;course_id&#39; to &#39;edx_course_key&#39; etc
+- Moved FA serialization from MMTrack to separate class
+- Got rid of pearson exam status variable setting in init
+- Cleaned up MMTrack final grade code
+- Revert &quot;Fixed Order Summary text&quot;
+- Fixed Order Summary text
+
 Version 0.53.4
 --------------
 

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -12,6 +12,7 @@ from backends.exceptions import InvalidCredentialStored
 from courses.models import Program
 from dashboard.api_edx_cache import CachedEdxDataApi, CachedEdxUserData
 from dashboard.utils import MMTrack
+from financialaid.serializers import FinancialAidDashboardSerializer
 from grades import api
 from grades.models import FinalGrade
 from exams.models import ExamAuthorization
@@ -172,18 +173,11 @@ def get_info_for_program(mmtrack):
         "title": mmtrack.program.title,
         "financial_aid_availability": mmtrack.financial_aid_available,
         "courses": [],
-        "pearson_exam_status": mmtrack.pearson_exam_status,
+        "pearson_exam_status": mmtrack.get_pearson_exam_status(),
         "grade_average": mmtrack.calculate_final_grade_average(),
     }
     if mmtrack.financial_aid_available:
-        data["financial_aid_user_info"] = {
-            "id": mmtrack.financial_aid_id,
-            "has_user_applied": mmtrack.financial_aid_applied,
-            "application_status": mmtrack.financial_aid_status,
-            "min_possible_cost": mmtrack.financial_aid_min_price,
-            "max_possible_cost": mmtrack.financial_aid_max_price,
-            "date_documents_sent": mmtrack.financial_aid_date_documents_sent,
-        }
+        data["financial_aid_user_info"] = FinancialAidDashboardSerializer.serialize(mmtrack.user, mmtrack.program)
     for course in mmtrack.program.course_set.all():
         data['courses'].append(
             get_info_for_course(course, mmtrack)

--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -5,7 +5,6 @@ from courses.utils import get_year_season_from_course_run
 from dashboard.models import CachedEnrollment
 from dashboard.utils import get_mmtrack
 from roles.api import is_learner
-from grades.models import FinalGrade
 
 
 class UserProgramSearchSerializer:
@@ -51,10 +50,7 @@ class UserProgramSearchSerializer:
         """
         final_grades = []
         for enrollment in enrollments:
-            try:
-                final_grade = mmtrack.get_final_grade(enrollment.course_run.edx_course_key)
-            except FinalGrade.DoesNotExist:
-                continue
+            final_grade = mmtrack.get_final_grade_percent(enrollment.course_run.edx_course_key)
             if final_grade:
                 final_grades.append({'title': enrollment.course_run.course.title, 'grade': final_grade})
         return final_grades

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -5,16 +5,13 @@ import logging
 from decimal import Decimal
 
 from datetime import datetime
-from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
-from django.db.models import Max, Min, Q
+from django.db.models import Q
 from pytz import utc
 
 from courses.models import CourseRun
 from dashboard.api_edx_cache import CachedEdxUserData
-from ecommerce.models import Line
-from financialaid.constants import FinancialAidStatus
-from financialaid.models import FinancialAid, TierProgram
+from ecommerce.models import Order, Line
 from grades.constants import FinalGradeStatus
 from grades.models import FinalGrade
 from exams.models import ExamProfile, ExamAuthorization
@@ -36,15 +33,8 @@ class MMTrack:
     enrollments = None
     current_grades = None
     certificates = None
-    course_ids = set()
-    paid_course_ids = set()  # financial aid course ids for paid with the MM app
-    financial_aid_available = None
-    financial_aid_applied = None
-    financial_aid_status = None
-    financial_aid_id = None
-    financial_aid_min_price = None
-    financial_aid_max_price = None
-    financial_aid_date_documents_sent = None
+    edx_course_keys = set()
+    paid_course_keys = set()  # Course keys for course runs that were paid for via financial aid
     pearson_exam_status = None
 
     def __init__(self, user, program, edx_user_data):
@@ -69,28 +59,12 @@ class MMTrack:
                     Q(edx_course_key__isnull=True) | Q(edx_course_key__exact='')
                 ).values_list("edx_course_key", "course__id")
             )
-            self.course_ids = self.edx_key_course_map.keys()
-            self.pearson_exam_status = self.get_pearson_exam_status()
+            self.edx_course_keys = set(self.edx_key_course_map.keys())
 
             if self.financial_aid_available:
-                self.paid_course_ids = set(Line.objects.filter(
-                    Q(order__status='fulfilled') & Q(course_key__in=self.course_ids) & Q(order__user=user)
+                self.paid_course_keys = set(Line.objects.filter(
+                    order__status=Order.FULFILLED, course_key__in=self.edx_course_keys, order__user=user
                 ).values_list("course_key", flat=True))
-
-                financial_aid_qset = FinancialAid.objects.filter(
-                    Q(user=user) & Q(tier_program__program=program)
-                ).exclude(status=FinancialAidStatus.RESET)
-                self.financial_aid_applied = financial_aid_qset.exists()
-                if self.financial_aid_applied:
-                    financial_aid = financial_aid_qset.first()
-                    self.financial_aid_status = financial_aid.status
-                    # set the sent document date
-                    self.financial_aid_date_documents_sent = financial_aid.date_documents_sent
-                    # and the financial aid ID
-                    self.financial_aid_id = financial_aid.id
-
-                # set the price range for the program
-                self.financial_aid_min_price, self.financial_aid_max_price = self._get_program_fa_prices()
 
     def __str__(self):
         return 'MMTrack for user {0} on program "{1}"'.format(
@@ -98,101 +72,98 @@ class MMTrack:
             self.program.title
         )
 
-    def _get_program_fa_prices(self):
+    def _is_course_in_program(self, edx_course_key):
         """
-        Returns the financial aid possible cost range.
+        Returns whether the edx_course_key id belongs to the program
         """
-        course_max_price = self.program.get_course_price()
-        # get all the possible discounts for the program
-        program_tiers_qset = TierProgram.objects.filter(
-            Q(program=self.program) & Q(current=True)).order_by('discount_amount')
-        if not program_tiers_qset.exists():
-            log.error('The program "%s" needs at least one tier configured', self.program.title)
-            raise ImproperlyConfigured(
-                'The program "{}" needs at least one tier configured'.format(self.program.title))
-        min_discount = program_tiers_qset.aggregate(
-            Min('discount_amount')).get('discount_amount__min', 0)
-        max_discount = program_tiers_qset.aggregate(
-            Max('discount_amount')).get('discount_amount__max', 0)
-        return course_max_price - max_discount, course_max_price - min_discount
+        return edx_course_key in self.edx_course_keys
 
-    def _is_course_in_program(self, course_id):
+    def get_course_ids(self):
         """
-        Returns whether the course id belongs to the program
-        """
-        return course_id in self.course_ids
+        Returns a set of valid Course id's in the given program
 
-    def is_enrolled(self, course_id):
+        Returns:
+            set: Course id integers
+        """
+        return set(self.edx_key_course_map.values())
+
+    def is_enrolled(self, edx_course_key):
         """
         Returns whether the user is enrolled at least audit in a course run.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
 
         Returns:
-            bool: whether the user is enrolled audit in the course
+            bool: whether the user is enrolled audit in the course run
         """
-        return self._is_course_in_program(course_id) and self.enrollments.is_enrolled_in(course_id)
+        return self._is_course_in_program(edx_course_key) and self.enrollments.is_enrolled_in(edx_course_key)
 
-    def is_enrolled_mmtrack(self, course_id):
+    def is_enrolled_mmtrack(self, edx_course_key):
         """
         Returns whether an used is enrolled mmtrack in a course run.
         This means if the user is enrolled verified for normal programs
         or enrolled and paid on micromasters for financial aid ones.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
 
         Returns:
-            bool: whether the user is enrolled mmtrack in the course
+            bool: whether the user is enrolled mmtrack in the course run
         """
-        return self.is_enrolled(course_id) and self.has_paid(course_id)
+        return self.is_enrolled(edx_course_key) and self.has_paid(edx_course_key)
 
-    def has_paid(self, course_id):
+    def has_paid(self, edx_course_key):
         """
-        Returns true if user paid for a course.
+        Returns true if user paid for a course run.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
 
         Returns:
             bool: whether the user is paid
         """
-        if self.has_paid_final_grade(course_id):
+        if self.has_paid_final_grade(edx_course_key):
             return True
 
         # financial aid programs need to have an audit enrollment and a paid entry for the course
         if self.financial_aid_available:
-            return course_id in self.paid_course_ids
+            return edx_course_key in self.paid_course_keys
 
         # normal programs need to have a verified enrollment
-        return self.has_verified_enrollment(course_id)
+        return self.has_verified_enrollment(edx_course_key)
 
-    def has_verified_enrollment(self, course_id):
+    def has_paid_for_any_in_program(self):
+        """
+        Returns true if a user has paid for any course run in the program
+        """
+        return any(self.has_paid(edx_course_key) for edx_course_key in self.edx_course_keys)
+
+    def has_verified_enrollment(self, edx_course_key):
         """
         Returns true if user has a verified enrollment
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
 
         Returns:
             bool: whether the user has a verified enrollment
         """
-        enrollment = self.enrollments.get_enrollment_for_course(course_id)
+        enrollment = self.enrollments.get_enrollment_for_course(edx_course_key)
         return bool(enrollment and enrollment.is_verified)
 
-    def has_passing_certificate(self, course_id):
+    def has_passing_certificate(self, edx_course_key):
         """
         Returns whether the user has a passing certificate.
 
         Args:
-            course_id (str): An edX course key
+            edx_course_key (str): An edX course key
         Returns:
             bool: whether the user has a passing certificate meaning that the user passed the course on edX
         """
-        if not self.certificates.has_verified_cert(course_id):
+        if not self.certificates.has_verified_cert(edx_course_key):
             return False
-        certificate = self.certificates.get_verified_cert(course_id)
+        certificate = self.certificates.get_verified_cert(edx_course_key)
         return certificate.status == 'downloadable'
 
     @property
@@ -200,100 +171,100 @@ class MMTrack:
         """Base queryset for the MMTrack User's completed FinalGrades"""
         return FinalGrade.objects.filter(user=self.user, status=FinalGradeStatus.COMPLETE)
 
-    def get_final_grade(self, course_id):
+    def get_final_grade(self, edx_course_key):
         """
         Gets a user's FinalGrade for a CourseRun matching a course run key
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Returns:
             FinalGrade: a Final Grade object or None
         """
-        return self.final_grade_qset.for_course_run_key(course_id).first()
+        return self.final_grade_qset.for_course_run_key(edx_course_key).first()
 
-    def get_required_final_grade(self, course_id):
+    def get_required_final_grade(self, edx_course_key):
         """
         Gets a user's FinalGrade for a CourseRun matching a course run key. This should be used
         in cases where a user is expected to have a FinalGrade for the given CourseRun.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Raises:
             FinalGrade.DoesNotExist: raised if a FinalGrade record was not found
         Returns:
             FinalGrade: a Final Grade object
         """
-        return self.final_grade_qset.for_course_run_key(course_id).get()
+        return self.final_grade_qset.for_course_run_key(edx_course_key).get()
 
-    def has_final_grade(self, course_id):
+    def has_final_grade(self, edx_course_key):
         """
         Checks if there is a final grade for the course run
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Returns:
             bool: whether a frozen final grade exists
         """
-        return self.final_grade_qset.for_course_run_key(course_id).exists()
+        return self.final_grade_qset.for_course_run_key(edx_course_key).exists()
 
-    def has_paid_final_grade(self, course_id):
+    def has_paid_final_grade(self, edx_course_key):
         """
         Checks if there is a a frozen final grade and the user paid for it.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Returns:
             bool: whether a frozen final grade exists
         """
-        return self.final_grade_qset.paid_on_edx().for_course_run_key(course_id).exists()
+        return self.final_grade_qset.paid_on_edx().for_course_run_key(edx_course_key).exists()
 
-    def has_passed_course(self, course_id):
+    def has_passed_course(self, edx_course_key):
         """
         Returns whether the user has passed a course run.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Returns:
             bool: whether the user has passed the course
         """
-        final_grade = self.get_final_grade(course_id)
+        final_grade = self.get_final_grade(edx_course_key)
         return final_grade.passed if final_grade else False
 
-    def get_final_grade_percent(self, course_id):
+    def get_final_grade_percent(self, edx_course_key):
         """
         Returns the course final grade number for the user if she passed.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Returns:
             float: the final grade of the user in the course
         """
-        final_grade = self.get_final_grade(course_id)
+        final_grade = self.get_final_grade(edx_course_key)
         return final_grade.grade_percent if final_grade else None
 
     def calculate_final_grade_average(self):
         """
         Calculates an average grade (integer) from the program final grades
         """
-        final_grades = self.final_grade_qset.for_course_run_keys(self.course_ids)
+        final_grades = self.final_grade_qset.for_course_run_keys(self.edx_course_keys)
         if final_grades:
             return round(
                 sum(Decimal(final_grade.grade_percent) for final_grade in final_grades) /
                 len(final_grades)
             )
 
-    def get_current_grade(self, course_id):
+    def get_current_grade(self, edx_course_key):
         """
-        Returns the current grade number for the user in the course if enrolled.
+        Returns the current grade number for the user in the course run if enrolled.
 
         Args:
-            course_id (str): an edX course run id
+            edx_course_key (str): an edX course run key
         Returns:
-            float: the current grade of the user in the course
+            float: the current grade of the user in the course run
         """
-        if not self.is_enrolled(course_id):
+        if not self.is_enrolled(edx_course_key):
             return
-        current_grade = self.current_grades.get_current_grade(course_id)
+        current_grade = self.current_grades.get_current_grade(edx_course_key)
         if current_grade is None:
             return
         return float(current_grade.percent) * 100
@@ -306,7 +277,7 @@ class MMTrack:
             int: A number of passed courses.
         """
         return (
-            self.final_grade_qset.for_course_run_keys(self.course_ids).passed()
+            self.final_grade_qset.for_course_run_keys(self.edx_course_keys).passed()
             .values_list('course_run__course__id', flat=True)
             .distinct().count()
         )

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -8,19 +8,16 @@ from unittest.mock import (
 )
 
 import pytz
-from django.core.exceptions import ImproperlyConfigured
 import ddt
 
 from courses.factories import ProgramFactory, CourseFactory, CourseRunFactory
 from dashboard.api_edx_cache import CachedEdxUserData
 from dashboard.models import CachedEnrollment, CachedCertificate, CachedCurrentGrade
 from dashboard.utils import get_mmtrack, MMTrack
-from ecommerce.factories import CoursePriceFactory, LineFactory, OrderFactory
+from ecommerce.factories import LineFactory, OrderFactory
 from ecommerce.models import Order
 from exams.factories import ExamProfileFactory, ExamAuthorizationFactory
 from exams.models import ExamProfile, ExamAuthorization
-from financialaid.constants import FinancialAidStatus
-from financialaid.factories import TierProgramFactory, FinancialAidFactory
 from grades.factories import FinalGradeFactory
 from grades.models import FinalGrade
 from micromasters.factories import UserFactory
@@ -93,23 +90,6 @@ class MMTrackTest(MockedESTestCase):
             edx_course_key=None
         )
 
-        # create price for the financial aid course
-        CoursePriceFactory.create(
-            course_run=cls.crun_fa,
-            is_valid=True,
-            price=1000
-        )
-        cls.min_tier_program = TierProgramFactory.create(
-            program=cls.program_financial_aid,
-            discount_amount=750,
-            current=True
-        )
-        cls.max_tier_program = TierProgramFactory.create(
-            program=cls.program_financial_aid,
-            discount_amount=0,
-            current=True
-        )
-
     def pay_for_fa_course(self, course_id):
         """
         Helper function to pay for a financial aid course
@@ -139,18 +119,12 @@ class MMTrackTest(MockedESTestCase):
         assert mmtrack.current_grades == self.cached_edx_user_data.current_grades
         assert mmtrack.certificates == self.cached_edx_user_data.certificates
         assert mmtrack.financial_aid_available == self.program.financial_aid_availability
-        assert mmtrack.course_ids == {
+        assert mmtrack.edx_course_keys == {
             "course-v1:edX+DemoX+Demo_Course",
             "course-v1:MITx+8.MechCX+2014_T1",
             "course-v1:odl+FOO102+CR-FALL16"
         }
-        assert mmtrack.paid_course_ids == set()
-        assert mmtrack.financial_aid_applied is None
-        assert mmtrack.financial_aid_status is None
-        assert mmtrack.financial_aid_id is None
-        assert mmtrack.financial_aid_min_price is None
-        assert mmtrack.financial_aid_max_price is None
-        assert mmtrack.financial_aid_date_documents_sent is None
+        assert mmtrack.paid_course_keys == set()
 
     def test_init_financial_aid_track(self):
         """
@@ -168,14 +142,8 @@ class MMTrackTest(MockedESTestCase):
         assert mmtrack.current_grades == self.cached_edx_user_data.current_grades
         assert mmtrack.certificates == self.cached_edx_user_data.certificates
         assert mmtrack.financial_aid_available == self.program_financial_aid.financial_aid_availability
-        assert mmtrack.course_ids == {"course-v1:odl+FOO101+CR-FALL15"}
-        assert mmtrack.paid_course_ids == set()
-        assert mmtrack.financial_aid_applied is False
-        assert mmtrack.financial_aid_status is None
-        assert mmtrack.financial_aid_id is None
-        assert mmtrack.financial_aid_min_price == 250
-        assert mmtrack.financial_aid_max_price == 1000
-        assert mmtrack.financial_aid_date_documents_sent is None
+        assert mmtrack.edx_course_keys == {"course-v1:odl+FOO101+CR-FALL15"}
+        assert mmtrack.paid_course_keys == set()
 
     def test_fa_paid(self):
         """
@@ -189,121 +157,14 @@ class MMTrackTest(MockedESTestCase):
             program=self.program_financial_aid,
             edx_user_data=self.cached_edx_user_data
         )
-        assert mmtrack_paid.paid_course_ids == {key}
+        assert mmtrack_paid.paid_course_keys == {key}
 
         mmtrack = MMTrack(
             user=UserFactory.create(),
             program=self.program_financial_aid,
             edx_user_data=self.cached_edx_user_data
         )
-        assert mmtrack.paid_course_ids == set()
-
-    def test_init_financial_aid_with_application(self):
-        """
-        Sub case of test_init_financial_aid_track where there is a financial aid application for the user
-        """
-        # create a financial aid application
-        fin_aid = FinancialAidFactory.create(
-            user=self.user,
-            tier_program=self.min_tier_program,
-            date_documents_sent=None,
-        )
-        mmtrack = MMTrack(
-            user=self.user,
-            program=self.program_financial_aid,
-            edx_user_data=self.cached_edx_user_data
-        )
-
-        assert mmtrack.financial_aid_applied is True
-        assert mmtrack.financial_aid_status == fin_aid.status
-        assert mmtrack.financial_aid_id == fin_aid.id
-        assert mmtrack.financial_aid_min_price == 250
-        assert mmtrack.financial_aid_max_price == 1000
-        assert mmtrack.financial_aid_date_documents_sent is None
-
-    def test_init_financial_aid_with_application_in_reset(self):
-        """
-        Sub case of test_init_financial_aid_with_application where
-        there is a financial aid application for the user but the state is `reset`
-        """
-        FinancialAidFactory.create(
-            user=self.user,
-            tier_program=self.min_tier_program,
-            date_documents_sent=None,
-            status=FinancialAidStatus.RESET
-        )
-        mmtrack = MMTrack(
-            user=self.user,
-            program=self.program_financial_aid,
-            edx_user_data=self.cached_edx_user_data
-        )
-        # the result is like if the user never applied
-        assert mmtrack.financial_aid_applied is False
-        assert mmtrack.financial_aid_status is None
-        assert mmtrack.financial_aid_id is None
-        assert mmtrack.financial_aid_min_price == 250
-        assert mmtrack.financial_aid_max_price == 1000
-        assert mmtrack.financial_aid_date_documents_sent is None
-
-    def test_init_financial_aid_with_documents_sent(self):
-        """
-        Sub case of test_init_financial_aid_with_application
-        where the user set a date for the financial aid documents sent
-        """
-        # create a financial aid application
-        fin_aid = FinancialAidFactory.create(
-            user=self.user,
-            tier_program=self.min_tier_program,
-            date_documents_sent=self.now,
-        )
-        mmtrack = MMTrack(
-            user=self.user,
-            program=self.program_financial_aid,
-            edx_user_data=self.cached_edx_user_data
-        )
-
-        assert mmtrack.financial_aid_applied is True
-        assert mmtrack.financial_aid_status == fin_aid.status
-        assert mmtrack.financial_aid_id == fin_aid.id
-        assert mmtrack.financial_aid_min_price == 250
-        assert mmtrack.financial_aid_max_price == 1000
-        assert mmtrack.financial_aid_date_documents_sent == self.now.date()
-
-    def test_course_price_mandatory(self):
-        """
-        Test that if financial aid is available for the program, at least one course price should be available.
-        """
-        program = ProgramFactory.create(live=True, financial_aid_availability=True)
-        TierProgramFactory.create(
-            program=program,
-            discount_amount=750,
-            current=True
-        )
-        with self.assertRaises(ImproperlyConfigured):
-            MMTrack(
-                user=self.user,
-                program=program,
-                edx_user_data=self.cached_edx_user_data
-            )
-
-    def test_course_tier_mandatory(self):
-        """
-        Test that if financial aid is available for the program, at least one tier should be available.
-        """
-        program = ProgramFactory.create(live=True, financial_aid_availability=True)
-        course = CourseFactory.create(program=program)
-        crun_fa = CourseRunFactory.create(course=course)
-        CoursePriceFactory.create(
-            course_run=crun_fa,
-            is_valid=True,
-            price=1000
-        )
-        with self.assertRaises(ImproperlyConfigured):
-            MMTrack(
-                user=self.user,
-                program=program,
-                edx_user_data=self.cached_edx_user_data
-            )
+        assert mmtrack.paid_course_keys == set()
 
     def test_is_course_in_program(self):
         """
@@ -651,6 +512,25 @@ class MMTrackTest(MockedESTestCase):
         final_grade.course_run_paid_on_edx = False
         final_grade.save()
         assert mmtrack.has_paid(key) is False
+
+    def test_has_paid_for_any_in_program(self):
+        """
+        Assert that has_paid_for_any_in_program returns True if any CourseRun associated with a Program has been
+        paid for.
+        """
+        new_program = ProgramFactory.create()
+        new_course_runs = CourseRunFactory.create_batch(2, course__program=new_program)
+        mmtrack = MMTrack(
+            user=self.user,
+            program=new_program,
+            edx_user_data=self.cached_edx_user_data
+        )
+        assert mmtrack.has_paid_for_any_in_program() is False
+        fg = FinalGradeFactory.create(user=self.user, course_run=new_course_runs[0], course_run_paid_on_edx=True)
+        assert mmtrack.has_paid_for_any_in_program() is True
+        fg.delete()
+        FinalGradeFactory.create(user=self.user, course_run=new_course_runs[1], course_run_paid_on_edx=True)
+        assert mmtrack.has_paid_for_any_in_program() is True
 
     @ddt.data(
         ("verified", "downloadable", True),

--- a/exams/utils.py
+++ b/exams/utils.py
@@ -119,7 +119,7 @@ def authorize_for_exam(mmtrack, course_run):
     # if user passed the course and currently not authorization for that run then give
     # her authorizations.
     ok_for_authorization = (
-        mmtrack.has_passed_course_for_exam(course_run.edx_course_key) and
+        mmtrack.has_passed_course(course_run.edx_course_key) and
         not ExamAuthorization.objects.filter(
             user=mmtrack.user,
             course=course_run.course,

--- a/exams/utils.py
+++ b/exams/utils.py
@@ -205,7 +205,7 @@ def authorize_for_exam_given_program(program, username=None):
             program_enrollment.user,
             program_enrollment.program
         )
-        course_ids = set(mmtrack.edx_key_course_map.values())
+        course_ids = mmtrack.get_course_ids()
 
         # get latest course_run from given course
         for course_id in course_ids:

--- a/financialaid/serializers_test.py
+++ b/financialaid/serializers_test.py
@@ -1,0 +1,136 @@
+"""
+Tests for financial aid serializers
+"""
+from datetime import datetime
+from pytz import utc
+from django.core.exceptions import ImproperlyConfigured
+
+from search.base import MockedESTestCase
+from financialaid.factories import TierProgramFactory, FinancialAidFactory
+from financialaid.constants import FinancialAidStatus
+from financialaid.serializers import FinancialAidDashboardSerializer
+from micromasters.factories import UserFactory
+from courses.factories import ProgramFactory
+from ecommerce.factories import CoursePriceFactory
+
+
+class FinancialAidDashboardSerializerTests(MockedESTestCase):
+    """
+    Tests for FinancialAidDashboardSerializer
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = UserFactory.create()
+        cls.program = ProgramFactory.create(live=True, financial_aid_availability=True)
+        CoursePriceFactory.create(
+            course_run__course__program=cls.program,
+            is_valid=True,
+            price=1000
+        )
+        cls.min_tier_program = TierProgramFactory.create(
+            program=cls.program,
+            discount_amount=750,
+            current=True
+        )
+        cls.max_tier_program = TierProgramFactory.create(
+            program=cls.program,
+            discount_amount=0,
+            current=True
+        )
+
+    def test_financial_aid_with_application(self):
+        """
+        Test that a user that has a FinancialAid record with a non-reset status will have serialized financial aid
+        information that indicates that they have applied
+        """
+        fin_aid = FinancialAidFactory.create(
+            user=self.user,
+            tier_program=self.min_tier_program,
+            date_documents_sent=None,
+        )
+        serialized = FinancialAidDashboardSerializer.serialize(self.user, self.program)
+        assert serialized == {
+            "id": fin_aid.id,
+            "has_user_applied": True,
+            "application_status": fin_aid.status,
+            "min_possible_cost": 250,
+            "max_possible_cost": 1000,
+            "date_documents_sent": None,
+        }
+
+    def test_financial_aid_with_application_in_reset(self):
+        """
+        Test that a user that has a FinancialAid record with the reset status will have serialized financial aid
+        information that indicates that they have not applied
+        """
+        FinancialAidFactory.create(
+            user=self.user,
+            tier_program=self.min_tier_program,
+            date_documents_sent=None,
+            status=FinancialAidStatus.RESET
+        )
+        serialized = FinancialAidDashboardSerializer.serialize(self.user, self.program)
+        assert serialized == {
+            "id": None,
+            "has_user_applied": False,
+            "application_status": None,
+            "min_possible_cost": 250,
+            "max_possible_cost": 1000,
+            "date_documents_sent": None,
+        }
+
+    def test_financial_aid_with_documents_sent(self):
+        """
+        Test that a user that has a FinancialAid record and has sent documents will have serialized financial aid
+        information that indicates the date that documents were sent
+        """
+        now = datetime.now(tz=utc)
+        fin_aid = FinancialAidFactory.create(
+            user=self.user,
+            tier_program=self.min_tier_program,
+            date_documents_sent=now,
+        )
+        serialized = FinancialAidDashboardSerializer.serialize(self.user, self.program)
+        assert serialized == {
+            "id": fin_aid.id,
+            "has_user_applied": True,
+            "application_status": fin_aid.status,
+            "min_possible_cost": 250,
+            "max_possible_cost": 1000,
+            "date_documents_sent": now.date(),
+        }
+
+    def test_course_price_mandatory(self):
+        """
+        Test that an attempt to serialize financial aid information will raise an exception if no course prices
+        are available.
+        """
+        new_program = ProgramFactory.create(live=True, financial_aid_availability=True)
+        TierProgramFactory.create(
+            program=new_program,
+            discount_amount=750,
+            current=True
+        )
+        with self.assertRaises(ImproperlyConfigured):
+            FinancialAidDashboardSerializer.serialize(self.user, new_program)
+
+    def test_course_tier_mandatory(self):
+        """
+        Test that an attempt to serialize financial aid information will raise an exception if no tiers are created.
+        """
+        new_program = ProgramFactory.create(live=True, financial_aid_availability=True)
+        CoursePriceFactory.create(
+            course_run__course__program=new_program,
+            is_valid=True,
+            price=1000
+        )
+        with self.assertRaises(ImproperlyConfigured):
+            FinancialAidDashboardSerializer.serialize(self.user, new_program)
+
+    def test_with_non_financial_aid_program(self):
+        """
+        Test that a non-financial aid program will serialize to an empty dict
+        """
+        non_fa_program = ProgramFactory.create(live=True, financial_aid_availability=False)
+        assert FinancialAidDashboardSerializer.serialize(self.user, non_fa_program) == {}

--- a/mail/permissions.py
+++ b/mail/permissions.py
@@ -5,7 +5,6 @@ Permission classes for mail views
 from rolepermissions.verifications import has_permission
 from rest_framework.permissions import BasePermission
 
-from courses.models import CourseRun
 from roles.roles import Permissions, Staff, Instructor
 from dashboard.models import ProgramEnrollment
 from dashboard.utils import MMTrack
@@ -67,12 +66,7 @@ class UserCanMessageSpecificLearnerPermission(BasePermission):
                 program_enrollment.program,
                 edx_user_data
             )
-            course_run_keys = (
-                CourseRun.objects
-                .filter(course__program=program_enrollment.program)
-                .values_list('edx_course_key', flat=True)
-            )
-            if any(mmtrack.has_paid(course_run_key) for course_run_key in course_run_keys):
+            if mmtrack.has_paid_for_any_in_program():
                 return True
 
         return False

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -22,7 +22,7 @@ from celery.schedules import crontab
 from django.core.exceptions import ImproperlyConfigured
 
 
-VERSION = "0.53.4"
+VERSION = "0.53.5"
 
 CONFIG_PATHS = [
     os.environ.get('MICROMASTERS_CONFIG', ''),

--- a/seed_data/management/commands/alter_data_test.py
+++ b/seed_data/management/commands/alter_data_test.py
@@ -25,7 +25,7 @@ class AlterDataCommandTests(MockedESTestCase):
         set_to_passed(user=self.user, course_run=self.course_run, grade=grade)
         mmtrack = get_mmtrack(self.user, self.course_run.course.program)
         assert mmtrack.has_passed_course(self.course_run.edx_course_key)
-        assert int(mmtrack.get_final_grade(self.course_run.edx_course_key)) == (grade * 100)
+        assert int(mmtrack.get_final_grade_percent(self.course_run.edx_course_key)) == (grade * 100)
 
     def test_set_to_failed(self):
         """set_to_failed should set a CourseRun to failed for a given User"""
@@ -33,4 +33,4 @@ class AlterDataCommandTests(MockedESTestCase):
         set_to_failed(user=self.user, course_run=self.course_run, grade=grade)
         mmtrack = get_mmtrack(self.user, self.course_run.course.program)
         assert not mmtrack.has_passed_course(self.course_run.edx_course_key)
-        assert int(mmtrack.get_final_grade(self.course_run.edx_course_key)) == (grade * 100)
+        assert int(mmtrack.get_final_grade_percent(self.course_run.edx_course_key)) == (grade * 100)

--- a/static/js/components/OrderSummary.js
+++ b/static/js/components/OrderSummary.js
@@ -38,9 +38,8 @@ class OrderSummary extends React.Component {
     let text;
     let price = (finalPrice !== undefined && finalPrice !== null) ? finalPrice : coursePrice.price;
     if (price > 0) {
-      text = "Clicking below with link outside of the MIT MicroMasters app" +
-        " to an external website, where you will be able to complete the transaction by" +
-        " paying with a credit card.";
+      text = "Clicking Continue will link to a website outside of the MicroMasters app, " +
+        "where you will be able to complete the transaction, by paying with a credit card";
     }else{
       text = "Because there is no cost to enroll in this course, when you click the button below" +
         " you will skip the normal payment process and be enrolled in the course immediately.";

--- a/static/js/components/OrderSummary.js
+++ b/static/js/components/OrderSummary.js
@@ -38,8 +38,9 @@ class OrderSummary extends React.Component {
     let text;
     let price = (finalPrice !== undefined && finalPrice !== null) ? finalPrice : coursePrice.price;
     if (price > 0) {
-      text = "Clicking Continue will link to a website outside of the MicroMasters app, " +
-        "where you will be able to complete the transaction, by paying with a credit card";
+      text = "Clicking below with link outside of the MIT MicroMasters app" +
+        " to an external website, where you will be able to complete the transaction by" +
+        " paying with a credit card.";
     }else{
       text = "Because there is no cost to enroll in this course, when you click the button below" +
         " you will skip the normal payment process and be enrolled in the course immediately.";


### PR DESCRIPTION
## Gavin Sidebottom
  - [x] Cleaned up more MMTrack code
    - [x] PR fix ([9976fd1d](../commit/9976fd1d34a72ec97533a73bd38568a91a8d334a))
    - [x] merge fix ([3df96a76](../commit/3df96a76b3aa008a9862b2bd0309674bcd6110f0))
    - [x] Added helper method for determining if user paid for any course run in a program ([586dc878](../commit/586dc8781e31551957a7c90db64be5fc11f80487))
    - [x] Renamed &#39;course_id&#39; to &#39;edx_course_key&#39; etc ([bbb18d1b](../commit/bbb18d1b6351107f8a02c6b1849cc39e2937facb))
    - [x] Moved FA serialization from MMTrack to separate class ([d4c218d1](../commit/d4c218d1b3125412fcd284c543516b3ccda2194a))
    - [x] Got rid of pearson exam status variable setting in init ([735c82c0](../commit/735c82c0c156fefb1b81dcb1dfb5c3410181ccd4))
  - [x] Cleaned up MMTrack final grade code ([fde83634](../commit/fde83634814074234d895e91df50f8dfe21d6ab2))

## annagav
  - [x] Revert &quot;Fixed Order Summary text&quot; ([ed82968d](../commit/ed82968d9b44ce7f7fad44f59e693681ef12939d))
  - [x] Fixed Order Summary text ([fad45049](../commit/fad450495f7be71db5ea9ffbe610a116279d86b1))