### PR TITLE
Fixed ProgramFactory price values (#3093)

### DIFF
--- a/courses/factories.py
+++ b/courses/factories.py
@@ -18,7 +18,7 @@ class ProgramFactory(DjangoModelFactory):
     live = factory.Faker('boolean')
     description = fuzzy.FuzzyText()
     exam_series_code = factory.Faker('lexify', text="????_MicroMasters")
-    price = fuzzy.FuzzyDecimal(low=0, high=12345)
+    price = fuzzy.FuzzyDecimal(low=100, high=12345)
 
     class Meta:
         model = Program


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3093

#### What's this PR do?
Increases the lowest `Program.price` the factory will generate so that the second generated `ProgramTier.discount_amount` will never be 0.

#### How should this be manually tested?
Tests should pass
