### PR TITLE
Fixed # of Courses Passed facet disappearing (#3095)

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -11,6 +11,7 @@ class ProgramSerializer(serializers.ModelSerializer):
     """Serializer for Program objects"""
     programpage_url = serializers.SerializerMethodField()
     enrolled = serializers.SerializerMethodField()
+    total_courses = serializers.SerializerMethodField()
 
     def get_programpage_url(self, program):
         """
@@ -38,6 +39,12 @@ class ProgramSerializer(serializers.ModelSerializer):
         user = self.context['request'].user
         return ProgramEnrollment.objects.filter(user=user, program=program).exists()
 
+    def get_total_courses(self, program):
+        """
+        Returns the number of courses in the program
+        """
+        return program.course_set.count()
+
     class Meta:
         model = Program
         fields = (
@@ -45,6 +52,7 @@ class ProgramSerializer(serializers.ModelSerializer):
             'title',
             'programpage_url',
             'enrolled',
+            'total_courses',
         )
 
 

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -77,6 +77,7 @@ class ProgramSerializerTests(MockedESTestCase):
             'title': self.program.title,
             'programpage_url': None,
             'enrolled': False,
+            'total_courses': 0,
         }
 
     def test_program_with_programpage(self):
@@ -92,6 +93,7 @@ class ProgramSerializerTests(MockedESTestCase):
             'title': self.program.title,
             'programpage_url': programpage.url,
             'enrolled': False,
+            'total_courses': 0,
         }
         assert len(programpage.url) > 0
 
@@ -112,6 +114,7 @@ class ProgramSerializerTests(MockedESTestCase):
             'title': self.program.title,
             'programpage_url': url,
             'enrolled': False,
+            'total_courses': 0,
         }
         assert programpage.url != url
 
@@ -126,4 +129,19 @@ class ProgramSerializerTests(MockedESTestCase):
             'title': self.program.title,
             'programpage_url': None,
             'enrolled': True,
+            'total_courses': 0,
+        }
+
+    def test_program_courses(self):
+        """
+        Test ProgramSerializer with multiple courses
+        """
+        CourseFactory.create_batch(5, program=self.program)
+        data = ProgramSerializer(self.program, context=self.context).data
+        assert data == {
+            'id': self.program.id,
+            'title': self.program.title,
+            'programpage_url': None,
+            'enrolled': False,
+            'total_courses': 5,
         }

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -76,6 +76,7 @@ const PROGRAM: AvailableProgram = {
   title: "Awesomesauce",
   enrolled: true,
   programpage_url: null,
+  total_courses: 0,
 };
 
 

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -135,7 +135,8 @@ export default class LearnerSearch extends SearchkitComponent {
   }
 
   getNumberOfCoursesInProgram = (): number => {
-    return R.pathOr(0, ['hits', 'hits', 0, '_source', 'program', 'total_courses'], this.getResults());
+    const { currentProgramEnrollment } = this.props;
+    return R.pathOr(0, ['total_courses'], currentProgramEnrollment);
   };
 
   renderSearchHeader = (): React$Element<*>|null => {

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -90,6 +90,12 @@ describe('LearnerSearchPage', function () {
     });
   });
 
+  it('uses total_courses for num courses passed max', () => {
+    return renderSearch().then(([wrapper]) => {
+      assert.equal(wrapper.find("RangeFilter").at(0).props().max, 1);
+    });
+  });
+
   it('should set sendAutomaticEmails flag', () => {
     const EMAIL_DIALOG_ACTIONS = [
       START_EMAIL_EDIT,

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -59,6 +59,7 @@ export const makeAvailablePrograms = (dashboard: Dashboard): AvailablePrograms =
     id: program.id,
     programpage_url: `/page/${program.id}`,
     title: `AvailableProgram for ${program.id}`,
+    total_courses: 1,
   }));
 };
 

--- a/static/js/flow/enrollmentTypes.js
+++ b/static/js/flow/enrollmentTypes.js
@@ -6,6 +6,7 @@ export type AvailableProgram = {
   title: string,
   programpage_url: ?string,
   enrolled: boolean,
+  total_courses: ?number,
 };
 
 export type AvailablePrograms = Array<AvailableProgram>;

--- a/static/js/reducers/programs.js
+++ b/static/js/reducers/programs.js
@@ -64,10 +64,8 @@ export const currentProgramEnrollment = (state: any = null, action: Action<any, 
       let enrollment = enrollments.find(enrollment => (
         enrollment.id === state.id
       ));
-      if (enrollment === undefined) {
-        // current enrollment not found in list
-        state = null;
-      }
+
+      state = _.isNil(enrollment) ? null : enrollment;
     }
     if (_.isNil(state) && enrollments.length > 0) {
       // no current enrollment selected, pick first from list if there are any

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -941,7 +941,8 @@ export const PROGRAMS: AvailablePrograms = deepFreeze(DASHBOARD_RESPONSE.program
   id: program.id,
   title: program.title,
   programpage_url: `/program${program.id}/`,
-  enrolled: true
+  enrolled: true,
+  total_courses: 1,
 })));
 
 export const FINANCIAL_AID_PARTIAL_RESPONSE: FinancialAidUserInfo = deepFreeze({


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3095

#### What's this PR do?
Adds the number of courses to the `/programs` api so that the learner search can set a proper maximum range value, rather than depending on the seemingly flaky value in the first hit (which we could be nonexistent if zero results).

#### How should this be manually tested?
- Adjust the bounds of the '# of courses passed' range filter (I set it to 2-3)
- Select any one of the course title filters (I chose 'Digital Learning 100')
- Verify the range slider for '# of courses passed' is still present