### PR TITLE
Use reverse nested aggregation for education and fix related tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "ajaxchimp": "^1.3.0",
     "autoprefixer": "^6.7.6",
     "awesome-phonenumber": "^1.1.3",
+    "axios-mock-adapter": "^1.8.1",
     "babel": "^6.23.0",
     "babel-core": "^6.22.1",
     "babel-eslint": "^7.1.1",

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -295,11 +295,7 @@ class Education(models.Model):
     school_country = models.TextField()
 
     def __str__(self):
-        degree_title = ''
-        for degree, title in self.DEGREE_CHOICES:
-            if self.degree_name == degree:
-                degree_title = title
-                break
+        degree_title = dict(self.DEGREE_CHOICES).get(self.degree_name, '')
 
         return 'Education for {user}, {degree} at {title} {date}'.format(
             user=self.profile.user.username,

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -271,7 +271,7 @@ class Profile(models.Model):
             name_components.append('({})'.format(self.preferred_name))
         return ' '.join(name_components)
 
-import json.tool
+
 class Education(models.Model):
     """
     A user education

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -48,7 +48,12 @@ class Employment(models.Model):
     profile = models.ForeignKey('Profile', on_delete=models.CASCADE, related_name='work_history')
 
     def __str__(self):
-        return 'Employment history for "{0}"'.format(self.profile.user.username)
+        return 'Employment for {user}, {title} {start}-{end}'.format(
+            user=self.profile.user.username,
+            title=self.company_name,
+            start=self.start_date.strftime("%b %Y") if self.start_date else "",
+            end=self.end_date.strftime("%b %Y") if self.end_date else "Current",
+        )
 
 
 class Profile(models.Model):
@@ -266,7 +271,7 @@ class Profile(models.Model):
             name_components.append('({})'.format(self.preferred_name))
         return ' '.join(name_components)
 
-
+import json.tool
 class Education(models.Model):
     """
     A user education
@@ -288,3 +293,17 @@ class Education(models.Model):
     school_city = models.TextField()
     school_state_or_territory = models.TextField()
     school_country = models.TextField()
+
+    def __str__(self):
+        degree_title = ''
+        for degree, title in self.DEGREE_CHOICES:
+            if self.degree_name == degree:
+                degree_title = title
+                break
+
+        return 'Education for {user}, {degree} at {title} {date}'.format(
+            user=self.profile.user.username,
+            degree=degree_title,
+            title=self.school_name,
+            date=self.graduation_date.strftime("%b %Y"),
+        )

--- a/static/js/babelhook.js
+++ b/static/js/babelhook.js
@@ -1,4 +1,20 @@
 const { babelSharedLoader } = require("../../webpack.config.shared");
 require('babel-polyfill');
 
+// window and global must be defined here before React is imported
+require('jsdom-global')(undefined, {
+  url: 'http://fake/'
+});
+
+// We need to explicitly change the URL when window.location is used
+const changeURL = require('jsdom').changeURL;
+Object.defineProperty(window, "location", {
+  set: value => {
+    if (!value.startsWith("http")) {
+      value = `http://fake${value}`;
+    }
+    changeURL(window, value);
+  },
+});
+
 require('babel-register')(babelSharedLoader.query);

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -25,6 +25,7 @@ import _ from 'lodash';
 import ProgramFilter from './ProgramFilter';
 import LearnerResult from './search/LearnerResult';
 import CountryRefinementOption from './search/CountryRefinementOption';
+import EducationFilter from './search/EducationFilter';
 import PatchedMenuFilter from './search/PatchedMenuFilter';
 import WorkHistoryFilter from './search/WorkHistoryFilter';
 import CustomPaginationDisplay from './search/CustomPaginationDisplay';
@@ -33,7 +34,6 @@ import CustomSortingColumnHeaders from './search/CustomSortingColumnHeaders';
 import FilterVisibilityToggle from './search/FilterVisibilityToggle';
 import HitsCount from './search/HitsCount';
 import CustomNoHits from './search/CustomNoHits';
-import { EDUCATION_LEVELS } from '../constants';
 import { wrapWithProps } from '../util/util';
 import type { Option } from '../flow/generalTypes';
 import type { AvailableProgram } from '../flow/enrollmentTypes';
@@ -48,14 +48,6 @@ const makeCountryNameTranslations: () => Object = () => {
     for (let stateCode of Object.keys(iso3166.data[code].sub)) {
       translations[stateCode] = iso3166.data[code].sub[stateCode].name;
     }
-  }
-  return translations;
-};
-
-const makeDegreeTranslations: () => Object = () => {
-  let translations = {};
-  for(let level of EDUCATION_LEVELS) {
-    translations[level.value] = level.label;
   }
   return translations;
 };
