### PR TITLE
Revert "Bypassed order summary for non FA courses and redirect users …

### DIFF
--- a/static/js/components/CourseEnrollmentDialog.js
+++ b/static/js/components/CourseEnrollmentDialog.js
@@ -23,28 +23,19 @@ export default class CourseEnrollmentDialog extends React.Component {
   };
 
   props: {
-    open:                     boolean,
-    setVisibility:            (v: boolean) => void,
-    course:                   Course,
-    courseRun:                CourseRun,
-    price:                    ?Decimal,
-    addCourseEnrollment:      (courseId: string) => Promise<*>,
-    financialAidAvailability: boolean,
+    open:                 boolean,
+    setVisibility:        (v: boolean) => void,
+    course:               Course,
+    courseRun:            CourseRun,
+    price:                ?Decimal,
+    addCourseEnrollment:  (courseId: string) => Promise<*>,
   };
 
   handlePayClick = () => {
-    const {
-      courseRun,
-      setVisibility,
-      financialAidAvailability,
-    } = this.props;
-    if (financialAidAvailability) {
-      setVisibility(false);
-      const url = `/order_summary/?course_key=${encodeURIComponent(courseRun.course_id)}`;
-      this.context.router.push(url);
-    } else if (courseRun.enrollment_url) {
-      window.open(courseRun.enrollment_url, '_blank');
-    }
+    const { courseRun, setVisibility } = this.props;
+    setVisibility(false);
+    const url = `/order_summary/?course_key=${encodeURIComponent(courseRun.course_id)}`;
+    this.context.router.push(url);
   }
 
   handleAuditClick = () => {

--- a/static/js/components/CourseEnrollmentDialog_test.js
+++ b/static/js/components/CourseEnrollmentDialog_test.js
@@ -13,14 +13,13 @@ import { makeCourse, makeRun } from '../factories/dashboard';
 import { getEl } from '../util/test_utils';
 
 describe("CourseEnrollmentDialog", () => {
-  let sandbox, setVisibilityStub, addCourseEnrollmentStub, routerPushStub, windowOpenStub;
+  let sandbox, setVisibilityStub, addCourseEnrollmentStub, routerPushStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     setVisibilityStub = sandbox.spy();
     addCourseEnrollmentStub = sandbox.spy();
     routerPushStub = sandbox.spy();
-    windowOpenStub = sandbox.stub(window, 'open');
   });
 
   afterEach(() => {
@@ -32,7 +31,6 @@ describe("CourseEnrollmentDialog", () => {
     courseRun = makeRun(1),
     course = makeCourse(1),
     open = true,
-    financialAidAvailability = true
   ) => {
     mount(
       <MuiThemeProvider muiTheme={getMuiTheme()}>
@@ -43,7 +41,6 @@ describe("CourseEnrollmentDialog", () => {
           price={price}
           setVisibility={setVisibilityStub}
           addCourseEnrollment={addCourseEnrollmentStub}
-          financialAidAvailability={financialAidAvailability}
         />
       </MuiThemeProvider>,
       {
@@ -104,26 +101,4 @@ describe("CourseEnrollmentDialog", () => {
     sinon.assert.calledWith(setVisibilityStub, false);
     sinon.assert.calledWith(addCourseEnrollmentStub, courseRun.course_id);
   });
-
-  const enrollmentUrlData = [
-    { url: undefined, expected: false },
-    { url: "http://test.com", expected: true }
-  ];
-
-  for (let urlExpectedPair of enrollmentUrlData) {
-    it(`pay button redirects to course enrollment url: ${String(urlExpectedPair.url)}`, () => {
-      const price = new Decimal("123.45");
-      const courseRun = makeRun(1);
-      courseRun['enrollment_url'] = urlExpectedPair.url;
-      const wrapper = renderDialog(
-        price, courseRun, makeCourse(1), true, false
-      );
-      const payButton = wrapper.querySelector('.pay-button');
-      TestUtils.Simulate.click(payButton);
-      assert.equal(
-        windowOpenStub.calledWith(urlExpectedPair.url, "_blank"),
-        urlExpectedPair.expected
-      );
-    });
-  }
 });

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -61,13 +61,8 @@ export default class CourseAction extends React.Component {
   }
 
   redirectToOrderSummary(run: CourseRun): void {
-    let { hasFinancialAid } = this.props;
-    if (hasFinancialAid) {
-      const url = `/order_summary/?course_key=${encodeURIComponent(run.course_id)}`;
-      this.context.router.push(url);
-    } else if (run.enrollment_url) {
-      window.open(run.enrollment_url, '_blank');
-    }
+    const url = `/order_summary/?course_key=${encodeURIComponent(run.course_id)}`;
+    this.context.router.push(url);
   }
 
   handleEnrollButtonClick(run: CourseRun): void {

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -24,7 +24,6 @@ import {
   FA_PENDING_STATUSES,
   FA_TERMINAL_STATUSES,
   FA_ALL_STATUSES,
-  FA_STATUS_APPROVED,
   STATUS_PAID_BUT_NOT_ENROLLED,
 } from '../../constants';
 import {
@@ -42,7 +41,6 @@ describe('CourseAction', () => {
   let setEnrollCourseDialogVisibilityStub;
   let openFinancialAidCalculatorStub;
   let routerPushStub;
-  let windowOpenStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -51,7 +49,6 @@ describe('CourseAction', () => {
     setEnrollCourseDialogVisibilityStub = sandbox.stub();
     openFinancialAidCalculatorStub = sandbox.stub();
     routerPushStub = sandbox.stub();
-    windowOpenStub = sandbox.stub(window, 'open');
   });
 
   afterEach(() => {
@@ -234,13 +231,7 @@ describe('CourseAction', () => {
     ));
     let firstRun = course.runs[0];
     const wrapper = renderCourseAction({
-      financialAid: {
-        ...FINANCIAL_AID_PARTIAL_RESPONSE,
-        has_user_applied: true,
-        application_status: FA_STATUS_APPROVED,
-      },
-      courseRun: firstRun,
-      hasFinancialAid: true,
+      courseRun: firstRun
     });
     let elements = getElements(wrapper);
     let formattedUpgradeDate = moment(firstRun.course_upgrade_deadline).format(DASHBOARD_FORMAT);
@@ -509,29 +500,5 @@ describe('CourseAction', () => {
         assert.equal(payButton.children().text(), 'Pay Now');
       });
     });
-
-    const enrollmentUrlData = [
-      { url: undefined, expected: false },
-      { url: "http://test.com", expected: true }
-    ];
-    for (let urlExpectedPair of enrollmentUrlData) {
-      it(`pay button redirects to course enrollment url: ${String(urlExpectedPair.url)}`, () => {
-        let firstRun = alterFirstRun(course, {
-          enrollment_start_date: now.toISOString(),
-          status: STATUS_CAN_UPGRADE,
-          enrollment_url: urlExpectedPair.url
-        });
-        const wrapper = renderCourseAction({
-          courseRun: firstRun,
-          hasFinancialAid: false,
-        });
-        const payButton = wrapper.find('.pay-button');
-        payButton.simulate('click');
-        assert.equal(
-          windowOpenStub.calledWith(urlExpectedPair.url, "_blank"),
-          urlExpectedPair.expected
-        );
-      });
-    }
   });
 });

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -585,7 +585,6 @@ class DashboardPage extends React.Component {
       course={course}
       courseRun={courseRun}
       price={price}
-      financialAidAvailability={program.financial_aid_availability}
       open={ui.enrollCourseDialogVisibility}
       setVisibility={this.setEnrollCourseDialogVisibility}
       addCourseEnrollment={this.addCourseEnrollment}


### PR DESCRIPTION
…to edX course enrollment page (#3135)"

This reverts commit b8acd611045ee3e8d1a09c155b25c9dcebb696a5.

The commit directs users to the edX enrollment URL instead of the checkout URL

#### What are the relevant tickets?

none

#### How should this be manually tested?

Using a non-FA program, confirm that Order Summary page links to an edX checkout page. 
