### PR TITLE
Added label for num courses passed (#3095)

### DIFF
--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -33,7 +33,8 @@ export const SEARCH_FACET_FIELD_LABEL_MAP = {
   'profile.birth_country': 'Country of Birth',
   'profile.country': 'Current Residence',
   'profile.education.degree_name': 'Degree',
-  'profile.work_history.company_name': 'Company'
+  'profile.work_history.company_name': 'Company',
+  'num-courses-passed': '# of Courses Passed',
 };
 
 // NOTE: these need to be kept in sync with ui/url_utils.py


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #3095 

#### What's this PR do?
Adds a label for the selected facets component for "# of courses passed"

#### How should this be manually tested?
Go to learner search (Analog), filter on "# of courses passed" and be sure the label shows up on the selected filters bar under the search box.