### PR TITLE
Fixed missing module column in exam auth export (#3142)

### DIFF
--- a/exams/pearson/writers.py
+++ b/exams/pearson/writers.py
@@ -272,6 +272,7 @@ class EADWriter(BaseTSVWriter):
             ('ClientAuthorizationID', 'id'),
             ('ClientCandidateID', 'user.profile.student_id'),
             ('ExamSeriesCode', 'exam_run.exam_series_code'),
+            ('Modules', lambda _: ''),
             ('Accommodations', lambda _: ''),
             ('EligibilityApptDateFirst', lambda exam_auth: self.format_date(exam_auth.exam_run.date_first_eligible)),
             ('EligibilityApptDateLast', lambda exam_auth: self.format_date(exam_auth.exam_run.date_last_eligible)),

--- a/exams/pearson/writers_test.py
+++ b/exams/pearson/writers_test.py
@@ -374,7 +374,7 @@ class EADWriterTest(TSVWriterTestCase, TestCase):
 
         assert self.tsv_header == (
             "AuthorizationTransactionType\tClientAuthorizationID\t"
-            "ClientCandidateID\tExamSeriesCode\t"
+            "ClientCandidateID\tExamSeriesCode\tModules\t"
             "Accommodations\tEligibilityApptDateFirst\tEligibilityApptDateLast\t"
             "LastUpdate"
         )
@@ -400,7 +400,7 @@ class EADWriterTest(TSVWriterTestCase, TestCase):
 
         assert self.tsv_rows[0] == (
             "add\t143\t"
-            "14879\tMM-DEDP\t"
+            "14879\tMM-DEDP\t\t"
             "\t2016/05/15\t2016/10/15\t"  # accommodation blank intentionally
             "2016/05/15 15:02:55"
         )


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3142 

#### What's this PR do?
Adds this column back in but with an fixed empty string value

#### How should this be manually tested?
Tests should pass, this is simple enough change.