### PR TITLE
CMS: Text changes to 'Future Semester Dates' section

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -97,7 +97,7 @@
           </h3>
           {% for semester_date in  page.semester_dates.all %}
             <div class="semester-date">
-              {{ semester_date.semester_name }}: Courses start {{ semester_date.start_date }}
+              {{ semester_date.semester_name }}: starts {{ semester_date.start_date }}
             </div>
           {% endfor %}
         </div>


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3045

#### What's this PR do?
Changes text on 'Future Semester Dates'.

#### How should this be manually tested?
Create a program page from CMS and add semester and publish it. Then go to that page and view 'Future Semester Dates' section.

@pdpinch 
#### Screenshots (if appropriate)
<img width="419" alt="screen shot 2017-04-14 at 3 51 34 pm" src="https://cloud.githubusercontent.com/assets/10431250/25041654/dd099888-212a-11e7-9272-286d3558e7ed.png">
