### PR TITLE
Fixed bug with freeze grade management command not using the right value in a call

### DIFF
--- a/grades/management/commands/freeze_final_grades.py
+++ b/grades/management/commands/freeze_final_grades.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
             )
             return
 
-        freeze_course_run_final_grades.delay(run)
+        freeze_course_run_final_grades.delay(run.id)
         self.stdout.write(
             self.style.SUCCESS(
                 'Successfully submitted async task to freeze final grades for course "{0}"'.format(edx_course_key)


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
fixes a management command that was not updated to call the celery task using the ID and not an object

#### How should this be manually tested?
run the management command: it should not raise a JSON serialization error
