### PR TITLE
Fixed course contact message for non fa courses

### DIFF
--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -524,6 +524,10 @@ class DashboardPage extends React.Component {
 
   renderCourseContactPaymentDialog() {
     const { ui } = this.props;
+    const program = this.getCurrentlyEnrolledProgram();
+    let messageTail = (
+      program && program.financial_aid_availability ? 'learners who have paid for the course.' : 'verified learners.'
+    );
     return (
       <Dialog
         title="Contact the Course Team"
@@ -537,7 +541,7 @@ class DashboardPage extends React.Component {
       >
         <div className="inner-content">
           <img src="/static/images/contact_course_team_icon.png" alt="Instructor icon" />
-          <p>This is a premium feature for learners who have paid for the course.</p>
+          <p>{`This is a premium feature for ${messageTail}`}</p>
         </div>
       </Dialog>
     );

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -526,7 +526,7 @@ class DashboardPage extends React.Component {
     const { ui } = this.props;
     const program = this.getCurrentlyEnrolledProgram();
     let messageTail = (
-      program && program.financial_aid_availability ? 'learners who have paid for the course.' : 'verified learners.'
+      program && program.financial_aid_availability ? 'learners who have paid for the course' : 'verified learners'
     );
     return (
       <Dialog
@@ -541,7 +541,7 @@ class DashboardPage extends React.Component {
       >
         <div className="inner-content">
           <img src="/static/images/contact_course_team_icon.png" alt="Instructor icon" />
-          <p>{`This is a premium feature for ${messageTail}`}</p>
+          <p>{`This is a premium feature for ${messageTail}.`}</p>
         </div>
       </Dialog>
     );

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -542,7 +542,7 @@ describe('DashboardPage', () => {
             contactLink.simulate('click');
           }).then((state) => {
             assert.equal(
-              wrapper.find('.inner-content > p').text()
+              wrapper.find('.inner-content > p').text(),
               faExpectedObj.expectedMessage
             );
             assert.isTrue(state.ui.paymentTeaserDialogVisibility);

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -542,7 +542,7 @@ describe('DashboardPage', () => {
             contactLink.simulate('click');
           }).then((state) => {
             assert.equal(
-              wrapper.find('.inner-content > p').text(),
+              document.querySelector('.inner-content > p').textContent,
               faExpectedObj.expectedMessage
             );
             assert.isTrue(state.ui.paymentTeaserDialogVisibility);

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -542,7 +542,7 @@ describe('DashboardPage', () => {
             contactLink.simulate('click');
           }).then((state) => {
             assert.equal(
-              document.querySelector('.inner-content > p').textContent,
+              wrapper.find('.inner-content > p').text()
               faExpectedObj.expectedMessage
             );
             assert.isTrue(state.ui.paymentTeaserDialogVisibility);


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2975

#### What's this PR do?
Fixes message on contact course dialog for non fa programs.

#### How should this be manually tested?
- open admin panel and add contact email to a course,
- then open dashboard and load the respective program
- click in contact course team link. Do this for programs with `financial aid` and  `no financial aid`

@pdpinch 
#### Screenshots (if appropriate)
<img width="774" alt="screen shot 2017-04-13 at 12 17 14 am" src="https://cloud.githubusercontent.com/assets/10431250/24975352/beaa4452-1fde-11e7-8ac9-e28db91a36f1.png">

<img width="922" alt="screen shot 2017-04-12 at 11 57 58 pm" src="https://cloud.githubusercontent.com/assets/10431250/24975363/cafe47e4-1fde-11e7-9f75-56e0bb661e03.png">

<img width="856" alt="screen shot 2017-04-12 at 11 58 26 pm" src="https://cloud.githubusercontent.com/assets/10431250/24975364/cb03674c-1fde-11e7-8280-5f02e296278f.png">

