### PR TITLE
Preserve search URL on reload

### DIFF
--- a/selenium_tests/base.py
+++ b/selenium_tests/base.py
@@ -4,7 +4,10 @@ from datetime import datetime, timedelta
 import logging
 import os
 import socket
-from subprocess import check_call
+from subprocess import (
+    check_call,
+    DEVNULL,
+)
 from tempfile import mkstemp
 from unittest.mock import patch
 from urllib.parse import (
@@ -203,7 +206,7 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
     def restore_db(cls):
         """Delete database and restore from database dump file"""
         cls.clear_db()
-        check_call(["psql", *cls._get_database_args(), "-f", cls.database_dump_path, "-q"])
+        check_call(["psql", *cls._get_database_args(), "-f", cls.database_dump_path, "-q"], stdout=DEVNULL)
 
     def wait(self):
         """Helper function for WebDriverWait"""
@@ -322,3 +325,9 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
             current_grade=later,
         )
         return user
+
+    def num_elements_on_page(self, selector, driver=None):
+        """Count hits from a selector"""
+        script = "return document.querySelectorAll({selector!r}).length".format(selector=selector)
+        driver = driver or self.selenium
+        return driver.execute_script(script)

--- a/selenium_tests/base.py
+++ b/selenium_tests/base.py
@@ -95,39 +95,19 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
         # Ensure Elasticsearch index exists
         recreate_index()
 
-        # Create a user with a profile and fake edX social auth data
-        with mute_signals(post_save):
-            profile = ProfileFactory.create()
-        self.user = profile.user
+        self.user = self.create_user()
         self.password = "pass"
         self.user.set_password(self.password)
         self.user.save()
 
         # Update profile to pass validation so we don't get redirected to the signup page
+        profile = self.user.profile
         profile.phone_number = '+93-23-232-3232'
         profile.filled_out = True
         profile.agreed_to_terms_of_service = True
         profile.save()
 
