### PR TITLE
Save database state during selenium tests

### DIFF
--- a/selenium_tests/pytest.ini
+++ b/selenium_tests/pytest.ini
@@ -1,4 +1,0 @@
-# This lacks --reuse-db because it won't work properly with selenium tests
-[pytest]
-addopts = --cov . --pep8 --pylint --cov-report term --cov-report html --ds=micromasters.settings
-pep8maxlinelength = 119


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2674 

#### What's this PR do?
Saves and restores the database after each selenium test. Running migrations from scratch takes roughly 30 seconds so this will greatly speed up selenium tests in the future.

#### How should this be manually tested?
Tests should pass. Selenium tests should be roughly 30 seconds faster than before.

#### Any background context you want to provide?
This ignores the keepdb flag, see #3030 for that
