### PR TITLE
Update edX cache only for active users

### DIFF
--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -57,12 +57,13 @@ def batch_update_user_data():
         users_expired_cache = UserCacheRefreshTime.objects.filter(
             Q(enrollment__lt=refresh_time_limit) |
             Q(certificate__lt=refresh_time_limit) |
-            Q(current_grade__lt=refresh_time_limit)
+            Q(current_grade__lt=refresh_time_limit),
+            user__is_active=True
         ).values_list('user', flat=True).distinct()
 
         users_not_in_cache = User.objects.exclude(
             Q(id__in=users_expired_cache)
-        ).values_list('id', flat=True)
+        ).filter(is_active=True).values_list('id', flat=True)
 
         users_to_refresh = list(set(users_expired_cache) | set(users_not_in_cache))
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #2099

#### What's this PR do?
Exclude all inactive users from cached users.

#### How should this be manually tested?
Set your user to `is_active=False` and make sure that user is not being cached anymore.
