### PR TITLE
On pay now redirected users to checkout page instead of order summary for non FA programs

### DIFF
--- a/static/js/components/CourseEnrollmentDialog.js
+++ b/static/js/components/CourseEnrollmentDialog.js
@@ -23,19 +23,30 @@ export default class CourseEnrollmentDialog extends React.Component {
   };
 
   props: {
-    open:                 boolean,
-    setVisibility:        (v: boolean) => void,
-    course:               Course,
-    courseRun:            CourseRun,
-    price:                ?Decimal,
-    addCourseEnrollment:  (courseId: string) => Promise<*>,
+    open:                     boolean,
+    setVisibility:            (v: boolean) => void,
+    course:                   Course,
+    courseRun:                CourseRun,
+    price:                    ?Decimal,
+    addCourseEnrollment:      (courseId: string) => Promise<*>,
+    checkout:                 Function,
+    financialAidAvailability: boolean,
   };
 
   handlePayClick = () => {
-    const { courseRun, setVisibility } = this.props;
-    setVisibility(false);
-    const url = `/order_summary/?course_key=${encodeURIComponent(courseRun.course_id)}`;
-    this.context.router.push(url);
+    const {
+      courseRun,
+      setVisibility,
+      checkout,
+      financialAidAvailability
+    } = this.props;
+    if (financialAidAvailability) {
+      setVisibility(false);
+      const url = `/order_summary/?course_key=${encodeURIComponent(courseRun.course_id)}`;
+      this.context.router.push(url);
+    } else{
+      return checkout(courseRun.course_id);
+    }
   }
 
   handleAuditClick = () => {

--- a/static/js/components/CourseEnrollmentDialog.js
+++ b/static/js/components/CourseEnrollmentDialog.js
@@ -69,7 +69,7 @@ export default class CourseEnrollmentDialog extends React.Component {
       payButton = (
         <Button key="pay" onClick={this.handlePayClick}
           colored className="dashboard-button pay-button">
-          Pay Now (${ price.toString() })
+          Pay Now
         </Button>
       );
     } else {

--- a/static/js/components/CourseEnrollmentDialog_test.js
+++ b/static/js/components/CourseEnrollmentDialog_test.js
@@ -13,13 +13,14 @@ import { makeCourse, makeRun } from '../factories/dashboard';
 import { getEl } from '../util/test_utils';
 
 describe("CourseEnrollmentDialog", () => {
-  let sandbox, setVisibilityStub, addCourseEnrollmentStub, routerPushStub;
+  let sandbox, setVisibilityStub, addCourseEnrollmentStub, routerPushStub, checkoutStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     setVisibilityStub = sandbox.spy();
     addCourseEnrollmentStub = sandbox.spy();
     routerPushStub = sandbox.spy();
+    checkoutStub = sandbox.spy();
   });
 
   afterEach(() => {
@@ -31,6 +32,7 @@ describe("CourseEnrollmentDialog", () => {
     courseRun = makeRun(1),
     course = makeCourse(1),
     open = true,
+    financialAidAvailability = true
   ) => {
     mount(
       <MuiThemeProvider muiTheme={getMuiTheme()}>
@@ -41,6 +43,8 @@ describe("CourseEnrollmentDialog", () => {
           price={price}
           setVisibility={setVisibilityStub}
           addCourseEnrollment={addCourseEnrollmentStub}
+          checkout={checkoutStub}
+          financialAidAvailability={financialAidAvailability}
         />
       </MuiThemeProvider>,
       {
@@ -100,5 +104,19 @@ describe("CourseEnrollmentDialog", () => {
     TestUtils.Simulate.click(auditButton);
     sinon.assert.calledWith(setVisibilityStub, false);
     sinon.assert.calledWith(addCourseEnrollmentStub, courseRun.course_id);
+  });
+
+  it('pay button redirects to checkout', () => {
+    const price = new Decimal("123.45");
+    const courseRun = makeRun(1);
+    const wrapper = renderDialog(
+      price, courseRun, makeCourse(1), true, false
+    );
+    const payButton = wrapper.querySelector('.pay-button');
+    TestUtils.Simulate.click(payButton);
+    assert.equal(
+      checkoutStub.calledWith(courseRun.course_id),
+      true
+    );
   });
 });

--- a/static/js/components/CourseEnrollmentDialog_test.js
+++ b/static/js/components/CourseEnrollmentDialog_test.js
@@ -71,7 +71,7 @@ describe("CourseEnrollmentDialog", () => {
     const price = new Decimal("123.45");
     const wrapper = renderDialog(price);
     const payButton = ((wrapper.querySelector('.pay-button'): any): HTMLButtonElement);
-    assert.equal(payButton.textContent, "Pay Now ($123.45)");
+    assert.equal(payButton.textContent, "Pay Now");
     assert.isFalse(payButton.disabled);
     const auditButton = getEl(wrapper, '.audit-button');
     assert.equal(auditButton.textContent, "Audit for Free & Pay Later");

--- a/static/js/components/OrderSummary.js
+++ b/static/js/components/OrderSummary.js
@@ -10,6 +10,7 @@ import type { Course, CourseRun } from '../flow/programTypes';
 import type { CoursePrice } from '../flow/dashboardTypes';
 import { formatPrice } from '../util/util';
 
+
 class OrderSummary extends React.Component {
   props: {
     course:           Course,

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -43,6 +43,7 @@ export default class CourseAction extends React.Component {
     setEnrollSelectedCourseRun: (r: CourseRun) => void,
     setEnrollCourseDialogVisibility: (b: boolean) => void,
     coupon?: Coupon,
+    checkout: Function
   };
 
   statusDescriptionClasses = {
@@ -61,8 +62,13 @@ export default class CourseAction extends React.Component {
   }
 
   redirectToOrderSummary(run: CourseRun): void {
-    const url = `/order_summary/?course_key=${encodeURIComponent(run.course_id)}`;
-    this.context.router.push(url);
+    let { hasFinancialAid, checkout } = this.props;
+    if (hasFinancialAid) {
+      const url = `/order_summary/?course_key=${encodeURIComponent(run.course_id)}`;
+      this.context.router.push(url);
+    } else {
+      return checkout(run.course_id);
+    }
   }
 
   handleEnrollButtonClick(run: CourseRun): void {

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -43,7 +43,7 @@ export default class CourseAction extends React.Component {
     setEnrollSelectedCourseRun: (r: CourseRun) => void,
     setEnrollCourseDialogVisibility: (b: boolean) => void,
     coupon?: Coupon,
-    checkout: Function
+    checkout: (s: string) => void,
   };
 
   statusDescriptionClasses = {

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -24,6 +24,7 @@ import {
   FA_PENDING_STATUSES,
   FA_TERMINAL_STATUSES,
   FA_ALL_STATUSES,
+  FA_STATUS_APPROVED,
   STATUS_PAID_BUT_NOT_ENROLLED,
 } from '../../constants';
 import {
@@ -41,6 +42,7 @@ describe('CourseAction', () => {
   let setEnrollCourseDialogVisibilityStub;
   let openFinancialAidCalculatorStub;
   let routerPushStub;
+  let checkoutStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -49,6 +51,7 @@ describe('CourseAction', () => {
     setEnrollCourseDialogVisibilityStub = sandbox.stub();
     openFinancialAidCalculatorStub = sandbox.stub();
     routerPushStub = sandbox.stub();
+    checkoutStub = sandbox.spy();
   });
 
   afterEach(() => {
@@ -103,6 +106,7 @@ describe('CourseAction', () => {
         now={now}
         courseRun={null}
         prices={prices}
+        checkout={checkoutStub}
         openFinancialAidCalculator={openFinancialAidCalculatorStub}
         {...props}
       />
@@ -244,7 +248,13 @@ describe('CourseAction', () => {
     ));
     let firstRun = course.runs[0];
     const wrapper = renderCourseAction({
-      courseRun: firstRun
+      financialAid: {
+        ...FINANCIAL_AID_PARTIAL_RESPONSE,
+        has_user_applied: true,
+        application_status: FA_STATUS_APPROVED,
+      },
+      courseRun: firstRun,
+      hasFinancialAid: true,
     });
     let elements = getElements(wrapper);
     let formattedUpgradeDate = moment(firstRun.course_upgrade_deadline).format(DASHBOARD_FORMAT);
@@ -512,6 +522,23 @@ describe('CourseAction', () => {
         }
         assert.equal(payButton.children().text(), 'Pay Now');
       });
+    });
+
+    it('pay button redirects to checkout', () => {
+      let firstRun = alterFirstRun(course, {
+        enrollment_start_date: now.toISOString(),
+        status: STATUS_CAN_UPGRADE
+      });
+      const wrapper = renderCourseAction({
+        courseRun: firstRun,
+        hasFinancialAid: false,
+      });
+      const payButton = wrapper.find('.pay-button');
+      payButton.simulate('click');
+      assert.equal(
+        checkoutStub.calledWith(firstRun.course_id),
+        true
+      );
     });
   });
 });

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -42,6 +42,7 @@ export default class CourseListCard extends React.Component {
     setEnrollSelectedCourseRun:   (r: CourseRun) => void,
     setEnrollCourseDialogVisibility: (bool: boolean) => void,
     ui:                           UIState,
+    checkout:                     Function,
   };
 
   renderFinancialAidPriceMessage(): ?React$Element<*> {
@@ -170,6 +171,7 @@ export default class CourseListCard extends React.Component {
       setEnrollSelectedCourseRun,
       setEnrollCourseDialogVisibility,
       ui,
+      checkout
     } = this.props;
     const now = this.props.now || moment();
 
@@ -190,6 +192,7 @@ export default class CourseListCard extends React.Component {
         setEnrollSelectedCourseRun={setEnrollSelectedCourseRun}
         setEnrollCourseDialogVisibility={setEnrollCourseDialogVisibility}
         ui={ui}
+        checkout={checkout}
         {...courseRowOptionalProps}
       />
     );

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -42,7 +42,7 @@ export default class CourseListCard extends React.Component {
     setEnrollSelectedCourseRun:   (r: CourseRun) => void,
     setEnrollCourseDialogVisibility: (bool: boolean) => void,
     ui:                           UIState,
-    checkout:                     Function,
+    checkout:                     (s: string) => void,
   };
 
   renderFinancialAidPriceMessage(): ?React$Element<*> {

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -69,6 +69,7 @@ describe('CourseListCard', () => {
             email={INITIAL_EMAIL_STATE}
             setEnrollCourseDialogVisibility={() => undefined}
             setEnrollSelectedCourseRun={() => undefined}
+            checkout={() => undefined}
             {...props}
           />
         </Provider>

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -37,7 +37,7 @@ export default class CourseRow extends React.Component {
     setEnrollSelectedCourseRun: (r: CourseRun) => void,
     setEnrollCourseDialogVisibility: (b: boolean) => void,
     ui: UIState,
-    checkout: Function,
+    checkout: (s: string) => void,
   };
 
   shouldDisplayGradeColumn = (run: CourseRun): boolean => (

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -37,6 +37,7 @@ export default class CourseRow extends React.Component {
     setEnrollSelectedCourseRun: (r: CourseRun) => void,
     setEnrollCourseDialogVisibility: (b: boolean) => void,
     ui: UIState,
+    checkout: Function,
   };
 
   shouldDisplayGradeColumn = (run: CourseRun): boolean => (
@@ -83,6 +84,7 @@ export default class CourseRow extends React.Component {
       openCourseContactDialog,
       setEnrollSelectedCourseRun,
       setEnrollCourseDialogVisibility,
+      checkout
     } = this.props;
 
     let lastColumnSize, lastColumnClass;
@@ -121,6 +123,7 @@ export default class CourseRow extends React.Component {
           now={now}
           prices={prices}
           hasFinancialAid={hasFinancialAid}
+          checkout={checkout}
           financialAid={financialAid}
           openFinancialAidCalculator={openFinancialAidCalculator}
           addCourseEnrollment={addCourseEnrollment}
@@ -144,6 +147,7 @@ export default class CourseRow extends React.Component {
       addCourseEnrollment,
       setEnrollSelectedCourseRun,
       setEnrollCourseDialogVisibility,
+      checkout,
     } = this.props;
 
     let firstRun = this.getFirstRun();
@@ -168,6 +172,7 @@ export default class CourseRow extends React.Component {
           openFinancialAidCalculator={openFinancialAidCalculator}
           addCourseEnrollment={addCourseEnrollment}
           key={i}
+          checkout={checkout}
           setEnrollSelectedCourseRun={setEnrollSelectedCourseRun}
           setEnrollCourseDialogVisibility={setEnrollCourseDialogVisibility}
         />

--- a/static/js/components/dashboard/CourseRow_test.js
+++ b/static/js/components/dashboard/CourseRow_test.js
@@ -33,7 +33,8 @@ describe('CourseRow', () => {
     addCourseEnrollment: sandbox.stub(),
     course: null,
     openCourseContactDialog: sandbox.stub(),
-    ui: INITIAL_UI_STATE
+    ui: INITIAL_UI_STATE,
+    checkout: () => undefined
   });
 
   beforeEach(() => {

--- a/static/js/components/dashboard/CourseSubRow.js
+++ b/static/js/components/dashboard/CourseSubRow.js
@@ -27,7 +27,7 @@ export default class CourseSubRow extends React.Component {
     addCourseEnrollment:         (courseId: string) => void,
     setEnrollSelectedCourseRun:  (r: CourseRun) => void,
     setEnrollCourseDialogVisibility: (b: boolean) => void,
-    checkout:                    Function,
+    checkout:                    (s: string) => void,
   };
 
   getFormattedDateOrFuzzy(dateKey: string, fuzzyDateKey: string): string|null {

--- a/static/js/components/dashboard/CourseSubRow.js
+++ b/static/js/components/dashboard/CourseSubRow.js
@@ -27,6 +27,7 @@ export default class CourseSubRow extends React.Component {
     addCourseEnrollment:         (courseId: string) => void,
     setEnrollSelectedCourseRun:  (r: CourseRun) => void,
     setEnrollCourseDialogVisibility: (b: boolean) => void,
+    checkout:                    Function,
   };
 
   getFormattedDateOrFuzzy(dateKey: string, fuzzyDateKey: string): string|null {
@@ -130,6 +131,7 @@ export default class CourseSubRow extends React.Component {
       prices,
       setEnrollSelectedCourseRun,
       setEnrollCourseDialogVisibility,
+      checkout
     } = this.props;
 
     let enrollStartDate = courseRun.enrollment_start_date ? moment(courseRun.enrollment_start_date) : null;
@@ -140,6 +142,7 @@ export default class CourseSubRow extends React.Component {
         now={now}
         prices={prices}
         hasFinancialAid={hasFinancialAid}
+        checkout={checkout}
         financialAid={financialAid}
         openFinancialAidCalculator={openFinancialAidCalculator}
         addCourseEnrollment={addCourseEnrollment}

--- a/static/js/components/dashboard/CourseSubRow_test.js
+++ b/static/js/components/dashboard/CourseSubRow_test.js
@@ -43,6 +43,7 @@ describe('CourseSubRow', () => {
         openFinancialAidCalculator={openFinancialAidCalculator}
         now={now}
         addCourseEnrollment={addCourseEnrollment}
+        checkout={() => undefined}
         key={1}
         {...props}
       />,

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -15,6 +15,7 @@ import { calculatePrices } from '../lib/coupon';
 import {
   FETCH_SUCCESS,
   FETCH_PROCESSING,
+  checkout,
 } from '../actions';
 import {
   updateCourseStatus,
@@ -98,6 +99,7 @@ import {
   pearsonSSOFailure,
   setPearsonError
 } from '../actions/pearson';
+import { processCheckout } from './OrderSummaryPage';
 import { generateSSOForm } from '../lib/pearson';
 import type { PearsonAPIState } from '../reducers/pearson';
 import type { RestState } from '../flow/restTypes';
@@ -550,6 +552,11 @@ class DashboardPage extends React.Component {
     );
   }
 
+  dispatchCheckout = (courseId: string) => {
+    const { dispatch } = this.props;
+    return dispatch(checkout(courseId)).then(processCheckout);
+  };
+
   renderCourseEnrollmentDialog() {
     const { ui, dashboard, prices, coupons } = this.props;
     const program = this.getCurrentlyEnrolledProgram();
@@ -585,6 +592,8 @@ class DashboardPage extends React.Component {
       course={course}
       courseRun={courseRun}
       price={price}
+      financialAidAvailability={program.financial_aid_availability}
+      checkout={this.dispatchCheckout}
       open={ui.enrollCourseDialogVisibility}
       setVisibility={this.setEnrollCourseDialogVisibility}
       addCourseEnrollment={this.addCourseEnrollment}
@@ -706,6 +715,7 @@ class DashboardPage extends React.Component {
               prices={calculatedPrices}
               key={program.id}
               ui={ui}
+              checkout={this.dispatchCheckout}
               openFinancialAidCalculator={this.openFinancialAidCalculator}
               addCourseEnrollment={this.addCourseEnrollment}
               openCourseContactDialog={this.openCourseContactDialog}

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -230,7 +230,7 @@ describe('LearnerSearchPage', function () {
         query: 'xyz',
         type: 'phrase_prefix',
       });
-      assert.equal(window.location.toString(), "http://edx.org/?q=xyz");
+      assert.equal(window.location.toString(), "http://fake/?q=xyz");
     });
   });
 

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -230,7 +230,7 @@ describe('LearnerSearchPage', function () {
         query: 'xyz',
         type: 'phrase_prefix',
       });
-      assert.equal(window.location.toString(), "http://fake/?q=xyz");
+      assert.equal(window.location.toString(), "http://edx.org/?q=xyz");
     });
   });
 

--- a/static/js/containers/OrderSummaryPage.js
+++ b/static/js/containers/OrderSummaryPage.js
@@ -25,6 +25,19 @@ import { calculatePrice } from '../lib/coupon';
 import { getOwnDashboard, getOwnCoursePrices } from '../reducers/util';
 import { actions } from '../lib/redux_rest';
 import type { RestState } from '../flow/restTypes';
+import type { CheckoutResponse } from '../flow/checkoutTypes';
+
+export const processCheckout = (result: CheckoutResponse) => {
+  const { payload, url, method } = result;
+  if (method === 'POST') {
+    const form = createForm(url, payload);
+    const body: HTMLElement = (document.querySelector("body"): any);
+    body.appendChild(form);
+    form.submit();
+  } else {
+    window.location = url;
+  }
+};
 
 class OrderSummaryPage extends React.Component {
   static contextTypes = {
@@ -86,19 +99,7 @@ class OrderSummaryPage extends React.Component {
 
   dispatchCheckout = (courseId: string) => {
     const { dispatch } = this.props;
-
-    return dispatch(checkout(courseId)).then(result => {
-      const { payload, url, method } = result;
-
-      if (method === 'POST') {
-        const form = createForm(url, payload);
-        const body: HTMLElement = (document.querySelector("body"): any);
-        body.appendChild(form);
-        form.submit();
-      } else {
-        window.location = url;
-      }
-    });
+    return dispatch(checkout(courseId)).then(processCheckout);
   };
 
   render() {

--- a/static/js/flow/checkoutTypes.js
+++ b/static/js/flow/checkoutTypes.js
@@ -2,6 +2,7 @@
 export type CheckoutResponse = {
   url: string,
   payload: CheckoutPayload,
+  method?: ?string
 };
 
 export type CheckoutPayload = {

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -48,6 +48,7 @@ afterEach(function () { // eslint-disable-line mocha/no-top-level-hooks
   global.SETTINGS = _createSettings();
   window.localStorage.reset();
   window.sessionStorage.reset();
+  window.location = 'http://fake/';
 });
 
 // required for interacting with react-mdl components


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3105

#### What's this PR do?
- Redirect user to checkout instead of progress summary for `NON FA` programs. 

#### How should this be manually tested?
- Click `pay now` buttons for no fa course

@pdpinch 
