### PR TITLE
Search: Fix SelectedFilters titles

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -40,8 +40,9 @@ import type { AvailableProgram } from '../flow/enrollmentTypes';
 import type { SearchSortItem } from '../flow/searchTypes';
 import type { Profile } from '../flow/profileTypes';
 import FinalGradeRangeFilter  from './search/FinalGradeRangeFilter';
+import ModifiedSelectedFilter from './search/ModifiedSelectedFilter';
 
-const makeCountryNameTranslations: () => Object = () => {
+export const makeCountryNameTranslations: () => Object = () => {
   let translations = {};
   for (let code of Object.keys(iso3166.data)) {
     translations[code] = iso3166.data[code].name;
@@ -190,7 +191,7 @@ export default class LearnerSearch extends SearchkitComponent {
           <Pagination showText={false} listComponent={CustomPaginationDisplay} />
         </Cell>
         <Cell col={12} className="mm-filters">
-          <SelectedFilters />
+          <SelectedFilters itemComponent={ModifiedSelectedFilter}/>
           <ResetFilters component={CustomResetFiltersDisplay} />
         </Cell>
         <Cell col={12} className="sorting-header">

--- a/static/js/components/search/ModifiedSelectedFilter.js
+++ b/static/js/components/search/ModifiedSelectedFilter.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { SEARCH_FACET_FIELD_LABEL_MAP } from '../../constants';
+import { makeCountryNameTranslations } from '../LearnerSearch';
+
+export default class ModifiedSelectedFilter extends React.Component {
+  props: {
+    labelKey: string,
+    labelValue: string,
+    removeFilters: Function,
+    bemBlocks?: any,
+    filterId: string
+  };
+
+  countryNameTranslations: Object = makeCountryNameTranslations();
+
+  render() {
+    let {
+      labelKey,
+      labelValue,
+      removeFilter,
+      bemBlocks,
+      filterId,
+    } = this.props;
+
+    if (labelKey in SEARCH_FACET_FIELD_LABEL_MAP) {
+      labelKey = SEARCH_FACET_FIELD_LABEL_MAP[labelKey];
+    } else if (labelKey in this.countryNameTranslations) {
+      labelKey = this.countryNameTranslations[labelKey];
+    }
+    if (labelValue in this.countryNameTranslations) {
+      labelValue = this.countryNameTranslations[labelValue];
+    }
+    // This comes from searchkit documentation on "Overriding Selected Filter Component"
+    return (
+      <div className={bemBlocks.option().mix(bemBlocks.container("item")).mix(`selected-filter--${filterId}`)()}>
+        <div className={bemBlocks.option("name")}>{labelKey}: {labelValue}</div>
+        <div className={bemBlocks.option("remove-action")} onClick={removeFilter}>x</div>
+      </div>
+    );
+  }
+}

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -24,6 +24,16 @@ export const EDUCATION_LEVELS = [
   {value: DOCTORATE, label: "Doctorate"}
 ];
 
+export const SEARCH_FACET_FIELD_LABEL_MAP = {
+  'courses': 'Course',
+  'program.semester_enrollments.semester': 'Semester',
+  'program.grade_average': 'Average Grade in Program',
+  'profile.birth_country': 'Country of Birth',
+  'profile.country': 'Current Residence',
+  'profile.education.degree_name': 'Degree',
+  'profile.work_history.company_name': 'Company'
+};
+
 // NOTE: these need to be kept in sync with ui/url_utils.py
 export const PERSONAL_STEP = 'personal';
 export const EMPLOYMENT_STEP = 'professional';


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #2964

#### What's this PR do?
Change the selected filter tag to display the filter name instead of the `field` prop.
Create SelectedFilter component to override the `SelectedFilters` component.
#### How should this be manually tested?
Go to learners search and select filters. Check the labels:
![screen shot 2017-04-04 at 2 27 47 pm](https://cloud.githubusercontent.com/assets/7574259/24672483/e85eb88e-1942-11e7-91dc-3bf8c1218793.png)