-        # Create a fake edX social auth to make this user look like they logged in via edX
-        later = datetime.now(tz=pytz.UTC) + timedelta(minutes=5)
-        self.username = username = "{}_edx".format(self.user.username)
-        self.user.social_auth.create(
-            provider=EdxOrgOAuth2.name,
-            uid=username,
-            extra_data={
-                'access_token': 'fake',
-                'refresh_token': 'fake',
-                'updated_at': later.timestamp(),
-                'expires_in': 3600,
-            }
-        )
-        UserCacheRefreshTime.objects.create(
-            user=self.user,
-            enrollment=later,
-            certificate=later,
-            current_grade=later,
-        )
+        self.edx_username = self.user.social_auth.get(provider=EdxOrgOAuth2.name).uid
 
         # Create a live program with valid prices and financial aid
         run = CourseRunFactory.create(
@@ -315,3 +295,30 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
     def dump_html(self):
         """Helper method to print out body HTML"""
         print(self.selenium.find_element_by_tag_name("body").get_attribute("innerHTML"))
+
+    @classmethod
+    def create_user(cls):
+        """Create a user with a profile and fake edX social auth data"""
+        with mute_signals(post_save):
+            profile = ProfileFactory.create(filled_out=True)
+        user = profile.user
+
+        # Create a fake edX social auth to make this user look like they logged in via edX
+        later = datetime.now(tz=pytz.UTC) + timedelta(minutes=5)
+        user.social_auth.create(
+            provider=EdxOrgOAuth2.name,
+            uid="{}_edx".format(user.username),
+            extra_data={
+                'access_token': 'fake',
+                'refresh_token': 'fake',
+                'updated_at': later.timestamp(),
+                'expires_in': 3600,
+            }
+        )
+        UserCacheRefreshTime.objects.create(
+            user=user,
+            enrollment=later,
+            certificate=later,
+            current_grade=later,
+        )
+        return user

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -17,6 +17,8 @@ from selenium_tests.base import SeleniumTestsBase
 class BasicTests(SeleniumTestsBase):
     """Basic selenium tests for MicroMasters"""
 
+    other_program = None
+
     def test_zero_price_purchase(self):
         """
         Do a $0 purchase using a 100% off program-level coupon

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -77,17 +77,17 @@ class BasicTests(SeleniumTestsBase):
             # Create enough profiles for two pages, but make the second page slightly smaller than the first
             # So we can assert that we're on the second page by counting the results
             for i in range((page_size * 2) - 5):
-                profile = ProfileFactory.create(filled_out=True)
-                ProgramEnrollment.objects.create(program=self.program, user=profile.user)
+                user = self.create_user()
+                ProgramEnrollment.objects.create(program=self.program, user=user)
 
                 if i % 2 == 0:
                     # Half the users are also enrolled in the other program
-                    ProgramEnrollment.objects.create(program=other_program, user=profile.user)
+                    ProgramEnrollment.objects.create(program=other_program, user=user)
                 else:
                     # The other half don't overlap
                     ProgramEnrollment.objects.create(
                         program=other_program,
-                        user=ProfileFactory.create(filled_out=True).user,
+                        user=self.create_user(),
                     )
 
         other_program = ProgramFactory.create(live=True)
@@ -115,7 +115,7 @@ class BasicTests(SeleniumTestsBase):
             lambda driver: "open" in driver.find_element_by_class_name("nav-drawer").get_attribute("class")
         )
         profile_link_selector = ".nav-drawer a[href='/learner/{username}']".format(
-            username=self.username,
+            username=self.edx_username,
         )
         self.selenium.find_element_by_css_selector(profile_link_selector).click()
         self.wait().until(lambda driver: driver.find_element_by_class_name("user-page"))

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -87,7 +87,7 @@ class BasicTests(SeleniumTestsBase):
                     # The other half don't overlap
                     ProgramEnrollment.objects.create(
                         program=other_program,
-                        user=ProfileFactory.create(filled_out=True),
+                        user=ProfileFactory.create(filled_out=True).user,
                     )
 
         other_program = ProgramFactory.create(live=True)

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -76,14 +76,15 @@ class BasicTests(SeleniumTestsBase):
                 ProgramEnrollment.objects.create(program=self.program, user=user)
 
                 if i % 2 == 0:
-                    # Half the users are also enrolled in the other program
+                    # Some of the users are also enrolled in the other program
                     ProgramEnrollment.objects.create(program=self.other_program, user=user)
                 else:
-                    # The other half don't overlap
-                    ProgramEnrollment.objects.create(
-                        program=self.other_program,
-                        user=self.create_user(),
-                    )
+                    # Others don't overlap
+                    for _ in range(2):
+                        ProgramEnrollment.objects.create(
+                            program=self.other_program,
+                            user=self.create_user(),
+                        )
 
         ProgramEnrollment.objects.create(
             user=self.user,

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -140,9 +140,7 @@ class BasicTests(SeleniumTestsBase):
         """The querystring should not be affected"""
         self.learner_setup()
         self.get("{}/learners/?q=xyz".format(self.live_server_url))
-        self.wait().until(lambda driver: driver.find_element_by_class_name('search-grid'))
-
-        assert self.num_elements_on_page('.learner-result') == 0
+        self.wait().until(lambda driver: self.num_elements_on_page('.learner-result', driver=driver) == 0)
         assert self.selenium.current_url.endswith('/learners/?q=xyz')
 
     def test_switch_program(self):
@@ -156,4 +154,4 @@ class BasicTests(SeleniumTestsBase):
         switcher = self.selenium.find_element_by_css_selector('.micromasters-header .Select-input')
         switcher.send_keys(Keys.DOWN)
         switcher.send_keys(Keys.ENTER)
-        self.wait().until(lambda driver: driver.find_element_by_class_name('.result-info span').text == '0 Results')
+        self.wait().until(lambda driver: driver.find_element_by_css_selector('.result-info span').text == '0 Results')

--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -5,7 +5,6 @@ from factory.django import mute_signals
 
 from courses.factories import ProgramFactory
 from dashboard.models import ProgramEnrollment
-from profiles.factories import ProfileFactory
 from roles.models import (
     Staff,
     Role,

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -16,7 +16,7 @@ class ProgramFilterAccessor extends StatefulAccessor {
     this.state = new State();
   }
 
-  buildOwnQuery(query) {
+  buildOwnQuery(query: Object) {
     let programId = this.state.getValue();
     if (_.isNil(programId)) {
       return query;
@@ -24,14 +24,14 @@ class ProgramFilterAccessor extends StatefulAccessor {
     return query.addFilter("program_filter", TermQuery("program.id", programId));
   }
 
-  fromQueryObject(ob: any) {
+  fromQueryObject() {
     // This space intentionally left blank
   }
 
   getQueryObject() {
     // Leave blank so that no query parameters are added to the query string
     return {};
-  };
+  }
 }
 
 export default class ProgramFilter extends SearchkitComponent {

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -36,7 +36,7 @@ class ProgramFilterAccessor extends StatefulAccessor {
 
 export default class ProgramFilter extends SearchkitComponent {
   props: {
-    currentProgramEnrollmentId: number,
+    currentProgramEnrollment: AvailableProgram,
   };
 
   _accessor = new ProgramFilterAccessor();
@@ -46,16 +46,25 @@ export default class ProgramFilter extends SearchkitComponent {
   }
 
   refreshSearchkit = (clearState: bool) => {
-    const { currentProgramEnrollmentId } = this.props;
+    const { currentProgramEnrollment } = this.props;
 
-    if (this._accessor.state.getValue() !== currentProgramEnrollmentId) {
+    if (_.isNil(currentProgramEnrollment)) {
+      // programs not yet loaded
+      return;
+    }
+
+    if (this._accessor.state.getValue() !== currentProgramEnrollment.id) {
       if (clearState) {
         this.searchkit.resetState();
       }
-      this._accessor.state = this._accessor.state.setValue(currentProgramEnrollmentId);
-      this.searchkit.registrationCompleted.then(() => {
+      this._accessor.state = this._accessor.state.setValue(currentProgramEnrollment.id);
+
+      if (_.isEmpty(this.searchkit.state) && !clearState) {
+        // workaround weird searchkit behavior which removes query parameter state
         this.searchkit._searchWhenCompleted(window.location);
-      });
+      } else {
+        this.searchkit.search();
+      }
     }
   };
 
@@ -64,7 +73,7 @@ export default class ProgramFilter extends SearchkitComponent {
   }
 
   componentDidUpdate(prevProps: Object): void {
-    const switchingPrograms = !_.isEqual(prevProps.currentProgramEnrollmentId, this.props.currentProgramEnrollmentId);
+    const switchingPrograms = !_.isEqual(prevProps.currentProgramEnrollment, this.props.currentProgramEnrollment);
     this.refreshSearchkit(switchingPrograms);
   }
 

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -6,6 +6,7 @@ import {
   State,
 } from 'searchkit';
 import _ from 'lodash';
+import qs from 'qs';
 
 import type { AvailableProgram } from '../flow/enrollmentTypes';
 
@@ -61,7 +62,7 @@ export default class ProgramFilter extends SearchkitComponent {
 
       if (_.isEmpty(this.searchkit.state) && !clearState) {
         // workaround weird searchkit behavior which removes query parameter state
-        this.searchkit.searchFromUrlQuery(window.location.query);
+        this.searchkit.searchFromUrlQuery(qs.parse(window.location.search.replace(/^\?/, "")));
       } else {
         this.searchkit.search();
       }

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -59,7 +59,7 @@ export default class ProgramFilter extends SearchkitComponent {
         this.searchkit.resetState();
       }
       this._accessor.state = this._accessor.state.setValue(currentProgramEnrollment.id);
-      this.searchkit.performSearch();
+      this.searchkit.registrationCompleted.then(() => this.searchkit.performSearch());
     }
   };
 

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -46,7 +46,7 @@ export default class ProgramFilter extends SearchkitComponent {
     return this._accessor;
   }
 
-  refreshSearchkit = () => {
+  refreshSearchkit = (clearState: bool) => {
     const { currentProgramEnrollment } = this.props;
 
     if (_.isNil(currentProgramEnrollment)) {
@@ -55,19 +55,21 @@ export default class ProgramFilter extends SearchkitComponent {
     }
 
     if (this._accessor.state.getValue() !== currentProgramEnrollment.id) {
+      if (clearState) {
+        this.searchkit.resetState();
+      }
       this._accessor.state = this._accessor.state.setValue(currentProgramEnrollment.id);
       this.searchkit.performSearch();
     }
   };
 
   componentDidMount() {
-    this.refreshSearchkit();
+    this.refreshSearchkit(false);
   }
 
   componentDidUpdate(prevProps: Object): void {
-    if (!_.isEqual(prevProps.currentProgramEnrollment, this.props.currentProgramEnrollment)) {
-      this.refreshSearchkit();
-    }
+    const switchingPrograms = !_.isEqual(prevProps.currentProgramEnrollment, this.props.currentProgramEnrollment);
+    this.refreshSearchkit(switchingPrograms);
   }
 
   render() {

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -61,7 +61,7 @@ export default class ProgramFilter extends SearchkitComponent {
 
       if (_.isEmpty(this.searchkit.state) && !clearState) {
         // workaround weird searchkit behavior which removes query parameter state
-        this.searchkit._searchWhenCompleted(window.location);
+        this.searchkit.searchFromUrlQuery(window.location.query);
       } else {
         this.searchkit.search();
       }

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -56,12 +56,7 @@ export default class ProgramFilter extends SearchkitComponent {
 
     if (this._accessor.state.getValue() !== currentProgramEnrollment.id) {
       this._accessor.state = this._accessor.state.setValue(currentProgramEnrollment.id);
-      if (this.searchkit.currentSearchRequest) {
-        // If there hasn't been a search request yet the value will be included as part of the initial
-        // search, so no need for an explicit search. Otherwise we need to trigger this to tell
-        // searchkit that we changed something.
-        this.searchkit.performSearch();
-      }
+      this.searchkit.performSearch();
     }
   };
 

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -17,7 +17,7 @@ class ProgramFilterAccessor extends StatefulAccessor {
   }
 
   buildOwnQuery(query: Object) {
-    let programId = this.state.getValue();
+    const programId = this.state.getValue();
     if (_.isNil(programId)) {
       return query;
     }

--- a/static/js/components/ProgramFilter.js
+++ b/static/js/components/ProgramFilter.js
@@ -36,30 +36,26 @@ class ProgramFilterAccessor extends StatefulAccessor {
 
 export default class ProgramFilter extends SearchkitComponent {
   props: {
-    currentProgramEnrollment: AvailableProgram,
+    currentProgramEnrollmentId: number,
   };
 
   _accessor = new ProgramFilterAccessor();
-
 
   defineAccessor() {
     return this._accessor;
   }
 
   refreshSearchkit = (clearState: bool) => {
-    const { currentProgramEnrollment } = this.props;
+    const { currentProgramEnrollmentId } = this.props;
 
-    if (_.isNil(currentProgramEnrollment)) {
-      // programs aren't loaded yet
-      return;
-    }
-
-    if (this._accessor.state.getValue() !== currentProgramEnrollment.id) {
+    if (this._accessor.state.getValue() !== currentProgramEnrollmentId) {
       if (clearState) {
         this.searchkit.resetState();
       }
-      this._accessor.state = this._accessor.state.setValue(currentProgramEnrollment.id);
-      this.searchkit.registrationCompleted.then(() => this.searchkit.performSearch());
+      this._accessor.state = this._accessor.state.setValue(currentProgramEnrollmentId);
+      this.searchkit.registrationCompleted.then(() => {
+        this.searchkit._searchWhenCompleted(window.location);
+      });
     }
   };
 
@@ -68,7 +64,7 @@ export default class ProgramFilter extends SearchkitComponent {
   }
 
   componentDidUpdate(prevProps: Object): void {
-    const switchingPrograms = !_.isEqual(prevProps.currentProgramEnrollment, this.props.currentProgramEnrollment);
+    const switchingPrograms = !_.isEqual(prevProps.currentProgramEnrollmentId, this.props.currentProgramEnrollmentId);
     this.refreshSearchkit(switchingPrograms);
   }
 

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -49,17 +49,7 @@ describe('LearnerSearchPage', function () {
   const renderSearch = () => {
     return renderComponent('/learners').then(([wrapper]) => {
       let searchkit = wrapper.find("SearchkitProvider").props().searchkit;
-      return searchkit.registrationCompleted.then(() => new Promise(resolve => {
-        // searchkit will trigger a search on load when loaded in a browser. I'm
-        // not sure why it's not happening in the test environment so this is
-        // done explicitly instead.
-        searchkit.search();
-
-        // wait 10 millis for the request to be made
-        setTimeout(() => {
-          resolve([wrapper]);
-        }, 10);
-      }));
+      return searchkit.registrationCompleted.then(() => Promise.resolve([wrapper]));
     });
   };
 

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -48,12 +48,18 @@ describe('LearnerSearchPage', function () {
 
   const renderSearch = () => {
     return renderComponent('/learners').then(([wrapper]) => {
-      return new Promise(resolve => {
+      let searchkit = wrapper.find("SearchkitProvider").props().searchkit;
+      return searchkit.registrationCompleted.then(() => new Promise(resolve => {
+        // searchkit will trigger a search on load when loaded in a browser. I'm
+        // not sure why it's not happening in the test environment so this is
+        // done explicitly instead.
+        searchkit.search();
+
         // wait 10 millis for the request to be made
         setTimeout(() => {
           resolve([wrapper]);
         }, 10);
-      });
+      }));
     });
   };
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3003

#### What's this PR do?
Changes `ProgramFilter` to use a `StatefulAccessor` which lets us propagate changes in the current enrollment to the state of the accessor when they happen. This lets us remove the workaround which calls `searchkit.resetState()`  which caused the existing query parameters to be removed.

#### How should this be manually tested?
Go to `/learners/?q=xyz` and verify that you see a text box with `xyz` in it. Click a facet then refresh the browser. It should remain selected after refresh. Switch programs and you should see the list of people change accordingly.

#### Any background context you want to provide?
This changes the behavior where we clear the search when switching between programs. I'm not sure what the ideal is here so I just left it alone.