### PR TITLE
Fix sending mails with automatic checked

### DIFF
--- a/mail/api.py
+++ b/mail/api.py
@@ -375,7 +375,7 @@ def get_mail_vars(emails):
 
     Returns:
         generator of dict:
-            A dictionary of template variables along with email so we can tell who is who
+            A dictionary of template variables which includes email so we can tell who is who
     """
     queryset = User.objects.filter(email__in=emails).values(
         'email',

--- a/mail/views.py
+++ b/mail/views.py
@@ -152,7 +152,7 @@ class SearchResultMailView(APIView):
                     MailgunClient.send_batch(
                         subject=email_subject,
                         body=email_body,
-                        recipients=get_mail_vars(recipient_emails),
+                        recipients=((context['email'], context) for context in get_mail_vars(recipient_emails)),
                         sender_name=sender_name,
                     )
             except SendBatchException as send_batch_exception:

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -209,7 +209,7 @@ class AutomaticEmailTests(SearchResultMailViewsBase):
         _, called_kwargs = mock_mailgun_client.send_batch.call_args
         assert called_kwargs['subject'] == self.request_data['email_subject']
         assert called_kwargs['body'] == self.request_data['email_body']
-        assert called_kwargs['recipients'] == [context for _, context in self.recipient_tuples]
+        assert list(called_kwargs['recipients']) == self.recipient_tuples
 
         assert mock_add_automatic_email.call_args[0][0].to_dict() == self.search_obj.to_dict()
         assert mock_add_automatic_email.call_args[1] == {
@@ -254,7 +254,7 @@ class AutomaticEmailTests(SearchResultMailViewsBase):
         _, called_kwargs = mock_mailgun_client.send_batch.call_args
         assert called_kwargs['subject'] == self.request_data['email_subject']
         assert called_kwargs['body'] == self.request_data['email_body']
-        assert called_kwargs['recipients'] == [context for _, context in self.recipient_tuples]
+        assert list(called_kwargs['recipients']) == self.recipient_tuples
 
         assert mock_add_automatic_email.call_args[0][0].to_dict() == self.search_obj.to_dict()
         assert mock_add_automatic_email.call_args[1] == {


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #2241 

#### What's this PR do?
Fixes a bug where `send_batch` was expecting email/context pairs but we were only sending the context.

#### How should this be manually tested?
With `MAILGUN_RECIPIENT_OVERRIDE` set, go to the learner search page. Send an email to some selection of users with the automatic option selected. Verify that you received an email with the list of emails that matches the search list (some may be missing if `email_optin` was false for that user)
