### PR TITLE
Fixed unexpected course enrollment counts/results in learners search

### DIFF
--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -10,70 +10,66 @@ class UserProgramSearchSerializer:
     """
     Provides functions for serializing a ProgramEnrollment for the ES index
     """
+    PAID_STATUS = 'Paid'
+    UNPAID_STATUS = 'Auditing'
+
     @classmethod
     def serialize_enrollments(cls, mmtrack):
         """
-        Serializes a user's enrollment data for search results
+        Serializes a user's enrollment data for search results in such a way that enrollments
+        in multiple runs of a single course will result in just one serialization.
 
         Args:
             mmtrack (MMTrack): An MMTrack object
         Returns:
-            list: Serialized courses
+            list: Serialized course enrollments
         """
-        enrollment_status_map = {}
-        course_runs = mmtrack.get_all_enrolled_course_runs()
-        for course_run in course_runs:
-            course_title = course_run.course.title
-            is_verified = mmtrack.is_enrolled_mmtrack(course_run.edx_course_key)
-            # If any course run for this course was verified/paid, maintain the verified status
-            enrollment_status_map[course_title] = enrollment_status_map.get(course_title) or is_verified
-        serialized_enrollments = []
-        for course_title, is_verified in enrollment_status_map.items():
-            enrollment_status = 'Paid' if is_verified else 'Auditing'
-            serialized_enrollments.extend([
-                {'level': 1, 'value': course_title, 'ancestors': []},
-                {'level': 2, 'value': enrollment_status, 'ancestors': [course_title]}
-            ])
-        return serialized_enrollments
-
-    @classmethod
-    def serialize_final_grades(cls, mmtrack):
-        """
-        Serializes a user's final grades
-
-        Args:
-            mmtrack (MMTrack): An MMTrack object
-        Returns:
-            list: Serialized final grades
-        """
-
-        serialized_final_grades = []
-        final_grades = mmtrack.get_all_final_grades()
-        for final_grade in final_grades.values():
-            serialized_final_grades.append({
-                'title': final_grade.course_run.course.title,
-                'grade': final_grade.grade_percent
-            })
-        return serialized_final_grades
-
-    @classmethod
-    def serialize_semester_enrollments(cls, mmtrack):
-        """
-        Serializes the semesters that a user is enrolled in
-
-        Args:
-            mmtrack (MMTrack): An MMTrack object
-        Returns:
-            list: Serialized semester enrollments
-        """
-        semester_values = set()
+        serialized_enrollments_map = {}
         for course_run in mmtrack.get_all_enrolled_course_runs():
-            year_season_tuple = get_year_season_from_course_run(course_run)
-            if year_season_tuple:
-                semester_values.add(
-                    '{} - {}'.format(year_season_tuple[0], year_season_tuple[1])
-                )
-        return [{'semester': semester_value} for semester_value in semester_values]
+            course_title = course_run.course.title
+            # If any course run for this course was verified/paid, count it as verified
+            if course_title not in serialized_enrollments_map or \
+                    serialized_enrollments_map[course_title]['payment_status'] == cls.UNPAID_STATUS:
+                serialized_enrollments_map[course_title] = cls.serialize_enrollment(mmtrack, course_run)
+        return list(serialized_enrollments_map.values())
+
+    @classmethod
+    def serialize_enrollment(cls, mmtrack, course_run):
+        """
+        Serializes information about a user's enrollment in a course run
+
+        Args:
+            mmtrack (MMTrack): An MMTrack object
+            course_run (CourseRun): An enrolled CourseRun
+        Returns:
+            dict: Serialized course enrollment
+        """
+        course_title = course_run.course.title
+        has_paid = mmtrack.has_paid(course_run.edx_course_key)
+        payment_status = cls.PAID_STATUS if has_paid else cls.UNPAID_STATUS
+        final_grade = mmtrack.get_final_grade_percent(course_run.edx_course_key)
+        semester = cls.serialize_semester(course_run)
+        return {
+            'final_grade': final_grade,
+            'semester': semester,
+            'course_title': course_title,
+            'payment_status': payment_status,
+        }
+
+    @classmethod
+    def serialize_semester(cls, course_run):
+        """
+        Serializes the semester in which a user has been enrolled
+
+        Args:
+            course_run (CourseRun): An enrolled CourseRun
+        Returns:
+            str: Serialized semester enrollment or None
+        """
+        year_season_tuple = get_year_season_from_course_run(course_run)
+        if year_season_tuple:
+            return '{} - {}'.format(year_season_tuple[0], year_season_tuple[1])
+        return None
 
     @classmethod
     def serialize(cls, program_enrollment):
