### PR TITLE
add automatic email index page

### DIFF
--- a/mail/serializers.py
+++ b/mail/serializers.py
@@ -27,5 +27,6 @@ class AutomaticEmailSerializer(serializers.ModelSerializer):
             'enabled',
             'email_subject',
             'email_body',
-            'sender_name'
+            'sender_name',
+            'id'
         )

--- a/mail/serializers_test.py
+++ b/mail/serializers_test.py
@@ -22,4 +22,5 @@ class AutomaticEmailSerializerTests(MockedESTestCase):
             "email_subject": automatic.email_subject,
             "email_body": automatic.email_body,
             "sender_name": automatic.sender_name,
+            "id": automatic.id,
         }

--- a/mail/urls.py
+++ b/mail/urls.py
@@ -1,5 +1,6 @@
 """URLs for mail app"""
-from django.conf.urls import url
+from django.conf.urls import url, include
+from rest_framework import routers
 
 from mail.views import (
     LearnerMailView,
@@ -9,11 +10,14 @@ from mail.views import (
     AutomaticEmailView,
 )
 
+router = routers.DefaultRouter()
+router.register(r'automatic_email', AutomaticEmailView, base_name='automatic_email_api')
+
 urlpatterns = [
     url(r'^api/v0/financial_aid_mail/(?P<financial_aid_id>[\d]+)/$', FinancialAidMailView.as_view(),
         name='financial_aid_mail_api'),
     url(r'^api/v0/mail/search/$', SearchResultMailView.as_view(), name='search_result_mail_api'),
     url(r'^api/v0/mail/course/(?P<course_id>[\d]+)/$', CourseTeamMailView.as_view(), name='course_team_mail_api'),
     url(r'^api/v0/mail/learner/(?P<student_id>[\d]+)/$', LearnerMailView.as_view(), name='learner_mail_api'),
-    url(r'^api/v0/mail/automatic_email/$', AutomaticEmailView.as_view(), name='automatic_email_api'),
+    url(r'^api/v0/mail/', include(router.urls)),
 ]

--- a/mail/views.py
+++ b/mail/views.py
@@ -9,7 +9,9 @@ from rest_framework import (
     status,
 )
 from rest_framework.generics import GenericAPIView, ListAPIView
+from rest_framework.mixins import UpdateModelMixin
 from rest_framework.views import APIView
+from rest_framework.viewsets import GenericViewSet
 from rest_framework.response import Response
 
 from courses.models import Course
@@ -74,7 +76,7 @@ class LearnerMailView(GenericAPIView):
         )
 
 
-class AutomaticEmailView(ListAPIView):
+class AutomaticEmailView(ListAPIView, UpdateModelMixin, GenericViewSet):
     """
     View class that deals with listing and editing automatic mails
     """
@@ -84,6 +86,9 @@ class AutomaticEmailView(ListAPIView):
     )
     permission_classes = (permissions.IsAuthenticated, UserCanMessageLearnersPermission, )
     serializer_class = AutomaticEmailSerializer
+    lookup_field = "id"
+    lookup_url_kwarg = "email_id"
+    lookup_value_regex = '[-\w.]+'  # pylint: disable=anomalous-backslash-in-string
 
     def get_queryset(self):
         """Get the queryset which should be serialized"""

--- a/static/js/actions/automatic_emails.js
+++ b/static/js/actions/automatic_emails.js
@@ -1,0 +1,5 @@
+// @flow
+import { createAction } from 'redux-actions';
+
+export const TOGGLE_EMAIL_PATCH_IN_FLIGHT = 'TOGGLE_EMAIL_PATCH_IN_FLIGHT';
+export const toggleEmailPatchInFlight = createAction(TOGGLE_EMAIL_PATCH_IN_FLIGHT);

