### PR TITLE
Firefox fixed email type radios

### DIFF
--- a/static/scss/email-composition-dialog.scss
+++ b/static/scss/email-composition-dialog.scss
@@ -126,13 +126,13 @@
       font-size: 15px;
     }
 
-    > div:first-child {
-      max-width: 35%;
-    }
-  }
+    > div {
+      display: flex !important;
 
-  .send-one-time-email {
-    display: flex !important;
+      &:first-child {
+        max-width: 35%;
+      }
+    }
   }
 
   .email-campaign-content {

--- a/static/scss/email-composition-dialog.scss
+++ b/static/scss/email-composition-dialog.scss
@@ -131,6 +131,10 @@
     }
   }
 
+  .send-one-time-email {
+    display: flex !important;
+  }
+
   .email-campaign-content {
     margin: 10px 5px 0;
     font-size: 14px;


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3111

#### What's this PR do?
fixes the style of radio buttons on email dialog search.

#### How should this be manually tested?
Go to learners search page as staff and op email dialog

#### Screenshots (if appropriate)
<img width="838" alt="screen shot 2017-05-03 at 12 48 49 am" src="https://cloud.githubusercontent.com/assets/10431250/25636946/814e1c46-2f9c-11e7-8e23-129aa875c030.png">