@@ -87,8 +83,6 @@ class UserProgramSearchSerializer:
         return {
             'id': program.id,
             'enrollments': cls.serialize_enrollments(mmtrack),
-            'final_grades': cls.serialize_final_grades(mmtrack),
-            'semester_enrollments': cls.serialize_semester_enrollments(mmtrack),
             'grade_average': mmtrack.calculate_final_grade_average(),
             'is_learner': is_learner(user, program),
             'num_courses_passed': mmtrack.count_courses_passed(),

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -273,7 +273,7 @@ class MMTrack:
             if course_id in final_grades or self.enrollments.is_enrolled_in(course_id):
                 enrolled_course_ids.append(course_id)
 
-        return list(CourseRun.objects.filter(edx_course_key__in=enrolled_course_ids))
+        return list(CourseRun.objects.filter(edx_course_key__in=enrolled_course_ids).select_related('course'))
 
     def calculate_final_grade_average(self):
         """

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -283,19 +283,12 @@ def program_enrolled_user_mapping():
         'num_courses_passed': LONG_TYPE,
         'total_courses': LONG_TYPE,
         'is_learner': BOOL_TYPE,
-        'final_grades': {'type': 'nested', 'properties': {
-            'title':  NOT_ANALYZED_STRING_TYPE,
-            'grade': LONG_TYPE
-        }},
         'enrollments': {'type': 'nested', 'properties': {
-            'level': LONG_TYPE,
-            'ancestors': NOT_ANALYZED_STRING_TYPE,
-            'value': NOT_ANALYZED_STRING_TYPE,
-            'order': LONG_TYPE
+            'final_grade': LONG_TYPE,
+            'semester': NOT_ANALYZED_STRING_TYPE,
+            'course_title': NOT_ANALYZED_STRING_TYPE,
+            'status': NOT_ANALYZED_STRING_TYPE,
         }},
-        'semester_enrollments': {'type': 'nested', 'properties': {
-            'semester': NOT_ANALYZED_STRING_TYPE
-        }}
     })
     # Make strings not_analyzed by default
     mapping.meta('dynamic_templates', [{

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -6,7 +6,6 @@ import {
   HierarchicalMenuFilter,
   Hits,
   SelectedFilters,
-  HierarchicalRefinementFilter,
   RefinementListFilter,
   HitsStats,
   Pagination,
@@ -26,7 +25,7 @@ import ProgramFilter from './ProgramFilter';
 import LearnerResult from './search/LearnerResult';
 import CountryRefinementOption from './search/CountryRefinementOption';
 import EducationFilter from './search/EducationFilter';
-import PatchedMenuFilter from './search/PatchedMenuFilter';
+import NestedAggregatingMenuFilter from './search/NestedAggregatingMenuFilter';
 import WorkHistoryFilter from './search/WorkHistoryFilter';
 import CustomPaginationDisplay from './search/CustomPaginationDisplay';
 import CustomResetFiltersDisplay from './search/CustomResetFiltersDisplay';
@@ -34,13 +33,12 @@ import CustomSortingColumnHeaders from './search/CustomSortingColumnHeaders';
 import FilterVisibilityToggle from './search/FilterVisibilityToggle';
 import HitsCount from './search/HitsCount';
 import CustomNoHits from './search/CustomNoHits';
+import ModifiedSelectedFilter from './search/ModifiedSelectedFilter';
 import { wrapWithProps } from '../util/util';
 import type { Option } from '../flow/generalTypes';
 import type { AvailableProgram } from '../flow/enrollmentTypes';
 import type { SearchSortItem } from '../flow/searchTypes';
 import type { Profile } from '../flow/profileTypes';
-import FinalGradeRangeFilter  from './search/FinalGradeRangeFilter';
-import ModifiedSelectedFilter from './search/ModifiedSelectedFilter';
 
 export const makeCountryNameTranslations: () => Object = () => {
   let translations = {};
@@ -202,30 +200,35 @@ export default class LearnerSearch extends SearchkitComponent {
           title="Course"
           filterName="courses"
         >
-          <HierarchicalRefinementFilter
-            field={"program.enrollments"}
+          <NestedAggregatingMenuFilter
+            field="program.enrollments.course_title"
+            fieldOptions={{ type: 'nested', options: {path: 'program.enrollments'} }}
             title=""
+            orderKey="_term"
             id="courses"
           />
         </FilterVisibilityToggle>
-        <div className="final-grade-wrapper">
-          <FinalGradeRangeFilter
-            field="program.final_grades.grade"
-            id="final-grade"
-            min={0}
-            max={100}
-            showHistogram={true}
-            title="Final Grade in Selected Course"
+        <FilterVisibilityToggle
+          {...this.props}
+          filterName="payment_status"
+          title="Payment Status"
+        >
+          <NestedAggregatingMenuFilter
+            field="program.enrollments.payment_status"
+            fieldOptions={{ type: 'nested', options: {path: 'program.enrollments'} }}
+            title=""
+            orderKey="_term"
+            id="payment_status"
           />
-        </div>
+        </FilterVisibilityToggle>
         <FilterVisibilityToggle
           {...this.props}
           filterName="semester"
           title="Semester"
         >
-          <PatchedMenuFilter
-            field="program.semester_enrollments.semester"
-            fieldOptions={{ type: 'nested', options: {path: 'program.semester_enrollments'} }}
+          <NestedAggregatingMenuFilter
+            field="program.enrollments.semester"
+            fieldOptions={{ type: 'nested', options: {path: 'program.enrollments'} }}
             title=""
             id="semester"
             bucketsTransform={sortSemesterBuckets}
@@ -287,17 +290,17 @@ export default class LearnerSearch extends SearchkitComponent {
         </FilterVisibilityToggle>
         <FilterVisibilityToggle
           {...this.props}
-          title="Degree"
           filterName="education-level"
+          title="Degree"
         >
-          <EducationFilter />
+          <EducationFilter id="education_level" />
         </FilterVisibilityToggle>
         <FilterVisibilityToggle
           {...this.props}
           filterName="company-name"
           title="Company"
         >
-          <WorkHistoryFilter />
+          <WorkHistoryFilter id="company_name" />
         </FilterVisibilityToggle>
 
       </Card>

--- a/static/js/components/search/EducationFilter.js
+++ b/static/js/components/search/EducationFilter.js
@@ -65,7 +65,7 @@ export default class EducationFilter extends SearchkitComponent {
 
   render() {
     return <PatchedMenuFilter
-      id="education_level"
+      id={this.props.id || "education_level"}
       bucketsTransform={this.bucketsTransform}
       title=""
       field="profile.education.degree_name"

--- a/static/js/components/search/FilterVisibilityToggle.js
+++ b/static/js/components/search/FilterVisibilityToggle.js
@@ -6,9 +6,11 @@ import Icon from 'react-mdl/lib/Icon';
 
 export const FILTER_ID_ADJUST = {
   "birth_location": "profile.birth_country",
-  "semester": "program.semester_enrollments.semester",
   "education_level": "profile.education.degree_name",
-  "company_name": "profile.work_history.company_name"
+  "company_name": "profile.work_history.company_name",
+  "courses": "program.enrollments.course_title",
+  "payment_status": "program.enrollments.payment_status",
+  "semester": "program.enrollments.semester",
 };
 
 export default class FilterVisibilityToggle extends SearchkitComponent {

--- a/static/js/components/search/NestedAggregatingMenuFilter.js
+++ b/static/js/components/search/NestedAggregatingMenuFilter.js
@@ -1,0 +1,297 @@
+import PatchedMenuFilter from './PatchedMenuFilter';
+import {
+  FacetAccessor, TermQuery, NestedQuery, TermsBucket, FilterBucket,
+  BoolMust, AggsContainer, CardinalityMetric
+} from "searchkit";
+import _ from 'lodash';
+import R from 'ramda';
+
+const REVERSE_NESTED_AGG_KEY = 'top_level_doc_count';
+const INNER_TERMS_AGG_KEY = 'nested_terms';
+
+/**
+ * Produces a Searchkit TermsBucket that includes a "reverse nested" aggregation.
+ *
+ * Example return value: {
+ *   "nested_terms": {
+ *     "terms":{
+ *       "field":"program.enrollments.course_title", ...
+ *     },
+ *     "aggs":{
+ *       "top_level_doc_count":{"reverse_nested":{}}
+ *     }
+ *   }
+ * }
+ */
+function ReverseNestedTermsBucket(key, field, options) {
+  let reverseNestedAgg = AggsContainer(REVERSE_NESTED_AGG_KEY, {'reverse_nested': {}});
+  return TermsBucket(key, field, options, reverseNestedAgg);
+}
+
+class NestedAggregatingFacetAccessor extends FacetAccessor {
+  /**
+   * Overrides buildSharedQuery in FacetAccessor
+   * If any filters are applied on the nested documents at this path, we need to build the shared
+   * query as normal, then alter the values for some searchkit internals in order to produce
+   * the correct query for ES. Searchkit essentially treats multiple filters on a nested set of
+   * documents as 'OR' filters, and the changes to 'query.index.filters' and 'query.index.filtersMap'
+   * are being made in order to treat those filters as 'AND'.
+   */
+  buildSharedQuery(query) {
+    query = super.buildSharedQuery(query);
+
+    // Construct an 'AND' query for all filters applied on this nested path
+    let groupedNestedFilter = this.createGroupedNestedFilter(query);
+    if (groupedNestedFilter) {
+      let nestedPath = this.getNestedPath();
+
+      let filters = _.cloneDeep(query.index.filters);
+      // Find the element that Searchkit added to query.index.filters for this nested document and remove it
+      _.remove(filters, (filter) => (
+        _.get(filter, ['nested', 'path']) === nestedPath
+      ));
+      // Add the 'AND' filter that we constructed
+      filters.push(groupedNestedFilter);
+      query = query.update({'filters': {$set: filters}});
+
+      let filtersMap = _.cloneDeep(query.index.filtersMap);
+      // Add the same 'AND' filter to query.index.filtersMap, with the nested path (not the uuid) as the key
+      filtersMap[nestedPath] = groupedNestedFilter;
+      // If it exists, delete the key for this specific filter (since all filters on this path are grouped together).
+      delete filtersMap[this.uuid];
+      query = query.update({'filtersMap': {$set: filtersMap}});
+    }
+
+    return query;
+  }
+
+  /**
+   * Overrides buildOwnQuery in FacetAccessor
+   * By default, Searchkit does this by creating an aggs bucket that applies all filters
+   * that aren't applied to the current element. This implementation accounts for (a) the fact
+   * that the logic for getting all other filters is changed in this custom Accessor, and
+   * (b) the need for additional filters on the term query for this nested path (in order to make those filters
+   * behave like an 'AND').
+   */
+  buildOwnQuery(query) {
+    if (!this.loadAggregations) {
+      return query;
+    } else {
+      return query
+        .setAggs(FilterBucket(
+          this.uuid,
+          this.createAggFilter(query),
+          ...this.fieldContext.wrapAggregations(
+            this.getTermsBucket(query),
+            CardinalityMetric(`${this.key}_count`, this.key)
+          )
+        ));
+    }
+  }
+
+  /**
+   * Overrides getRawBuckets in FacetAccessor
+   * If any filters are applied on the nested path for this element, we alter the aggs portion of
+   * the query in a way that puts the buckets/doc_count data at a different path. This implementation returns the
+   * buckets/doc_count data at the altered path if it doesn't exist at the default path.
+   */
+  getRawBuckets() {
+    let baseAggsPath = [
+      this.uuid,
+      this.fieldContext.getAggregationPath(),
+      this.key
+    ];
+    let aggs = this.getAggregations(
+      baseAggsPath.concat(["buckets"]), []
+    );
+    if (aggs.length > 0) {
+      return aggs;
+    } else {
+      return this.getAggregations(
+        baseAggsPath.concat([INNER_TERMS_AGG_KEY, "buckets"]), []
+      );
+    }
+  }
+
+  /**
+   * Returns the ES path for this nested document type (eg: 'program.enrollments')
+   */
+  getNestedPath() {
+    return this.fieldContext.fieldOptions.options.path;
+  }
+
+  /**
+   * Creates a nested filter element that has every filter on this nested path applied in
+   * an 'AND' fashion.
+   *
+   * Example return value: {
+   *   "nested": {
+   *     "path": "program.enrollments",
+   *     "filter": {
+   *       "bool": {
+   *         "must":[{"term": ... }]
+   *       }
+   *     }
+   *   }
+   * }
+   */
+  createGroupedNestedFilter(query) {
+    let nestedPathKeyPrefix = `${this.getNestedPath()}.`;
+
+    // For all applied filters on this element's nested path, create a mapping from the
+    // element's key (NOT the uuid) to the filtered value.
+    // E.g.: {
+    //   'program.enrollments.course_title': 'Some Course Title',
+    //   'program.enrollments.payment_status': 'Paid'
+    // }
+    let appliedFilterMap = R.compose(
+      R.fromPairs,
+      R.map(R.props(['name', 'value'])),
+      R.filter(
+        (selectedFilter) => (selectedFilter.name.indexOf(nestedPathKeyPrefix) === 0)
+      )
+    )(query.getSelectedFilters());
+
+    // If this element has a filter applied, add it to the map.
+    let filters = this.state.getValue();
+    if (filters.length > 0) {
+      appliedFilterMap[this.key] = filters[0];
+    }
+
+    if (!_.isEmpty(appliedFilterMap)) {
+      // Create actual term queries for each pair in the filter map and wrap it in the nested filter context
+      let filterTermQueries = _.map(appliedFilterMap, (filterValue, filterKey) => (
+        TermQuery(filterKey, filterValue)
+      ));
+      return this.fieldContext.wrapFilter(BoolMust(filterTermQueries));
+    } else {
+      return undefined;
+    }
+  }
+
+  /**
+   * Creates the filter for the aggregations of this element. The filter will include (a) any filters that don't apply
+   * to this element's nested path, and (b) filters on this element's nested path minus the filter for this specific
+   * element.
+   */
+  createAggFilter(query) {
+    let filters = [];
+    let nestedPath = this.getNestedPath();
+    let unrelatedFilters = query.getFiltersWithoutKeys(nestedPath);
+    if (unrelatedFilters) {
+      filters.push(unrelatedFilters);
+    }
+    let otherAppliedFiltersOnPath = this.createFilterForOtherElementsOnPath(query);
+    if (otherAppliedFiltersOnPath) {
+      filters.push(NestedQuery(nestedPath, otherAppliedFiltersOnPath));
+    }
+    return filters.length > 0 ? BoolMust(filters) : undefined;
+  }
+
+  /**
+   * Gets an array of all term filters that are applied to this element's same nested path. Returns undefined if no
+   * filters are applied on this element's nested path.
+   *
+   * Example return value: [
+   *   {'term': {'program.enrollments.course_title': 'Some Course Title'},
+   *   {'term': {'program.enrollments.payment_status': 'Paid'}
+   * ]
+   */
+  getAllTermFiltersOnPath(query) {
+    let nestedPath = this.getNestedPath();
+    let appliedNestedFilters = query.getFiltersWithKeys(nestedPath);
+    let filterElement = R.pathOr({}, ['nested', 'filter'], appliedNestedFilters);
+    if (R.path(['bool', 'must'], filterElement)) {
+      return R.path(['bool', 'must'], filterElement);
+    } else if (filterElement.term) {
+      return [filterElement];
+    } else {
+      return [];
+    }
+  }
+
+  /**
+   * Creates an 'AND' filter for all filters that are applied on this element's nested path, minus the filter for
+   * this specific element (if it exists). If no other filters are applied on this element's nested path, undefined is
+   * returned.
+   *
+   * Example return value: {
+   *   'bool': {
+   *     'must': [
+   *       {'term': {'program.enrollments.course_title': 'Some Course Title'}}
+   *     ]
+   *   }
+   * }
+   */
+  createFilterForOtherElementsOnPath(query) {
+    let allTermFilters = this.getAllTermFiltersOnPath(query);
+    let otherTermFilters = [];
+    if (allTermFilters.length > 0) {
+      // Filter out term filters for this element
+      otherTermFilters = R.filter(
+        R.compose(
+          R.not,
+          R.equals(this.key),
+          R.head,
+          R.keys,
+          R.prop('term')
+        )
+      )(allTermFilters);
+    }
+    return otherTermFilters.length > 0 ? BoolMust(otherTermFilters) : undefined;
+  }
+
+  /**
+   * Gets the appropriate terms bucket for this element's agg query.
+   */
+  getTermsBucket(query) {
+    let otherAppliedFiltersOnPath = this.createFilterForOtherElementsOnPath(query);
+    let termsKey = otherAppliedFiltersOnPath ? INNER_TERMS_AGG_KEY : this.key;
+    let termsBucket = ReverseNestedTermsBucket(termsKey, this.key, _.omitBy({
+      size:this.size,
+      order:this.getOrder(),
+      include: this.options.include,
+      exclude: this.options.exclude,
+      min_doc_count:this.options.min_doc_count
+    }, _.isUndefined));
+
+    if (otherAppliedFiltersOnPath) {
+      return FilterBucket(
+        this.key,
+        otherAppliedFiltersOnPath,
+        termsBucket
+      );
+    } else {
+      return termsBucket;
+    }
+  }
+}
+
+export default class NestedAggregatingMenuFilter extends PatchedMenuFilter {
+  /**
+   * Overrides defineAccessor in MenuFilter
+   * Sets a custom Accessor for this Filter type. This is otherwise identical to the original implementation.
+   */
+  defineAccessor() {
+    return new NestedAggregatingFacetAccessor(
+      this.props.field, this.getAccessorOptions()
+    );
+  }
+
+  /**
+   * Overrides getItems in MenuFilter
+   * Before the aggregation results are rendered, set the doc_count of each item to be the
+   * "reverse nested" doc_count. This effectively means that we will show how many unique users
+   * match the query against a set of nested elements, as opposed to the total count of nested
+   * elements that match (which could be greater than the number of users).
+   */
+  getItems() {
+    let items = super.getItems();
+    return items.map(
+      item => ({
+        ...item,
+        doc_count: item[REVERSE_NESTED_AGG_KEY] ? item[REVERSE_NESTED_AGG_KEY].doc_count : item.doc_count
+      })
+    );
+  }
+}

--- a/static/js/components/search/WorkHistoryFilter.js
+++ b/static/js/components/search/WorkHistoryFilter.js
@@ -48,9 +48,9 @@ export default class WorkHistoryFilter extends SearchkitComponent {
   render() {
     return (
       <RefinementListFilter
+        id={this.props.id || "company_name"}
         field="profile.work_history.company_name"
         title=""
-        id="company_name"
         operator="OR"
         fieldOptions={{type: 'nested', options: { path: 'profile.work_history'}}}
         listComponent={ModifiedMultiSelect}

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -487,21 +487,73 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
       },
       "doc_count": 1
     },
-    "program.semester_enrollments.semester5": {
+    // Adding aggregation response for an enrollment field, which is structured differently
+    // because of custom query building...
+    //
+    // This agg response is structured as if no filters were applied to enrollments
+    "program.enrollments.course_title3": {
+      "doc_count": 250,
       "inner": {
-        "program.semester_enrollments.semester": {
-          "doc_count_error_upper_bound": 0,
-          "buckets": [],
-          "sum_other_doc_count": 0
+        "doc_count": 250,
+        "program.enrollments.course_title_count": {
+          "value": 3
         },
-        "doc_count": 0,
-        "program.semester_enrollments.semester_count": {
-          "value": 0
+        "program.enrollments.course_title": {
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+          "buckets": [
+            {
+              "key": "Test Course 100",
+              "doc_count": 150,
+              "top_level_doc_count": {
+                "doc_count": 15
+              }
+            },
+            {
+              "key": "Test Course 200",
+              "doc_count": 100,
+              "top_level_doc_count": {
+                "doc_count": 10
+              }
+            }
+          ]
         }
-      },
-      "doc_count": 1
+      }
+    },
+    // This agg response is structured as if one or more filters were applied to enrollments
+    "program.enrollments.payment_status4": {
+      "doc_count": 20,
+      "inner": {
+        "doc_count": 50,
+        "program.enrollments.payment_status": {
+          "doc_count": 20,
+          "nested_terms": {
+            "doc_count_error_upper_bound": 0,
+            "sum_other_doc_count": 0,
+            "buckets": [
+              {
+                "key": "Auditing",
+                "doc_count": 15,
+                "top_level_doc_count": {
+                  "doc_count": 15
+                }
+              },
+              {
+                "key": "Paid",
+                "doc_count": 5,
+                "top_level_doc_count": {
+                  "doc_count": 5
+                }
+              }
+            ]
+          }
+        },
+        "program.enrollments.payment_status_count": {
+          "value": 2
+        }
+      }
     }
-  },
+  }
 });
 
 export const USER_PROFILE_RESPONSE = deepFreeze({

--- a/static/scss/search-page.scss
+++ b/static/scss/search-page.scss
@@ -159,17 +159,6 @@
       }
     }
 
-    .filter--courses {
-      .sk-item-list-option {
-        margin-bottom: 8px;
-
-        .sk-item-list-option__text {
-          margin-top: 2px;
-          line-height: 1.3;
-        }
-      }
-    }
-
     .filter--final-grade {
       margin-left: 30px;
     }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2942

#### What's this PR do?
Fixes the bug we had where search results were being filtered in ways that our users weren't expecting. Filters on our course enrollments were being treated as 'OR' filters rather than 'AND', and the number of results being reported was a count of the nested documents that matched rather than the number of users.

#### How should this be manually tested?
I'll add some detail here later, but in general, you want to get users into a state where there is a venn-diagram-like overlap between course enrollments based on course title, course payment statuses, and enrolled semesters.

#### Where should the reviewer start?
Probably dashboard/serializers.py and static/js/components/search/NestedAggregatingMenuFilter.js

#### Any background context you want to provide?
1. The per-course final grade histogram was removed and will be reimplemented in another issue.
1. The course payment status was moved to its own facet

#### Screenshots (if appropriate)
<img width="1000" alt="ss 2017-04-04 at 09 11 01" src="https://cloud.githubusercontent.com/assets/14932219/24658089/aaae44ea-1916-11e7-8f4a-168a94315b3d.png">
