### PR TITLE
Upgrade postgres-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,15 @@ LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 # Add package files, install updated node and pip
 WORKDIR /tmp
 
+# Install packages and add repo needed for postgres 9.6
 COPY apt.txt /tmp/apt.txt
+RUN echo deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main > /etc/apt/sources.list.d/pgdg.list
+RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt-get update
 RUN apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ")
+
+# Add repo needed for postgres 9.6 and install it
+RUN apt-get update && apt-get install libpq-dev postgresql-client-9.6 -y
 
 # pip
 RUN curl --silent --location https://bootstrap.pypa.io/get-pip.py | python3 -

--- a/apt.txt
+++ b/apt.txt
@@ -1,10 +1,6 @@
 # Core requirements
 git
 curl
-libpq-dev
 libjpeg-dev
 zlib1g-dev
 net-tools
-
-# developer requirements
-postgresql-client


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #2674 

#### What's this PR do?
Upgrades postgres client. This is needed to fix the version incompatibility to do the database dump required in #2674 

#### How should this be manually tested?
NA

#### Any background context you want to provide?
@aliceriot after this is merged can you update the relevant image in Docker hub?
