### PR TITLE
Remove remove_user

### DIFF
--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -174,18 +174,6 @@ def remove_program_enrolled_user(program_enrollment, indices=None):
         _delete_item(program_enrollment.id, USER_DOC_TYPE, index)
 
 
-def remove_user(user):
-    """
-    Remove a user from Elasticsearch.
-
-    Args:
-        user (django.contrib.auth.models.User): A user to remove
-    """
-    program_enrollments = ProgramEnrollment.objects.filter(user=user).select_related('user', 'program').all()
-    for program_enrollment in program_enrollments:
-        remove_program_enrolled_user(program_enrollment)
-
-
 def serialize_program_enrolled_user(program_enrollment):
     """
     Serializes a program-enrolled user for use with Elasticsearch.

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -148,18 +148,6 @@ class IndexTests(ESTestCase):
         profile.save()
         assert_search(es.search(), [program_enrollment])
 
-    def test_program_enrollment_clear_upon_profile_deletion(self):
-        """
-        Test that all ProgramEnrollments are cleared from the index after the User's Profile has been deleted
-        """
-        with mute_signals(post_save):
-            profile = ProfileFactory.create()
-        ProgramEnrollmentFactory.create(user=profile.user)
-        ProgramEnrollmentFactory.create(user=profile.user)
-        assert es.search()['total'] == 2
-        profile.delete()
-        assert es.search()['total'] == 0
-
     def test_education_add(self):
         """
         Test that Education is indexed after being added

--- a/search/signals.py
+++ b/search/signals.py
@@ -16,7 +16,6 @@ from profiles.models import (
 from search.models import PercolateQuery
 from search.tasks import (
     index_users,
-    remove_user,
     index_percolate_queries,
     delete_percolate_query,
 )
@@ -47,12 +46,6 @@ def handle_update_education(sender, instance, **kwargs):
 def handle_update_employment(sender, instance, **kwargs):
     """Update index when Employment model is updated."""
     index_users.delay([instance.profile.user])
-
-
-@receiver(post_delete, sender=Profile, dispatch_uid="profile_post_delete_index")
-def handle_delete_profile(sender, instance, **kwargs):
-    """Update index when Profile model instance is deleted."""
-    remove_user.delay(instance.user)
 
 
 @receiver(post_delete, sender=Education, dispatch_uid="education_post_delete_index")

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -12,7 +12,6 @@ from search.indexing_api import (
     index_program_enrolled_users as _index_program_enrolled_users,
     remove_program_enrolled_user as _remove_program_enrolled_user,
     index_users as _index_users,
-    remove_user as _remove_user,
     index_percolate_queries as _index_percolate_queries,
     delete_percolate_query as _delete_percolate_query,
     refresh_index as _refresh_index,
@@ -61,17 +60,6 @@ def index_users(users):
     _refresh_index(get_default_alias())
     for program_enrollment in ProgramEnrollment.objects.filter(user__in=users):
         _send_automatic_emails(program_enrollment)
-
-
-@async.task
-def remove_user(user):
-    """
-    Remove user from index
-
-    Args:
-        user (User): A user to remove from index
-    """
-    _remove_user(user)
 
 
 @async.task


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2718 

#### What's this PR do?
Removes signal and related task and functions for removing an enrollment from the index when a profile is deleted. We are currently not deleting profiles and it seems like this function is likely to fail since it looks up the enrollments in the database after the profile is already deleted.

#### How should this be manually tested?
None
