### PR TITLE
Prevent course run coupons from being created

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -233,8 +233,6 @@ class Coupon(TimestampedModel, AuditableModel):
             return CourseRun.objects.filter(course__program=obj).values_list('edx_course_key', flat=True)
         elif isinstance(obj, Course):
             return CourseRun.objects.filter(course=obj).values_list('edx_course_key', flat=True)
-        elif isinstance(obj, CourseRun):
-            return [obj.edx_course_key]
         else:
             # Should probably not get here, clean() should take care of validating this
             raise ImproperlyConfigured("content_object expected to be one of Program, Course, CourseRun")
@@ -249,8 +247,6 @@ class Coupon(TimestampedModel, AuditableModel):
             return obj
         elif isinstance(obj, Course):
             return obj.program
-        elif isinstance(obj, CourseRun):
-            return obj.course.program
         else:
             # Should probably not get here, clean() should take care of validating this
             raise ImproperlyConfigured("content_object expected to be one of Program, Course, CourseRun")

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -334,10 +334,9 @@ class Coupon(TimestampedModel, AuditableModel):
 
         if self.content_type.model_class() not in (
                 Course,
-                CourseRun,
                 Program,
         ):
-            raise ValidationError("content_object must be of type Course, CourseRun, or Program")
+            raise ValidationError("content_object must be of type Course or Program")
 
         if self.amount_type == self.PERCENT_DISCOUNT:
             if self.amount is None or not 0 <= self.amount <= 1:

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -1,6 +1,7 @@
 """
 Tests for ecommerce serializers
 """
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from courses.factories import CourseRunFactory
@@ -46,13 +47,6 @@ class SerializerTests(TestCase):
         """
         Test coupon serializer
         """
-        coupon = CouponFactory.create(content_object=CourseRunFactory.create())
-        assert CouponSerializer(coupon).data == {
-            'amount': str(coupon.amount),
-            'amount_type': coupon.amount_type,
-            'content_type': 'courserun',
-            'coupon_type': Coupon.STANDARD,
-            'coupon_code': coupon.coupon_code,
-            'program_id': coupon.program.id,
-            'object_id': coupon.object_id,
-        }
+        with self.assertRaises(ValidationError) as ex:
+            CouponFactory.create(content_object=CourseRunFactory.create())
+        assert ex.exception.args[0]['__all__'][0].args[0] == 'content_object must be of type Course or Program'


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3157 

#### What's this PR do?
Fails validation if the user creates a course run coupon.

#### How should this be manually tested?
Try to create a course run coupon in the Django admin or the Django shell. It should cause a validation error.

#### Any background context you want to provide?
We shouldn't have any course run coupons and we don't have any plans to have them in the future, so this PR should cut down the number of edge cases we deal with.
