### PR TITLE
Fixed handling of currently active email dialog on page without config

### DIFF
--- a/static/js/components/email/hoc.js
+++ b/static/js/components/email/hoc.js
@@ -86,6 +86,7 @@ export const withEmailDialog = R.curry(
 
         if (!activeEmailType) return null;
 
+        const emailConfig = emailConfigs[activeEmailType] || {};
         return (
           <EmailCompositionDialog
             updateEmailFieldEdit={this.updateEmailFieldEdit}
@@ -93,9 +94,9 @@ export const withEmailDialog = R.curry(
             closeEmailComposerAndSend={this.closeEmailComposerAndSend}
             dialogVisibility={dialogVisibility[EMAIL_COMPOSITION_DIALOG]}
             activeEmail={this.getActiveEmailState()}
-            title={emailConfigs[activeEmailType].title}
-            subheadingRenderer={emailConfigs[activeEmailType].renderSubheading}
-            renderRecipients={emailConfigs[activeEmailType].renderRecipients}
+            title={emailConfig.title}
+            subheadingRenderer={emailConfig.renderSubheading}
+            renderRecipients={emailConfig.renderRecipients}
           />
         );
       }

--- a/static/js/components/email/hoc_test.js
+++ b/static/js/components/email/hoc_test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import R from 'ramda';
 import { mount } from 'enzyme';
 import { assert } from 'chai';
-import sinon from 'sinon';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
@@ -39,11 +38,10 @@ describe('Email higher-order component', () => {
   beforeEach(() => {
     helper = new IntegrationTestHelper();
     listenForActions = helper.listenForActions.bind(helper);
-    openEmailSpy = sinon.spy(TEST_EMAIL_CONFIG, 'emailOpenParams');
+    openEmailSpy = helper.sandbox.spy(TEST_EMAIL_CONFIG, 'emailOpenParams');
   });
 
   afterEach(() => {
-    TEST_EMAIL_CONFIG.emailOpenParams.restore();
     helper.cleanup();
   });
 
@@ -71,6 +69,21 @@ describe('Email higher-order component', () => {
       wrapper.find('button').simulate('click');
     }).then(() => {
       assert.isTrue(openEmailSpy.called);
+      assert.equal(wrapper.find("EmailCompositionDialog").props().title, "Test Email Dialog");
     });
+  });
+
+  it("should gracefully handle a currentlyActive email config that isn't present", () => {
+    let wrapper = mount(
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <WrappedTestContainerPage
+          dispatch={helper.store.dispatch}
+          ui={{dialogVisibility: {[EMAIL_COMPOSITION_DIALOG]: false}}}
+          email={{...INITIAL_TEST_EMAIL_STATE, currentlyActive: "missing"}}
+        />
+      </MuiThemeProvider>
+    );
+    // No error should happen and there should be no text here
+    assert.equal(wrapper.find("EmailCompositionDialog").props().title, undefined);
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3043 

#### What's this PR do?
Fixes null reference error when email dialog is rendered without a matching config

#### How should this be manually tested?
 - Open an email dialog, either the course email dialog on the dashboard or one of the dialogs from the learner search page. 
 - Close it, you don't need to enter any text or submit it
 - Navigate to profile page by clicking the hamburger menu icon on the upper left and clicking 'My profile'. On master you should get an exception but in this PR it should behave as expected.


https://sentry.io/mit-office-of-digital-learning/micromasters/issues/228916007/