### PR TITLE
Release 0.57.4

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+Version 0.57.4
+--------------
+
+- Fixed missing module column in exam auth export (#3142)
+- Pass through code coverage environment variables (#3140)
+- Fixed CourseRunFactory.edx_course_key against collisions (#3113)
+
 Version 0.57.3
 --------------
 

--- a/courses/factories.py
+++ b/courses/factories.py
@@ -1,6 +1,4 @@
 """Factories for making test data"""
-from random import randint
-
 import faker
 import pytz
 import factory
@@ -67,8 +65,8 @@ class CourseRunFactory(DjangoModelFactory):
     )
     course = factory.SubFactory(CourseFactory)
     # Try to make sure we escape this correctly
-    edx_course_key = factory.LazyAttribute(
-        lambda x: "course:/v{}/{}".format(randint(1, 100), FAKE.slug())
+    edx_course_key = factory.Sequence(
+        lambda number: "course:/v{}/{}".format(number, FAKE.slug())
     )
     enrollment_start = factory.Faker(
         'date_time_this_month', before_now=True, after_now=False, tzinfo=pytz.utc

--- a/exams/pearson/writers.py
+++ b/exams/pearson/writers.py
@@ -272,6 +272,7 @@ class EADWriter(BaseTSVWriter):
             ('ClientAuthorizationID', 'id'),
             ('ClientCandidateID', 'user.profile.student_id'),
             ('ExamSeriesCode', 'exam_run.exam_series_code'),
+            ('Modules', lambda _: ''),
             ('Accommodations', lambda _: ''),
             ('EligibilityApptDateFirst', lambda exam_auth: self.format_date(exam_auth.exam_run.date_first_eligible)),
             ('EligibilityApptDateLast', lambda exam_auth: self.format_date(exam_auth.exam_run.date_last_eligible)),

--- a/exams/pearson/writers_test.py
+++ b/exams/pearson/writers_test.py
@@ -374,7 +374,7 @@ class EADWriterTest(TSVWriterTestCase, TestCase):
 
         assert self.tsv_header == (
             "AuthorizationTransactionType\tClientAuthorizationID\t"
-            "ClientCandidateID\tExamSeriesCode\t"
+            "ClientCandidateID\tExamSeriesCode\tModules\t"
             "Accommodations\tEligibilityApptDateFirst\tEligibilityApptDateLast\t"
             "LastUpdate"
         )
@@ -400,7 +400,7 @@ class EADWriterTest(TSVWriterTestCase, TestCase):
 
         assert self.tsv_rows[0] == (
             "add\t143\t"
-            "14879\tMM-DEDP\t"
+            "14879\tMM-DEDP\t\t"
             "\t2016/05/15\t2016/10/15\t"  # accommodation blank intentionally
             "2016/05/15 15:02:55"
         )

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -22,7 +22,7 @@ from celery.schedules import crontab
 from django.core.exceptions import ImproperlyConfigured
 
 
-VERSION = "0.57.3"
+VERSION = "0.57.4"
 
 CONFIG_PATHS = [
     os.environ.get('MICROMASTERS_CONFIG', ''),

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ passenv =
     BROKER_URL
     CELERY_RESULT_BACKEND
     PORT
+    TRAVIS*
+    CI
 setenv =
     ELASTICSEARCH_INDEX=testindex
     DEBUG=False


### PR DESCRIPTION
## Nathan Levesque
  - [x] Fixed missing module column in exam auth export (#3142) ([57580c61](../commit/57580c61e46f23668cbe62f78b09466bb834ee01))
  - [x] Fixed CourseRunFactory.edx_course_key against collisions (#3113) ([b7811309](../commit/b78113092441857551d44a3fb7f3728beb02945f))

## George Schneeloch
  - [x] Pass through code coverage environment variables (#3140) ([c2df4a03](../commit/c2df4a03d179c4bf831cc29532f6e353e9d4eb54))