### PR TITLE
Add specific environment variables to tox.ini instead of using *

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,10 +14,18 @@ commands =
     {toxinidir}/scripts/test/detect_missing_migrations.sh
     {toxinidir}/scripts/test/no_auto_migrations.sh
 
-passenv = *
+passenv =
+    COVERAGE_DIR
+    DATABASE_URL
+    ELASTICSEARCH_URL
+    BROKER_URL
+    CELERY_RESULT_BACKEND
+    PORT
 setenv =
     ELASTICSEARCH_INDEX=testindex
     DEBUG=False
     CELERY_ALWAYS_EAGER=True
     SENTRY_DSN=
     DISABLE_WEBPACK_LOADER_STATS=True
+    MICROMASTERS_DB_DISABLE_SSL=True
+    MICROMASTERS_SECURE_SSL_REDIRECT=False


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2983 

#### What's this PR do?
Removes `passenv = *` and whitelists the environment variables we pass in so that they only cover ones necessary for the tests to connect to services they need.

#### How should this be manually tested?
No manual testing needed
