### PR TITLE
Switched off is_public flag from financial_aid footer

### DIFF
--- a/financialaid/views.py
+++ b/financialaid/views.py
@@ -241,7 +241,7 @@ class ReviewFinancialAidView(UserPassesTestMixin, ListView):
         }
         context["js_settings_json"] = json.dumps(js_settings)
         context["authenticated"] = not self.request.user.is_anonymous()
-        context["is_public"] = True
+        context["is_public"] = False
         context["has_zendesk_widget"] = True
         context["is_staff"] = has_role(self.request.user, [Staff.ROLE_ID, Instructor.ROLE_ID])
         return context

--- a/financialaid/views_test.py
+++ b/financialaid/views_test.py
@@ -252,14 +252,12 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
                 'financial_aid',
                 'sentry_client',
                 'style',
-                'style_public',
                 'zendesk_widget',
             }
 
             assert response.context['has_zendesk_widget'] is True
-            assert response.context['is_public'] is Flase
+            assert response.context['is_public'] is False
             assert response.context['is_staff'] is True
-            self.assertContains(response, 'Share this page')
             assert json.loads(response.context['js_settings_json']) == {
                 'gaTrackingID': ga_tracking_id,
                 'reactGaDebug': react_ga_debug,

--- a/financialaid/views_test.py
+++ b/financialaid/views_test.py
@@ -257,7 +257,7 @@ class ReviewTests(FinancialAidBaseTestCase, APIClient):
             }
 
             assert response.context['has_zendesk_widget'] is True
-            assert response.context['is_public'] is True
+            assert response.context['is_public'] is Flase
             assert response.context['is_staff'] is True
             self.assertContains(response, 'Share this page')
             assert json.loads(response.context['js_settings_json']) == {


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/1928

#### What's this PR do?
hid social icons and public things from footer of FA review

#### How should this be manually tested?
go to FA review form and see social icons are not available.

@pdpinch 
#### Screenshots (if appropriate)
<img width="643" alt="screen shot 2017-04-28 at 3 44 09 pm" src="https://cloud.githubusercontent.com/assets/10431250/25525740/bd88d848-2c29-11e7-8445-078a4ee20c14.png">

