### PR TITLE
Fixed menu icon display when user is logged out

### DIFF
--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -173,6 +173,13 @@ export default class Navbar extends React.Component {
     );
   };
 
+  renderMenu = (setNavDrawerOpen: (b: boolean) => void): React$Element<*>|null => (
+    SETTINGS.user ? (
+      <div className="mobile-visible">
+        <Icon name="menu" className="menu-icon" onClick={() => setNavDrawerOpen(true)} />
+      </div>
+    ) : null
+  );
 
   render () {
     const {
@@ -195,9 +202,7 @@ export default class Navbar extends React.Component {
         <Header className="micromasters-nav">
           <HeaderRow className="micromasters-header">
             <div className="micromasters-title">
-              <div className="mobile-visible">
-                <Icon name="menu" className="menu-icon" onClick={() => setNavDrawerOpen(true)} />
-              </div>
+              { this.renderMenu(setNavDrawerOpen) }
               { PROFILE_REGEX.test(pathname) ? this.renderProfileHeader() : this.renderNormalHeader(link) }
             </div>
             <div className="desktop-visible">

--- a/static/js/components/Navbar_test.js
+++ b/static/js/components/Navbar_test.js
@@ -64,4 +64,16 @@ describe('Navbar', () => {
     let wrapper = renderNavbar();
     assert.equal(wrapper.find("a[href='/logout']").text(), "Logout");
   });
+
+  it('should display menu icon when user is logged in', () => {
+    SETTINGS.user = { username: "tester" };
+    let wrapper = renderNavbar();
+    assert.isTrue(wrapper.find(".menu-icon").exists(), 'menu icon should display');
+  });
+
+  it('should not display menu icon when user is logged out', () => {
+    SETTINGS.user = undefined;
+    let wrapper = renderNavbar();
+    assert.isFalse(wrapper.find(".menu-icon").exists(), 'menu icon should display');
+  });
 });

--- a/static/js/components/Navbar_test.js
+++ b/static/js/components/Navbar_test.js
@@ -68,12 +68,12 @@ describe('Navbar', () => {
   it('should display menu icon when user is logged in', () => {
     SETTINGS.user = { username: "tester" };
     let wrapper = renderNavbar();
-    assert.isTrue(wrapper.find(".menu-icon").exists(), 'menu icon should display');
+    assert.isTrue(wrapper.find(".menu-icon").exists(), 'menu icon should be displayed');
   });
 
   it('should not display menu icon when user is logged out', () => {
     SETTINGS.user = undefined;
     let wrapper = renderNavbar();
-    assert.isFalse(wrapper.find(".menu-icon").exists(), 'menu icon should display');
+    assert.isFalse(wrapper.find(".menu-icon").exists(), 'menu icon should not be displayed');
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3054

#### What's this PR do?
Hides menu icon when user is logged out

#### How should this be manually tested?
Open url `http://192.168.99.100:8079/learner/(user name)`

@pdpinch 
#### Screenshots (if appropriate)
<img width="843" alt="screen shot 2017-04-12 at 4 57 27 pm" src="https://cloud.githubusercontent.com/assets/10431250/24956459/2ef0f302-1fa1-11e7-869c-82f49f26e167.png">
<img width="921" alt="screen shot 2017-04-12 at 4 57 40 pm" src="https://cloud.githubusercontent.com/assets/10431250/24956460/2ef4daee-1fa1-11e7-9cba-e5139ce44947.png">