--- a/static/js/components/EmailCampaignsCard.js
+++ b/static/js/components/EmailCampaignsCard.js
@@ -1,0 +1,68 @@
+// @flow
+import React from 'react';
+import { Card, CardTitle } from 'react-mdl/lib/Card';
+import Switch from 'react-mdl/lib/Switch';
+import R from 'ramda';
+import Spinner from 'react-mdl/lib/Spinner';
+
+import type { AutomaticEmail } from '../flow/emailTypes';
+import type { Either } from '../flow/sanctuaryTypes';
+import { S } from '../lib/sanctuary';
+
+const renderEmptyMessage = msg => (
+  <div className="empty-message">
+    { msg }
+  </div>
+);
+
+const wrapEmailRows = rows => (
+  <div className="automatic-email-rows">
+    <div className="header">
+      <div>Email name / subject</div>
+      <div>Start date</div>
+      <div>Stop date</div>
+      <div>Active</div>
+    </div>
+    { rows }
+  </div>
+);
+
+const renderEmailRow = R.curry((toggleEmailActive, emailsInFlight, automaticEmail, idx) => (
+  <div className="email-row" key={idx}>
+    <div>{ automaticEmail.email_subject }</div>
+    <div>--</div>
+    <div>--</div>
+    <div>
+      <Switch
+        checked={automaticEmail.enabled}
+        ripple={false}
+        onChange={() => toggleEmailActive(automaticEmail)}
+      />
+      { emailsInFlight.has(automaticEmail.id) ? <Spinner singleColor /> : null }
+    </div>
+  </div>
+));
+
+const renderEmailRows = (toggleEmailActive, emailsInFlight) => R.compose(
+  wrapEmailRows, R.addIndex(R.map)(renderEmailRow(toggleEmailActive, emailsInFlight))
+);
+
+type CampaignCardProps = {
+  getEmails:          () => Either<React$Element<string>, Array<AutomaticEmail>>,
+  emailsInFlight:     Set<number>,
+  toggleEmailActive:  (e: AutomaticEmail) => void,
+};
+
+const EmailCampaignsCard = (props: CampaignCardProps) => {
+  const { getEmails, toggleEmailActive, emailsInFlight } = props;
+
+  return (
+    <Card shadow={1} className="email-campaigns-card">
+      <CardTitle>
+        Manage Email Campaigns
+      </CardTitle>
+      { S.either(renderEmptyMessage, renderEmailRows(toggleEmailActive, emailsInFlight), getEmails()) }
+    </Card>
+  );
+};
+export default EmailCampaignsCard;

