### PR TITLE
CMS: increased file upload size of a document

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -26,5 +26,6 @@ server {
         uwsgi_pass web:8077;
         uwsgi_pass_request_headers on;
         uwsgi_pass_request_body on;
+        client_max_body_size 25M;
     }
 }

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -84,6 +84,7 @@ http {
             uwsgi_pass unix:/tmp/nginx.socket;
             uwsgi_pass_request_headers on;
             uwsgi_pass_request_body on;
+            client_max_body_size 25M;
         }
     }
 }

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -452,6 +452,7 @@ REACT_GA_DEBUG = get_var("REACT_GA_DEBUG", False)
 
 # Wagtail
 WAGTAIL_SITE_NAME = "MIT MicroMasters"
+WAGTAILIMAGES_MAX_UPLOAD_SIZE = get_var('WAGTAILIMAGES_MAX_UPLOAD_SIZE', 20971620)  # default 25 MB
 MEDIA_ROOT = get_var('MEDIA_ROOT', '/var/media/')
 MEDIA_URL = '/media/'
 MICROMASTERS_USE_S3 = get_var('MICROMASTERS_USE_S3', False)


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2988

#### What's this PR do?
Fixes the max upload size of the file.

#### How should this be manually tested?
- Use max 25mb image or pdf and upload to `http://192.168.99.100:8079/cms/documents/multiple/add/`

@pdpinch 