### PR TITLE
Fixed error with bucket reference (#3183)

### DIFF
--- a/static/js/components/search/EducationFilter.js
+++ b/static/js/components/search/EducationFilter.js
@@ -9,6 +9,7 @@ import {
   SearchkitComponent,
   TermsBucket,
 } from 'searchkit';
+import R from 'ramda';
 
 import { EDUCATION_LEVELS } from '../../constants';
 import PatchedMenuFilter from './PatchedMenuFilter';
@@ -58,7 +59,7 @@ export default class EducationFilter extends SearchkitComponent {
 
   bucketsTransform = (buckets: Array<Object>) => (
     buckets.map(bucket => ({
-      doc_count: bucket.school_name_count.doc_count,
+      doc_count: R.pathOr(0, ['school_name_count', 'doc_count'], bucket),
       key: bucket.key,
     }))
   );


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3183 

#### What's this PR do?
Fixes an issue where SearchKit can send us error info in the bucket data (see ticket for details).

#### How should this be manually tested?
- Go to learner search
- Filter on education
- Filter on other criteria untli you get 0 results (search on a nonexistent name being easiest)
- Reload the page and verify you get the same UI and not the "There are no users in the Analog Learning program." error.