### PR TITLE
Mail: displayed search filters as recipients

### DIFF
--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -6,7 +6,7 @@ import AutomaticEmailOptions from './AutomaticEmailOptions';
 import { FETCH_PROCESSING } from '../../actions';
 import { dialogActions } from '../inputs/util';
 import { isNilOrBlank } from '../../util/util';
-import type { EmailState } from '../../flow/emailTypes';
+import type { EmailState, Filter } from '../../flow/emailTypes';
 
 export default class EmailCompositionDialog extends React.Component {
   props: {
@@ -17,7 +17,7 @@ export default class EmailCompositionDialog extends React.Component {
     closeAndClearEmailComposer: () => void,
     closeEmailComposerAndSend:  () => void,
     updateEmailFieldEdit:       () => void,
-    renderRecipients?:          (filters: ?Array<any>) => React$Element<*>
+    renderRecipients?:          (filters: ?Array<Filter>) => React$Element<*>
   };
 
   showValidationError = (fieldName: string): ?React$Element<*> => {

--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -16,7 +16,8 @@ export default class EmailCompositionDialog extends React.Component {
     subheadingRenderer?:        (activeEmail: EmailState) => React$Element<*>,
     closeAndClearEmailComposer: () => void,
     closeEmailComposerAndSend:  () => void,
-    updateEmailFieldEdit:       () => void
+    updateEmailFieldEdit:       () => void,
+    renderRecipients?:          (filters: ?Array<any>) => React$Element<*>
   };
 
   showValidationError = (fieldName: string): ?React$Element<*> => {
@@ -63,16 +64,13 @@ export default class EmailCompositionDialog extends React.Component {
     if (!this.props.activeEmail) return null;
 
     const {
-      activeEmail: {
-        fetchStatus,
-        inputs,
-        supportsAutomaticEmails
-      },
+      activeEmail: { fetchStatus, inputs, supportsAutomaticEmails, filters },
       title,
       dialogVisibility,
       closeAndClearEmailComposer,
       closeEmailComposerAndSend,
-      updateEmailFieldEdit
+      updateEmailFieldEdit,
+      renderRecipients,
     } = this.props;
 
     return <Dialog
@@ -94,6 +92,7 @@ export default class EmailCompositionDialog extends React.Component {
       <div className="email-composition-contents">
         { supportsAutomaticEmails ? this.renderAutomaticEmailSettings(inputs.sendAutomaticEmails || false) : null }
         { this.renderSubheading() }
+        { renderRecipients ? renderRecipients(filters) : null }
         <textarea
           rows="1"
           className="email-subject"

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -7,6 +7,7 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import TestUtils from 'react-addons-test-utils';
 
+import { SEARCH_RESULT_EMAIL_CONFIG } from './lib';
 import * as inputUtil from '../inputs/util';
 import { FETCH_PROCESSING } from '../../actions';
 import { modifyTextField } from '../../util/test_utils';
@@ -159,5 +160,32 @@ describe('EmailCompositionDialog', () => {
         assert.equal(message, errorMessage);
       });
     });
+  });
+
+  it('should render recipients', () => {
+    let emailState = updateObject(INITIAL_TEST_EMAIL_STATE[TEST_EMAIL_TYPE], {});
+    emailState.filters = [{
+      id: '1',
+      name: "key",
+      value: "test"
+    }];
+    mount(
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <EmailCompositionDialog
+          updateEmailFieldEdit={() => (updateStub)}
+          closeAndClearEmailComposer={closeStub}
+          closeEmailComposerAndSend={sendStub}
+          dialogVisibility={true}
+          activeEmail={emailState}
+          title={TEST_EMAIL_CONFIG.title}
+          subheadingRenderer={TEST_EMAIL_CONFIG.renderSubheading}
+          renderRecipients={SEARCH_RESULT_EMAIL_CONFIG.renderRecipients}
+        />
+      </MuiThemeProvider>
+    );
+    assert.include(
+      getDialog().querySelector('.sk-selected-filters-option__name').textContent,
+      "key: test"
+    );
   });
 });

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -163,26 +163,14 @@ describe('EmailCompositionDialog', () => {
   });
 
   it('should render recipients', () => {
-    let emailState = updateObject(INITIAL_TEST_EMAIL_STATE[TEST_EMAIL_TYPE], {});
-    emailState.filters = [{
-      id: '1',
-      name: "key",
-      value: "test"
-    }];
-    mount(
-      <MuiThemeProvider muiTheme={getMuiTheme()}>
-        <EmailCompositionDialog
-          updateEmailFieldEdit={() => (updateStub)}
-          closeAndClearEmailComposer={closeStub}
-          closeEmailComposerAndSend={sendStub}
-          dialogVisibility={true}
-          activeEmail={emailState}
-          title={TEST_EMAIL_CONFIG.title}
-          subheadingRenderer={TEST_EMAIL_CONFIG.renderSubheading}
-          renderRecipients={SEARCH_RESULT_EMAIL_CONFIG.renderRecipients}
-        />
-      </MuiThemeProvider>
-    );
+    renderDialog({
+      filters: [{
+        id: '1',
+        name: "key",
+        value: "test"
+      }]
+    }, { renderRecipients: SEARCH_RESULT_EMAIL_CONFIG.renderRecipients });
+
     assert.include(
       getDialog().querySelector('.sk-selected-filters-option__name').textContent,
       "key: test"

--- a/static/js/components/email/hoc.js
+++ b/static/js/components/email/hoc.js
@@ -95,6 +95,7 @@ export const withEmailDialog = R.curry(
             activeEmail={this.getActiveEmailState()}
             title={emailConfigs[activeEmailType].title}
             subheadingRenderer={emailConfigs[activeEmailType].renderSubheading}
+            renderRecipients={emailConfigs[activeEmailType].renderRecipients}
           />
         );
       }

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
+import _ from 'lodash';
 
 import {
   sendCourseTeamMail,
@@ -46,6 +47,7 @@ export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
   emailOpenParams: (searchkit: Object) => ({
     subheading: `${searchkit.getHitsCount() || 0} recipients selected`,
     supportsAutomaticEmails: true,
+    filters: searchkit.query.getSelectedFilters()
   }),
 
   getEmailSendFunction: () => sendSearchResultMail,
@@ -55,7 +57,31 @@ export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
     emailState.inputs.body || '',
     emailState.searchkit.buildQuery().query,
     emailState.inputs.sendAutomaticEmails || false,
-  ])
+  ]),
+
+  renderRecipients: (filters?: Array<any>) => {
+    if (!filters || filters.length <= 0) {
+      return null;
+    }
+    console.log(filters);
+    const renderFilterOptions = _.map(filters, filter => (
+      <div className="sk-selected-filters-option sk-selected-filters__item" key={filter.id}>
+        <div className="sk-selected-filters-option__name">
+          {filter.name}: {filter.value}
+        </div>
+      </div>
+    ));
+    return (
+      <div className="sk-selected-filters-display">
+        <div className="sk-selected-filters-title">
+          Recipients
+        </div>
+        <div className="sk-selected-filters">
+          {renderFilterOptions}
+        </div>
+      </div>
+    );
+  }
 };
 
 export const LEARNER_EMAIL_CONFIG: EmailConfig = {

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
-import _ from 'lodash';
+import R from 'ramda';
 
 import {
   sendCourseTeamMail,
@@ -10,10 +10,18 @@ import {
 import { makeProfileImageUrl } from '../../util/util';
 import type { Profile } from '../../flow/profileTypes';
 import type { Course } from '../../flow/programTypes';
-import type { EmailConfig, EmailState } from '../../flow/emailTypes';
+import type { EmailConfig, EmailState, Filter } from '../../flow/emailTypes';
 
 // NOTE: getEmailSendFunction is a function that returns a function. It is implemented this way
 // so that we can stub/mock the function that it returns (as we do in integration_test_helper.js)
+
+const renderFilterOptions = R.map(filter => (
+  <div className="sk-selected-filters-option sk-selected-filters__item" key={filter.id}>
+    <div className="sk-selected-filters-option__name">
+      {filter.name}: {filter.value}
+    </div>
+  </div>
+));
 
 export const COURSE_TEAM_EMAIL_CONFIG: EmailConfig = {
   title: 'Contact the Course Team',
@@ -59,24 +67,17 @@ export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
     emailState.inputs.sendAutomaticEmails || false,
   ]),
 
-  renderRecipients: (filters?: Array<any>) => {
+  renderRecipients: (filters?: Array<Filter>) => {
     if (!filters || filters.length <= 0) {
       return null;
     }
-    const renderFilterOptions = _.map(filters, filter => (
-      <div className="sk-selected-filters-option sk-selected-filters__item" key={filter.id}>
-        <div className="sk-selected-filters-option__name">
-          {filter.name}: {filter.value}
-        </div>
-      </div>
-    ));
     return (
       <div className="sk-selected-filters-display">
         <div className="sk-selected-filters-title">
           Recipients
         </div>
         <div className="sk-selected-filters">
-          {renderFilterOptions}
+          {renderFilterOptions(filters)}
         </div>
       </div>
     );

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -63,7 +63,6 @@ export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
     if (!filters || filters.length <= 0) {
       return null;
     }
-    console.log(filters);
     const renderFilterOptions = _.map(filters, filter => (
       <div className="sk-selected-filters-option sk-selected-filters__item" key={filter.id}>
         <div className="sk-selected-filters-option__name">

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -9,6 +9,13 @@ export type EmailInputs = {
   body?:                ?string,
   sendAutomaticEmails?: boolean,
 };
+
+export type Filter = {
+  id:    string,
+  name?: string,
+  value: string
+}
+
 export type EmailValidationErrors = EmailInputs;
 
 export type EmailState = {
@@ -19,7 +26,7 @@ export type EmailState = {
   sendError:                EmailSendError,
   fetchStatus?:             ?string,
   supportsAutomaticEmails?: boolean,
-  filters:                  ?Array<any>,
+  filters:                  ?Array<Filter>,
 };
 
 export type AllEmailsState = {
@@ -34,5 +41,5 @@ export type EmailConfig = {
   emailOpenParams: (args: any) => Object,
   getEmailSendFunction: () => Function,
   emailSendParams: (emailState: EmailState) => Array<any>,
-  renderRecipients?: (filters: ?Array<any>) => React$Element<*>,
+  renderRecipients?: (filters: ?Array<Filter>) => React$Element<*>,
 };

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -34,5 +34,5 @@ export type EmailConfig = {
   emailOpenParams: (args: any) => Object,
   getEmailSendFunction: () => Function,
   emailSendParams: (emailState: EmailState) => Array<any>,
-  renderRecipients?: (filters: Array<any>) => React$Element<*>,
+  renderRecipients?: (filters: ?Array<any>) => React$Element<*>,
 };

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -19,6 +19,7 @@ export type EmailState = {
   sendError:                EmailSendError,
   fetchStatus?:             ?string,
   supportsAutomaticEmails?: boolean,
+  filters:                  ?Array<any>,
 };
 
 export type AllEmailsState = {
@@ -32,5 +33,6 @@ export type EmailConfig = {
   renderSubheading: (activeEmail: EmailState) => React$Element<*>,
   emailOpenParams: (args: any) => Object,
   getEmailSendFunction: () => Function,
-  emailSendParams: (emailState: EmailState) => Array<any>
+  emailSendParams: (emailState: EmailState) => Array<any>,
+  renderRecipients?: (filters: Array<any>) => React$Element<*>,
 };

--- a/static/js/reducers/email.js
+++ b/static/js/reducers/email.js
@@ -33,6 +33,7 @@ export const INITIAL_EMAIL_STATE: EmailState = {
   sendError: {},
   subheading: undefined,
   supportsAutomaticEmails: false,
+  filters: undefined
 };
 
 export const INITIAL_ALL_EMAILS_STATE: AllEmailsState = {
@@ -68,6 +69,7 @@ export const email = (state: AllEmailsState = INITIAL_ALL_EMAILS_STATE, action: 
       params: action.payload.params || {},
       subheading: action.payload.subheading,
       supportsAutomaticEmails: action.payload.supportsAutomaticEmails,
+      filters: action.payload.filters
     };
     newState.currentlyActive = emailType;
     return newState;

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -61,6 +61,7 @@ $block-padding: 20px;
 $page-padding: 40px;
 $progress-widget-bg-stroke: rgba(0,0,0,0.06);
 $progress-button-background: #000000;
+$recipient_bg: #f5f5f5;
 
 @font-face {
   font-family: 'Roboto';

--- a/static/scss/email-composition-dialog.scss
+++ b/static/scss/email-composition-dialog.scss
@@ -123,7 +123,7 @@
     margin-left: 10px;
 
     .sk-selected-filters-option {
-      background: #F5F5F5;
+      background: $recipient_bg;
       padding: 5px 10px;
       margin: 0 3px 6px 3px;
 

--- a/static/scss/email-composition-dialog.scss
+++ b/static/scss/email-composition-dialog.scss
@@ -104,3 +104,32 @@
     font-size: 14px;
   }
 }
+
+.sk-selected-filters-display {
+  display: flex;
+  flex-direction: row;
+  border: 1px solid $border-color;
+  border-radius: 3px 3px 0 0;
+  margin-bottom: -1px;
+  padding: 10px 15px 5px;
+
+  .sk-selected-filters-title {
+    padding-top: 4px;
+    font-size: 16px;
+    color: $font-gray-light;
+  }
+
+  .sk-selected-filters {
+    margin-left: 10px;
+
+    .sk-selected-filters-option {
+      background: #F5F5F5;
+      padding: 5px 10px;
+      margin: 0 3px 6px 3px;
+
+      .sk-selected-filters-option__name {
+        color: $darkgray;
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2953

#### What's this PR do?
- Added filers selected on learners search to email composer as recipients

#### How should this be manually tested?
- Go to `/learners/` select filters and open `Email These Learners`.

#### Screenshots (if appropriate)
<img width="801" alt="screen shot 2017-04-03 at 10 16 05 pm" src="https://cloud.githubusercontent.com/assets/10431250/24621530/382b1af2-18bb-11e7-82f7-8c05f5d6ac5d.png">


