### PR TITLE
Ensure facet titles for selected filters stay visible

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -10,7 +10,6 @@ import {
   HitsStats,
   Pagination,
   ResetFilters,
-  RangeFilter,
   SearchBox,
   SortingSelector,
   MultiMatchQuery,
@@ -35,6 +34,7 @@ import HitsCount from './search/HitsCount';
 import CustomNoHits from './search/CustomNoHits';
 import ModifiedSelectedFilter from './search/ModifiedSelectedFilter';
 import FinalGradeRangeFilter from './search/FinalGradeRangeFilter';
+import EnabledSelectionRangeFilter from './search/EnabledSelectionRangeFilter';
 import { wrapWithProps } from '../util/util';
 import type { Option } from '../flow/generalTypes';
 import type { AvailableProgram } from '../flow/enrollmentTypes';
@@ -258,7 +258,7 @@ export default class LearnerSearch extends SearchkitComponent {
           filterName="num-courses-passed"
           title="# of Courses Passed"
         >
-          <RangeFilter
+          <EnabledSelectionRangeFilter
             field="program.num_courses_passed"
             id="num-courses-passed"
             min={0}
@@ -271,7 +271,7 @@ export default class LearnerSearch extends SearchkitComponent {
           filterName="grade-average"
           title="Average Grade in Program"
         >
-          <RangeFilter
+          <EnabledSelectionRangeFilter
             field="program.grade_average"
             id="grade-average"
             min={0}

--- a/static/js/components/search/EnabledSelectionRangeFilter.js
+++ b/static/js/components/search/EnabledSelectionRangeFilter.js
@@ -1,0 +1,20 @@
+import { RangeFilter, RangeAccessor } from "searchkit";
+
+export class EnabledSelectionRangeAccessor extends RangeAccessor {
+  isDisabled() {
+    return !this.state.hasValue() && super.isDisabled();
+  }
+}
+
+export default class EnabledSelectionRangeFilter extends RangeFilter {
+  defineAccessor() {
+    const {
+      id, title, min, max, field, fieldOptions,
+      interval, showHistogram
+    } = this.props;
+    return new EnabledSelectionRangeAccessor(id, {
+      id, min, max, title, field,
+      interval, loadHistogram: showHistogram, fieldOptions
+    });
+  }
+}

--- a/static/js/components/search/FilterVisibilityToggle.js
+++ b/static/js/components/search/FilterVisibilityToggle.js
@@ -64,15 +64,19 @@ export default class FilterVisibilityToggle extends SearchkitComponent {
     return false;
   };
 
+  isFilterSelected = (id: string): boolean => {
+    return this.searchkit.state && id && getAppliedFilterValue(this.searchkit.state[id]);
+  };
+
   stayVisibleIfEmpty = (): boolean => {
     const { stayVisibleIfFilterApplied } = this.props;
-    return this.searchkit.state &&
-      stayVisibleIfFilterApplied &&
-      getAppliedFilterValue(this.searchkit.state[stayVisibleIfFilterApplied]);
+    return this.isFilterSelected(stayVisibleIfFilterApplied);
   };
 
   renderFilterTitle = (children: React$Element<*>): React$Element<*>|null => {
-    if (!this.isInResults(children.props.id) && !this.stayVisibleIfEmpty()) {
+    if (!this.isInResults(children.props.id) &&
+        !this.isFilterSelected(children.props.id) &&
+        !this.stayVisibleIfEmpty()) {
       return null;
     }
     const { title } = this.props;

--- a/static/js/components/search/FilterVisibilityToggle_test.js
+++ b/static/js/components/search/FilterVisibilityToggle_test.js
@@ -78,6 +78,21 @@ describe('FilterVisibilityToggle', () => {
     assert.lengthOf(icon, 0);
   });
 
+  it('shows title when doc_count is 0 but filter selected', () => {
+    sandbox.stub(FilterVisibilityToggle.prototype, 'getResults').returns({
+      aggregations: {
+        test: {
+          doc_count: 0
+        }
+      }
+    });
+    searchKit.state = {
+      test: 'value',
+    };
+    const wrapper = renderWrappedToggle(props, <div id="test">Test Text</div>);
+    assert.lengthOf(wrapper.find(".title-row"), 1);
+  });
+
   it('hides toggle icon with a nested field that has an inner doc_count of 0', () => {
     sandbox.stub(FilterVisibilityToggle.prototype, 'getResults').returns({
       aggregations: {

--- a/static/js/components/search/FinalGradeRangeFilter.js
+++ b/static/js/components/search/FinalGradeRangeFilter.js
@@ -1,13 +1,14 @@
 import {
-  RangeFilter, RangeAccessor, RangeQuery,
+  RangeFilter, RangeQuery,
   HistogramBucket, FilterBucket, CardinalityMetric
 } from "searchkit";
 import _ from 'lodash';
 import { NestedAccessorMixin } from './util';
+import { EnabledSelectionRangeAccessor } from './EnabledSelectionRangeFilter';
 
 const REQUIRED_FILTER_ID = 'courses';
 
-class FinalGradeRangeAccessor extends NestedAccessorMixin(RangeAccessor) {
+class FinalGradeRangeAccessor extends NestedAccessorMixin(EnabledSelectionRangeAccessor) {
   /**
    * Overrides buildOwnQuery in RangeAccessor
    * By default, Searchkit does this by creating an aggs bucket that applies all filters


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3095 

#### What's this PR do?
Adds logic to still show titles if the filter is selected when there are 0 results.

#### How should this be manually tested?
- Go to learner search
- Selected any combination of filters to get 0 results (hint: you can select filters that narrow your search down to 1 and then search for a nonmatching name to test all of them).
- Verify the facet titles remain

Known issue: #3187 
