### PR TITLE
Don't prompt for confirmation when running migrations locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     command: >
       /bin/bash -c '
       sleep 3 &&
-      python3 manage.py migrate &&
+      python3 manage.py migrate --no-input &&
       uwsgi uwsgi.ini'
     ports:
       - "8077:8077"


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Skips confirmation for the migrate command run when starting the web docker container.

#### How should this be manually tested?
Run `docker-compose up` and verify that the web container is up and running
