### PR TITLE
Fixed exam auth operation on exam run update (#3133)

### DIFF
--- a/exams/api.py
+++ b/exams/api.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import pytz
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.db.models import Q
 
 from dashboard.models import (
     CachedEnrollment,
@@ -161,7 +162,9 @@ def update_authorizations_for_exam_run(exam_run):
         exam_run(exams.models.ExamRun): the ExamRun that updated
     """
     # Update all existing auths to pending
-    ExamAuthorization.objects.filter(exam_run=exam_run).exclude(exam_taken=True).update(
+    ExamAuthorization.objects.filter(exam_run=exam_run).exclude(
+        Q(status=ExamAuthorization.STATUS_PENDING) | Q(exam_taken=True)
+    ).update(
         status=ExamAuthorization.STATUS_PENDING,
         operation=ExamAuthorization.OPERATION_UPDATE,
         updated_on=datetime.now(pytz.utc)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3133

#### What's this PR do?
Addresses a race condition where the signal that triggers on `ExamRun.post_save` incorrectly sets `ExamAuhorization.operation` to `ExamAuthorization.OPERATION_UPDATE` when they haven't been created yet.

#### How should this be manually tested?

- Ensure you have a user with that is paid and has a final grade for a course
- Create an exam run for that course, set schedule first date to now
- Run `exams.tasks.authorize_exam_runs()` and ensure you get an `ExamAuthorization and it keeps `operation == 'update'`
