### PR TITLE
Progress widget: Removed apply for master button and text

### DIFF
--- a/static/js/components/ProgressWidget.js
+++ b/static/js/components/ProgressWidget.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import { Card, CardTitle } from 'react-mdl/lib/Card';
-import Button from 'react-mdl/lib/Button';
 
 import type {
   Program
@@ -70,12 +69,6 @@ export default class ProgressWidget extends React.Component {
       <Card className="progress-widget" shadow={0}>
         <CardTitle className="progress-title">Progress</CardTitle>
         {circularProgressWidget(63, 7, totalPassedCourses, totalCourses)}
-        <p className="heading-paragraph">
-          On completion, you can apply for
-          the master’s degree program</p>
-           <Button className="progress-button" disabled>
-             Apply for Master’s
-           </Button>
       </Card>
     );
   }

--- a/static/js/components/ProgressWidget_test.js
+++ b/static/js/components/ProgressWidget_test.js
@@ -134,10 +134,5 @@ describe('ProgressWidget', () => {
       wrapper.find(".circular-progress-widget-txt").text(),
       "3/5"
     );
-    assert.equal(
-      wrapper.find(".heading-paragraph").text(),
-      "On completion, you can apply for the master’s degree program"
-    );
-    assert.isTrue(wrapper.find(".progress-button").props().disabled, 'Button is disable');
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2979

#### What's this PR do?
- removed `Apply for Master` and text from progress widget.

#### How should this be manually tested?
- go to /dashboard and see widget on the right side

@pdpinch 
#### Screenshots (if appropriate)
##### Old Image
<img width="409" alt="screen shot 2017-04-04 at 3 01 43 am" src="https://cloud.githubusercontent.com/assets/10431250/24633680/349ad54e-18e3-11e7-8e22-e5b9f45ffa63.png">

##### New Image
<img width="744" alt="screen shot 2017-04-04 at 2 43 57 am" src="https://cloud.githubusercontent.com/assets/10431250/24633298/469389fa-18e1-11e7-94c8-6efa3f2ae554.png">

