### PR TITLE
Switched library for python social auth

### DIFF
--- a/backends/edxorg.py
+++ b/backends/edxorg.py
@@ -6,7 +6,7 @@ from urllib.parse import urljoin
 
 from django.conf import settings
 import pytz
-from social.backends.oauth import BaseOAuth2
+from social_core.backends.oauth import BaseOAuth2
 
 
 class EdxOrgOAuth2(BaseOAuth2):

--- a/backends/edxorg_test.py
+++ b/backends/edxorg_test.py
@@ -2,7 +2,10 @@
 Oauth Backend Tests
 """
 from unittest import TestCase
-from .edxorg import EdxOrgOAuth2
+
+from social_django.utils import load_strategy
+
+from backends.edxorg import EdxOrgOAuth2
 
 
 class EdxOrgOAuth2Tests(TestCase):
@@ -11,7 +14,7 @@ class EdxOrgOAuth2Tests(TestCase):
         """
         Should have properly formed payload if working.
         """
-        eoo = EdxOrgOAuth2()
+        eoo = EdxOrgOAuth2(strategy=load_strategy())
         result = eoo.get_user_details({
             'id': 5,
             'username': 'darth',
@@ -32,7 +35,7 @@ class EdxOrgOAuth2Tests(TestCase):
         """
         If the user only has one name, last_name should be blank.
         """
-        eoo = EdxOrgOAuth2()
+        eoo = EdxOrgOAuth2(strategy=load_strategy())
         result = eoo.get_user_details({
             'id': 5,
             'username': 'staff',

--- a/backends/utils.py
+++ b/backends/utils.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import pytz
 
 from requests.exceptions import HTTPError
-from social.apps.django_app.utils import load_strategy
+from social_django.utils import load_strategy
 
 from backends.exceptions import InvalidCredentialStored
 

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import User
 from django.core.cache import caches
 from django.db.models import Q
 from edx_api.client import EdxApi
-from social.apps.django_app.default.models import UserSocialAuth
+from social_django.models import UserSocialAuth
 
 from backends import utils
 from backends.edxorg import EdxOrgOAuth2

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -110,7 +110,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'rest_framework.authtoken',
     'server_status',
-    'social.apps.django_app.default',
+    'social_django',
 
     # WAGTAIL
     'wagtail.wagtailforms',
@@ -165,7 +165,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
     'wagtail.wagtailcore.middleware.SiteMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
-    'social.apps.django_app.middleware.SocialAuthExceptionMiddleware',
+    'social_django.middleware.SocialAuthExceptionMiddleware',
 )
 
 # enable the nplusone profiler only in debug mode
@@ -189,17 +189,17 @@ EDXORG_BASE_URL = get_var('EDXORG_BASE_URL', 'https://courses.edx.org/')
 SOCIAL_AUTH_EDXORG_KEY = get_var('EDXORG_CLIENT_ID', '')
 SOCIAL_AUTH_EDXORG_SECRET = get_var('EDXORG_CLIENT_SECRET', '')
 SOCIAL_AUTH_PIPELINE = (
-    'social.pipeline.social_auth.social_details',
-    'social.pipeline.social_auth.social_uid',
-    'social.pipeline.social_auth.auth_allowed',
-    'social.pipeline.social_auth.social_user',
-    'social.pipeline.user.get_username',
-    'social.pipeline.user.create_user',
-    'social.pipeline.social_auth.associate_user',
+    'social_core.pipeline.social_auth.social_details',
+    'social_core.pipeline.social_auth.social_uid',
+    'social_core.pipeline.social_auth.auth_allowed',
+    'social_core.pipeline.social_auth.social_user',
+    'social_core.pipeline.user.get_username',
+    'social_core.pipeline.user.create_user',
+    'social_core.pipeline.social_auth.associate_user',
     # the following custom pipeline func goes before load_extra_data
     'backends.pipeline_api.set_last_update',
-    'social.pipeline.social_auth.load_extra_data',
-    'social.pipeline.user.user_details',
+    'social_core.pipeline.social_auth.load_extra_data',
+    'social_core.pipeline.user.user_details',
     'backends.pipeline_api.update_profile_from_edx',
 )
 SOCIAL_AUTH_EDXORG_AUTH_EXTRA_ARGUMENTS = {
@@ -227,8 +227,8 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'social.apps.django_app.context_processors.backends',
-                'social.apps.django_app.context_processors.login_redirect',
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
                 'ui.context_processors.api_keys',
                 'ui.context_processors.do_not_track',
             ],

--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -18,7 +18,7 @@ if settings.DEBUG:
     ]
 
 urlpatterns += [
-    url('', include('social.apps.django_app.urls', namespace='social')),
+    url('', include('social_django.urls', namespace='social')),
     url(r'^admin/', include(admin.site.urls)),
     url('', include('courses.urls')),
     url('', include('dashboard.urls')),

--- a/requirements.in
+++ b/requirements.in
@@ -26,10 +26,10 @@ psycopg2==2.6
 pycountry==16.11.27.1
 pysftp==0.2.9
 python-dateutil
-python-social-auth==0.2.21
 raven
 redis==2.10.5
 requests
+social-auth-app-django==1.1.0
 robohash
 static3==0.5.1
 uwsgi

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,11 +12,11 @@ beautifulsoup4==4.5.3     # via wagtail
 billiard==3.3.0.23        # via celery
 boto==2.39.0
 celery==3.1.23
-cffi==1.9.1               # via cryptography
+cffi==1.10.0              # via cryptography
 contextlib2==0.5.4        # via raven
 cryptography==1.8.1       # via paramiko
 decorator==4.0.11         # via ipython, traitlets
-defusedxml==0.5.0         # via python3-openid
+defusedxml==0.5.0         # via python3-openid, social-auth-core
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-discover-runner==1.0  # via django-role-permissions
@@ -28,7 +28,7 @@ django-storages-redux==1.3.2
 django-taggit==0.22.0     # via wagtail
 django-treebeard==4.1.0   # via wagtail
 django-webpack-loader==0.4.1
-Django==1.10.5            # via django-role-permissions, django-server-status, django-treebeard, jsonfield, wagtail
+django==1.10.5            # via django-role-permissions, django-server-status, django-treebeard, jsonfield, wagtail
 djangorestframework==3.5.2
 edx-api-client==0.3.0
 edx-opaque-keys==0.4
@@ -43,48 +43,49 @@ ipython==5.3.0
 jsonfield==1.0.3
 kombu==3.0.37             # via celery, django-server-status
 newrelic==2.82.0.62
-oauthlib==2.0.1           # via python-social-auth, requests-oauthlib
+oauthlib==2.0.2           # via requests-oauthlib, social-auth-core
 packaging==16.8           # via cryptography, setuptools
 paramiko==2.1.2           # via pysftp
 pbr==2.0.0                # via stevedore
 pexpect==4.2.1            # via ipython
 phonenumbers==8.3.2
 pickleshare==0.7.4        # via ipython
-Pillow==3.4.2             # via wagtail
-prompt-toolkit==1.0.13    # via ipython
+pillow==3.4.2             # via robohash, wagtail
+prompt-toolkit==1.0.14    # via ipython
 psycopg2==2.6
 ptyprocess==0.5.1         # via pexpect
 pyasn1==0.2.3             # via paramiko
 pycountry==16.11.27.1
 pycparser==2.17           # via cffi
 pygments==2.2.0           # via ipython
-PyJWT==1.4.2              # via python-social-auth
+pyjwt==1.4.2              # via social-auth-core
 pymongo==3.4.0            # via edx-opaque-keys
 pyparsing==2.2.0          # via packaging
 pysftp==0.2.9
 python-dateutil==2.5.3
-python-social-auth==0.2.21
-python3-openid==3.1.0     # via python-social-auth
-pytz==2016.10             # via celery, django-modelcluster
-PyYAML==3.11
+python3-openid==3.1.0     # via social-auth-core
+pytz==2017.2              # via celery, django-modelcluster
+pyyaml==3.11
 raven==6.0.0
 redis==2.10.5
-requests-oauthlib==0.8.0  # via python-social-auth
+requests-oauthlib==0.8.0  # via social-auth-core
 requests==2.11.1
 robohash==1.0
 simplegeneric==0.8.1      # via ipython
-six==1.10.0               # via cryptography, django-role-permissions, django-server-status, edx-api-client, edx-opaque-keys, elasticsearch-dsl, faker, html5lib, packaging, prompt-toolkit, python-dateutil, python-social-auth, setuptools, stevedore, traitlets
+six==1.10.0               # via cryptography, django-role-permissions, django-server-status, edx-api-client, edx-opaque-keys, elasticsearch-dsl, faker, html5lib, packaging, prompt-toolkit, python-dateutil, setuptools, social-auth-app-django, social-auth-core, stevedore, traitlets
+social-auth-app-django==1.1.0
+social-auth-core==1.2.0   # via social-auth-app-django
 static3==0.5.1
 stevedore==1.21.0         # via edx-opaque-keys
 tornado==4.4.2            # via robohash
 traitlets==4.3.2          # via ipython
-Unidecode==0.4.20         # via wagtail
+unidecode==0.4.20         # via wagtail
 urllib3==1.20             # via elasticsearch
 uwsgi==2.0.14
 wagtail==1.9
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5         # via html5lib
-Willow==0.4               # via wagtail
+willow==0.4               # via wagtail
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools                # via cryptography, html5lib, ipython

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.5.3


### PR DESCRIPTION
#### What are the relevant tickets?
closes #2850

#### What's this PR do?
Switches to the new library for python social auth and removes the deprecated one.

#### How should this be manually tested?
Everything should keep working and the existing social auth should be left intact.

NOTE: I added an upgrade of the runtime of python to the latest version
