### PR TITLE
Fixed issue where date change is empty

### DIFF
--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -57,9 +57,15 @@ export default class FinancialAidCard extends React.Component {
     updateDocumentSentDate(financialAidId, documents.documentSentDate);
   };
 
+  setDocumentSentDate = (dateObj: moment): void => {
+    const { setDocumentSentDate } = this.props;
+    if (dateObj) {
+      setDocumentSentDate(dateObj.format(ISO_8601_FORMAT));
+    }
+  }
+
   renderDocumentStatus() {
     const {
-      setDocumentSentDate,
       documents: {
         documentSentDate,
         fetchStatus,
@@ -91,7 +97,7 @@ export default class FinancialAidCard extends React.Component {
           <Cell col={12} className="document-sent-button-container">
             <DatePicker
               selected={moment(documentSentDate)}
-              onChange={(obj) => setDocumentSentDate(obj.format(ISO_8601_FORMAT))}
+              onChange={this.setDocumentSentDate}
             />
             <SpinnerButton
               className="dashboard-button document-sent-button"


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2432

#### What's this PR do?
It fixes the issue on dashboard, which appears when you clear a date field using keyboard from FA calculator, when state is pending-doc. This is because date object is null at that time.

#### Note:
We dont need validation here because date widget is sticky, when u remove date and focus out the text field it automatically picks the current date.

#### How should this be manually tested?
- Go To dashboard, 
- Land to FA calculator with state pending doc. 
- Try to clear date using back space/delete
- See the console, there must be no error
- Focus out the text field, you will see the current date on it

@pdpinch 
#### Screenshots (if appropriate)
<img width="843" alt="screen shot 2017-04-19 at 4 54 27 pm" src="https://cloud.githubusercontent.com/assets/10431250/25179124/f2f4339c-2521-11e7-82dc-7dd75f283ae5.png">