### PR TITLE
Exams: Updated Pearson TOS text

### DIFF
--- a/static/js/components/dashboard/FinalExamCard.js
+++ b/static/js/components/dashboard/FinalExamCard.js
@@ -152,13 +152,20 @@ const renderPearsonTOSDialog = (open, show, submitPearsonSSO, pearson) => (
     <div className="dialog-container">
       <img src="/static/images/pearson_vue.png" width="180"/>
       <h3 className="dialog-title">You are being redirected to Pearson VUE’s website.</h3>
-      <p className="tos-container">
+      <div className="tos-container">
+      <p>
         You acknowledge that by clicking Continue, you will be leaving the MITx MicroMasters website
         and going to a third-party website over which MIT’s MITx does not have control, and that you
-        accept the Pearson VUE Business Group’s Terms of Service. MIT is not responsible for the content
-        of third-party sites hyper-linked from the Pearson VUE website, nor does MIT guarantee or endorse
-        the information, recommendations, products or services offered on third-party sites.<br/><br/>
-        By clicking Continue, you further acknowledge, understand, and agree that:<br/><br/>
+        accept the Pearson VUE Business Group’s <a target="_blank"
+          href="https://home.pearsonvue.com/Legal/Privacy-and-cookies-policy.aspx">Terms of Service</a>.
+        MIT is not responsible for the content of third-party sites hyper-linked from the Pearson
+        VUE website, nor does MIT guarantee or endorse the information, recommendations,
+        products or services offered on third-party sites.
+      </p>
+      <p>
+        By clicking Continue, you further acknowledge, understand, and agree that:
+      </p>
+      <p>
         <b>MIT makes no representations or warranties of any kind regarding the facilities
         or services provided by Pearson VUE, including, but not limited to, at any Pearson
         VUE authorized testing center. MIT hereby disclaims all representations and warranties,
@@ -170,6 +177,7 @@ const renderPearsonTOSDialog = (open, show, submitPearsonSSO, pearson) => (
         from any and all claims, demands, suits, judgments, damages, actions and liabilities of
         every kind and nature whatsoever, that you may suffer at any time as a result of the Purpose.</b>
       </p>
+      </div>
       <p className="attention">
         By clicking Continue, I agree to above Terms and Conditions.
       </p>

--- a/static/js/components/dashboard/FinalExamCard.js
+++ b/static/js/components/dashboard/FinalExamCard.js
@@ -153,30 +153,30 @@ const renderPearsonTOSDialog = (open, show, submitPearsonSSO, pearson) => (
       <img src="/static/images/pearson_vue.png" width="180"/>
       <h3 className="dialog-title">You are being redirected to Pearson VUE’s website.</h3>
       <div className="tos-container">
-      <p>
-        You acknowledge that by clicking Continue, you will be leaving the MITx MicroMasters website
-        and going to a third-party website over which MIT’s MITx does not have control, and that you
-        accept the Pearson VUE Business Group’s <a target="_blank"
-          href="https://home.pearsonvue.com/Legal/Privacy-and-cookies-policy.aspx">Terms of Service</a>.
-        MIT is not responsible for the content of third-party sites hyper-linked from the Pearson
-        VUE website, nor does MIT guarantee or endorse the information, recommendations,
-        products or services offered on third-party sites.
-      </p>
-      <p>
-        By clicking Continue, you further acknowledge, understand, and agree that:
-      </p>
-      <p>
-        <b>MIT makes no representations or warranties of any kind regarding the facilities
-        or services provided by Pearson VUE, including, but not limited to, at any Pearson
-        VUE authorized testing center. MIT hereby disclaims all representations and warranties,
-        express or implied, including, without limitation, accuracy and fitness for a particular purpose.
-        To the extent permissible by law, you assume the risk of injury or loss or damage to property
-        while visiting any Pearson VUE testing center for in-person testing for any MITx MicroMasters
-        course (the “Purpose”). You hereby release MIT and all of its officers, directors, members,
-        employees, volunteers, agents, administrators, assigns, and contractors (collectively “Releasees”),
-        from any and all claims, demands, suits, judgments, damages, actions and liabilities of
-        every kind and nature whatsoever, that you may suffer at any time as a result of the Purpose.</b>
-      </p>
+        <p>
+          You acknowledge that by clicking Continue, you will be leaving the MITx MicroMasters website
+          and going to a third-party website over which MIT’s MITx does not have control, and that you
+          accept the Pearson VUE Business Group’s <a target="_blank"
+            href="https://home.pearsonvue.com/Legal/Privacy-and-cookies-policy.aspx">Terms of Service</a>.
+          MIT is not responsible for the content of third-party sites hyper-linked from the Pearson
+          VUE website, nor does MIT guarantee or endorse the information, recommendations,
+          products or services offered on third-party sites.
+        </p>
+        <p>
+          By clicking Continue, you further acknowledge, understand, and agree that:
+        </p>
+        <p>
+          <b>MIT makes no representations or warranties of any kind regarding the facilities
+          or services provided by Pearson VUE, including, but not limited to, at any Pearson
+          VUE authorized testing center. MIT hereby disclaims all representations and warranties,
+          express or implied, including, without limitation, accuracy and fitness for a particular purpose.
+          To the extent permissible by law, you assume the risk of injury or loss or damage to property
+          while visiting any Pearson VUE testing center for in-person testing for any MITx MicroMasters
+          course (the “Purpose”). You hereby release MIT and all of its officers, directors, members,
+          employees, volunteers, agents, administrators, assigns, and contractors (collectively “Releasees”),
+          from any and all claims, demands, suits, judgments, damages, actions and liabilities of
+          every kind and nature whatsoever, that you may suffer at any time as a result of the Purpose.</b>
+        </p>
       </div>
       <p className="attention">
         By clicking Continue, I agree to above Terms and Conditions.

--- a/static/js/components/dashboard/FinalExamCard.js
+++ b/static/js/components/dashboard/FinalExamCard.js
@@ -151,11 +151,27 @@ const renderPearsonTOSDialog = (open, show, submitPearsonSSO, pearson) => (
     autoScrollBodyContent={true}>
     <div className="dialog-container">
       <img src="/static/images/pearson_vue.png" width="180"/>
-      <h3 className="dialog-title">Test Registration is completed on the <br/>Pearson VUE website</h3>
-      <p>
-        I acknowledge that by clicking Continue I will be leaving the MicroMasters <br/>website and going to
-        the Pearson VUE website, and that I accept the <br/>Pearson VUE Group’s <a target="_blank"
-          href="https://home.pearsonvue.com/Legal/Privacy-and-cookies-policy.aspx">Terms of Service</a>.
+      <h3 className="dialog-title">You are being redirected to Pearson VUE’s website.</h3>
+      <p className="tos-container">
+        You acknowledge that by clicking Continue, you will be leaving the MITx MicroMasters website
+        and going to a third-party website over which MIT’s MITx does not have control, and that you
+        accept the Pearson VUE Business Group’s Terms of Service. MIT is not responsible for the content
+        of third-party sites hyper-linked from the Pearson VUE website, nor does MIT guarantee or endorse
+        the information, recommendations, products or services offered on third-party sites.<br/><br/>
+        By clicking Continue, you further acknowledge, understand, and agree that:<br/><br/>
+        <b>MIT makes no representations or warranties of any kind regarding the facilities
+        or services provided by Pearson VUE, including, but not limited to, at any Pearson
+        VUE authorized testing center. MIT hereby disclaims all representations and warranties,
+        express or implied, including, without limitation, accuracy and fitness for a particular purpose.
+        To the extent permissible by law, you assume the risk of injury or loss or damage to property
+        while visiting any Pearson VUE testing center for in-person testing for any MITx MicroMasters
+        course (the “Purpose”). You hereby release MIT and all of its officers, directors, members,
+        employees, volunteers, agents, administrators, assigns, and contractors (collectively “Releasees”),
+        from any and all claims, demands, suits, judgments, damages, actions and liabilities of
+        every kind and nature whatsoever, that you may suffer at any time as a result of the Purpose.</b>
+      </p>
+      <p className="attention">
+        By clicking Continue, I agree to above Terms and Conditions.
       </p>
     </div>
   </Dialog>

--- a/static/js/components/dashboard/FinalExamCard_test.js
+++ b/static/js/components/dashboard/FinalExamCard_test.js
@@ -165,20 +165,10 @@ pay for the course and pass the online work.`;
     assert.include(
       getEl(document, ".tos-container").textContent,
       'You acknowledge that by clicking Continue, you will be leaving the MITx MicroMasters ' +
-      'website and going to a third-party website over which MIT’s MITx does not have control, ' +
-      'and that you accept the Pearson VUE Business Group’s Terms of Service. MIT is not responsible ' +
-      'for the content of third-party sites hyper-linked from the Pearson VUE website, ' +
-      'nor does MIT guarantee or endorse the information, recommendations, products or ' +
-      'services offered on third-party sites.By clicking Continue, you further acknowledge, ' +
-      'understand, and agree that:MIT makes no representations or warranties of any kind regarding ' +
-      'the facilities or services provided by Pearson VUE, including, but not limited to, ' +
-      'at any Pearson VUE authorized testing center. MIT hereby disclaims all representations ' +
-      'and warranties, express or implied, including, without limitation, accuracy and ' +
-      'fitness for a particular purpose. To the extent permissible by law, you assume the ' +
-      'risk of injury or loss or damage to property while visiting any Pearson VUE testing ' +
-      'center for in-person testing for any MITx MicroMasters course (the “Purpose”). ' +
-      'You hereby release MIT and all of its officers, directors, members, employees, ' +
-      'volunteers, agents, administrators, assigns, and contractors (collectively “Releasees”),' +
+      'website and going to a third-party website over which MIT’s MITx does not have control, '
+    );
+    assert.include(
+      getEl(document, ".tos-container").textContent,
       ' from any and all claims, demands, suits, judgments, damages, actions and liabilities ' +
       'of every kind and nature whatsoever, that you may suffer at any time as a result of the Purpose.'
     );

--- a/static/js/components/dashboard/FinalExamCard_test.js
+++ b/static/js/components/dashboard/FinalExamCard_test.js
@@ -159,13 +159,32 @@ pay for the course and pass the online work.`;
     props.program.pearson_exam_status = PEARSON_PROFILE_SCHEDULABLE;
     renderCard(props);
     assert.include(
-      getEl(document, ".dialog-container").textContent,
-      "Test Registration is completed on the Pearson VUE website"
+      getEl(document, ".dialog-title").textContent,
+      "You are being redirected to Pearson VUE’s website."
     );
     assert.include(
-      getEl(document, ".dialog-container").textContent,
-      'I acknowledge that by clicking Continue I will be leaving the MicroMasters website and going to ' +
-      'the Pearson VUE website, and that I accept the Pearson VUE Group’s Terms of Service'
+      getEl(document, ".tos-container").textContent,
+      'You acknowledge that by clicking Continue, you will be leaving the MITx MicroMasters ' +
+      'website and going to a third-party website over which MIT’s MITx does not have control, ' +
+      'and that you accept the Pearson VUE Business Group’s Terms of Service. MIT is not responsible ' +
+      'for the content of third-party sites hyper-linked from the Pearson VUE website, ' +
+      'nor does MIT guarantee or endorse the information, recommendations, products or ' +
+      'services offered on third-party sites.By clicking Continue, you further acknowledge, ' +
+      'understand, and agree that:MIT makes no representations or warranties of any kind regarding ' +
+      'the facilities or services provided by Pearson VUE, including, but not limited to, ' +
+      'at any Pearson VUE authorized testing center. MIT hereby disclaims all representations ' +
+      'and warranties, express or implied, including, without limitation, accuracy and ' +
+      'fitness for a particular purpose. To the extent permissible by law, you assume the ' +
+      'risk of injury or loss or damage to property while visiting any Pearson VUE testing ' +
+      'center for in-person testing for any MITx MicroMasters course (the “Purpose”). ' +
+      'You hereby release MIT and all of its officers, directors, members, employees, ' +
+      'volunteers, agents, administrators, assigns, and contractors (collectively “Releasees”),' +
+      ' from any and all claims, demands, suits, judgments, damages, actions and liabilities ' +
+      'of every kind and nature whatsoever, that you may suffer at any time as a result of the Purpose.'
+    );
+    assert.include(
+       getEl(document, ".attention").textContent,
+       'By clicking Continue, I agree to above Terms and Conditions.'
     );
   });
 

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -493,16 +493,15 @@
 
       .tos-container {
         max-height: 200px;
-        overflow-x: hidden;
-        overflow-y: auto;
-        border: 1px solid $medgray;
+        overflow-y: scroll;
+        border: 1px solid $border-color;
         padding: 15px;
       }
 
       .attention {
         color: $medlightgray;
         font-size: 13px;
-        margin-left: 15px;
+        margin: 20px 0 0 15px;
       }
     }
 

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -490,6 +490,20 @@
       > p {
         color: $font-black;
       }
+
+      .tos-container {
+        max-height: 200px;
+        overflow-x: hidden;
+        overflow-y: auto;
+        border: 1px solid $medgray;
+        padding: 15px;
+      }
+
+      .attention {
+        color: $medlightgray;
+        font-size: 13px;
+        margin-left: 15px;
+      }
     }
 
     .actions {


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3086

#### What's this PR do?
- Updates Pearson TOS text on a dialog, see image below

#### How should this be manually tested?
- you must have `FEATURE_EXAMS=True` flag.
- and `program.pearson_exam_status=PEARSON_PROFILE_SCHEDULABLE` in `static/js/components/dashboard/FinalExamCard.js`

@pdpinch 
#### Screenshots (if appropriate):
<img width="691" alt="screen shot 2017-04-21 at 3 36 04 pm" src="https://cloud.githubusercontent.com/assets/10431250/25274356/1e05fa1a-26a9-11e7-96e7-a9acd177f467.png">

