### PR TITLE
If you check for None values you need to be specific.

### DIFF
--- a/grades/models.py
+++ b/grades/models.py
@@ -93,7 +93,7 @@ class FinalGrade(TimestampedModel, AuditableModel):
     @property
     def grade_percent(self):
         """Returns the grade field value as a number out of 100 (or None if the value is None)"""
-        return self.grade * 100 if self.grade else None
+        return self.grade * 100 if self.grade is not None else None
 
     @classmethod
     def get_frozen_users(cls, course_run):

--- a/grades/models_test.py
+++ b/grades/models_test.py
@@ -24,23 +24,21 @@ class FinalGradeModelTests(MockedESTestCase):
         cls.user1 = UserFactory.create()
         cls.user2 = UserFactory.create()
         cls.course_run = CourseRunFactory.create()
+        cls.grade1 = FinalGrade.objects.create(
+            user=cls.user1,
+            course_run=cls.course_run,
+            grade=0.65,
+        )
 
     def test_grade_validation_save(self):
         """
         Tests that the save method performs a full validation of the rade input
         """
-        # basic final grade creation
-        grade1 = FinalGrade.objects.create(
-            user=self.user1,
-            course_run=self.course_run,
-            grade=0.65,
-        )
-
         # it fails to modify it to a value >1 or <0
         for val in (-0.5, 1.3, ):
             with self.assertRaises(ValidationError):
-                grade1.grade = val
-                grade1.save()
+                self.grade1.grade = val
+                self.grade1.save()
 
         # it fails also to create the grades from scratch
         for val in (-0.5, 1.3, ):
@@ -50,6 +48,16 @@ class FinalGradeModelTests(MockedESTestCase):
                     course_run=self.course_run,
                     grade=val,
                 )
+
+    def test_grade_percent(self):
+        """
+        test for grade_percent property method
+        """
+        assert self.grade1.grade_percent == 65.0
+
+        self.grade1.grade = 0.0
+        self.grade1.save()
+        assert self.grade1.grade_percent == 0.0
 
 
 class CourseRunGradingStatusTests(MockedESTestCase):


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes bug where a `grade_percentage` for a grade equal to 0 returns `None`

#### How should this be manually tested?
Create a final Grade with grade 0 and run the reindex 

