### PR TITLE
Mail: Filter recipient variables

### DIFF
--- a/mail/api.py
+++ b/mail/api.py
@@ -20,6 +20,7 @@ from mail.models import (
     FinancialAidEmailAudit,
     SentAutomaticEmail,
 )
+from mail.utils import filter_recipient_variables
 from micromasters.utils import chunks
 from search.api import (
     adjust_search_for_percolator,
@@ -145,9 +146,9 @@ class MailgunClient:
 
             params = {
                 'to': emails,
-                'subject': subject,
-                'html': body,
-                'text': fallback_text,
+                'subject': filter_recipient_variables(subject),
+                'html': filter_recipient_variables(body),
+                'text': filter_recipient_variables(fallback_text),
                 'recipient-variables': json.dumps(chunk_dict),
             }
             if sender_address:

--- a/mail/utils.py
+++ b/mail/utils.py
@@ -21,6 +21,11 @@ from financialaid.constants import (
 
 log = logging.getLogger(__name__)
 
+RECIPIENT_VARIABLE_NAMES = {
+    'PreferredName': 'preferred_name',
+    'Email': 'email',
+}
+
 
 def generate_financial_aid_email(financial_aid):
     """
@@ -95,11 +100,8 @@ def filter_recipient_variables(text):
     Returns:
         string: with replaced correct recipient variables
     """
-    substitute_values = {
-        'PreferredName': 'recipient.preferred_name',
-        'Email': 'recipient.email',
-    }
-    for key, value in substitute_values.items():
-        text = text.replace('[{}]'.format(key), '%{}%'.format(value))
+
+    for key, value in RECIPIENT_VARIABLE_NAMES.items():
+        text = text.replace('[{}]'.format(key), '%recipient.{}%'.format(value))
 
     return text

--- a/mail/utils.py
+++ b/mail/utils.py
@@ -88,6 +88,13 @@ def generate_mailgun_response_json(response):
 
 
 def filter_recipient_variables(text):
+    """
+    Filter out recipient variables, like [PreferredName], and substitute it with %recipient.preferred_name%
+    Args:
+        text (string): subject or body of the email
+    Returns:
+        string: with replaced correct recipient variables
+    """
     substitute_values = {
         'PreferredName': 'recipient.preferred_name',
         'Email': 'recipient.email',

--- a/mail/utils.py
+++ b/mail/utils.py
@@ -85,3 +85,14 @@ def generate_mailgun_response_json(response):
             "message": response.reason
         }
     return response_json
+
+
+def filter_recipient_variables(text):
+    substitute_values = {
+        'PreferredName': 'recipient.preferred_name',
+        'Email': 'recipient.email',
+    }
+    for key, value in substitute_values.items():
+        text = text.replace('[{}]'.format(key), '%{}%'.format(value))
+
+    return text

--- a/mail/utils_test.py
+++ b/mail/utils_test.py
@@ -21,7 +21,12 @@ from financialaid.constants import (
     FinancialAidStatus
 )
 from financialaid.factories import FinancialAidFactory
-from mail.utils import generate_financial_aid_email, generate_mailgun_response_json
+from mail.utils import (
+    generate_financial_aid_email,
+    generate_mailgun_response_json,
+    filter_recipient_variables,
+    RECIPIENT_VARIABLE_NAMES,
+)
 from mail.views_test import mocked_json
 from search.base import MockedESTestCase
 
@@ -133,3 +138,11 @@ class MailUtilsTests(MockedESTestCase):
             generate_mailgun_response_json(response),
             {"message": response.reason}
         )
+
+    def test_filter_recipient_variables(self):
+        """
+        Test that recipient variables get to mailgun format, e.g. %recipient.[variable_name]%
+        """
+        text = ' '.join(map('[{}]'.format, RECIPIENT_VARIABLE_NAMES.keys()))
+        result = ' '.join(map('%recipient.{}%'.format, RECIPIENT_VARIABLE_NAMES.values()))
+        assert filter_recipient_variables(text) == result


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #2949

#### What's this PR do?
Convert users inserted variables like `[PreferredName]` to mailgun recipient variables `%recipient.preferred_name%`

#### How should this be manually tested?
Send an email to your user (with your email address). Use [PreferredName] and [Email] in the header or body of the email. Make sure your variable `MAILGUN_RECIPIENT_OVERRIDE` is not set.
