### PR TITLE
Small css change to headers on tab pages

### DIFF
--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -245,6 +245,12 @@
       margin-top: 44px;
       margin-bottom: 36px;
     }
+
+    h3 {
+      color: $mm-brand-bg;
+      font-size: 20px;
+      font-weight: 500;
+    }
   }
 
   .faqs {
@@ -252,12 +258,6 @@
 
     @include breakpoint(phone) {
       margin: 18px auto;
-    }
-
-    h3.faq-category {
-      color: $mm-brand-bg;
-      font-size: 20px;
-      font-weight: 500;
     }
 
     * {


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/2811

#### What's this PR do?
This is a very small css change, so that the h3 header styles are consistent on all tab pages. Currently, the H3 header on the FAQ page has a selector specifically for that page. This PR, makes the selector for H3 applicable to all tab pages.

#### How should this be manually tested?
To test this, create a new program page tab in the CMS. In the rich text editor, enter some text and make it an H3. See that this style matches the header style on the current program page FAQ tab.
