### PR TITLE
Fixed is_exam_schedulable to check schedule dates (#3150)

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -16,7 +16,7 @@ from financialaid.serializers import FinancialAidDashboardSerializer
 from grades import api
 from grades.models import FinalGrade
 from grades.serializers import ProctoredExamGradeSerializer
-from exams.models import ExamAuthorization
+from exams.models import ExamAuthorization, ExamRun
 
 log = logging.getLogger(__name__)
 
@@ -426,4 +426,5 @@ def is_exam_schedulable(user, course):
     """
     Check if a course is ready to schedule an exam or not
     """
-    return ExamAuthorization.objects.filter(course=course, user=user).exists()
+    schedulable_exam_runs = ExamRun.get_currently_schedulable(course)
+    return ExamAuthorization.objects.filter(user=user, exam_run__in=schedulable_exam_runs).exists()


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3150 

#### What's this PR do?
Updates the function we use to show schedulable exams on dashboard to respect schedulable `ExamRun`s.

#### How should this be manually tested?

-  Ensure you have an `ExamProfile` record in `status=ExamProfile.PROFILE_SUCCESS` for your user.
- Be sure `FEATURE_EXAMS_CARD_ENABLED=True` in `.env`.
- Create 3 exam run for each of 3 different courses (past/present/future):
```python
from courses.models import Course
from exams.factories import *
from exams.models import *
er1=ExamRunFactory.create(course=Course.objects.get(title='Digital Learning 100'))
er2=ExamRunFactory.create(course=Course.objects.get(title='Digital Learning 200'), scheduling_past=True)
er3=ExamRunFactory.create(course=Course.objects.get(title='Digital Learning 200'), scheduling_future=True)
ExamAuthorizationFactory.create(user=user, exam_run=er1,status=ExamAuthorization.STATUS_SUCCESS)
ExamAuthorizationFactory.create(user=user, exam_run=er2,status=ExamAuthorization.STATUS_SUCCESS)
ExamAuthorizationFactory.create(user=user, exam_run=er3,status=ExamAuthorization.STATUS_SUCCESS)
```
- Verify only Digital 100 is listed in the courses you're authorized for.