### PR TITLE
Bringing back the runtime to python-3.5.2

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.3
+python-3.5.2


### PR DESCRIPTION
#### What are the relevant tickets?
N/A/

#### What's this PR do?
Reverts the change of the python version for Heroku

#### How should this be manually tested?
Heroku should just stop screaming

