### PR TITLE
Pin selenium container to a non-broken version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       - grid
 
   grid:
-    image: elgalu/selenium
+    image: elgalu/selenium:2
 
 volumes:
   django_media: {}

--- a/travis-docker-compose.yml
+++ b/travis-docker-compose.yml
@@ -76,4 +76,4 @@ services:
       - grid
 
   grid:
-    image: elgalu/selenium
+    image: elgalu/selenium:2


### PR DESCRIPTION
#### What are the relevant tickets?
N/A, blocking deployments because failing Travis.

#### What's this PR do?
Fixes selenium tests that are failing Travis tests because new tags for the container got pushed.

#### How should this be manually tested?
If Travis passes, we're good.

#### Any background context you want to provide?
:notes: Cause if you want it to pass you better put a pin on it. :notes: 
