### PR TITLE
Mail: displayed search filters as recipients

### DIFF
--- a/static/js/actions/email.js
+++ b/static/js/actions/email.js
@@ -11,6 +11,9 @@ export const startEmailEdit = createAction(START_EMAIL_EDIT);
 export const UPDATE_EMAIL_EDIT = 'UPDATE_EMAIL_EDIT';
 export const updateEmailEdit = createAction(UPDATE_EMAIL_EDIT);
 
+export const AUTOMATIC_EMAIL_TYPE = "AUTOMATIC_EMAIL_TYPE";
+export const setAutomaticEmailType = createAction(AUTOMATIC_EMAIL_TYPE);
+
 export const CLEAR_EMAIL_EDIT = 'CLEAR_EMAIL_EDIT';
 export const clearEmailEdit = createAction(CLEAR_EMAIL_EDIT);
 

--- a/static/js/actions/email_test.js
+++ b/static/js/actions/email_test.js
@@ -4,11 +4,13 @@ import {
   updateEmailEdit,
   clearEmailEdit,
   updateEmailValidation,
+  setAutomaticEmailType,
 
   START_EMAIL_EDIT,
   UPDATE_EMAIL_EDIT,
   CLEAR_EMAIL_EDIT,
   UPDATE_EMAIL_VALIDATION,
+  AUTOMATIC_EMAIL_TYPE,
 } from './email';
 import { assertCreatedActionHelper } from './test_util';
 
