### PR TITLE
fix Promise error handling

### DIFF
--- a/static/js/actions/course_enrollments.js
+++ b/static/js/actions/course_enrollments.js
@@ -28,8 +28,7 @@ export const addCourseEnrollment = (courseId: string): Dispatcher<*> => {
         dispatch(fetchCoursePrices(SETTINGS.user.username, true));
         dispatch(showEnrollPayLaterSuccessMessage(courseId));
         return Promise.resolve();
-      }).
-      catch(() => {
+      }, () => {
         dispatch(receiveAddCourseEnrollmentFailure());
         return Promise.reject();
       });

--- a/static/js/actions/course_prices.js
+++ b/static/js/actions/course_prices.js
@@ -3,7 +3,6 @@ import type { Dispatch } from 'redux';
 
 import * as api from '../lib/api';
 import type { Dispatcher } from '../flow/reduxTypes';
-import type { CoursePrices } from '../flow/dashboardTypes';
 import { withUsername } from './util';
 
 export const REQUEST_COURSE_PRICES = 'REQUEST_COURSE_PRICES';
@@ -18,12 +17,13 @@ export const receiveCoursePricesFailure = withUsername(RECEIVE_COURSE_PRICES_FAI
 export const CLEAR_COURSE_PRICES = 'CLEAR_COURSE_PRICES';
 export const clearCoursePrices = withUsername(CLEAR_COURSE_PRICES);
 
-export function fetchCoursePrices(username: string, noSpinner: boolean = false): Dispatcher<CoursePrices> {
+export function fetchCoursePrices(username: string, noSpinner: boolean = false): Dispatcher<void> {
   return (dispatch: Dispatch) => {
     dispatch(requestCoursePrices(username, noSpinner));
     return api.getCoursePrices(username).
-      then(coursePrices => dispatch(receiveCoursePricesSuccess(username, coursePrices))).
-      catch(error => {
+      then(coursePrices => {
+        dispatch(receiveCoursePricesSuccess(username, coursePrices));
+      }, error => {
         dispatch(receiveCoursePricesFailure(username, error));
         // the exception is assumed handled and will not be propagated
       });

--- a/static/js/actions/dashboard.js
+++ b/static/js/actions/dashboard.js
@@ -3,7 +3,6 @@ import type { Dispatch } from 'redux';
 
 import * as api from '../lib/api';
 import type { Dispatcher } from '../flow/reduxTypes';
-import type { Dashboard } from '../flow/dashboardTypes';
 import { withUsername } from './util';
 
 export const UPDATE_COURSE_STATUS = 'UPDATE_COURSE_STATUS';
@@ -24,12 +23,13 @@ export const receiveDashboardFailure = withUsername(RECEIVE_DASHBOARD_FAILURE);
 export const CLEAR_DASHBOARD = 'CLEAR_DASHBOARD';
 export const clearDashboard = withUsername(CLEAR_DASHBOARD);
 
-export function fetchDashboard(username: string, noSpinner: boolean = false): Dispatcher<Dashboard> {
+export function fetchDashboard(username: string, noSpinner: boolean = false): Dispatcher<void> {
   return (dispatch: Dispatch) => {
     dispatch(requestDashboard(username, noSpinner));
     return api.getDashboard(username).
-      then(dashboard => dispatch(receiveDashboardSuccess(username, dashboard))).
-      catch(error => {
+      then(dashboard => {
+        dispatch(receiveDashboardSuccess(username, dashboard));
+      }, error => {
         dispatch(receiveDashboardFailure(username, error));
         // the exception is assumed handled and will not be propagated
       });

--- a/static/js/actions/email.js
+++ b/static/js/actions/email.js
@@ -30,14 +30,14 @@ export function sendEmail(
   emailType: string,
   sendFunction: () => Promise<EmailSendResponse>,
   sendFunctionParams: Array<*>
-): Dispatcher<EmailSendResponse> {
+): Dispatcher<?EmailSendResponse> {
   return (dispatch: Dispatch) => {
     dispatch(initiateSendEmail(emailType));
     return sendFunction(...sendFunctionParams).
       then(response => {
         dispatch(sendEmailSuccess(emailType));
         return Promise.resolve(response);
-      }).catch(error => {
+      }, error => {
         dispatch(sendEmailFailure({type: emailType, error: error}));
       });
   };

--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -20,7 +20,7 @@ export const requestCheckout = (courseId: string) => ({
   payload: { courseId }
 });
 
-export function checkout(courseId: string): Dispatcher<CheckoutResponse> {
+export function checkout(courseId: string): Dispatcher<?CheckoutResponse> {
   return (dispatch: Dispatch) => {
     dispatch(requestCheckout(courseId));
     return api.checkout(courseId).
@@ -28,7 +28,7 @@ export function checkout(courseId: string): Dispatcher<CheckoutResponse> {
         const {url, payload} = response;
         dispatch(receiveCheckoutSuccess(url, payload));
         return Promise.resolve(response);
-      }).catch(error => {
+      }, error => {
         dispatch(receiveCheckoutFailure(error));
       });
   };

--- a/static/js/actions/profile.js
+++ b/static/js/actions/profile.js
@@ -47,12 +47,13 @@ const receivePatchUserProfileFailure = createAction(RECEIVE_PATCH_USER_PROFILE_F
   (username, errorInfo) => ({ username, errorInfo })
 );
 
-export const saveProfile = (username: string, profile: Profile): Dispatcher<Profile> => {
+export const saveProfile = (username: string, profile: Profile): Dispatcher<void> => {
   return (dispatch: Dispatch) => {
     dispatch(requestPatchUserProfile(username));
     return api.patchUserProfile(username, profile).
-      then(newProfile => dispatch(receivePatchUserProfileSuccess(username, newProfile))).
-      catch(error => {
+      then(newProfile => {
+        dispatch(receivePatchUserProfileSuccess(username, newProfile));
+      }, error => {
         dispatch(receivePatchUserProfileFailure(username, error));
         // the exception is assumed handled and will not be propagated
       });
@@ -69,12 +70,13 @@ export const updateValidationVisibility = createAction(UPDATE_VALIDATION_VISIBIL
   (username, keySet) => ({ username, keySet })
 );
 
-export function fetchUserProfile(username: string): Dispatcher<Profile> {
+export function fetchUserProfile(username: string): Dispatcher<void> {
   return (dispatch: Dispatch) => {
     dispatch(requestGetUserProfile(username));
     return api.getUserProfile(username).
-      then(json => dispatch(receiveGetUserProfileSuccess(username, json))).
-      catch(error => {
+      then(json => {
+        dispatch(receiveGetUserProfileSuccess(username, json));
+      }, error => {
         dispatch(receiveGetUserProfileFailure(username, error));
         // the exception is assumed handled and will not be propagated
       });

--- a/static/js/actions/programs.js
+++ b/static/js/actions/programs.js
@@ -11,10 +11,7 @@ import { fetchDashboard } from './dashboard';
 import { fetchCoursePrices } from './course_prices';
 import { setToastMessage, setEnrollProgramDialogVisibility } from '../actions/ui';
 import type { Dispatcher } from '../flow/reduxTypes';
-import type {
-  AvailableProgram,
-  AvailablePrograms,
-} from '../flow/enrollmentTypes';
+import type { AvailableProgram } from '../flow/enrollmentTypes';
 import * as api from '../lib/api';
 
 export const SET_CURRENT_PROGRAM_ENROLLMENT = 'SET_CURRENT_PROGRAM_ENROLLMENT';
@@ -29,12 +26,13 @@ export const receiveGetProgramEnrollmentsSuccess = createAction(RECEIVE_GET_PROG
 export const RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE = 'RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE';
 export const receiveGetProgramEnrollmentsFailure = createAction(RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE);
 
-export function fetchProgramEnrollments(): Dispatcher<AvailablePrograms> {
+export function fetchProgramEnrollments(): Dispatcher<void> {
   return (dispatch: Dispatch) => {
     dispatch(requestGetProgramEnrollments());
     return api.getPrograms().
-      then(enrollments => dispatch(receiveGetProgramEnrollmentsSuccess(enrollments))).
-      catch(error => {
+      then(enrollments => {
+        dispatch(receiveGetProgramEnrollmentsSuccess(enrollments));
+      }, error => {
         dispatch(receiveGetProgramEnrollmentsFailure(error));
         // the exception is assumed handled and will not be propagated
       });
@@ -50,7 +48,7 @@ export const receiveAddProgramEnrollmentSuccess = createAction(RECEIVE_ADD_PROGR
 export const RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE = 'RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE';
 export const receiveAddProgramEnrollmentFailure = createAction(RECEIVE_ADD_PROGRAM_ENROLLMENT_FAILURE);
 
-export const addProgramEnrollment = (programId: number): Dispatcher<AvailableProgram> => {
+export const addProgramEnrollment = (programId: number): Dispatcher<?AvailableProgram> => {
   return (dispatch: Dispatch) => {
     dispatch(requestAddProgramEnrollment(programId));
     return api.addProgramEnrollment(programId).
@@ -63,8 +61,7 @@ export const addProgramEnrollment = (programId: number): Dispatcher<AvailablePro
         dispatch(setEnrollProgramDialogVisibility(false));
         dispatch(fetchDashboard(SETTINGS.user.username));
         dispatch(fetchCoursePrices(SETTINGS.user.username));
-      }).
-      catch(error => {
+      }, error => {
         dispatch(receiveAddProgramEnrollmentFailure(error));
         dispatch(setToastMessage({
           message: "There was an error during enrollment",

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -9,14 +9,17 @@ import Navbar from '../components/Navbar';
 import {
   REQUEST_DASHBOARD,
   RECEIVE_DASHBOARD_SUCCESS,
+  CLEAR_DASHBOARD,
 } from '../actions/dashboard';
 import {
   REQUEST_COURSE_PRICES,
   RECEIVE_COURSE_PRICES_SUCCESS,
+  CLEAR_COURSE_PRICES,
 } from '../actions/course_prices';
 import {
   REQUEST_FETCH_COUPONS,
   RECEIVE_FETCH_COUPONS_SUCCESS,
+  CLEAR_COUPONS,
 } from '../actions/coupons';
 import {
   REQUEST_GET_USER_PROFILE,
@@ -143,15 +146,18 @@ describe('App', function() {
       helper.programsGetStub.returns(Promise.reject("error"));
       let types = [
         REQUEST_DASHBOARD,
-        RECEIVE_DASHBOARD_SUCCESS,
         REQUEST_COURSE_PRICES,
-        RECEIVE_COURSE_PRICES_SUCCESS,
         REQUEST_FETCH_COUPONS,
-        RECEIVE_FETCH_COUPONS_SUCCESS,
         REQUEST_GET_USER_PROFILE,
-        RECEIVE_GET_USER_PROFILE_SUCCESS,
         REQUEST_GET_PROGRAM_ENROLLMENTS,
         RECEIVE_GET_PROGRAM_ENROLLMENTS_FAILURE,
+        CLEAR_DASHBOARD,
+        CLEAR_COURSE_PRICES,
+        CLEAR_COUPONS,
+        RECEIVE_DASHBOARD_SUCCESS,
+        RECEIVE_COURSE_PRICES_SUCCESS,
+        RECEIVE_FETCH_COUPONS_SUCCESS,
+        RECEIVE_GET_USER_PROFILE_SUCCESS,
       ];
       return renderComponent('/dashboard', types).then(([wrapper]) => {
         let text = wrapper.find('.page-content').text();

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -356,7 +356,7 @@ class DashboardPage extends React.Component {
       this.context.router.push('/dashboard/');
       // update coupon state in Redux
       dispatch(fetchCoupons());
-    }).catch(() => {
+    }, () => {
       dispatch(setToastMessage({
         title: "Coupon failed",
         message: "This coupon code is invalid or does not exist.",
@@ -407,7 +407,7 @@ class DashboardPage extends React.Component {
     ) {
       dispatch(skipFinancialAid(programId)).then(() => {
         this.setConfirmSkipDialogVisibility(false);
-      }).catch(() => {
+      }, () => {
         this.setConfirmSkipDialogVisibility(false);
         dispatch(setToastMessage({
           message: "Failed to skip financial aid.",

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -654,7 +654,7 @@ describe('api', function() {
           method: 'PATCH',
           body: JSON.stringify(expectedJSON)
         }).then(responseBody => {
-          assert.deepEqual(responseBody, '');
+          assert.deepEqual(responseBody, {});
         });
       });
 

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -89,7 +89,7 @@ export const deriveAction = (endpoint: Endpoint, verb: string): DerivedAction =>
         return fetchFunc(...params).then(data => {
           dispatch(successAction(data));
           return Promise.resolve(data);
-        }).catch(error => {
+        }, error => {
           dispatch(failureAction(error));
           return Promise.reject(error);
         });

--- a/static/js/lib/sanctuary.js
+++ b/static/js/lib/sanctuary.js
@@ -44,3 +44,20 @@ export const guard = (func: Function) => (...args: any) => {
 export const getm = R.curry((prop, obj) => (
   S.toMaybe(R.prop(prop, obj))
 ));
+
+// parseJSON :: String -> Either Object Object
+// A Right value indicates the JSON parsed successfully,
+// a Left value indicates the JSON was malformed (a Left contains
+// an empty object)
+export const parseJSON = S.encaseEither(() => ({}), JSON.parse);
+
+// filterE :: (Either -> Boolean) -> Either -> Either
+// filterE takes a function f and an either E(v).
+// if the Either is a Left, it returns it.
+// if the f(v) === true, it returns, E. Else,
+// if returns Left(v).
+export const filterE = R.curry((predicate, either) => S.either(
+  S.Left,
+  right => predicate(right) ? S.Right(right) : S.Left(right),
+  either
+));


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

I was looking at a JavaScript error in Sentry this morning and I realized (after reading [this issue](https://github.com/facebook/react/issues/7617), among others) that our error handling for `Promises` is done incorrectly, in a way that can swallow errors and lead to some strange behavior.

In short, these two things are not equivalent:

```js
// pattern we have in our code a fair amount right now:
promise.then(success => {
  doSomethingWithSuccess(success);
  return Promise.resolve(success); // maybe, we don't always do this
}).catch(error => {
  ohNoAnError(error); // :(
  return Promise.reject();
};

// correct pattern
promise.then(success => {
  doSomethingWithSuccess(success);
  return Promise.resolve(success); // maybe, we don't always do this
}, error => {
  ohNoAnError(error); // :(
  return Promise.reject();
});
```

basically, the first problem is an issue because `.catch` becomes overly broad. Instead of just handling the `rejected` case for `promise`, it also catches any errors that happen in the `.then` handler. This can, in certain cases, include rendering / UI errors which are not related to the `promise` itself, but related to an error in the code we use to handle or render the data once it comes back. In this case, the UI error will be silently swallowed by the `.catch` (because it's occurring in the `.then` handler) and we won't see it. Then, often, the error will show up somewhat cryptically with a different stack trace.

this is a problem in particular with redux, because our async (redux-thunk) action dispatchers trigger a `render()` call when `dispatch` fires, so that if there is an error anywhere in that `render()` call (say, because of wacky data) it will trace back to the `dispatch()` and be silently swallowed by `.catch`. yucky.

The correct way to use promises is `.then(onResolve, onReject)`. Then our handler functions are strictly confined to dealing with resolution or rejection of the original promise itself. Of course, if want to chain off of this function that is fine and dandy as well, but we need to make sure that there is an `onReject` handler for the initial promise beforehand, otherwise the error can be propagated somewhat strangely.

Anyway, I believe this is the root cause of a React error we're seeing rarely but consistently (`Cannot read property 'getHostNode' of null`).

two other React issues relating to this:

https://github.com/facebook/react/issues/8267

https://github.com/facebook/react/issues/4199


#### How should this be manually tested?

tests should pass, app should behave normally, there should be no regressions.