### PR TITLE
Fixed selected search filter label regression

### DIFF
--- a/static/js/components/search/ModifiedSelectedFilter.js
+++ b/static/js/components/search/ModifiedSelectedFilter.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import R from 'ramda';
 import { SEARCH_FACET_FIELD_LABEL_MAP } from '../../constants';
 import { makeCountryNameTranslations } from '../LearnerSearch';
 
@@ -21,8 +22,9 @@ export default class ModifiedSelectedFilter extends React.Component {
       bemBlocks,
       filterId,
     } = this.props;
-
-    if (labelKey in SEARCH_FACET_FIELD_LABEL_MAP) {
+    if (R.isEmpty(labelKey)) {
+      labelKey = SEARCH_FACET_FIELD_LABEL_MAP[filterId];
+    } else if (labelKey in SEARCH_FACET_FIELD_LABEL_MAP) {
       labelKey = SEARCH_FACET_FIELD_LABEL_MAP[labelKey];
     } else if (labelKey in this.countryNameTranslations) {
       labelKey = this.countryNameTranslations[labelKey];

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -27,6 +27,7 @@ export const EDUCATION_LEVELS = [
 export const SEARCH_FACET_FIELD_LABEL_MAP = {
   'program.enrollments.course_title': 'Course',
   'program.enrollments.semester': 'Semester',
+  'program.enrollments.payment_status': 'Payment Status',
   'program.grade_average': 'Average Grade in Program',
   'grade-average': 'Average Grade in Program',
   'profile.birth_country': 'Country of Birth',

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -25,9 +25,10 @@ export const EDUCATION_LEVELS = [
 ];
 
 export const SEARCH_FACET_FIELD_LABEL_MAP = {
-  'courses': 'Course',
-  'program.semester_enrollments.semester': 'Semester',
+  'program.enrollments.course_title': 'Course',
+  'program.enrollments.semester': 'Semester',
   'program.grade_average': 'Average Grade in Program',
+  'grade-average': 'Average Grade in Program',
   'profile.birth_country': 'Country of Birth',
   'profile.country': 'Current Residence',
   'profile.education.degree_name': 'Degree',


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3037

#### What's this PR do?
Fixed a regression which is cased by https://github.com/mitodl/micromasters/issues/2942. So that selected search filter display fine.

#### How should this be manually tested?
- go to learners search page and select semester from facets.

@pdpinch 

#### Screenshots (if appropriate)
<img width="780" alt="screen shot 2017-04-11 at 5 21 45 pm" src="https://cloud.githubusercontent.com/assets/10431250/24908915/5feb4988-1edb-11e7-95e3-b0be6e8f1887.png">

