### PR TITLE
Fixed an issue with old ExamAuthorizations updating (#3146)

### DIFF
--- a/exams/api.py
+++ b/exams/api.py
@@ -161,6 +161,9 @@ def update_authorizations_for_exam_run(exam_run):
     Args:
         exam_run(exams.models.ExamRun): the ExamRun that updated
     """
+    if not exam_run.is_schedulable:
+        return
+
     # Update all existing auths to pending
     ExamAuthorization.objects.filter(exam_run=exam_run).exclude(
         Q(status=ExamAuthorization.STATUS_PENDING) | Q(exam_taken=True)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3146 

#### What's this PR do?
Adds a check not to update `ExamAuthorizations` if the `ExamRun` is not currently schedulable.

#### How should this be manually tested?
If the tests pass, that's sufficient.