### PR TITLE
Search: fixed error message, when there are no results

### DIFF
--- a/static/js/components/search/CustomNoHits.js
+++ b/static/js/components/search/CustomNoHits.js
@@ -4,7 +4,7 @@ import { NoHits } from 'searchkit';
 
 export default class CustomNoHits extends NoHits {
   render() {
-    let message;
+    let message = "There were no results found for this search. Please remove some filters or start over.";
 
     if ((this.hasHits() || this.isInitialLoading() || this.isLoading()) && !this.getError()) {
       return null;
@@ -13,14 +13,7 @@ export default class CustomNoHits extends NoHits {
     if (this.getError()) {
       if (this.getError().data && this.getError().data.detail) {
         message = this.getError().data.detail;
-      } else {
-        message = this.translate("NoHits.Error");
       }
-    } else {
-      const suggestion = this.getSuggestion();
-      const query = this.getQuery().getQueryString();
-      let infoKey = suggestion ? "NoHits.NoResultsFoundDidYouMean" : "NoHits.NoResultsFound";
-      message = this.translate(infoKey, {query: query, suggestion: suggestion});
     }
 
     return (

--- a/static/js/components/search/CustomNoHits_test.js
+++ b/static/js/components/search/CustomNoHits_test.js
@@ -38,7 +38,10 @@ describe('CustomNoHits', () => {
     sandbox.stub(CustomNoHits.prototype, 'getError').returns(false);
 
     let results = renderCustomNoHits();
-    assert.equal(results, "No results found for search students");
+    assert.equal(
+      results,
+      "There were no results found for this search. Please remove some filters or start over."
+    );
   });
 
   it('hid when have search results', () => {


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2182

#### What's this PR do?
- Show static error message in case of search error.

#### How should this be manually tested?
- Search some there where you are sure of no data

@pdpinch 
#### Screenshots (if appropriate)
<img width="645" alt="screen shot 2017-04-17 at 6 06 14 pm" src="https://cloud.githubusercontent.com/assets/10431250/25089710/b7909d5c-2398-11e7-9ce0-44f061f66e60.png">

