### PR TITLE
Fixed CourseRunFactory.edx_course_key against collisions (#3113)

### DIFF
--- a/courses/factories.py
+++ b/courses/factories.py
@@ -1,6 +1,4 @@
 """Factories for making test data"""
-from random import randint
-
 import faker
 import pytz
 import factory
@@ -67,8 +65,8 @@ class CourseRunFactory(DjangoModelFactory):
     )
     course = factory.SubFactory(CourseFactory)
     # Try to make sure we escape this correctly
-    edx_course_key = factory.LazyAttribute(
-        lambda x: "course:/v{}/{}".format(randint(1, 100), FAKE.slug())
+    edx_course_key = factory.Sequence(
+        lambda number: "course:/v{}/{}".format(number, FAKE.slug())
     )
     enrollment_start = factory.Faker(
         'date_time_this_month', before_now=True, after_now=False, tzinfo=pytz.utc


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3113 

#### What's this PR do?
Converts the factory to use a sequence so the keys don't collide.

#### How should this be manually tested?
Tests should pass
