### PR TITLE
Program Page: Move tabs to the top

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -31,41 +31,46 @@
 {% include "header.html" %}
 <main class="page-content program-page">
   {% image page.background_image fill-1310x613 as background_image %}
-  <div class="hero-image" style="background-image: url({{ background_image.url }})">
-    <!-- big image, and sign-up links, etc -->
-    <h1 class="title">
-      {{ page.title }} MicroMasters
-    </h1>
-    <div class="description">
-      {{ page.title_over_image|richtext }}
-    </div>
-    {% if not authenticated %}
-    <button class="mdl-button hero-button open-signup-dialog mdl-cell--hide-phone">
-      Sign Up Now
-    </button>
-    <div class="log-in mdl-cell--hide-phone">
-      Already a Member?
-      <a href="/login/edxorg">
-        Log In
-      </a>
-    </div>
-    {% endif %}
-  </div>
-    <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
+  <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
     <div class="mdl-tabs__tab-bar">
       <div class="tab-container">
-        <a href="{{ page.url }}"
-           class="tab-link {% if active_tab == 'about' %}active-tab{% endif %}">
-          About the Program
-        </a>
-        {% for child in page.get_children.live %}
-          <a href="{{ child.url }}"
-             class="tab-link {% if child.title == active_tab %}active-tab{% endif %}">
-            {{ child.title }}
+        <div class="tab-wrapper">
+          <a href="{{ page.url }}"
+             class="tab-link {% if active_tab == 'about' %}active-tab{% endif %}">
+            About the Program
           </a>
-        {% endfor %}
+          {% for child in page.get_children.live %}
+            <a href="{{ child.url }}"
+               class="tab-link {% if child.title == active_tab %}active-tab{% endif %}">
+              {{ child.title }}
+            </a>
+          {% endfor %}
+        </div>
       </div>
     </div>
+    {% if active_tab == 'about' %}
+      <div class="hero-image" style="background-image: url({{ background_image.url }})">
+        <!-- big image, and sign-up links, etc -->
+        <h1 class="title">
+          {{ page.title }} MicroMasters
+        </h1>
+        <div class="description">
+          {{ page.title_over_image|richtext }}
+        </div>
+        {% if not authenticated %}
+          <button class="mdl-button hero-button open-signup-dialog mdl-cell--hide-phone">
+            Sign Up Now
+          </button>
+          <div class="log-in mdl-cell--hide-phone">
+            Already a Member?
+            <a href="/login/edxorg">
+              Log In
+            </a>
+          </div>
+        {% endif %}
+      </div>
+    {% endif %}
+
     <div class="mdl-grid tabs-content">
       <div class="mdl-cell mdl-cell--8-col">
       {% if active_tab == 'about' %}

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -105,9 +105,9 @@
     }
 
     .mdl-tabs__tab-bar {
-      height: 57px;
+      height: 56px;
       overflow: hidden;
-      border-bottom: 1px solid $mm-brand-bg;
+      border-bottom: none;
     }
 
     .panel-content {

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -64,32 +64,38 @@
 
   .mdl-tabs {
     .tab-container {
-      width: 96%;
-      max-width: 1150px;
-      display: flex;
-      overflow-x: scroll;
+      background-color: $mm-brand-bg;
+      width: 100%;
 
-      a {
-        white-space: nowrap;
-      }
+      .tab-wrapper {
+        display: flex;
+        overflow-x: scroll;
+        margin-left: 8px;
 
-      a:focus, a:hover {
-        text-decoration: none;
-      }
+        a {
+          white-space: nowrap;
+          font-weight: 400;
+          font-size: 13px;
+        }
 
-      a.tab-link {
-        padding: 0 24px;
-        float: left;
-        height: 56px;
-        line-height: 55px;
-        text-transform: uppercase;
-        color: rgba(0,0,0,.54);
+        a:focus, a:hover {
+          text-decoration: none;
+        }
 
-      }
+        a.tab-link {
+          padding: 0 24px;
+          float: left;
+          height: 56px;
+          line-height: 55px;
+          text-transform: uppercase;
+          color: rgba(255,255,255,.75);
 
-      a.active-tab {
-        color: rgba(0,0,0,.87);
-        border-bottom: 3px solid $mm-brand-bg;
+        }
+
+        a.active-tab {
+          color: white;
+          border-bottom: 3px solid white;
+        }
       }
     }
 
@@ -99,9 +105,9 @@
     }
 
     .mdl-tabs__tab-bar {
-      margin-bottom: 30px;
       height: 57px;
       overflow: hidden;
+      border-bottom: 1px solid $mm-brand-bg;
     }
 
     .panel-content {
@@ -205,7 +211,7 @@
 
   .tabs-content {
     width: 94%;
-    margin: 0 auto;
+    margin: 20px auto 0;
     max-width: 1150px;
 
     @include breakpoint(phone) {

--- a/static/scss/public_style/bootstrap-extend.css
+++ b/static/scss/public_style/bootstrap-extend.css
@@ -3322,8 +3322,6 @@ fieldset[disabled] .btn-pure.focus {
 }
 .navbar {
   border: none;
-  -webkit-box-shadow: 0 2px 4px rgba(0, 0, 0, .08);
-          box-shadow: 0 2px 4px rgba(0, 0, 0, .08);
 }
 .navbar-fixed-top,
 .navbar-fixed-bottom {


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3173

#### What's this PR do?
Move the tabs on the program page above the hero image. Now the hero image is displayed only in the 'about' tab.

#### How should this be manually tested?
Go to the any program page. Play with the tabs.

![screen shot 2017-05-12 at 2 50 59 pm](https://cloud.githubusercontent.com/assets/7574259/26012457/862a98f6-3722-11e7-8e03-af1a4a1065d0.png)
