### PR TITLE
Added temporary message for FA final grades (#3176)

### DIFF
--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -139,13 +139,13 @@ export default class CourseAction extends React.Component {
   renderStatusDescription = this.renderDescription('boxed description');
 
   renderContents(run: CourseRun) {
-    const { now } = this.props;
+    const { now, hasFinancialAid } = this.props;
 
     let action, description;
 
     switch (run.status) {
     case STATUS_PASSED:
-      description = this.renderStatusDescription(run.status, 'Passed');
+      description = this.renderStatusDescription(run.status, hasFinancialAid ? 'Final grade coming soon' : 'Passed');
       break;
     case STATUS_NOT_PASSED:
       description = this.renderStatusDescription(run.status, 'Failed');

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -121,6 +121,19 @@ describe('CourseAction', () => {
     assert.equal(wrapper.find(".passed").text(), 'Passed');
   });
 
+  it('shows grades pending for a passed FA course', () => {
+    let course = findCourse(course => (
+      course.runs.length > 0 &&
+      course.runs[0].status === STATUS_PASSED
+    ));
+    let firstRun = course.runs[0];
+    const wrapper = renderCourseAction({
+      courseRun: firstRun,
+      hasFinancialAid: true,
+    });
+    assert.equal(wrapper.find(".passed").text(), 'Final grade coming soon');
+  });
+
   it('shows a message for a failed course', () => {
     let course = findCourse(course => (
       course.runs.length > 0 &&

--- a/static/js/components/dashboard/CourseSubRow.js
+++ b/static/js/components/dashboard/CourseSubRow.js
@@ -62,10 +62,11 @@ export default class CourseSubRow extends React.Component {
   );
 
   courseRunStatus = (courseRun: CourseRun) => {
+    const { hasFinancialAid } = this.props;
     if (courseRun.status === STATUS_NOT_PASSED) {
       return 'Failed';
     } else if (courseRun.status === STATUS_PASSED) {
-      return 'Passed';
+      return hasFinancialAid ? 'Final grade coming soon' : 'Passed';
     }
   };
 

--- a/static/js/components/dashboard/CourseSubRow_test.js
+++ b/static/js/components/dashboard/CourseSubRow_test.js
@@ -34,11 +34,10 @@ describe('CourseSubRow', () => {
     sandbox.restore();
   });
 
-  let renderSubRow = (props = {}, isShallow = true) => {
+  let renderSubRow = (props = {hasFinancialAid: true}, isShallow = true) => {
     let render = isShallow ? shallow : mount;
     return render(
       <CourseSubRow
-        hasFinancialAid={true}
         financialAid={FINANCIAL_AID_PARTIAL_RESPONSE}
         coursePrice={COURSE_PRICES_RESPONSE[0]}
         openFinancialAidCalculator={openFinancialAidCalculator}
@@ -136,6 +135,7 @@ describe('CourseSubRow', () => {
     });
     const wrapper = renderSubRow({
       courseRun: courseRun,
+      hasFinancialAid: false,
     });
     assert.equal(wrapper.find(".course-grade").text(), "50%");
     assert.equal(wrapper.find(".course-action").text(), "Failed");
@@ -149,11 +149,25 @@ describe('CourseSubRow', () => {
     };
     const wrapper = renderSubRow({
       courseRun: courseRun,
+      hasFinancialAid: false,
     });
     assert.equal(wrapper.find(".course-grade").text(), "100%");
     assert.equal(wrapper.find(".course-action").text(), "Passed");
   });
 
+  it('should display grade pending if a course was passed with financial aid', () => {
+    let courseRun = {
+      ...courseRun,
+      status: STATUS_PASSED,
+      final_grade: 100
+    };
+    const wrapper = renderSubRow({
+      courseRun: courseRun,
+      hasFinancialAid: true,
+    });
+    assert.equal(wrapper.find(".course-grade").text(), "100%");
+    assert.equal(wrapper.find(".course-action").text(), "Final grade coming soon");
+  });
 
   it('shows a course date range for a failed course run', () => {
     Object.assign(courseRun, {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3176

#### What's this PR do?
Changes the message for FA courses when we have a final grade + exam.

#### How should this be manually tested?

- Create an enrollment, final grade, and proctored exam grade for a past course. Check the dashboard and be sure you see the expected message.
- Repeat the above for a current course.