### PR TITLE
add automatic email admin editing

### DIFF
--- a/static/js/components/EmailCampaignsCard.js
+++ b/static/js/components/EmailCampaignsCard.js
@@ -27,7 +27,7 @@ const wrapEmailRows = rows => (
   </div>
 );
 
-const renderEmailRow = R.curry((toggleEmailActive, emailsInFlight, automaticEmail, idx) => (
+const renderEmailRow = R.curry((toggleEmailActive, emailsInFlight, openEmailComposer, automaticEmail, idx) => (
   <div className="email-row" key={idx}>
     <div>{ automaticEmail.email_subject }</div>
     <div>--</div>
@@ -39,29 +39,42 @@ const renderEmailRow = R.curry((toggleEmailActive, emailsInFlight, automaticEmai
         onChange={() => toggleEmailActive(automaticEmail)}
       />
       { emailsInFlight.has(automaticEmail.id) ? <Spinner singleColor /> : null }
+      <a onClick={() => openEmailComposer(automaticEmail)}>
+        Edit
+      </a>
     </div>
   </div>
 ));
 
-const renderEmailRows = (toggleEmailActive, emailsInFlight) => R.compose(
-  wrapEmailRows, R.addIndex(R.map)(renderEmailRow(toggleEmailActive, emailsInFlight))
+const renderEmailRows = (toggleEmailActive, emailsInFlight, openEmailComposer) => R.compose(
+  wrapEmailRows, R.addIndex(R.map)(renderEmailRow(toggleEmailActive, emailsInFlight, openEmailComposer))
 );
 
 type CampaignCardProps = {
   getEmails:          () => Either<React$Element<string>, Array<AutomaticEmail>>,
   emailsInFlight:     Set<number>,
   toggleEmailActive:  (e: AutomaticEmail) => void,
+  openEmailComposer:  (e: AutomaticEmail) => void,
 };
 
 const EmailCampaignsCard = (props: CampaignCardProps) => {
-  const { getEmails, toggleEmailActive, emailsInFlight } = props;
+  const {
+    getEmails,
+    toggleEmailActive,
+    emailsInFlight,
+    openEmailComposer,
+  } = props;
 
   return (
     <Card shadow={1} className="email-campaigns-card">
       <CardTitle>
         Manage Email Campaigns
       </CardTitle>
-      { S.either(renderEmptyMessage, renderEmailRows(toggleEmailActive, emailsInFlight), getEmails()) }
+    { S.either(
+      renderEmptyMessage,
+      renderEmailRows(toggleEmailActive, emailsInFlight, openEmailComposer),
+      getEmails()
+    ) }
     </Card>
   );
 };

--- a/static/js/components/EmailCampaignsCard_test.js
+++ b/static/js/components/EmailCampaignsCard_test.js
@@ -19,6 +19,7 @@ describe('EmailCampaignsCard', () => {
       getEmails: sandbox.stub(),
       emailsInFlight: new Set(),
       toggleEmailActive: sandbox.stub(),
+      openEmailComposer: sandbox.stub(),
     };
 
     emailCardProps.getEmails.returns(S.Right(GET_AUTOMATIC_EMAILS_RESPONSE));
@@ -62,6 +63,12 @@ describe('EmailCampaignsCard', () => {
     let card = renderCard();
     card.find(Switch).first().props().onChange();
     assert(emailCardProps.toggleEmailActive.calledWith(GET_AUTOMATIC_EMAILS_RESPONSE[0]));
+  });
+
+  it('should render an "edit" button, and call openEmailComposer with the AutomaticEmail on click', () => {
+    let card = renderCard();
+    card.find('a').first().simulate('click');
+    assert(emailCardProps.openEmailComposer.calledWith(GET_AUTOMATIC_EMAILS_RESPONSE[0]));
   });
 
   it('should show a spinner when a request is in-flight', () => {

--- a/static/js/components/email/constants.js
+++ b/static/js/components/email/constants.js
@@ -2,3 +2,4 @@ export const EMAIL_COMPOSITION_DIALOG = 'emailComposition';
 export const SEARCH_EMAIL_TYPE = 'searchResultEmail';
 export const COURSE_EMAIL_TYPE = 'courseTeamEmail';
 export const LEARNER_EMAIL_TYPE = 'learnerEmail';
+export const AUTOMATIC_EMAIL_ADMIN_TYPE = 'automaticEmailAdmin';

--- a/static/js/components/email/hoc.js
+++ b/static/js/components/email/hoc.js
@@ -67,15 +67,21 @@ export const withEmailDialog = R.curry(
         let errors = emailValidation(activeEmail.inputs);
         dispatch(updateEmailValidation({type: currentlyActive, errors: errors}));
         if (R.isEmpty(errors)) {
-          dispatch(
-            sendEmail(
-              currentlyActive,
-              emailConfigs[currentlyActive].getEmailSendFunction(),
-              emailConfigs[currentlyActive].emailSendParams(activeEmail)
-            )
-          ).then(() => {
-            this.closeAndClearEmailComposer();
-          });
+          if (emailConfigs[currentlyActive].editEmail) {
+            dispatch(
+              emailConfigs[currentlyActive].editEmail(
+                emailConfigs[currentlyActive].emailSendParams(activeEmail)
+              )
+            ).then(this.closeAndClearEmailComposer);
+          } else {
+            dispatch(
+              sendEmail(
+                currentlyActive,
+                emailConfigs[currentlyActive].getEmailSendFunction(),
+                emailConfigs[currentlyActive].emailSendParams(activeEmail)
+              )
+            ).then(this.closeAndClearEmailComposer);
+          }
         }
       };
 

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -7,10 +7,11 @@ import {
   sendSearchResultMail,
   sendLearnerMail
 } from '../../lib/api';
-import { makeProfileImageUrl } from '../../util/util';
+import { makeProfileImageUrl, mapObj } from '../../util/util';
 import type { Profile } from '../../flow/profileTypes';
 import type { Course } from '../../flow/programTypes';
 import type { EmailConfig, EmailState, Filter } from '../../flow/emailTypes';
+import { actions } from '../../lib/redux_rest.js';
 
 // NOTE: getEmailSendFunction is a function that returns a function. It is implemented this way
 // so that we can stub/mock the function that it returns (as we do in integration_test_helper.js)
@@ -120,4 +121,15 @@ export const LEARNER_EMAIL_CONFIG: EmailConfig = {
     emailState.inputs.body || '',
     emailState.params.studentId
   ])
+};
+
+export const convertEmailEdit = mapObj(([k, v]) => (
+  [k.match(/^subject$|^body$/) ? `email_${k}` : k.replace(/^email_/, ""), v]
+));
+
+export const AUTOMATIC_EMAIL_ADMIN_CONFIG: EmailConfig = {
+  title: 'Edit Message',
+  editEmail: actions.automaticEmails.patch,
+  emailOpenParams: R.compose(R.objOf('inputs'), convertEmailEdit),
+  emailSendParams: R.compose(convertEmailEdit, R.prop('inputs')),
 };

--- a/static/js/containers/AutomaticEmailPage.js
+++ b/static/js/containers/AutomaticEmailPage.js
@@ -14,6 +14,9 @@ import type { RestState } from '../flow/restTypes';
 import { hasAnyStaffRole } from '../lib/roles';
 import Spinner from 'react-mdl/lib/Spinner';
 import { toggleEmailPatchInFlight } from '../actions/automatic_emails';
+import { withEmailDialog } from '../components/email/hoc';
+import { AUTOMATIC_EMAIL_ADMIN_TYPE } from '../components/email/constants';
+import { AUTOMATIC_EMAIL_ADMIN_CONFIG } from '../components/email/lib';
 
 const fetchingEmail = R.propEq('getStatus', FETCH_PROCESSING);
 
@@ -35,8 +38,9 @@ type AutomaticEmailsType = RestState<Array<AutomaticEmail>> & {
 
 class AutomaticEmailPage extends React.Component {
   props: {
-    automaticEmails:  AutomaticEmailsType,
-    dispatch:         Dispatch,
+    automaticEmails:    AutomaticEmailsType,
+    dispatch:           Dispatch,
+    openEmailComposer:  (e: string) => (e: AutomaticEmail) => void,
   };
 
   static contextTypes = {
@@ -86,7 +90,10 @@ class AutomaticEmailPage extends React.Component {
   };
 
   render () {
-    const { automaticEmails: { emailsInFlight }} = this.props;
+    const {
+      automaticEmails: { emailsInFlight },
+      openEmailComposer,
+    } = this.props;
 
     return (
       <div className="single-column automatic-emails">
@@ -94,6 +101,7 @@ class AutomaticEmailPage extends React.Component {
           getEmails={this.getEmails}
           toggleEmailActive={this.toggleEmailActive}
           emailsInFlight={emailsInFlight}
+          openEmailComposer={openEmailComposer(AUTOMATIC_EMAIL_ADMIN_TYPE)}
         />
       </div>
     );
@@ -101,7 +109,12 @@ class AutomaticEmailPage extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  automaticEmails: state.automaticEmails
+  automaticEmails: state.automaticEmails,
+  email: state.email,
+  ui: state.ui,
 });
 
-export default connect(mapStateToProps)(AutomaticEmailPage);
+export default R.compose(
+  connect(mapStateToProps),
+  withEmailDialog({ [AUTOMATIC_EMAIL_ADMIN_TYPE]: AUTOMATIC_EMAIL_ADMIN_CONFIG }),
+)(AutomaticEmailPage);

--- a/static/js/reducers/email.js
+++ b/static/js/reducers/email.js
@@ -69,7 +69,8 @@ export const email = (state: AllEmailsState = INITIAL_ALL_EMAILS_STATE, action: 
       params: action.payload.params || {},
       subheading: action.payload.subheading,
       supportsAutomaticEmails: action.payload.supportsAutomaticEmails,
-      filters: action.payload.filters
+      filters: action.payload.filters,
+      inputs: action.payload.inputs || NEW_EMAIL_EDIT,
     };
     newState.currentlyActive = emailType;
     return newState;

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -546,3 +546,11 @@ export function sortedCourseRuns(program: Program): Array<CourseRun> {
     R.map(R.sortBy(R.prop('position')), R.pluck('runs', sortedCourses))
   );
 }
+
+// lets you edit both keys and values
+// just pass a function that expects and returns [key, value]
+export const mapObj = R.curry((fn, obj) => R.compose(
+  R.fromPairs,
+  R.map(fn),
+  R.toPairs
+)(obj));

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -35,6 +35,7 @@ import {
   isNilOrBlank,
   highlight,
   sortedCourseRuns,
+  mapObj,
 } from '../util/util';
 import {
   EDUCATION_LEVELS,
@@ -846,6 +847,16 @@ describe('utility functions', () => {
       const expected = [run1, run2, run3, run4];
       const actual = sortedCourseRuns(program);
       assert.deepEqual(actual, expected);
+    });
+  });
+
+  describe('mapObj', () => {
+    it('it allows you to edit keys and values', () => {
+      let obj = { foo: 'bar' };
+      let edited = mapObj(
+        ([k, v]) => [`baz_${k}`, `baz_${v}`], obj
+      );
+      assert.deepEqual(edited, { baz_foo: 'baz_bar' });
     });
   });
 });

--- a/static/scss/automatic-emails.scss
+++ b/static/scss/automatic-emails.scss
@@ -28,6 +28,16 @@
     .email-row {
       border-top: 1px solid $border-color;
 
+      > div:last-child {
+        display: flex;
+        justify-content: space-between;
+
+        a {
+          padding-right: 20px;
+          cursor: pointer;
+        }
+      }
+
       .mdl-spinner {
         width: 16px;
         height: 16px;


### PR DESCRIPTION
#### What are the relevant tickets?

closes #3028 

#### What's this PR do?

This adds the ability to edit the already-created automatic emails.

#### How should this be manually tested?

Make sure you have an automatic email, and to go `/automaticemails`. You should be able to click the 'edit' link and edit the subject or body of the email there.