### PR TITLE
Upgraded celery to 3.1.25 as 1st step to migrate to celery 4

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ Django==1.10.5
 Pillow==3.4.2
 PyYAML==3.11
 boto==2.39.0
-celery==3.1.23
+celery==3.1.25
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-redis==4.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ asn1crypto==0.22.0        # via cryptography
 beautifulsoup4==4.5.3     # via wagtail
 billiard==3.3.0.23        # via celery
 boto==2.39.0
-celery==3.1.23
+celery==3.1.25
 cffi==1.10.0              # via cryptography
 contextlib2==0.5.4        # via raven
 cryptography==1.8.1       # via paramiko
@@ -77,11 +77,11 @@ social-auth-app-django==1.1.0
 social-auth-core==1.2.0   # via social-auth-app-django
 static3==0.5.1
 stevedore==1.21.0         # via edx-opaque-keys
-tornado==4.4.2            # via robohash
+tornado==4.4.3            # via robohash
 traitlets==4.3.2          # via ipython
 unidecode==0.4.20         # via wagtail
 urllib3==1.20             # via elasticsearch
-uwsgi==2.0.14
+uwsgi==2.0.15
 wagtail==1.9
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5         # via html5lib


### PR DESCRIPTION
#### What are the relevant tickets?
part of #2696

#### What's this PR do?
upgrades to Celery 3.1.25 as suggested in http://docs.celeryproject.org/en/latest/whatsnew-4.0.html#step-1-upgrade-to-celery-3-1-25

#### How should this be manually tested?
Everything should just keep working as before