### PR TITLE
implement simple exam grade display

### DIFF
--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -102,7 +102,7 @@ export default class CourseRow extends React.Component {
     if (this.shouldDisplayGradeColumn(run)) {
       columns.push(
         <Cell col={3} key="2">
-          <CourseGrade courseRun={run} />
+          <CourseGrade courseRun={run} course={course} />
         </Cell>
       );
       lastColumnSize = 3;

--- a/static/js/components/dashboard/CourseRow_test.js
+++ b/static/js/components/dashboard/CourseRow_test.js
@@ -84,7 +84,7 @@ describe('CourseRow', () => {
     assert.deepEqual(descriptionProps.courseRun, courseRun);
     assert.deepEqual(descriptionProps.courseTitle, courseTitle);
     assert.deepEqual(wrapper.find(CourseGrade).props(), {
-      courseRun,
+      courseRun, course,
     });
     let subRowProps = wrapper.find("CourseSubRow").props();
     for (const key of keys) {

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -1,7 +1,7 @@
 // @flow
 import R from 'ramda';
 import Decimal from 'decimal.js-light';
-
+import moment from 'moment';
 import {
   COUPON_TYPE_STANDARD,
   STATUS_OFFERED,
@@ -28,6 +28,7 @@ import type {
   Course,
   CourseRun,
   Program,
+  ProctoredExamResult,
 } from '../flow/programTypes';
 
 const makeCounter = (): (() => number) => {
@@ -141,3 +142,18 @@ export const makeCoursePrice = (program: Program): CoursePrice => ({
 export const makeCoursePrices = (dashboard: Dashboard): CoursePrices => (
   dashboard.programs.map(makeCoursePrice)
 );
+
+export const makeProctoredExamResult = (): ProctoredExamResult => {
+  let passingScore = Math.random() * 100;
+  let score = Math.random() * 100;
+
+  return {
+    exam_date:               moment().format(),
+    passing_score:           passingScore,
+    score:                   score,
+    grade:                   score > passingScore ? 'Pass' : 'Fail',
+    client_authorization_id: 'asdfj3j3rj;lkjd',
+    passed:                  score > passingScore,
+    percentage_grade:        score / 100,
+  };
+};

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -29,22 +29,33 @@ export type FinancialAidUserInfo = {
 };
 
 export type Program = {
-  courses: Array<Course>,
-  id: number,
-  title: string,
+  courses:                    Array<Course>,
+  id:                         number,
+  title:                      string,
   financial_aid_availability: boolean,
-  financial_aid_user_info: FinancialAidUserInfo,
-  pearson_exam_status: string,
-  grade_average: ?number,
+  financial_aid_user_info:    FinancialAidUserInfo,
+  pearson_exam_status:        string,
+  grade_average:              ?number,
+};
+
+export type ProctoredExamResult = {
+  exam_date:               string,
+  passing_score:           number,
+  score:                   number,
+  grade:                   string,
+  client_authorization_id: string,
+  passed:                  boolean,
+  percentage_grade:        number
 };
 
 export type Course = {
-  runs: Array<CourseRun>,
-  title: string,
-  has_contact_email: boolean,
-  id: number,
-  position_in_program: number,
-  can_schedule_exam: boolean,
+  runs:                     Array<CourseRun>,
+  title:                    string,
+  has_contact_email:        boolean,
+  id:                       number,
+  position_in_program:      number,
+  can_schedule_exam:        boolean,
+  proctorate_exams_grades?: Array<ProctoredExamResult>,
 };
 
 export type ProgramPageCourse = {
@@ -56,21 +67,21 @@ export type ProgramPageCourse = {
 };
 
 export type CourseRun = {
-  id: number,
-  position: number,
-  current_grade?: number,
-  final_grade?: number,
-  course_id: string,
-  title: string,
+  id:                           number,
+  position:                     number,
+  current_grade?:               number,
+  final_grade?:                 number,
+  course_id:                    string,
+  title:                        string,
   fuzzy_enrollment_start_date?: string,
-  status: string,
-  enrollment_start_date?: string,
-  fuzzy_start_date?: string,
-  course_start_date?: string,
-  course_end_date?: string,
-  course_upgrade_deadline?: string,
-  price?: number,
-  enrollment_url?: ?string,
+  status:                       string,
+  enrollment_start_date?:       string,
+  fuzzy_start_date?:            string,
+  course_start_date?:           string,
+  course_end_date?:             string,
+  course_upgrade_deadline?:     string,
+  price?:                       number,
+  enrollment_url?:              ?string,
 };
 
 export type UserProgram = {

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -200,6 +200,10 @@
         .caption {
           color: $darkgray;
           font-size: 9pt;
+
+          &:not(:last-child) {
+            padding-bottom: 10px;
+          }
         }
       }
 


### PR DESCRIPTION
#### What are the relevant tickets?

a temporary shim for part of #2792

#### What's this PR do?

this just implements a super basic display of the highest exam grade (per-course) on the dashboard.

#### How should this be manually tested?

Add an exam grade to a course you're enrolled in, and you should see it on the dashboard. Add two exams, and you should see the highest grade.

![weewewewewe](https://cloud.githubusercontent.com/assets/6207644/25394144/73817744-29ab-11e7-8db7-562fa9639f36.png)

