### PR TITLE
Fixed alter_data payment and grade issues, and cleaned up docs

### DIFF
--- a/seed_data/management/commands/alter_data_test.py
+++ b/seed_data/management/commands/alter_data_test.py
@@ -2,35 +2,57 @@
 Tests for alter_data commands
 """
 from decimal import Decimal
+import ddt
 from search.base import MockedESTestCase
 from seed_data.management.commands.alter_data import (
     set_to_passed,
     set_to_failed,
+    set_to_enrolled
 )
 from micromasters.factories import UserFactory
 from courses.factories import CourseRunFactory
+from dashboard.factories import ProgramEnrollmentFactory
 from dashboard.utils import get_mmtrack
 
 
+@ddt.ddt
 class AlterDataCommandTests(MockedESTestCase):
     """Test cases for alter_data commands"""
     @classmethod
     def setUpTestData(cls):
-        cls.user = UserFactory.create()
-        cls.course_run = CourseRunFactory.create()
+        cls.user = UserFactory.create(username='username1', email='email1@example.com')
+        cls.course_runs = {
+            'fa': CourseRunFactory.create(course__program__financial_aid_availability=True),
+            'non_fa': CourseRunFactory.create(course__program__financial_aid_availability=False)
+        }
+        for course_run in cls.course_runs.values():
+            ProgramEnrollmentFactory.create(user=cls.user, program=course_run.course.program)
 
-    def test_set_to_passed(self):
+    @ddt.data('fa', 'non_fa')
+    def test_set_to_passed(self, course_run_program_type):
         """set_to_passed should set a CourseRun to passed for a given User"""
+        course_run = self.course_runs[course_run_program_type]
         grade = Decimal('0.75')
-        set_to_passed(user=self.user, course_run=self.course_run, grade=grade)
-        mmtrack = get_mmtrack(self.user, self.course_run.course.program)
-        assert mmtrack.has_passed_course(self.course_run.edx_course_key)
-        assert int(mmtrack.get_final_grade_percent(self.course_run.edx_course_key)) == (grade * 100)
+        set_to_passed(user=self.user, course_run=course_run, grade=grade)
+        mmtrack = get_mmtrack(self.user, course_run.course.program)
+        assert mmtrack.has_passed_course(course_run.edx_course_key)
+        assert int(mmtrack.get_final_grade_percent(course_run.edx_course_key)) == (grade * 100)
 
-    def test_set_to_failed(self):
+    @ddt.data('fa', 'non_fa')
+    def test_set_to_failed(self, course_run_program_type):
         """set_to_failed should set a CourseRun to failed for a given User"""
+        course_run = self.course_runs[course_run_program_type]
         grade = Decimal('0.55')
-        set_to_failed(user=self.user, course_run=self.course_run, grade=grade)
-        mmtrack = get_mmtrack(self.user, self.course_run.course.program)
-        assert not mmtrack.has_passed_course(self.course_run.edx_course_key)
-        assert int(mmtrack.get_final_grade_percent(self.course_run.edx_course_key)) == (grade * 100)
+        set_to_failed(user=self.user, course_run=course_run, grade=grade)
+        mmtrack = get_mmtrack(self.user, course_run.course.program)
+        assert not mmtrack.has_passed_course(course_run.edx_course_key)
+        assert int(mmtrack.get_final_grade_percent(course_run.edx_course_key)) == (grade * 100)
+
+    @ddt.data('fa', 'non_fa')
+    def test_set_payment_status(self, course_run_program_type):
+        """Commands that set a User's payment status should work based on the audit flag value"""
+        course_run = self.course_runs[course_run_program_type]
+        for audit_setting in (True, False):
+            set_to_enrolled(user=self.user, course_run=course_run, audit=audit_setting)
+            mmtrack = get_mmtrack(self.user, course_run.course.program)
+            assert mmtrack.has_paid(course_run.edx_course_key) is not audit_setting


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #3072 

#### What's this PR do?

- Fixes the way that `alter_data` sets a user's payment status and grade for course runs
- Cleans up some docs
- Removes some obsolete functions

#### How should this be manually tested?

Run commands that change your user's payment/grading status in some course runs. Example commands:

```shell
# Set most recent course run in course to enrolled & unpaid
alter_data set_to_enrolled --username=YOUR_USERNAME --course-title='Analog Learning 100' --audit
# Set most recent course run in course to enrolled & paid
alter_data set_to_enrolled --username=YOUR_USERNAME --course-title='Analog Learning 100'
# Set most recent course run in course to passed & unpaid
alter_data set_to_passed --username=YOUR_USERNAME --course-title='Analog Learning 100' --audit
```

Do this with both 'Analog Learning' (non-FA) and 'Digital Learning' courses

#### Where should the reviewer start?
`alter_data.py`