@@ -129,7 +121,6 @@ export default class LearnerSearch extends SearchkitComponent {
   ];
 
   countryNameTranslations: Object = makeCountryNameTranslations();
-  degreeTranslations: Object = makeDegreeTranslations();
 
   constructor(props: Object) {
     super(props);
@@ -140,15 +131,7 @@ export default class LearnerSearch extends SearchkitComponent {
   }
 
   getNumberOfCoursesInProgram = (): number => {
-    let results = this.getResults();
-    if (!results) {
-      return 0;
-    }
-
-    const hit = (
-       results.hits && results.hits.hits && results.hits.hits.length > 0 ? results.hits.hits[0] : null
-    );
-    return hit !== null ? hit._source.program.total_courses : 0;
+    return R.pathOr(0, ['hits', 'hits', 0, '_source', 'program', 'total_courses'], this.getResults());
   };
 
   renderSearchHeader = (): React$Element<*>|null => {
@@ -306,20 +289,14 @@ export default class LearnerSearch extends SearchkitComponent {
           title="Degree"
           filterName="education-level"
         >
-          <PatchedMenuFilter
-            id="education_level"
-            title=""
-            field="profile.education.degree_name"
-            fieldOptions={{type: 'nested', options: { path: 'profile.education' } }}
-            translations={this.degreeTranslations}
-          />
+          <EducationFilter />
         </FilterVisibilityToggle>
         <FilterVisibilityToggle
           {...this.props}
           filterName="company-name"
           title="Company"
         >
-          <WorkHistoryFilter id="company_name" />
+          <WorkHistoryFilter />
         </FilterVisibilityToggle>
 
       </Card>

--- a/static/js/components/email/AutomaticEmailOptions.js
+++ b/static/js/components/email/AutomaticEmailOptions.js
@@ -33,10 +33,12 @@ export default class AutomaticEmailOptions extends React.Component {
           <RadioButton
             value={false}
             label="Send a one-time email"
+            className="send-one-time-email"
           />
           <RadioButton
             value={true}
             label="Create an Email Campaign"
+            className="create-campaign"
           />
         </RadioButtonGroup>
         { sendAutomaticEmails ? this.renderEmailCampaign() : null }

--- a/static/js/components/search/EducationFilter.js
+++ b/static/js/components/search/EducationFilter.js
@@ -1,0 +1,76 @@
+// @flow
+import React from 'react';
+import {
+  AggsContainer,
+  AnonymousAccessor,
+  CardinalityMetric,
+  FilterBucket,
+  NestedBucket,
+  SearchkitComponent,
+  TermsBucket,
+} from 'searchkit';
+
+import { EDUCATION_LEVELS } from '../../constants';
+import PatchedMenuFilter from './PatchedMenuFilter';
+
+const makeDegreeTranslations: () => Object = () => {
+  let translations = {};
+  for(let level of EDUCATION_LEVELS) {
+    translations[level.value] = level.label;
+  }
+  return translations;
+};
+
+export default class EducationFilter extends SearchkitComponent {
+  degreeTranslations: Object = makeDegreeTranslations();
+
+  _accessor = new AnonymousAccessor(function(query) {
+    // Note: the function(...) syntax is required since this refers to AnonymousAccessor
+    /**
+     *  Modify query to perform aggregation on unique users,
+     *  to avoid duplicate counts of multiple education objects
+     *  for the same user
+     **/
+
+    let cardinality = CardinalityMetric("count", 'user_id');
+    let aggsContainer = AggsContainer('school_name_count',{"reverse_nested": {}}, [cardinality]);
+    let termsBucket = TermsBucket(
+      'profile.education.degree_name',
+      'profile.education.degree_name',
+      {},
+      aggsContainer
+    );
+    const nestedBucket = NestedBucket('inner', 'profile.education', termsBucket);
+
+    // uuid + 1 is the number of the accessor in the RefinementListFilter in the render method
+    // I'm guessing uuid + 1 because its accessors get defined right after this accessor
+    return query.setAggs(FilterBucket(
+      `profile.education.degree_name${parseInt(this.uuid) + 1}`,
+      {},
+      nestedBucket
+    ));
+  });
+
+
+  defineAccessor() {
+    return this._accessor;
+  }
+
+  bucketsTransform = (buckets: Array<Object>) => (
+    buckets.map(bucket => ({
+      doc_count: bucket.school_name_count.doc_count,
+      key: bucket.key,
+    }))
+  );
+
+  render() {
+    return <PatchedMenuFilter
+      id="education_level"
+      bucketsTransform={this.bucketsTransform}
+      title=""
+      field="profile.education.degree_name"
+      fieldOptions={{type: 'nested', options: { path: 'profile.education' } }}
+      translations={this.degreeTranslations}
+    />;
+  }
+}

--- a/static/js/components/search/WorkHistoryFilter.js
+++ b/static/js/components/search/WorkHistoryFilter.js
@@ -11,14 +11,10 @@ import {
 } from 'searchkit';
 
 import ModifiedMultiSelect from './ModifiedMultiSelect';
-import type { AvailableProgram } from '../../flow/enrollmentTypes';
 
 export default class WorkHistoryFilter extends SearchkitComponent {
-  props: {
-    currentProgramEnrollment: AvailableProgram,
-  };
-
-  _accessor = new AnonymousAccessor(query => {
+  _accessor = new AnonymousAccessor(function(query) {
+    // Note: the function(...) syntax is required since this refers to AnonymousAccessor
     /**
      *  Modify query to perform aggregation on unique users,
      *  to avoid duplicate counts of multiple work histories
@@ -35,8 +31,10 @@ export default class WorkHistoryFilter extends SearchkitComponent {
     );
 
     let nestedBucket = NestedBucket('inner', 'profile.work_history', termsBucket);
+    // uuid + 1 is the number of the accessor in the RefinementListFilter in the render method
+    // I'm guessing uuid + 1 because its accessors get defined right after this accessor
     return query.setAggs(FilterBucket(
-      'profile.work_history.company_name11',
+      `profile.work_history.company_name${parseInt(this.uuid) + 1}`,
       {},
       nestedBucket
     ));

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -1,6 +1,5 @@
 // @flow
 /* global document: false, window: false, SETTINGS: false */
-import '../global_init';
 
 import ReactDOM from 'react-dom';
 import { assert } from 'chai';

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -1,6 +1,4 @@
 /* global document: false, window: false, SETTINGS: false */
-import '../global_init';
-
 import { assert } from 'chai';
 import sinon from 'sinon';
 import moment from 'moment';

--- a/static/js/containers/LearnerPage_test.js
+++ b/static/js/containers/LearnerPage_test.js
@@ -1,5 +1,4 @@
 /* global SETTINGS: false */
-import '../global_init';
 import TestUtils from 'react-addons-test-utils';
 import { assert } from 'chai';
 import _ from 'lodash';

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -2,6 +2,9 @@
 import { assert } from 'chai';
 import _ from 'lodash';
 import sinon from 'sinon';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import { Utils as SearchkitUtils } from 'searchkit';
 
 import IntegrationTestHelper from '../util/integration_test_helper';
 import {
@@ -24,36 +27,53 @@ import { EMAIL_COMPOSITION_DIALOG } from '../components/email/constants';
 import { modifyTextField } from '../util/test_utils';
 
 describe('LearnerSearchPage', function () {
-  let renderComponent, listenForActions, helper, server;
+  let renderComponent, listenForActions, helper, mockAxios, replySpy;
 
   beforeEach(() => {
+    // reset Searchkit's guid counter so that it matches our expected data for each test
+    SearchkitUtils.guidCounter = 1;
+    mockAxios = new MockAdapter(axios);
+
     helper = new IntegrationTestHelper();
+    replySpy = helper.sandbox.stub().returns(Promise.resolve([200, _.cloneDeep(ELASTICSEARCH_RESPONSE)]));
+    mockAxios.onPost('/_search').reply(replySpy);
     renderComponent = helper.renderComponent.bind(helper);
     listenForActions = helper.listenForActions.bind(helper);
-    server = helper.sandbox.useFakeServer();
-    server.respondWith("POST", "http://localhost:9200/_search", [
-      200, { "Content-Type": "application/json" }, JSON.stringify(ELASTICSEARCH_RESPONSE)
-    ]);
   });
 
   afterEach(() => {
     helper.cleanup();
+    mockAxios.restore();
   });
 
+  const renderSearch = () => {
+    return renderComponent('/learners').then(([wrapper]) => {
+      return new Promise(resolve => {
+        // wait 10 millis for the request to be made
+        setTimeout(() => {
+          resolve([wrapper]);
+        }, 10);
+      });
+    });
+  };
+
   it('calls the elasticsearch API', () => {
-    assert(_.isEmpty(server.requests));
-    return renderComponent('/learners').then(() => {
-      assert(!_.isEmpty(server.requests));
-      let request = server.requests[0];
-      assert.deepEqual(request.url, "/_search");
-      assert.deepEqual(request.method, "POST");
+    assert.equal(replySpy.callCount, 0);
+    return renderSearch().then(() => {
+      assert.equal(replySpy.callCount, 1);
+
+      const callArgs = replySpy.firstCall.args[0];
+      assert.deepEqual(callArgs.url, "_search");
+      assert.deepEqual(callArgs.method, "post");
     });
   });
 
   it('filters by program id for current enrollment', () => {
-    return renderComponent('/learners').then(() => {
-      let request = server.requests[server.requests.length - 1];
-      let body = JSON.parse(request.requestBody);
+    return renderSearch().then(() => {
+      assert.equal(replySpy.callCount, 1);
+
+      const callArgs = replySpy.firstCall.args[0];
+      const body = JSON.parse(callArgs.data);
       assert.deepEqual(body.post_filter.term['program.id'], PROGRAMS[0].id);
     });
   });
@@ -61,8 +81,8 @@ describe('LearnerSearchPage', function () {
   it("doesn't filter by program id for current enrollment if it's not set to anything", () => {
     helper.programsGetStub.returns(Promise.resolve([]));
 
-    return renderComponent('/learners').then(() => {
-      assert.lengthOf(server.requests, 0);
+    return renderSearch().then(() => {
+      assert.equal(replySpy.callCount, 0);
     });
   });
 
@@ -73,7 +93,7 @@ describe('LearnerSearchPage', function () {
       SHOW_DIALOG
     ];
 
-    return renderComponent('/learners').then(([wrapper]) => {
+    return renderSearch().then(([wrapper]) => {
       let emailLink = wrapper.find(EMAIL_LINK_SELECTOR).at(0);
 
       return listenForActions(EMAIL_DIALOG_ACTIONS, () => {
@@ -134,23 +154,18 @@ describe('LearnerSearchPage', function () {
   });
 
   it('sends a request to find users by name when text is entered into the search box', () => {
-    return renderComponent('/learners').then(([wrapper]) => {
-      return new Promise(resolve => {
-        wrapper.find("SearchBox").find('input[type="text"]').props().onInput({
-          target: {
-            value: 'xyz'
-          }
-        });
-
-        // wait 500 millis for the request to be made
-        setTimeout(() => {
-          resolve();
-        }, 500);
+    return renderSearch().then(([wrapper]) => {
+      wrapper.find("SearchBox").find('input[type="text"]').props().onInput({
+        target: {
+          value: 'xyz'
+        }
       });
     }).then(() => {
-      let request = server.requests[server.requests.length - 1];
-      let body = JSON.parse(request.requestBody);
-      let query = body.query.multi_match;
+      // initial load, then update for value of xyz
+      assert.equal(replySpy.callCount, 2);
+      const callArgs = replySpy.secondCall.args[0];
+      const body = JSON.parse(callArgs.data);
+      const query = body.query.multi_match;
       assert.deepEqual(query, {
         fields: [
           'profile.first_name.folded',
@@ -165,6 +180,145 @@ describe('LearnerSearchPage', function () {
         type: 'phrase_prefix',
       });
       assert.equal(window.location.toString(), "http://fake/?q=xyz");
+    });
+  });
+
+  describe('work history facet', () => {
+    it('has the expected aggregations', () => {
+      return renderSearch().then(() => {
+        assert.equal(replySpy.callCount, 1);
+        const callArgs = replySpy.firstCall.args[0];
+        const body = JSON.parse(callArgs.data);
+
+        const keys = Object.keys(body.aggs);
+        const degreeNameKeys = keys.filter(key => key.startsWith("profile.work_history.company_name"));
+
+        // make sure the accessor is modifying an existing field and not adding a new one with a different name
+        assert.lengthOf(degreeNameKeys, 1);
+        const degreeNameKey = degreeNameKeys[0];
+
+        assert.deepEqual(body.aggs[degreeNameKey], {
+          "aggs": {
+            "inner": {
+              "aggs": {
+                "profile.work_history.company_name": {
+                  "aggs": {
+                    "company_name_count": {
+                      "aggs": {
+                        "count": {
+                          "cardinality": {
+                            "field": "user_id"
+                          }
+                        }
+                      },
+                      "reverse_nested": {}
+                    }
+                  },
+                  "terms": {
+                    "field": "profile.work_history.company_name",
+                    "order": {
+                      "company_name_count": "desc"
+                    },
+                    "size": 20
+                  }
+                },
+                "profile.work_history.company_name_count": {
+                  "cardinality": {
+                    "field": "profile.work_history.company_name"
+                  }
+                }
+              },
+              "nested": {
+                "path": "profile.work_history"
+              }
+            }
+          },
+          "filter": {
+            "term": {
+              "program.id": PROGRAMS[0].id
+            }
+          }
+        });
+      });
+    });
+
+    it('displays the correct number in the UI', () => {
+      return renderSearch().then(([wrapper]) => {
+        const workHistoryItems = wrapper.find("ModifiedMultiSelect Select").props().options;
+        assert.deepEqual(workHistoryItems, [{
+          'label': 'Microsoft (1) ',
+          'value': 'Microsoft'
+        }]);
+      });
+    });
+  });
+
+  describe('education', () => {
+    it('has the expected aggregations', () => {
+      return renderSearch().then(() => {
+        assert.equal(replySpy.callCount, 1);
+        const callArgs = replySpy.firstCall.args[0];
+        const body = JSON.parse(callArgs.data);
+
+        const keys = Object.keys(body.aggs);
+        const degreeNameKeys = keys.filter(key => key.startsWith("profile.education.degree_name"));
+
+        // make sure the accessor is modifying an existing field and not adding a new one with a different name
+        assert.lengthOf(degreeNameKeys, 1);
+        const degreeNameKey = degreeNameKeys[0];
+
+        assert.deepEqual(body.aggs[degreeNameKey], {
+          "filter": {
+            "term": {
+              "program.id": 3
+            }
+          },
+          "aggs": {
+            "inner": {
+              "nested": {
+                "path": "profile.education"
+              },
+              "aggs": {
+                "profile.education.degree_name": {
+                  "terms": {
+                    "field": "profile.education.degree_name",
+                    "size": 50
+                  },
+                  "aggs": {
+                    "school_name_count": {
+                      "reverse_nested": {},
+                      "aggs": {
+                        "count": {
+                          "cardinality": {
+                            "field": "user_id"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "profile.education.degree_name_count": {
+                  "cardinality": {
+                    "field": "profile.education.degree_name"
+                  }
+                }
+              }
+            }
+          },
+        });
+      });
+    });
+
+    it('displays the correct number in the UI', () => {
+      return renderSearch().then(([wrapper]) => {
+        let educationItems = wrapper.find('EducationFilter ItemList').props().items;
+
+        assert.deepEqual(educationItems, [
+          {doc_count: 1, key: 'b'},
+          {doc_count: 1, key: 'hs'},
+          {doc_count: 1, key: 'm'}
+        ]);
+      });
     });
   });
 });

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -101,7 +101,7 @@ describe('LearnerSearchPage', function () {
       }).then((state) => {
         assert.isTrue(state.ui.dialogVisibility[EMAIL_COMPOSITION_DIALOG]);
         return listenForActions([UPDATE_EMAIL_EDIT], () => {
-          document.querySelectorAll('input')[1].click();
+          document.querySelector('.create-campaign input').click();
         }).then((state) => {
           assert.isTrue(state.email[state.email.currentlyActive].inputs.sendAutomaticEmails);
         });
@@ -126,7 +126,7 @@ describe('LearnerSearchPage', function () {
 
         modifyTextField(document.querySelector('.email-subject'), 'subject');
         modifyTextField(document.querySelector('.email-body'), 'body');
-        document.querySelectorAll('input')[1].click();
+        document.querySelector('.create-campaign input').click();
 
         return listenForActions([
           UPDATE_EMAIL_VALIDATION,

--- a/static/js/containers/OrderSummaryPage_test.js
+++ b/static/js/containers/OrderSummaryPage_test.js
@@ -1,6 +1,4 @@
 /* global SETTINGS: false */
-import '../global_init';
-
 import { assert } from 'chai';
 
 import IntegrationTestHelper from '../util/integration_test_helper';

--- a/static/js/containers/SettingsPage_test.js
+++ b/static/js/containers/SettingsPage_test.js
@@ -1,5 +1,4 @@
 /* global SETTINGS: false */
-import '../global_init';
 import TestUtils from 'react-addons-test-utils';
 import { assert } from 'chai';
 import _ from 'lodash';

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -32,23 +32,10 @@ if (!Object.entries) {
   entries.shim();
 }
 
-let jsdom = require('jsdom');
-require('jsdom-global')(undefined, {
-  url: 'http://fake/'
-});
-
 let localStorageMock = require('./util/test_utils').localStorageMock;
 beforeEach(() => { // eslint-disable-line mocha/no-top-level-hooks
   window.localStorage = localStorageMock();
   window.sessionStorage = localStorageMock();
-  Object.defineProperty(window, "location", {
-    set: value => {
-      if (!value.startsWith("http")) {
-        value = `http://fake${value}`;
-      }
-      jsdom.changeURL(window, value);
-    },
-  });
 });
 
 // cleanup after each test run

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -72,7 +72,18 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
                 "industry": "Accounting",
                 "end_date": null,
                 "start_date": "1999-12-01"
-              }
+              },
+              {
+                "id": 95,
+                "city": "Kabul",
+                "state_or_territory": "AF-BDS",
+                "country": "AF",
+                "company_name": "Test Corp",
+                "position": "Assistant Foobar",
+                "industry": "Accounting",
+                "end_date": null,
+                "start_date": "1999-12-01"
+              },
             ],
             "edx_level_of_education": "jhs",
             "education": [
@@ -86,7 +97,18 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
                 "school_city": "Kabul",
                 "school_state_or_territory": "AF-BDS",
                 "school_country": "AF"
-              }
+              },
+              {
+                "id": 72,
+                "degree_name": "hs",
+                "graduation_date": "1998-07-12",
+                "field_of_study": null,
+                "online_degree": false,
+                "school_name": " High School",
+                "school_city": "Kabul",
+                "school_state_or_territory": "AF-BDS",
+                "school_country": "AF"
+              },
             ]
           },
           "id": 3
@@ -149,73 +171,337 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
       { // extreme worst-case empty profile
         '_source': {
           "profile": {}
-        }
+        },
+        '_id': 999
       }
     ]
   },
   "aggregations": {
-    "profile.birth_country3": {
-      "doc_count": 2,
-      "inner": {
-        "doc_count": 2,
-        "profile.birth_country_count": {
-          "value": 1
-        },
-        "profile.birth_country": {
-          "doc_count_error_upper_bound": 0,
-          "sum_other_doc_count": 0,
-          "buckets": [
-            {
-              "key": "AF",
-              "doc_count": 2
-            }
-          ]
+    "grade-average": {
+      "grade-average": {
+        "buckets": [
+          {
+            "doc_count": 0,
+            "key": 0
+          },
+          {
+            "doc_count": 0,
+            "key": 5
+          },
+          {
+            "doc_count": 0,
+            "key": 10
+          },
+          {
+            "doc_count": 0,
+            "key": 15
+          },
+          {
+            "doc_count": 0,
+            "key": 20
+          },
+          {
+            "doc_count": 0,
+            "key": 25
+          },
+          {
+            "doc_count": 0,
+            "key": 30
+          },
+          {
+            "doc_count": 0,
+            "key": 35
+          },
+          {
+            "doc_count": 0,
+            "key": 40
+          },
+          {
+            "doc_count": 0,
+            "key": 45
+          },
+          {
+            "doc_count": 0,
+            "key": 50
+          },
+          {
+            "doc_count": 0,
+            "key": 55
+          },
+          {
+            "doc_count": 0,
+            "key": 60
+          },
+          {
+            "doc_count": 0,
+            "key": 65
+          },
+          {
+            "doc_count": 0,
+            "key": 70
+          },
+          {
+            "doc_count": 0,
+            "key": 75
+          },
+          {
+            "doc_count": 0,
+            "key": 80
+          },
+          {
+            "doc_count": 0,
+            "key": 85
+          },
+          {
+            "doc_count": 0,
+            "key": 90
+          },
+          {
+            "doc_count": 0,
+            "key": 95
+          },
+          {
+            "doc_count": 0,
+            "key": 100
+          }
+        ]
+      },
+      "doc_count": 0
+    },
+    "courses": {
+      "children": {
+        "doc_count": 0,
+        "lvl0": {
+          "children": {
+            "doc_count_error_upper_bound": 0,
+            "buckets": [],
+            "sum_other_doc_count": 0
+          },
+          "doc_count": 0
         }
+      },
+      "doc_count": 1
+    },
+    "final-grade": {
+      "final-grade": {
+        "final-grade": {
+          "final-grade": {
+            "buckets": [
+              {
+                "doc_count": 0,
+                "key": 0
+              },
+              {
+                "doc_count": 0,
+                "key": 5
+              },
+              {
+                "doc_count": 0,
+                "key": 10
+              },
+              {
+                "doc_count": 0,
+                "key": 15
+              },
+              {
+                "doc_count": 0,
+                "key": 20
+              },
+              {
+                "doc_count": 0,
+                "key": 25
+              },
+              {
+                "doc_count": 0,
+                "key": 30
+              },
+              {
+                "doc_count": 0,
+                "key": 35
+              },
+              {
+                "doc_count": 0,
+                "key": 40
+              },
+              {
+                "doc_count": 0,
+                "key": 45
+              },
+              {
+                "doc_count": 0,
+                "key": 50
+              },
+              {
+                "doc_count": 0,
+                "key": 55
+              },
+              {
+                "doc_count": 0,
+                "key": 60
+              },
+              {
+                "doc_count": 0,
+                "key": 65
+              },
+              {
+                "doc_count": 0,
+                "key": 70
+              },
+              {
+                "doc_count": 0,
+                "key": 75
+              },
+              {
+                "doc_count": 0,
+                "key": 80
+              },
+              {
+                "doc_count": 0,
+                "key": 85
+              },
+              {
+                "doc_count": 0,
+                "key": 90
+              },
+              {
+                "doc_count": 0,
+                "key": 95
+              },
+              {
+                "doc_count": 0,
+                "key": 100
+              }
+            ]
+          },
+          "doc_count": 0
+        },
+        "doc_count": 0
+      },
+      "doc_count": 0
+    },
+    "num-courses-passed": {
+      "doc_count": 1,
+      "num-courses-passed": {
+        "value": 1
       }
     },
-    "profile.country4": {
-      "doc_count": 2,
+    "profile.birth_country8": {
+      "profile.birth_country": {
+        "doc_count_error_upper_bound": 0,
+        "buckets": [
+          {
+            "doc_count": 1,
+            "key": "DZ"
+          }
+        ],
+        "sum_other_doc_count": 0
+      },
+      "doc_count": 1,
+      "profile.birth_country_count": {
+        "value": 1
+      }
+    },
+    "profile.work_history.company_name13": {
       "inner": {
         "doc_count": 2,
+        "profile.work_history.company_name": {
+          "doc_count_error_upper_bound": 0,
+          "buckets": [
+            {
+              "company_name_count": {
+                "doc_count": 1,
+                "count": {
+                  "value": 1
+                }
+              },
+              "doc_count": 2,
+              "key": "Microsoft"
+            }
+          ],
+          "sum_other_doc_count": 0
+        },
+        "profile.work_history.company_name_count": {
+          "value": 1
+        }
+      },
+      "doc_count": 1
+    },
+    "country": {
+      "profile.country": {
         "profile.country": {
           "doc_count_error_upper_bound": 0,
-          "sum_other_doc_count": 0,
           "buckets": [
             {
-              "key": "AF",
-              "doc_count": 2
+              "doc_count": 1,
+              "key": "US"
+            }
+          ],
+          "sum_other_doc_count": 0
+        },
+        "doc_count": 1
+      },
+      "doc_count": 1
+    },
+    "profile.education.degree_name11": {
+      "inner": {
+        "profile.education.degree_name": {
+          "doc_count_error_upper_bound": 0,
+          "buckets": [
+            {
+              "doc_count": 2,
+              "key": "b",
+              "school_name_count": {
+                "doc_count": 1,
+                "count": {
+                  "value": 1
+                }
+              }
             },
             {
-              "key": null,
-              "doc_count": 2
-            }
-          ]
-        },
-        "profile.country_count": {
-          "value": 1
-        }
-      }
-    },
-    "profile.gender2": {
-      "doc_count": 2,
-      "inner": {
-        "doc_count": 2,
-        "profile.gender": {
-          "doc_count_error_upper_bound": 0,
-          "sum_other_doc_count": 0,
-          "buckets": [
+              "doc_count": 1,
+              "key": "hs",
+              "school_name_count": {
+                "doc_count": 1,
+                "count": {
+                  "value": 1
+                }
+              }
+            },
             {
-              "key": "f",
-              "doc_count": 2
+              "doc_count": 1,
+              "key": "m",
+              "school_name_count": {
+                "doc_count": 1,
+                "count": {
+                  "value": 1
+                }
+              }
             }
-          ]
+          ],
+          "sum_other_doc_count": 0
         },
-        "profile.gender_count": {
-          "value": 1
+        "doc_count": 4,
+        "profile.education.degree_name_count": {
+          "value": 3
         }
-      }
+      },
+      "doc_count": 1
+    },
+    "program.semester_enrollments.semester5": {
+      "inner": {
+        "program.semester_enrollments.semester": {
+          "doc_count_error_upper_bound": 0,
+          "buckets": [],
+          "sum_other_doc_count": 0
+        },
+        "doc_count": 0,
+        "program.semester_enrollments.semester_count": {
+          "value": 0
+        }
+      },
+      "doc_count": 1
     }
-  }
+  },
 });
 
 export const USER_PROFILE_RESPONSE = deepFreeze({

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,6 +358,12 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axios-mock-adapter@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.8.1.tgz#70085e5d70c93d5fa93e323011c4b64f02bd2ad1"
+  dependencies:
+    deep-equal "^1.0.1"
+
 axios@^0.15.3:
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.15.3.tgz#2c9d638b2e191a08ea1d6cc988eadd6ba5bdc053"
@@ -1948,7 +1954,7 @@ deep-eql@^0.1.3:
   dependencies:
     type-detect "0.1.1"
 
-deep-equal@^1.0.0:
+deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2963 
Fixes #3009 

#### What's this PR do?
Uses a reverse nested aggregation to ensure that the education count is per person, not per education. It also fixes a problem with the searchkit id for the work history facet and fixes the tests to mock the elasticsearch responses properly.

#### How should this be manually tested?
For a user set up two `Employment` objects which are both current for the same company name (non-current employments are filtered out). Using the search box filter the name of the user so that they are the only user in the learner search page. Verify that the work history facet shows the employment for that user with a `(1)` in the name.

Do a similar thing for `Education` but with two `Education` objects for that user who have the same degree type. You should see `1` next to the degree type in the facet.
