### PR TITLE
Release 0.57.7

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+Version 0.57.7
+--------------
+
+- Added signal to authorize for exams on order fulfillment (#3161)
+- Bypassed order summary for non FA courses and redirect users to edX course enrollment page (#3135)
+- small css change to headers on tab pages (#3149)
+
 Version 0.57.6
 --------------
 

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -22,7 +22,7 @@ from celery.schedules import crontab
 from django.core.exceptions import ImproperlyConfigured
 
 
-VERSION = "0.57.6"
+VERSION = "0.57.7"
 
 CONFIG_PATHS = [
     os.environ.get('MICROMASTERS_CONFIG', ''),

--- a/static/js/components/CourseEnrollmentDialog.js
+++ b/static/js/components/CourseEnrollmentDialog.js
@@ -23,19 +23,28 @@ export default class CourseEnrollmentDialog extends React.Component {
   };
 
   props: {
-    open:                 boolean,
-    setVisibility:        (v: boolean) => void,
-    course:               Course,
-    courseRun:            CourseRun,
-    price:                ?Decimal,
-    addCourseEnrollment:  (courseId: string) => Promise<*>,
+    open:                     boolean,
+    setVisibility:            (v: boolean) => void,
+    course:                   Course,
+    courseRun:                CourseRun,
+    price:                    ?Decimal,
+    addCourseEnrollment:      (courseId: string) => Promise<*>,
+    financialAidAvailability: boolean,
   };
 
   handlePayClick = () => {
-    const { courseRun, setVisibility } = this.props;
-    setVisibility(false);
-    const url = `/order_summary/?course_key=${encodeURIComponent(courseRun.course_id)}`;
-    this.context.router.push(url);
+    const {
+      courseRun,
+      setVisibility,
+      financialAidAvailability,
+    } = this.props;
+    if (financialAidAvailability) {
+      setVisibility(false);
+      const url = `/order_summary/?course_key=${encodeURIComponent(courseRun.course_id)}`;
+      this.context.router.push(url);
+    } else if (courseRun.enrollment_url) {
+      window.open(courseRun.enrollment_url, '_blank');
+    }
   }
 
   handleAuditClick = () => {

--- a/static/js/components/CourseEnrollmentDialog_test.js
+++ b/static/js/components/CourseEnrollmentDialog_test.js
@@ -13,13 +13,14 @@ import { makeCourse, makeRun } from '../factories/dashboard';
 import { getEl } from '../util/test_utils';
 
 describe("CourseEnrollmentDialog", () => {
-  let sandbox, setVisibilityStub, addCourseEnrollmentStub, routerPushStub;
+  let sandbox, setVisibilityStub, addCourseEnrollmentStub, routerPushStub, windowOpenStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     setVisibilityStub = sandbox.spy();
     addCourseEnrollmentStub = sandbox.spy();
     routerPushStub = sandbox.spy();
+    windowOpenStub = sandbox.stub(window, 'open');
   });
 
   afterEach(() => {
@@ -31,6 +32,7 @@ describe("CourseEnrollmentDialog", () => {
     courseRun = makeRun(1),
     course = makeCourse(1),
     open = true,
+    financialAidAvailability = true
   ) => {
     mount(
       <MuiThemeProvider muiTheme={getMuiTheme()}>
@@ -41,6 +43,7 @@ describe("CourseEnrollmentDialog", () => {
           price={price}
           setVisibility={setVisibilityStub}
           addCourseEnrollment={addCourseEnrollmentStub}
+          financialAidAvailability={financialAidAvailability}
         />
       </MuiThemeProvider>,
       {
@@ -101,4 +104,26 @@ describe("CourseEnrollmentDialog", () => {
     sinon.assert.calledWith(setVisibilityStub, false);
     sinon.assert.calledWith(addCourseEnrollmentStub, courseRun.course_id);
   });
+
+  const enrollmentUrlData = [
+    { url: undefined, expected: false },
+    { url: "http://test.com", expected: true }
+  ];
+
+  for (let urlExpectedPair of enrollmentUrlData) {
+    it(`pay button redirects to course enrollment url: ${String(urlExpectedPair.url)}`, () => {
+      const price = new Decimal("123.45");
+      const courseRun = makeRun(1);
+      courseRun['enrollment_url'] = urlExpectedPair.url;
+      const wrapper = renderDialog(
+        price, courseRun, makeCourse(1), true, false
+      );
+      const payButton = wrapper.querySelector('.pay-button');
+      TestUtils.Simulate.click(payButton);
+      assert.equal(
+        windowOpenStub.calledWith(urlExpectedPair.url, "_blank"),
+        urlExpectedPair.expected
+      );
+    });
+  }
 });

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -61,8 +61,13 @@ export default class CourseAction extends React.Component {
   }
 
   redirectToOrderSummary(run: CourseRun): void {
-    const url = `/order_summary/?course_key=${encodeURIComponent(run.course_id)}`;
-    this.context.router.push(url);
+    let { hasFinancialAid } = this.props;
+    if (hasFinancialAid) {
+      const url = `/order_summary/?course_key=${encodeURIComponent(run.course_id)}`;
+      this.context.router.push(url);
+    } else if (run.enrollment_url) {
+      window.open(run.enrollment_url, '_blank');
+    }
   }
 
   handleEnrollButtonClick(run: CourseRun): void {

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -24,6 +24,7 @@ import {
   FA_PENDING_STATUSES,
   FA_TERMINAL_STATUSES,
   FA_ALL_STATUSES,
+  FA_STATUS_APPROVED,
   STATUS_PAID_BUT_NOT_ENROLLED,
 } from '../../constants';
 import {
@@ -41,6 +42,7 @@ describe('CourseAction', () => {
   let setEnrollCourseDialogVisibilityStub;
   let openFinancialAidCalculatorStub;
   let routerPushStub;
+  let windowOpenStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -49,6 +51,7 @@ describe('CourseAction', () => {
     setEnrollCourseDialogVisibilityStub = sandbox.stub();
     openFinancialAidCalculatorStub = sandbox.stub();
     routerPushStub = sandbox.stub();
+    windowOpenStub = sandbox.stub(window, 'open');
   });
 
   afterEach(() => {
@@ -231,7 +234,13 @@ describe('CourseAction', () => {
     ));
     let firstRun = course.runs[0];
     const wrapper = renderCourseAction({
-      courseRun: firstRun
+      financialAid: {
+        ...FINANCIAL_AID_PARTIAL_RESPONSE,
+        has_user_applied: true,
+        application_status: FA_STATUS_APPROVED,
+      },
+      courseRun: firstRun,
+      hasFinancialAid: true,
     });
     let elements = getElements(wrapper);
     let formattedUpgradeDate = moment(firstRun.course_upgrade_deadline).format(DASHBOARD_FORMAT);
@@ -500,5 +509,29 @@ describe('CourseAction', () => {
         assert.equal(payButton.children().text(), 'Pay Now');
       });
     });
+
+    const enrollmentUrlData = [
+      { url: undefined, expected: false },
+      { url: "http://test.com", expected: true }
+    ];
+    for (let urlExpectedPair of enrollmentUrlData) {
+      it(`pay button redirects to course enrollment url: ${String(urlExpectedPair.url)}`, () => {
+        let firstRun = alterFirstRun(course, {
+          enrollment_start_date: now.toISOString(),
+          status: STATUS_CAN_UPGRADE,
+          enrollment_url: urlExpectedPair.url
+        });
+        const wrapper = renderCourseAction({
+          courseRun: firstRun,
+          hasFinancialAid: false,
+        });
+        const payButton = wrapper.find('.pay-button');
+        payButton.simulate('click');
+        assert.equal(
+          windowOpenStub.calledWith(urlExpectedPair.url, "_blank"),
+          urlExpectedPair.expected
+        );
+      });
+    }
   });
 });

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -585,6 +585,7 @@ class DashboardPage extends React.Component {
       course={course}
       courseRun={courseRun}
       price={price}
+      financialAidAvailability={program.financial_aid_availability}
       open={ui.enrollCourseDialogVisibility}
       setVisibility={this.setEnrollCourseDialogVisibility}
       addCourseEnrollment={this.addCourseEnrollment}

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -245,6 +245,12 @@
       margin-top: 44px;
       margin-bottom: 36px;
     }
+
+    h3 {
+      color: $mm-brand-bg;
+      font-size: 20px;
+      font-weight: 500;
+    }
   }
 
   .faqs {
@@ -252,12 +258,6 @@
 
     @include breakpoint(phone) {
       margin: 18px auto;
-    }
-
-    h3.faq-category {
-      color: $mm-brand-bg;
-      font-size: 20px;
-      font-weight: 500;
     }
 
     * {


### PR DESCRIPTION
## Nathan Levesque
  - [x] Added signal to authorize for exams on order fulfillment (#3161) ([d3c63a40](../commit/d3c63a40402221809c4df9aae88adda052d333be))

## Amir Qayyum Khan
  - [x] Bypassed order summary for non FA courses and redirect users to edX course enrollment page (#3135) ([b8acd611](../commit/b8acd611045ee3e8d1a09c155b25c9dcebb696a5))

## Robert W House
  - [x] small css change to headers on tab pages (#3149) ([c8f817f9](../commit/c8f817f96a60c87120762fc15ed49b7d54628bae))