### PR TITLE
Shown public_to_mm profiles when requesting user is enrolled in one of the programs where profile user is enrolled

### DIFF
--- a/profiles/permissions.py
+++ b/profiles/permissions.py
@@ -13,6 +13,7 @@ from roles.roles import (
     Staff,
 )
 from profiles.models import Profile
+from dashboard.models import ProgramEnrollment
 
 
 class CanEditIfOwner(BasePermission):
@@ -60,8 +61,9 @@ class CanSeeIfNotPrivate(BasePermission):
             # anonymous user accessing profiles.
             if request.user.is_anonymous():
                 raise Http404
-            # user who is not a micromaster verified user is accessing profiles.
-            elif not request.user.profile.verified_micromaster_user:
+            # requesting user must have enrollment in one of program where profile user is enroll.
+            program_ids = ProgramEnrollment.objects.filter(user=profile.user).values_list('program__id', flat=True)
+            if not ProgramEnrollment.objects.filter(user=request.user, program__id__in=program_ids).exists():
                 raise Http404
         elif profile.account_privacy not in [Profile.PRIVATE, Profile.PUBLIC_TO_MM, Profile.PUBLIC]:
             raise Http404

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -194,6 +194,16 @@ class ProfileGETTests(ProfileBaseTests):
         with mute_signals(post_save):
             profile = ProfileFactory.create(user=self.user2, account_privacy=Profile.PUBLIC_TO_MM)
             ProfileFactory.create(user=self.user1, verified_micromaster_user=True)
+            program = ProgramFactory.create()
+            ProgramEnrollment.objects.create(
+                program=program,
+                user=self.user2,
+            )
+            ProgramEnrollment.objects.create(
+                program=program,
+                user=self.user1,
+            )
+
         profile_data = ProfileLimitedSerializer(profile).data
         self.client.force_login(self.user1)
         resp = self.client.get(self.url2)


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/2947#issuecomment-296650753

#### What's this PR do?
- Now non staff users can view  public_to_mm profiles, when they are enrolled in one of the programs where profile user is enrolled.
- Staff can already view profiles.

#### How should this be manually tested?
- Create a learner and try to view profile of other learner in same program.
- Create a learner and try to view profile of other learner in other program.

@pdpinch 
