### PR TITLE
Center align toast message

### DIFF
--- a/static/scss/toast.scss
+++ b/static/scss/toast.scss
@@ -20,6 +20,9 @@
 
     .toast-body {
       padding: 0 10px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
 
       h1 {
         font-size: 18px;

--- a/static/scss/toast.scss
+++ b/static/scss/toast.scss
@@ -21,8 +21,7 @@
     .toast-body {
       padding: 0 10px;
       display: flex;
-      flex-direction: column;
-      justify-content: center;
+      align-items: center;
 
       h1 {
         font-size: 18px;


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/2725

#### What's this PR do?
CSS fix to align toast message to center.

#### How should this be manually tested?
Go to dashboard enroll in a course, you will get a message.

@pdpinch 
#### Screenshots (if appropriate)
<img width="674" alt="screen shot 2017-04-28 at 3 17 21 pm" src="https://cloud.githubusercontent.com/assets/10431250/25525217/3b5d8866-2c27-11e7-9cbb-c95fd2a05dcd.png">


<img width="735" alt="screen shot 2017-04-28 at 3 25 33 pm" src="https://cloud.githubusercontent.com/assets/10431250/25525218/3b8745fc-2c27-11e7-9907-139991e98ab7.png">

