### PR TITLE
Pdpinch/change order courserun

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -25,13 +25,20 @@ class LineAdmin(admin.ModelAdmin):
     """Admin for Line"""
     model = Line
 
-    readonly_fields = [name for name in get_field_names(Line) if name != 'edx_course_key']
+    readonly_fields = [name for name in get_field_names(Line) if name != 'course_key']
 
     def has_add_permission(self, request):
         return False
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    def save_model(self, request, obj, form, change):
+        """
+        Saves object and logs change to object
+        """
+        super(LineAdmin, self).save_model(request, obj, form, change)
+        obj.order.save_and_log(request.user)
 
 
 class OrderAdmin(admin.ModelAdmin):

--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -25,7 +25,7 @@ class LineAdmin(admin.ModelAdmin):
     """Admin for Line"""
     model = Line
 
-    readonly_fields = get_field_names(Line)
+    readonly_fields = [name for name in get_field_names(Line) if name != 'edx_course_key']
 
     def has_add_permission(self, request):
         return False

--- a/ecommerce/admin_test.py
+++ b/ecommerce/admin_test.py
@@ -18,11 +18,22 @@ class AdminTest(MockedESTestCase):
     """
     def test_save_and_log_model(self):
         """
-        Tests that the save_model() function on OrderAdmin creates an OrderAudit entry
+        Tests that the save_model() function on OrderAdmin and LineAdmin create OrderAudit entries
         """
         assert OrderAudit.objects.count() == 0
         order = OrderFactory.create()
         admin = OrderAdmin(model=order, admin_site=Mock())
+        mock_request = Mock(user=UserFactory.create())
+        admin.save_model(
+            request=mock_request,
+            obj=admin.model,
+            form=Mock(),
+            change=Mock()
+        )
+        assert OrderAudit.objects.count() == 1
+
+        order = LineFactory.create()
+        admin = LineAdmin(model=line, admin_site=Mock())
         mock_request = Mock(user=UserFactory.create())
         admin.save_model(
             request=mock_request,

--- a/ecommerce/admin_test.py
+++ b/ecommerce/admin_test.py
@@ -5,8 +5,8 @@ from unittest.mock import Mock
 
 from search.base import MockedESTestCase
 
-from ecommerce.admin import OrderAdmin
-from ecommerce.factories import OrderFactory
+from ecommerce.admin import OrderAdmin, LineAdmin
+from ecommerce.factories import OrderFactory, LineFactory
 from ecommerce.models import OrderAudit
 from profiles.factories import UserFactory
 
@@ -32,13 +32,13 @@ class AdminTest(MockedESTestCase):
         )
         assert OrderAudit.objects.count() == 1
 
-        order = LineFactory.create()
-        admin = LineAdmin(model=line, admin_site=Mock())
+        line = LineFactory.create()
+        line_admin = LineAdmin(model=line, admin_site=Mock())
         mock_request = Mock(user=UserFactory.create())
-        admin.save_model(
+        line_admin.save_model(
             request=mock_request,
-            obj=admin.model,
+            obj=line_admin.model,
             form=Mock(),
             change=Mock()
         )
-        assert OrderAudit.objects.count() == 1
+        assert OrderAudit.objects.count() == 2


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #2654

#### What's this PR do?

Makes `line.course_key` editable in the admin. Any changes create a corresponding `OrderAudit`

#### How should this be manually tested?

Open up the admin at `/admin/ecommerce/line/` and try changing a course_key. Check to see that an OrderAudit is created in `/admin/ecommerce/orderaudit/`

Note that there isn't any validation applied to the course key. It's up to the admin to make sure that a valid course key is used. 

#### Any background context you want to provide?

Learners asking to defer their payments to another semester is our 2nd most common support issue (after financial aid resets).

It's the only issue that currently requires an admin (i.e me) to change data via the django shell. I'd feel much more comfortable doing this via the admin. 

#### What GIF best describes this PR or how it makes you feel?

![image001](https://media.giphy.com/media/HKngptd77pt4c/giphy.gif)

