### PR TITLE
fix email composiition dialog body loading

### DIFF
--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -82,7 +82,7 @@ export default class EmailCompositionDialog extends React.Component {
   }
 
   componentWillReceiveProps (nextProps: EmailDialogProps) {
-    if (R.isNil(this.state.editorState)) {
+    if (!this.state.editorState.getCurrentContent().hasText()) {
       this.setState(editorStateFromProps(nextProps));
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #3181 

#### What's this PR do?

this fixes the check we do to see if we need to reload the email composition dialog body.

#### How should this be manually tested?

follow the steps for reproducing the bug in the attached issue on master. then switch to this branch, follow the same steps, and ensure it's fixed.