--- a/static/js/components/EmailCampaignsCard_test.js
+++ b/static/js/components/EmailCampaignsCard_test.js
@@ -1,0 +1,72 @@
+// @flow
+import React from 'react';
+import { mount } from 'enzyme';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import Switch from 'react-mdl/lib/Switch';
+import Spinner from 'react-mdl/lib/Spinner';
+
+import EmailCampaignsCard from './EmailCampaignsCard';
+import { GET_AUTOMATIC_EMAILS_RESPONSE } from '../test_constants';
+import { S } from '../lib/sanctuary';
+
+describe('EmailCampaignsCard', () => {
+  let emailCardProps, sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    emailCardProps = {
+      getEmails: sandbox.stub(),
+      emailsInFlight: new Set(),
+      toggleEmailActive: sandbox.stub(),
+    };
+
+    emailCardProps.getEmails.returns(S.Right(GET_AUTOMATIC_EMAILS_RESPONSE));
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const renderCard = (props = emailCardProps) => (
+    mount(<EmailCampaignsCard {...props} />)
+  );
+
+  const headers = [
+    "Email name / subject",
+    "Start date",
+    "Stop date",
+    "Active",
+  ];
+
+  it('should render all emails and header text, if Right', () => {
+    let cardText = renderCard().text();
+    GET_AUTOMATIC_EMAILS_RESPONSE.forEach(email => {
+      assert.include(cardText, email.email_subject);
+    });
+    headers.forEach(header => {
+      assert.include(cardText, header);
+    });
+  });
+
+  it('should render an error message and no header text, if Left', () => {
+    emailCardProps.getEmails.returns(S.Left(<div>I'm a message</div>));
+    let cardText = renderCard().text();
+    assert.include(cardText, "I'm a message");
+    headers.forEach(header => {
+      assert.notInclude(cardText, header);
+    });
+  });
+
+  it('should render a switch, and call toggleEmailActive on click', () => {
+    let card = renderCard();
+    card.find(Switch).first().props().onChange();
+    assert(emailCardProps.toggleEmailActive.calledWith(GET_AUTOMATIC_EMAILS_RESPONSE[0]));
+  });
+
+  it('should show a spinner when a request is in-flight', () => {
+    emailCardProps.emailsInFlight.add(GET_AUTOMATIC_EMAILS_RESPONSE[0].id);
+    let card = renderCard();
+    assert.lengthOf(card.find(Spinner), 1);
+  });
+});

--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -153,6 +153,7 @@ export default class Navbar extends React.Component {
                 true,
                 true
               )}
+              { adminLink(closeDrawer, '/automaticemails', 'Email Campaigns', 'email') }
               { learnerLink(closeDrawer, '/dashboard', 'Dashboard', 'dashboard') }
               { navLink(closeDrawer, `/learner/${SETTINGS.user.username}`, 'My Profile', 'person')}
               { navLink(

--- a/static/js/components/Navbar_test.js
+++ b/static/js/components/Navbar_test.js
@@ -33,13 +33,14 @@ describe('Navbar', () => {
     ]);
   });
 
-  it('has a link to the learner page if the user is staff or instructor', () => {
+  it('has a link to the learner page and the email page if the user is staff or instructor', () => {
     for (let role of ['staff', 'instructor']) {
       SETTINGS.roles = [{ role, permissions: [] }];
       let wrapper = renderNavbar();
       let hrefs = wrapper.find(Link).map(link => link.props()['to']);
       assert.deepEqual(hrefs, [
         '/learners',
+        '/automaticemails',
         '/learner/jane',
         null,
         '/settings',

--- a/static/js/containers/AutomaticEmailPage.js
+++ b/static/js/containers/AutomaticEmailPage.js
@@ -1,0 +1,107 @@
+// @flow
+/* global SETTINGS: false */
+import React from 'react';
+import { connect } from 'react-redux';
+import R from 'ramda';
+import type { Dispatch } from 'redux';
+
+import { FETCH_PROCESSING } from '../actions';
+import { actions } from '../lib/redux_rest.js';
+import { S, getm } from '../lib/sanctuary';
+import EmailCampaignsCard from '../components/EmailCampaignsCard';
+import type { AutomaticEmail } from '../flow/emailTypes';
+import type { RestState } from '../flow/restTypes';
+import { hasAnyStaffRole } from '../lib/roles';
+import Spinner from 'react-mdl/lib/Spinner';
+import { toggleEmailPatchInFlight } from '../actions/automatic_emails';
+
+const fetchingEmail = R.propEq('getStatus', FETCH_PROCESSING);
+
+const noEmailsMessage = () => (
+  <div>
+    You haven't created any Email Campaigns yet.
+  </div>
+);
+
+const emptyMessage = automaticEmails => (
+  fetchingEmail(automaticEmails) ? <Spinner singleColor /> : noEmailsMessage()
+);
+
+const notEmpty = R.compose(R.not, R.isEmpty);
+
+type AutomaticEmailsType = RestState<Array<AutomaticEmail>> & {
+  emailsInFlight: Set<number>
+};
+
+class AutomaticEmailPage extends React.Component {
+  props: {
+    automaticEmails:  AutomaticEmailsType,
+    dispatch:         Dispatch,
+  };
+
+  static contextTypes = {
+    router: React.PropTypes.object.isRequired
+  };
+
+  componentWillMount () {
+    if (!hasAnyStaffRole(SETTINGS.roles)) {
+      this.context.router.push('/dashboard');
+    }
+  }
+
+  componentDidMount () {
+    const { dispatch, automaticEmails } = this.props;
+
+    if (!automaticEmails.processing) {
+      dispatch(actions.automaticEmails.get());
+    }
+  }
+
+  // we use getm to get Maybe Array AutomaticEmail out of the store
+  // if the data is [] we want to show a placeholder message instead
+  // so we use filter to do Just([]) -> Nothing
+  // 
+  // Then we use `maybeToEither` to hold
+  // Left(placeholderMessage) or Right(automaticEmails)
+  // The placeholder message depends on whether we currently have a
+  // GET request inflight or not
+  getEmails = () => {
+    const { automaticEmails } = this.props;
+    return S.maybeToEither(
+      emptyMessage(automaticEmails),
+      S.filter(notEmpty, getm('data', automaticEmails))
+    );
+  };
+
+  toggleEmailActive = email => {
+    const { dispatch, automaticEmails: { emailsInFlight }} = this.props;
+
+    if (! emailsInFlight.has(email.id)) {
+      let updatedEmail = R.evolve({enabled: R.not}, email);
+      dispatch(toggleEmailPatchInFlight(email.id));
+      dispatch(actions.automaticEmails.patch(updatedEmail)).then(() => {
+        dispatch(toggleEmailPatchInFlight(email.id));
+      });
+    }
+  };
+
+  render () {
+    const { automaticEmails: { emailsInFlight }} = this.props;
+
+    return (
+      <div className="single-column automatic-emails">
+        <EmailCampaignsCard
+          getEmails={this.getEmails}
+          toggleEmailActive={this.toggleEmailActive}
+          emailsInFlight={emailsInFlight}
+        />
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  automaticEmails: state.automaticEmails
+});
+
+export default connect(mapStateToProps)(AutomaticEmailPage);

--- a/static/js/containers/AutomaticEmailPage_test.js
+++ b/static/js/containers/AutomaticEmailPage_test.js
@@ -1,0 +1,94 @@
+// @flow
+/* global SETTINGS: false */
+import { assert } from 'chai';
+
+import IntegrationTestHelper from '../util/integration_test_helper';
+import { actions } from '../lib/redux_rest.js';
+import * as api from '../lib/api';
+import { GET_AUTOMATIC_EMAILS_RESPONSE } from '../test_constants';
+import { DASHBOARD_SUCCESS_ACTIONS } from './test_util';
+import {
+  REQUEST_GET_USER_PROFILE,
+  RECEIVE_GET_USER_PROFILE_SUCCESS,
+} from '../actions/profile';
+import {
+  REQUEST_GET_PROGRAM_ENROLLMENTS,
+  RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+} from '../actions/programs';
+import Spinner from 'react-mdl/lib/Spinner';
+
+describe('AutomaticEmailPage', () => {
+  let renderComponent, helper, fetchStub;
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper();
+    renderComponent = helper.renderComponent.bind(helper);
+    fetchStub = helper.sandbox.stub(api, 'fetchJSONWithCSRF');
+    fetchStub.returns(Promise.resolve(GET_AUTOMATIC_EMAILS_RESPONSE));
+
+    SETTINGS.roles = [{
+      "role": "staff",
+      "program": 1,
+      "permissions": [],
+    }];
+  });
+
+  afterEach(() => {
+    helper.cleanup();
+  }); 
+
+  const baseActions = [
+    REQUEST_GET_USER_PROFILE,
+    RECEIVE_GET_USER_PROFILE_SUCCESS,
+    REQUEST_GET_PROGRAM_ENROLLMENTS,
+    RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+  ];
+
+  const successActions = baseActions.concat(
+    actions.automaticEmails.get.requestType,
+    actions.automaticEmails.get.successType,
+  );
+
+  it('redirects you to /dashboard if you are not staff', () => {
+    SETTINGS.roles = [];
+    let expectedActions = DASHBOARD_SUCCESS_ACTIONS.concat(
+      actions.automaticEmails.get.requestType,
+      actions.automaticEmails.get.successType,
+    );
+    return renderComponent("/automaticemails", expectedActions).then(() => {
+      assert.equal(helper.currentLocation.pathname, '/dashboard');
+    });
+  });
+
+  it('has all the cards it should', () => {
+    return renderComponent('/automaticemails', successActions).then(([wrapper]) => {
+      assert.lengthOf(wrapper.find(".email-campaigns-card"), 1);
+    });
+  });
+
+  it('shows a spinner while the email info request is in-flight', () => {
+    helper.store.dispatch({ type: actions.automaticEmails.get.requestType });
+
+    return renderComponent('/automaticemails', baseActions).then(([wrapper]) => {
+      assert.lengthOf(wrapper.find(Spinner), 1);
+    });
+  });
+
+  it('shows the automatic emails for the logged-in user', () => {
+    return renderComponent('/automaticemails', successActions).then(([wrapper]) => {
+      let cardText = wrapper.find(".email-campaigns-card").text();
+      GET_AUTOMATIC_EMAILS_RESPONSE.forEach(email => {
+        assert.include(cardText, email.email_subject);
+      });
+    });
+  });
+
+  it('shows a placeholder if there is no data', () => {
+    fetchStub.returns(Promise.resolve([]));
+
+    return renderComponent('/automaticemails', successActions).then(([wrapper]) => {
+      let cardText = wrapper.find(".empty-message").text();
+      assert.equal(cardText, "You haven't created any Email Campaigns yet.");
+    });
+  });
+});

--- a/static/js/dashboard_routes.js
+++ b/static/js/dashboard_routes.js
@@ -118,6 +118,14 @@ export const routes = {
           .then(loadRoute(cb))
           .catch(errorLoading);
       }
+    },
+    {
+      path: 'automaticemails',
+      getComponent(nextState, cb) {
+        import('./containers/AutomaticEmailPage')
+          .then(loadRoute(cb))
+          .catch(errorLoading);
+      }
     }
   ]
 };

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -43,3 +43,11 @@ export type EmailConfig = {
   emailSendParams: (emailState: EmailState) => Array<any>,
   renderRecipients?: (filters: ?Array<Filter>) => React$Element<*>,
 };
+
+export type AutomaticEmail = {
+  enabled:        boolean,
+  email_subject:  string,
+  email_body:     string,
+  sender_name:    string,
+  id:             number,
+};

--- a/static/js/flow/restTypes.js
+++ b/static/js/flow/restTypes.js
@@ -1,7 +1,7 @@
 // @flow
 
-export type RestState = {
-  data?: any,
+export type RestState<T> = {
+  data?: T,
   error?: any,
   processing: boolean,
   loaded: boolean,
@@ -10,12 +10,18 @@ export type RestState = {
 
 export type Endpoint = {
   name: string,
-  url: string,
-  makeOptions: (...args: any) => Object,
+  getUrl?: string|(...args: any) => string,
+  postUrl?: string|(...args: any) => string,
+  patchUrl?: string|(...args: any) => string,
+  getOptions?: (...args: any) => Object,
+  postOptions?: (...args: any) => Object,
+  patchOptions?: (...args: any) => Object,
   extraActions?: Object,
   getPrefix?: string,
   postPrefix?: string,
+  patchPrefix?: string,
   getFunc?: Function,
   postFunc?: Function,
+  patchFunc?: Function,
   verbs: Array<string>,
 };

--- a/static/js/flow/sanctuaryTypes.js
+++ b/static/js/flow/sanctuaryTypes.js
@@ -1,0 +1,15 @@
+// @flow
+
+export type Left<L> = {
+  value: L,
+  isLeft: true,
+  isRight: false,
+};
+
+export type Right<R> = {
+  value: R,
+  isLeft: false,
+  isRight: true,
+};
+
+export type Either<L,R> = Left<L> | Right<R>

--- a/static/js/lib/redux_rest_test.js
+++ b/static/js/lib/redux_rest_test.js
@@ -20,7 +20,7 @@ import {
   INITIAL_STATE,
   actions,
 } from './redux_rest';
-import { couponEndpoint } from '../reducers/coupons';
+import { automaticEmailsEndpoint } from '../reducers/automatic_emails';
 import { GET, POST } from '../constants';
 import rootReducer from '../reducers';
 
@@ -59,6 +59,17 @@ describe('redux REST', () => {
         [clearActionType, 'CLEAR_FOOBAR'],
       ].forEach(([deriver, expectation]) => {
         assert.equal(deriver('foobar'), expectation);
+      });
+    });
+
+    it('should snake_case a camelCase name', () => {
+      [
+        [requestActionType, 'REQUEST_FOO_BAR'],
+        [successActionType, 'RECEIVE_FOO_BAR_SUCCESS'],
+        [failureActionType, 'RECEIVE_FOO_BAR_FAILURE'],
+        [clearActionType, 'CLEAR_FOO_BAR'],
+      ].forEach(([deriver, expectation]) => {
+        assert.equal(deriver('fooBar'), expectation);
       });
     });
   });
@@ -171,10 +182,10 @@ describe('redux REST', () => {
     describe('exported derived actions', () => {
       it('should define all the actions we need', () => {
         [
-          'coupons'
+          automaticEmailsEndpoint
         ].forEach(endpoint => {
-          let endpointActions = actions[endpoint];
-          checkForVerbs(couponEndpoint, verb => {
+          let endpointActions = actions[endpoint.name];
+          checkForVerbs(endpoint, verb => {
             assert.isFunction(endpointActions[R.toLower(verb)]);
           });
         });
@@ -314,7 +325,7 @@ describe('redux REST', () => {
       });
     });
 
-    describe.skip('exported reducers', () => { // eslint-disable-line mocha/no-skipped-tests
+    describe('exported reducers', () => { // eslint-disable-line mocha/no-skipped-tests
       beforeEach(() => {
         sandbox = sinon.sandbox.create();
         store = configureTestStore(rootReducer);
@@ -326,7 +337,7 @@ describe('redux REST', () => {
       });
 
       let endpoints = [
-        couponEndpoint
+        automaticEmailsEndpoint
       ];
 
       it('should include all reducers that we expect it to', () => {

--- a/static/js/reducers/automatic_emails.js
+++ b/static/js/reducers/automatic_emails.js
@@ -1,0 +1,30 @@
+// @flow
+import R from 'ramda';
+
+import { GET, PATCH } from '../constants';
+import type { Endpoint } from '../flow/restTypes';
+import type { Action } from '../flow/reduxTypes';
+import { INITIAL_STATE } from '../lib/redux_rest';
+import { TOGGLE_EMAIL_PATCH_IN_FLIGHT } from '../actions/automatic_emails';
+
+export const automaticEmailsEndpoint: Endpoint = {
+  name: 'automaticEmails',
+  verbs: [GET, PATCH],
+  getUrl: '/api/v0/mail/automatic_email/',
+  patchUrl: email => `/api/v0/mail/automatic_email/${email.id}/`,
+  patchOptions: emailRecord => ({
+    method: PATCH,
+    body: JSON.stringify(emailRecord)
+  }),
+  patchSuccessHandler: (payload, oldData) => R.update(
+    R.findIndex(R.propEq('id', payload.id), oldData), payload, oldData
+  ),
+  initialState: { ...INITIAL_STATE, emailsInFlight: new Set()},
+  extraActions: {
+    [TOGGLE_EMAIL_PATCH_IN_FLIGHT]: (state: Object, action: Action<number, void>) => {
+      const emails = new Set(state.emailsInFlight);
+      const { payload: id } = action;
+      return { ...state, emailsInFlight: emails.delete(id) ? emails : emails.add(id) };
+    }
+  }
+};

--- a/static/js/reducers/automatic_emails_test.js
+++ b/static/js/reducers/automatic_emails_test.js
@@ -1,0 +1,35 @@
+// @flow
+import configureTestStore from 'redux-asserts';
+import { assert } from 'chai';
+
+import rootReducer from '../reducers';
+import {
+  TOGGLE_EMAIL_PATCH_IN_FLIGHT,
+  toggleEmailPatchInFlight,
+} from '../actions/automatic_emails';
+
+describe('automatic email reducer', () => {
+  let store, dispatchThen;
+
+  beforeEach(() => {
+    store = configureTestStore(rootReducer);
+    dispatchThen = store.createDispatchThen(state => state.automaticEmails);
+  });
+
+  it('should let you add email IDs to the in-flight list', () => {
+    return dispatchThen(toggleEmailPatchInFlight(2), [
+      TOGGLE_EMAIL_PATCH_IN_FLIGHT
+    ]).then(state => {
+      assert(state.emailsInFlight.has(2));
+    });
+  });
+
+  it('should let you toggle an email ID which is already added', () => {
+    store.dispatch(toggleEmailPatchInFlight(2));
+    return dispatchThen(toggleEmailPatchInFlight(2), [
+      TOGGLE_EMAIL_PATCH_IN_FLIGHT
+    ]).then(state => {
+      assert(!state.emailsInFlight.has(2));
+    });
+  });
+});

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -49,6 +49,7 @@ import { pearson } from './pearson';
 import { dashboard } from './dashboard';
 import { prices } from './course_prices';
 import { ALL_ERRORS_VISIBLE } from '../constants';
+import { reducers } from '../lib/redux_rest';
 
 export const INITIAL_PROFILES_STATE = {};
 export const profiles = (state: Profiles = INITIAL_PROFILES_STATE, action: Action<any, null>) => {
@@ -217,4 +218,5 @@ export default combineReducers({
   orderReceipt,
   coupons,
   pearson,
+  ...reducers,
 });

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -1103,3 +1103,20 @@ export const EDX_CHECKOUT_RESPONSE = deepFreeze({
   "method": "GET"
 });
 /* eslint-enable max-len */
+
+export const GET_AUTOMATIC_EMAILS_RESPONSE = [
+  {
+    enabled: true,
+    email_subject: 'First Email',
+    email_body: 'such a great email, literally so great',
+    sender_name: 'Simone de Beauvoir',
+    id: 1,
+  },
+  {
+    enabled: false,
+    email_subject: 'Second (disabled) Email',
+    email_body: 'this one was not as good :(',
+    sender_name: 'Jean-Paul Sartre',
+    id: 2,
+  }
+];

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -29,6 +29,7 @@ import EmploymentTab from '../components/EmploymentTab';
 import LearnerPage from '../containers/LearnerPage';
 import Learner from '../components/Learner';
 import LearnerSearchPage from '../containers/LearnerSearchPage';
+import AutomaticEmailPage from '../containers/AutomaticEmailPage';
 
 export function findCourse(courseSelector: (course: ?Course, program: ?Program) => boolean): Course {
   let [, course, ] = findCourseRun(
@@ -281,6 +282,7 @@ export const testRoutes = (
       <Route path=":username" component={Learner} />
     </Route>
     <Route path="/learners" component={LearnerSearchPage} />
+    <Route path="/automaticemails" component={AutomaticEmailPage} />
   </Route>
 );
 

--- a/static/scss/automatic-emails.scss
+++ b/static/scss/automatic-emails.scss
@@ -1,0 +1,43 @@
+.email-campaigns-card {
+  .empty-message {
+    text-align: center;
+  }
+
+  .automatic-email-rows {
+    .header, .email-row {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      padding: 15px 0;
+
+      > div:first-child {
+        width: 40%;
+      }
+
+      > div:not(:first-child) {
+        width: 20%;
+      }
+    }
+
+    .header {
+      color: $font-gray-light;
+      text-transform: uppercase;
+      font-size: 13px;
+    }
+
+    .email-row {
+      border-top: 1px solid $border-color;
+
+      .mdl-spinner {
+        width: 16px;
+        height: 16px;
+        top: 4px;
+        margin-left: 18px;
+      }
+
+      .mdl-switch {
+        width: 0;
+      }
+    }
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -36,6 +36,7 @@
 @import "order-summary";
 @import "final-exam-card";
 @import "staff-learner-info-card";
+@import "automatic-emails";
 
 .selected {
   font-weight: bold;

--- a/ui/url_utils.py
+++ b/ui/url_utils.py
@@ -11,6 +11,7 @@ TERMS_OF_SERVICE_URL = '/terms_of_service/'
 SETTINGS_URL = "/settings/"
 SEARCH_URL = "/learners/"
 ORDER_SUMMARY = "/order_summary/"
+EMAIL_URL = "/automaticemails/"
 
 DASHBOARD_URLS = [
     DASHBOARD_URL,
@@ -21,4 +22,5 @@ DASHBOARD_URLS = [
     SETTINGS_URL,
     SEARCH_URL,
     ORDER_SUMMARY,
+    EMAIL_URL,
 ]


### PR DESCRIPTION
#### What are the relevant tickets?

closes #3011

#### What's this PR do?

This

- adds a new page (at `/automaticemails`) which allows staff users to edit automatic emails that they created
- adds a link to the sidebar nav to this page, which appears if you are staff
- added some redirect protection, so that if you do not have a staff role you will be redirected away from the automatic emails page (even though the API wouldn't let you see anything anyway)

I think that's it!

#### How should this be manually tested?

Confirm the following things:

- a link to the email page shows up in the sidebar if you are staff, and not if you are a learner
- the automatic emails page shows any automatic emails you've created.
- the automatic emails page should show a placeholder message if you haven't yet created any.
- the automatic emails page should show a spinner while the GET request is in-flight
- you should be able to toggle the 'active' state of an automatic email, and it should show a little spinner while that's in-flight (you can use chrome's internet connection throttling feature to make this more obvious)
- if you are not a staff user, when you try to load `/automaticemails` you should be redirected to `/dashboard`	

I think that's it...