### PR TITLE
Fixed faulty course ordering in search facet

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -204,7 +204,6 @@ export default class LearnerSearch extends SearchkitComponent {
             field="program.enrollments.course_title"
             fieldOptions={{ type: 'nested', options: {path: 'program.enrollments'} }}
             title=""
-            orderKey="_term"
             id="courses"
           />
         </FilterVisibilityToggle>


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3040

#### What's this PR do?
Fixes the ordering of courses in the search facet

#### How should this be manually tested?
See details in comment

#### Any background context you want to provide?
These courses were never actually being ordered by their position in the program. The order is (presumably) a result of the id's of the courses, which coincidentally matches an ordering based on the `Course.position_in_program` value. If we want to make this _actually_ order on `position_in_program`, we should do that in a separate issue (FYI @pdpinch)