@@ -17,6 +19,7 @@ describe('generated email action helpers', () => {
     [
       [startEmailEdit, START_EMAIL_EDIT],
       [updateEmailEdit, UPDATE_EMAIL_EDIT],
+      [setAutomaticEmailType, AUTOMATIC_EMAIL_TYPE],
       [clearEmailEdit, CLEAR_EMAIL_EDIT],
       [updateEmailValidation, UPDATE_EMAIL_VALIDATION],
     ].forEach(assertCreatedActionHelper);

--- a/static/js/components/email/AutomaticEmailOptions.js
+++ b/static/js/components/email/AutomaticEmailOptions.js
@@ -1,0 +1,51 @@
+// @flow
+import React from 'react';
+import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
+
+import {
+  ONE_TIME_EMAIL,
+  EMAIL_CAMPAIGN
+} from './constants';
+
+export default class EmailCompositionType extends React.Component {
+  props: {
+    automaticEmailType:    ?string,
+    setAutomaticEmailType: (b: string) => void,
+  };
+
+  handleRadioClick = (event: Event, value: string): void => {
+    const { setAutomaticEmailType } = this.props;
+    setAutomaticEmailType(value);
+  }
+
+  renderEmailCampaign = (): React$Element<*> => (
+    <div className="email-campaign-content">
+      This email will be sent now and in the future whenever users meet the criteria.
+    </div>
+  );
+
+  render() {
+    const { automaticEmailType } = this.props;
+
+    return (
+      <div className="email-type">
+        <RadioButtonGroup
+          className="type-radio-group"
+          name="email-composition-type"
+          valueSelected={automaticEmailType}
+          onChange={this.handleRadioClick}
+        >
+          <RadioButton
+            value={ONE_TIME_EMAIL}
+            label="Send a one-time email"
+            className="one-time-email" />
+          <RadioButton
+            value={EMAIL_CAMPAIGN}
+            label="Create an Email Campaign"
+            className="email-campaign" />
+        </RadioButtonGroup>
+        { automaticEmailType === EMAIL_CAMPAIGN ? this.renderEmailCampaign() : null }
+      </div>
+    );
+  }
+}

--- a/static/js/components/email/AutomaticEmailOptions_test.js
+++ b/static/js/components/email/AutomaticEmailOptions_test.js
@@ -1,0 +1,64 @@
+// @flow
+import React from 'react';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+import { assert } from 'chai';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+
+import {
+  ONE_TIME_EMAIL,
+  EMAIL_CAMPAIGN
+} from './constants';
+import AutomaticEmailOptions from './AutomaticEmailOptions';
+
+describe('AutomaticEmailOptions', () => {
+  let sandbox, setEmailCompositionTypeStub;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    setEmailCompositionTypeStub = sandbox.stub();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const renderComponent = (automaticEmailType: string = ONE_TIME_EMAIL) => (
+    mount(
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <AutomaticEmailOptions
+          setAutomaticEmailType={setEmailCompositionTypeStub}
+          automaticEmailType={automaticEmailType}
+        />
+      </MuiThemeProvider>
+    )
+  );
+
+  it('div renders', () => {
+    let wrapper = renderComponent(ONE_TIME_EMAIL);
+    assert.equal(wrapper.find(".type-radio-group").children().length, 2);
+  });
+
+  it(`div renders for type: ${ONE_TIME_EMAIL}`, () => {
+    let wrapper = renderComponent(ONE_TIME_EMAIL);
+    assert.equal(wrapper.find(".type-radio-group").children().length, 2);
+    // test setEmailCompositionType is called when one time email selected
+    let radioOneTime = wrapper.find(".one-time-email input");
+    radioOneTime.simulate('change');
+    assert.isTrue(setEmailCompositionTypeStub.called, "called set email composition type handler");
+  });
+
+  it(`div renders for type: ${EMAIL_CAMPAIGN}`, () => {
+    let wrapper = renderComponent(EMAIL_CAMPAIGN);
+    assert.equal(wrapper.find(".type-radio-group").children().length, 2);
+    assert.include(
+      wrapper.text(),
+      'This email will be sent now and in the future whenever users meet the criteria.'
+    );
+    // test setEmailCompositionType is called when campaign selected
+    let radioCampaign = wrapper.find(".email-campaign input");
+    radioCampaign.simulate('change');
+    assert.isTrue(setEmailCompositionTypeStub.called, "called set email composition type handler");
+  });
+});

--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -22,6 +22,7 @@ export default class EmailCompositionDialog extends React.Component {
     updateEmailFieldEdit:       () => void,
     showExtraUI?:               boolean,
     setAutomaticEmailType:      (b: string) => void,
+    renderRecipients?:          (filters: ?Array<any>) => React$Element<*>
   };
 
   showValidationError = (fieldName: string): ?React$Element<*> => {
@@ -77,7 +78,8 @@ export default class EmailCompositionDialog extends React.Component {
         fetchStatus,
         inputs,
         supportsAutomaticEmails,
-        automaticEmailType = ONE_TIME_EMAIL
+        automaticEmailType = ONE_TIME_EMAIL,
+        filters
       },
       title,
       dialogVisibility,
@@ -85,7 +87,8 @@ export default class EmailCompositionDialog extends React.Component {
       closeEmailComposerAndSend,
       updateEmailFieldEdit,
       showExtraUI,
-      setAutomaticEmailType
+      setAutomaticEmailType,
+      renderRecipients,
     } = this.props;
 
     return <Dialog
@@ -108,6 +111,7 @@ export default class EmailCompositionDialog extends React.Component {
         { R.equals(showExtraUI, true) ? <AutomaticEmailOptions automaticEmailType={automaticEmailType}
           setAutomaticEmailType={setAutomaticEmailType} /> : null }
         { this.renderSubheading() }
+        { renderRecipients ? renderRecipients(filters) : null }
         <textarea
           rows="1"
           className="email-subject"

--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -1,12 +1,15 @@
 // @flow
 import React from 'react';
+import R from 'ramda';
 import Dialog from 'material-ui/Dialog';
 import Checkbox from 'material-ui/Checkbox';
 
+import AutomaticEmailOptions from './AutomaticEmailOptions';
 import { FETCH_PROCESSING } from '../../actions';
 import { dialogActions } from '../inputs/util';
 import { isNilOrBlank } from '../../util/util';
 import type { EmailState } from '../../flow/emailTypes';
+import { ONE_TIME_EMAIL } from './constants';
 
 export default class EmailCompositionDialog extends React.Component {
   props: {
@@ -16,7 +19,9 @@ export default class EmailCompositionDialog extends React.Component {
     subheadingRenderer?:        (activeEmail: EmailState) => React$Element<*>,
     closeAndClearEmailComposer: () => void,
     closeEmailComposerAndSend:  () => void,
-    updateEmailFieldEdit:       () => void
+    updateEmailFieldEdit:       () => void,
+    showExtraUI?:               boolean,
+    setAutomaticEmailType:      (b: string) => void,
   };
 
   showValidationError = (fieldName: string): ?React$Element<*> => {
@@ -68,12 +73,19 @@ export default class EmailCompositionDialog extends React.Component {
     if (!this.props.activeEmail) return null;
 
     const {
-      activeEmail: { fetchStatus, inputs, supportsAutomaticEmails },
+      activeEmail: {
+        fetchStatus,
+        inputs,
+        supportsAutomaticEmails,
+        automaticEmailType = ONE_TIME_EMAIL
+      },
       title,
       dialogVisibility,
       closeAndClearEmailComposer,
       closeEmailComposerAndSend,
-      updateEmailFieldEdit
+      updateEmailFieldEdit,
+      showExtraUI,
+      setAutomaticEmailType
     } = this.props;
 
     return <Dialog
@@ -93,6 +105,8 @@ export default class EmailCompositionDialog extends React.Component {
       onRequestClose={closeAndClearEmailComposer}
     >
       <div className="email-composition-contents">
+        { R.equals(showExtraUI, true) ? <AutomaticEmailOptions automaticEmailType={automaticEmailType}
+          setAutomaticEmailType={setAutomaticEmailType} /> : null }
         { this.renderSubheading() }
         <textarea
           rows="1"

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -16,6 +16,7 @@ import {
   TEST_EMAIL_CONFIG,
   INITIAL_TEST_EMAIL_STATE
 } from './test_constants';
+import { SEARCH_RESULT_EMAIL_CONFIG } from './lib';
 
 describe('EmailCompositionDialog', () => {
   let sandbox, sendStub, closeStub, updateStub;
@@ -53,6 +54,7 @@ describe('EmailCompositionDialog', () => {
           activeEmail={emailState}
           title={TEST_EMAIL_CONFIG.title}
           subheadingRenderer={TEST_EMAIL_CONFIG.renderSubheading}
+          setEmailCompositionType={(): void => {}}
           { ...props }
         />
       </MuiThemeProvider>
@@ -62,6 +64,34 @@ describe('EmailCompositionDialog', () => {
   it('should have a title', () => {
     renderDialog();
     assert.equal(document.querySelector('h3').textContent, 'Test Email Dialog');
+  });
+
+  it('renders radio button for email type config', () => {
+    let emailState = updateObject(INITIAL_TEST_EMAIL_STATE[TEST_EMAIL_TYPE], {});
+    mount(
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <EmailCompositionDialog
+          updateEmailFieldEdit={() => (updateStub)}
+          closeAndClearEmailComposer={closeStub}
+          closeEmailComposerAndSend={sendStub}
+          dialogVisibility={true}
+          activeEmail={emailState}
+          title={SEARCH_RESULT_EMAIL_CONFIG.title}
+          subheadingRenderer={SEARCH_RESULT_EMAIL_CONFIG.renderSubheading}
+          showExtraUI={SEARCH_RESULT_EMAIL_CONFIG.showExtraUI}
+          setEmailCompositionType={(): void => {}}
+        />
+      </MuiThemeProvider>
+    );
+    assert.equal(document.querySelector(".type-radio-group").childElementCount, 2);
+    assert.include(
+      document.querySelector(".type-radio-group").textContent,
+      'Send a one-time email'
+    );
+    assert.include(
+      document.querySelector(".type-radio-group").textContent,
+      'Create an Email Campaign'
+    );
   });
 
   it('should fire the send handler when the "send" button is clicked', () => {

--- a/static/js/components/email/constants.js
+++ b/static/js/components/email/constants.js
@@ -2,3 +2,5 @@ export const EMAIL_COMPOSITION_DIALOG = 'emailComposition';
 export const SEARCH_EMAIL_TYPE = 'searchResultEmail';
 export const COURSE_EMAIL_TYPE = 'courseTeamEmail';
 export const LEARNER_EMAIL_TYPE = 'learnerEmail';
+export const ONE_TIME_EMAIL = "one-time-email";
+export const EMAIL_CAMPAIGN = "email-campaign";

--- a/static/js/components/email/hoc.js
+++ b/static/js/components/email/hoc.js
@@ -10,7 +10,8 @@ import {
   updateEmailEdit,
   clearEmailEdit,
   updateEmailValidation,
-  sendEmail
+  sendEmail,
+  setAutomaticEmailType
 } from '../../actions/email';
 import { emailValidation } from '../../lib/validation/profile';
 import { EMAIL_COMPOSITION_DIALOG } from './constants';
@@ -55,6 +56,14 @@ export const withEmailDialog = R.curry(
         }
       });
 
+      setAutomaticEmailType = (automaticEmailType: string): void => {
+        const {dispatch, email: { currentlyActive }} = this.props;
+        dispatch(setAutomaticEmailType({
+          type: currentlyActive,
+          automaticEmailType: automaticEmailType
+        }));
+      };
+
       closeAndClearEmailComposer = (): void => {
         const { dispatch, email: { currentlyActive } } = this.props;
         dispatch(clearEmailEdit(currentlyActive));
@@ -95,6 +104,8 @@ export const withEmailDialog = R.curry(
             activeEmail={this.getActiveEmailState()}
             title={emailConfigs[activeEmailType].title}
             subheadingRenderer={emailConfigs[activeEmailType].renderSubheading}
+            showExtraUI={emailConfigs[activeEmailType].showExtraUI}
+            setAutomaticEmailType={this.setAutomaticEmailType}
           />
         );
       }

--- a/static/js/components/email/hoc.js
+++ b/static/js/components/email/hoc.js
@@ -104,6 +104,7 @@ export const withEmailDialog = R.curry(
             activeEmail={this.getActiveEmailState()}
             title={emailConfigs[activeEmailType].title}
             subheadingRenderer={emailConfigs[activeEmailType].renderSubheading}
+            renderRecipients={emailConfigs[activeEmailType].renderRecipients}
             showExtraUI={emailConfigs[activeEmailType].showExtraUI}
             setAutomaticEmailType={this.setAutomaticEmailType}
           />

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
+import _ from 'lodash';
 
 import {
   sendCourseTeamMail,
@@ -46,6 +47,7 @@ export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
   emailOpenParams: (searchkit: Object) => ({
     subheading: `${searchkit.getHitsCount() || 0} recipients selected`,
     supportsAutomaticEmails: true,
+    filters: searchkit.query.getSelectedFilters()
   }),
 
   getEmailSendFunction: () => sendSearchResultMail,
@@ -57,7 +59,30 @@ export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
     emailState.inputs.sendAutomaticEmails || false,
   ]),
 
-  showExtraUI: true
+  showExtraUI: true,
+
+  renderRecipients: (filters: ?Array<any>) => {
+    if (!filters || filters.length <= 0) {
+      return null;
+    }
+    const renderFilterOptions = _.map(filters, filter => (
+      <div className="sk-selected-filters-option sk-selected-filters__item" key={filter.id}>
+        <div className="sk-selected-filters-option__name">
+          {filter.name}: {filter.value}
+        </div>
+      </div>
+    ));
+    return (
+      <div className="sk-selected-filters-display">
+        <div className="sk-selected-filters-title">
+          Recipients
+        </div>
+        <div className="sk-selected-filters">
+          {renderFilterOptions}
+        </div>
+      </div>
+    );
+  }
 };
 
 export const LEARNER_EMAIL_CONFIG: EmailConfig = {

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -55,7 +55,9 @@ export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
     emailState.inputs.body || '',
     emailState.searchkit.buildQuery().query,
     emailState.inputs.sendAutomaticEmails || false,
-  ])
+  ]),
+
+  showExtraUI: true
 };
 
 export const LEARNER_EMAIL_CONFIG: EmailConfig = {

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -19,7 +19,8 @@ export type EmailState = {
   sendError:                EmailSendError,
   fetchStatus?:             ?string,
   supportsAutomaticEmails?: boolean,
-  automaticEmailType?:      string
+  automaticEmailType?:      string,
+  filters:                  ?Array<any>
 };
 
 export type AllEmailsState = {
@@ -34,5 +35,6 @@ export type EmailConfig = {
   emailOpenParams: (args: any) => Object,
   getEmailSendFunction: () => Function,
   emailSendParams: (emailState: EmailState) => Array<any>,
-  showExtraUI?:    boolean
+  showExtraUI?:    boolean,
+  renderRecipients?: (filters: ?Array<any>) => React$Element<*>,
 };

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -19,6 +19,7 @@ export type EmailState = {
   sendError:                EmailSendError,
   fetchStatus?:             ?string,
   supportsAutomaticEmails?: boolean,
+  automaticEmailType?:      string
 };
 
 export type AllEmailsState = {
@@ -32,5 +33,6 @@ export type EmailConfig = {
   renderSubheading: (activeEmail: EmailState) => React$Element<*>,
   emailOpenParams: (args: any) => Object,
   getEmailSendFunction: () => Function,
-  emailSendParams: (emailState: EmailState) => Array<any>
+  emailSendParams: (emailState: EmailState) => Array<any>,
+  showExtraUI?:    boolean
 };

--- a/static/js/reducers/email.js
+++ b/static/js/reducers/email.js
@@ -7,7 +7,8 @@ import {
   UPDATE_EMAIL_VALIDATION,
   INITIATE_SEND_EMAIL,
   SEND_EMAIL_SUCCESS,
-  SEND_EMAIL_FAILURE
+  SEND_EMAIL_FAILURE,
+  AUTOMATIC_EMAIL_TYPE
 } from '../actions/email';
 import {
   FETCH_FAILURE,
@@ -20,6 +21,7 @@ import type {
   EmailState,
   EmailInputs,
 } from '../flow/emailTypes';
+import { ONE_TIME_EMAIL } from '../components/email/constants';
 
 export const NEW_EMAIL_EDIT: EmailInputs = {
   subject:    null,
@@ -33,6 +35,7 @@ export const INITIAL_EMAIL_STATE: EmailState = {
   sendError: {},
   subheading: undefined,
   supportsAutomaticEmails: false,
+  automaticEmailType: ONE_TIME_EMAIL
 };
 
 export const INITIAL_ALL_EMAILS_STATE: AllEmailsState = {
@@ -73,6 +76,8 @@ export const email = (state: AllEmailsState = INITIAL_ALL_EMAILS_STATE, action: 
     return newState;
   case UPDATE_EMAIL_EDIT:
     return updatedState(state, emailType, { inputs: action.payload.inputs });
+  case AUTOMATIC_EMAIL_TYPE:
+    return updatedState(state, emailType, { automaticEmailType: action.payload.automaticEmailType });
   case CLEAR_EMAIL_EDIT:
     return resetState(state, emailType);
   case UPDATE_EMAIL_VALIDATION:

--- a/static/js/reducers/email.js
+++ b/static/js/reducers/email.js
@@ -35,7 +35,8 @@ export const INITIAL_EMAIL_STATE: EmailState = {
   sendError: {},
   subheading: undefined,
   supportsAutomaticEmails: false,
-  automaticEmailType: ONE_TIME_EMAIL
+  automaticEmailType: ONE_TIME_EMAIL,
+  filters: undefined
 };
 
 export const INITIAL_ALL_EMAILS_STATE: AllEmailsState = {
@@ -71,6 +72,7 @@ export const email = (state: AllEmailsState = INITIAL_ALL_EMAILS_STATE, action: 
       params: action.payload.params || {},
       subheading: action.payload.subheading,
       supportsAutomaticEmails: action.payload.supportsAutomaticEmails,
+      filters: action.payload.filters
     };
     newState.currentlyActive = emailType;
     return newState;

--- a/static/js/reducers/email_test.js
+++ b/static/js/reducers/email_test.js
@@ -9,6 +9,7 @@ import {
   clearEmailEdit,
   updateEmailValidation,
   sendEmail,
+  setAutomaticEmailType,
   START_EMAIL_EDIT,
   UPDATE_EMAIL_EDIT,
   CLEAR_EMAIL_EDIT,
@@ -16,9 +17,14 @@ import {
   INITIATE_SEND_EMAIL,
   SEND_EMAIL_SUCCESS,
   SEND_EMAIL_FAILURE,
+  AUTOMATIC_EMAIL_TYPE,
 } from '../actions/email';
 import { INITIAL_ALL_EMAILS_STATE, INITIAL_EMAIL_STATE } from './email';
-import { SEARCH_EMAIL_TYPE } from '../components/email/constants';
+import {
+  SEARCH_EMAIL_TYPE,
+  EMAIL_CAMPAIGN,
+  ONE_TIME_EMAIL
+} from '../components/email/constants';
 import type { EmailSendResponse } from '../flow/emailTypes';
 import rootReducer from '../reducers';
 import { assert } from 'chai';
@@ -88,6 +94,18 @@ describe('email reducers', () => {
       assert.deepEqual(state[emailType].validationErrors, errors);
     });
   });
+
+  for (let type of [EMAIL_CAMPAIGN, ONE_TIME_EMAIL]) {
+    it(`should let you set the email composition type: ${type}`, () => {
+      store.dispatch(startEmailEdit(emailType));
+      return dispatchThen(
+        setAutomaticEmailType({type: emailType, automaticEmailType: type}),
+        [AUTOMATIC_EMAIL_TYPE]
+      ).then((state) => {
+        assert.equal(state[emailType].automaticEmailType, type);
+      });
+    });
+  }
 });
 
 describe('email reducers for the sendMail action', () => {

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -34,6 +34,7 @@ $select-menu-outer-bg: rgba(0,0,0,.8);
 $select-menu-bg: rgba(0,0,0,.1);
 
 // general colors
+$darkergray: #3d3f41;
 $darkgray: #696969;
 $medlightgray: #8d8d8d;
 $medgray: #d2d2d2;
@@ -53,6 +54,7 @@ $validation-red: #f44336;
 $program_selector_border: rgba(255,255,255,.2);
 $header_font_color: white;
 $text-highlight: #fbf9db;
+$email-composition-type: #e3eef8;
 
 // other
 $block-padding: 20px;

--- a/static/scss/email-composition-dialog.scss
+++ b/static/scss/email-composition-dialog.scss
@@ -1,67 +1,133 @@
-.email-composition-dialog {
-  .email-composition-contents {
-    display: flex;
-    flex-direction: column;
+.email-composition-dialog-wrapper {
+  overflow: auto;
 
-    .subheading-section {
-      padding-bottom: 20px;
+  .email-composition-dialog {
+    padding-top: 0 !important;
 
-      .subheading-to {
-        padding: 0 10px;
-
+    > div {
+      &:first-child {
+        > div {
+          height: auto !important;
+          max-height: inherit !important;
+        }
       }
+    }
 
-      .subheading {
-        letter-spacing: normal;
-        margin: 0;
-        padding: 0;
-        font-size: 16px;
-        font-weight: normal;
+    .email-composition-contents {
+      display: flex;
+      flex-direction: column;
+      max-height: inherit;
 
-        &.default {
-          font-style: italic;
+      .subheading-section {
+        padding-bottom: 20px;
+
+        .subheading-to {
+          padding: 0 10px;
         }
 
-        &.rounded {
-          background-color: $bg-med-gray;
-          line-height: 22px;
-          padding: 10px 10px 10px 20px;
-          border-radius: 20px;
-          font-style: normal;
-        }
+        .subheading {
+          letter-spacing: normal;
+          margin: 0;
+          padding: 0;
+          font-size: 16px;
+          font-weight: normal;
 
-        &.profile-image-bubble {
-          background-color: $bg-med-gray;
-          border-radius: 50px;
-          padding: 0 30px 0 0;
-          height: 43px;
-          display: inline-block;
+          &.default {
+            font-style: italic;
+          }
 
-          >span {
+          &.rounded {
+            background-color: $bg-med-gray;
+            line-height: 22px;
+            padding: 10px 10px 10px 20px;
+            border-radius: 20px;
+            font-style: normal;
+          }
+
+          &.profile-image-bubble {
+            background-color: $bg-med-gray;
+            border-radius: 50px;
+            padding: 0 30px 0 0;
+            height: 43px;
             display: inline-block;
-            padding-left: 15px;
+
+            > span {
+              display: inline-block;
+              padding-left: 15px;
+            }
           }
         }
       }
-    }
 
-    .validation-error {
-      font-size: 12px;
-      color: $validation-red;
-    }
+      .validation-error {
+        font-size: 12px;
+        color: $validation-red;
+      }
 
-    textarea {
-      padding: 15px;
-      border-color: $border-color;
-      border-radius: 2px;
+      textarea {
+        padding: 15px;
+        border-color: $border-color;
+        border-radius: 2px;
+        overflow: hidden;
 
-      &.email-subject {
-        margin-bottom: 5px;
+        &.email-subject {
+          padding: 8px 15px;
+          margin-bottom: 5px;
+          height: 60px;
+        }
+      }
+
+      .email-automatic {
+        padding: 20px 0 0;
       }
     }
+  }
+}
 
-    .email-automatic {
-      padding: 20px 0;
+.email-type {
+  width: 100%;
+  margin: 0 0 10px;
+  background-color: $email-composition-type;
+  padding: 15px;
+  border-radius: 8px;
+
+  .type-radio-group {
+    display: flex;
+    flex-direction: row;
+
+    label {
+      color: $darkergray;
+      font-size: 15px;
     }
+  }
+
+  .one-time-email {
+    display: flex !important;
+    flex-direction: row;
+    flex-grow: 1;
+    width: 55% !important;
+
+    > div {
+      > div {
+        margin-right: 6px !important;
+      }
+    }
+  }
+
+  .email-campaign {
+    display: flex !important;
+    flex-direction: row;
+    flex-grow: 5;
+
+    > div {
+      > div {
+        margin-right: 6px !important;
+      }
+    }
+  }
+
+  .email-campaign-content {
+    margin: 10px 5px 0;
+    font-size: 14px;
   }
 }

--- a/static/scss/email-composition-dialog.scss
+++ b/static/scss/email-composition-dialog.scss
@@ -131,3 +131,32 @@
     font-size: 14px;
   }
 }
+
+.sk-selected-filters-display {
+  display: flex;
+  flex-direction: row;
+  border: 1px solid $border-color;
+  border-radius: 3px 3px 0 0;
+  margin-bottom: -1px;
+  padding: 10px 15px 5px;
+
+  .sk-selected-filters-title {
+    padding-top: 4px;
+    font-size: 16px;
+    color: $font-gray-light;
+  }
+
+  .sk-selected-filters {
+    margin-left: 10px;
+
+    .sk-selected-filters-option {
+      background: #F5F5F5;
+      padding: 5px 10px;
+      margin: 0 3px 6px 3px;
+
+      .sk-selected-filters-option__name {
+        color: $darkgray;
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2953

#### What's this PR do?
- Added filers selected on learners search to email composer as recipients

#### How should this be manually tested?
- Go to `/learners/` select filters and open `Email These Learners`.

#### Screenshots (if appropriate)
<img width="775" alt="screen shot 2017-04-03 at 6 41 24 pm" src="https://cloud.githubusercontent.com/assets/10431250/24612637/466f0dc4-189f-11e7-9470-1fb0d60352cc.png">

