### PR TITLE
[Regression] Fixed recipient keys on email composition dialog

### DIFF
--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -172,6 +172,10 @@ describe('EmailCompositionDialog', () => {
         id: '2',
         name: "ES",
         value: "foo"
+      },{
+        id: '3',
+        name: "profile.birth_country",
+        value: "ES"
       }]
     }, { renderRecipients: SEARCH_RESULT_EMAIL_CONFIG.renderRecipients });
 
@@ -182,6 +186,10 @@ describe('EmailCompositionDialog', () => {
     assert.include(
       getDialog().querySelector('.sk-selected-filters').textContent,
       "Spain: foo"
+    );
+    assert.include(
+      getDialog().querySelector('.sk-selected-filters').textContent,
+      "Country of Birth: Spain"
     );
   });
 });

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -168,12 +168,20 @@ describe('EmailCompositionDialog', () => {
         id: '1',
         name: "program.enrollments.semester",
         value: "2015"
+      }, {
+        id: '2',
+        name: "ES",
+        value: "foo"
       }]
     }, { renderRecipients: SEARCH_RESULT_EMAIL_CONFIG.renderRecipients });
 
     assert.include(
-      getDialog().querySelector('.sk-selected-filters-option__name').textContent,
+      getDialog().querySelector('.sk-selected-filters').textContent,
       "Semester: 2015"
+    );
+    assert.include(
+      getDialog().querySelector('.sk-selected-filters').textContent,
+      "Spain: foo"
     );
   });
 });

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -166,14 +166,14 @@ describe('EmailCompositionDialog', () => {
     renderDialog({
       filters: [{
         id: '1',
-        name: "key",
-        value: "test"
+        name: "program.enrollments.semester",
+        value: "2015"
       }]
     }, { renderRecipients: SEARCH_RESULT_EMAIL_CONFIG.renderRecipients });
 
     assert.include(
       getDialog().querySelector('.sk-selected-filters-option__name').textContent,
-      "key: test"
+      "Semester: 2015"
     );
   });
 });

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -12,17 +12,31 @@ import type { Profile } from '../../flow/profileTypes';
 import type { Course } from '../../flow/programTypes';
 import type { EmailConfig, EmailState, Filter } from '../../flow/emailTypes';
 import { actions } from '../../lib/redux_rest.js';
+import { SEARCH_FACET_FIELD_LABEL_MAP } from '../../constants';
+import { makeCountryNameTranslations } from '../LearnerSearch';
 
 // NOTE: getEmailSendFunction is a function that returns a function. It is implemented this way
 // so that we can stub/mock the function that it returns (as we do in integration_test_helper.js)
 
-const renderFilterOptions = R.map(filter => (
-  <div className="sk-selected-filters-option sk-selected-filters__item" key={filter.id}>
-    <div className="sk-selected-filters-option__name">
-      {filter.name}: {filter.value}
+const countryNameTranslations: Object = makeCountryNameTranslations();
+const renderFilterOptions = R.map(filter => {
+  let labelKey;
+  if (R.isEmpty(filter.name)) {
+    labelKey = SEARCH_FACET_FIELD_LABEL_MAP[filter.id];
+  } else if (filter.name in SEARCH_FACET_FIELD_LABEL_MAP) {
+    labelKey = SEARCH_FACET_FIELD_LABEL_MAP[filter.name];
+  } else if (filter.name in countryNameTranslations) {
+    labelKey = countryNameTranslations[filter.name];
+  }
+
+  return (
+    <div className="sk-selected-filters-option sk-selected-filters__item" key={filter.id}>
+      <div className="sk-selected-filters-option__name">
+        {labelKey}: {filter.value}
+      </div>
     </div>
-  </div>
-));
+  );
+});
 
 export const COURSE_TEAM_EMAIL_CONFIG: EmailConfig = {
   title: 'Contact the Course Team',

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -20,7 +20,7 @@ import { makeCountryNameTranslations } from '../LearnerSearch';
 
 const countryNameTranslations: Object = makeCountryNameTranslations();
 const renderFilterOptions = R.map(filter => {
-  let labelKey;
+  let labelKey, labelValue;
   if (R.isEmpty(filter.name)) {
     labelKey = SEARCH_FACET_FIELD_LABEL_MAP[filter.id];
   } else if (filter.name in SEARCH_FACET_FIELD_LABEL_MAP) {
@@ -29,10 +29,16 @@ const renderFilterOptions = R.map(filter => {
     labelKey = countryNameTranslations[filter.name];
   }
 
+  if (filter.value in countryNameTranslations) {
+    labelValue = countryNameTranslations[filter.value];
+  } else {
+    labelValue = filter.value;
+  }
+
   return (
     <div className="sk-selected-filters-option sk-selected-filters__item" key={filter.id}>
       <div className="sk-selected-filters-option__name">
-        {labelKey}: {filter.value}
+        {labelKey}: {labelValue}
       </div>
     </div>
   );


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3071

#### What's this PR do?
Fixes regression of #2942, key if recipients object.  

#### How should this be manually tested?
select filter and open email dialog.

@pdpinch 
#### Screenshots (if appropriate)
<img width="812" alt="screen shot 2017-04-17 at 6 39 09 pm" src="https://cloud.githubusercontent.com/assets/10431250/25090528/2f303f26-239d-11e7-9720-3da27c7de0db.png">

<img width="680" alt="screen shot 2017-04-17 at 6 39 13 pm" src="https://cloud.githubusercontent.com/assets/10431250/25090529/2f5828c4-239d-11e7-94e7-a1d95aaba135.png">
