### PR TITLE
Added wait function

### DIFF
--- a/static/js/actions/course_enrollments.js
+++ b/static/js/actions/course_enrollments.js
@@ -2,18 +2,15 @@
 /* global SETTINGS: false */
 import type { Dispatch } from 'redux';
 
+import { wait } from '../util/util';
 import type { Dispatcher } from '../flow/reduxTypes';
 import { showEnrollPayLaterSuccess } from './ui';
 
 export const showEnrollPayLaterSuccessMessage = (courseId: string): Dispatcher<*> => {
   return (dispatch: Dispatch) => {
     dispatch(showEnrollPayLaterSuccess(courseId));
-    let promise = new Promise(function(resolve) {
-      window.setTimeout(function() {
-        dispatch(showEnrollPayLaterSuccess(null));
-        resolve();
-      }, 9000);
+    return wait(900).then(() => {
+      dispatch(showEnrollPayLaterSuccess(null));
     });
-    return promise;
   };
 };

--- a/static/js/components/Toast.js
+++ b/static/js/components/Toast.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { wait } from '../util/util';
+
 export default class Toast extends React.Component {
   props: {
     children: any,
@@ -15,7 +17,7 @@ export default class Toast extends React.Component {
     const { onTimeout, timeout } = this.props;
 
     if (onTimeout) {
-      setTimeout(onTimeout, timeout);
+      wait(timeout).then(onTimeout);
     }
   }
 

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -105,6 +105,7 @@ import type { PearsonAPIState } from '../reducers/pearson';
 import type { RestState } from '../flow/restTypes';
 import { getOwnDashboard, getOwnCoursePrices } from '../reducers/util';
 import { actions } from '../lib/redux_rest';
+import { wait } from '../util/util';
 
 const isProcessing = R.equals(FETCH_PROCESSING);
 const PEARSON_TOS_DIALOG = "pearsonTOSDialogVisible";
@@ -235,7 +236,7 @@ class DashboardPage extends React.Component {
     dispatch(updateCourseStatus(SETTINGS.user.username, run.course_id, STATUS_PENDING_ENROLLMENT));
 
     if (!this.props.orderReceipt.timeoutActive) {
-      setTimeout(() => {
+      wait(3000).then(() => {
         const { orderReceipt } = this.props;
         dispatch(setTimeoutActive(false));
         let deadline = moment(orderReceipt.initialTime).add(2, 'minutes');
@@ -248,7 +249,7 @@ class DashboardPage extends React.Component {
             icon: TOAST_FAILURE,
           }));
         }
-      }, 3000);
+      });
       dispatch(setTimeoutActive(true));
     }
   };

--- a/static/js/containers/LearnerPage_test.js
+++ b/static/js/containers/LearnerPage_test.js
@@ -45,7 +45,8 @@ import { HIGH_SCHOOL, DOCTORATE } from '../constants';
 import {
   generateNewEducation,
   generateNewWorkHistory,
-  getPreferredName
+  getPreferredName,
+  wait,
 } from '../util/util';
 import IntegrationTestHelper from '../util/integration_test_helper';
 import * as api from '../lib/api';
@@ -207,11 +208,9 @@ describe("LearnerPage", function() {
             }
             TestUtils.Simulate.click(getSave());
           }).then(() => {
-            return new Promise(resolve => {
-              setTimeout(() => { // ensure that the DOM update after clicking 'save' has finished
-                assert(helper.scrollIntoViewStub.called, "Not called yet");
-                resolve();
-              }, 100);
+            // ensure that the DOM update after clicking 'save' has finished
+            return wait(100).then(() => {
+              assert(helper.scrollIntoViewStub.called, "Not called yet");
             });
           });
         });

--- a/static/js/entry/zendesk_widget.js
+++ b/static/js/entry/zendesk_widget.js
@@ -2,6 +2,8 @@
 __webpack_public_path__ = `${SETTINGS.public_path}`;  // eslint-disable-line no-undef, camelcase
 import R from 'ramda';
 
+import { wait } from '../util/util';
+
 // Start of odl Zendesk Widget script
 /*<![CDATA[*/
 window.zEmbed || function (e, t) {
@@ -104,17 +106,17 @@ const zendeskCallbacks = {
         // Apparently we can't modify the ticket submission form *immediately*
         // on the click event -- I assume that the Javascript that Zendesk runs
         // re-renders the form immediately, which would override any modification
-        // that might happen here. Instead, we use `setTimeout` to modify the
+        // that might happen here. Instead, we use `wait` to modify the
         // form after a short delay. This way, we modify the re-rendered version,
         // and the changes we make will be visible to the user.
-        setTimeout(() => {
+        wait(100).then(() => {
           const ticketIFrame = document.querySelector("iframe.zEWidget-ticketSubmissionForm");
           let select = ticketIFrame.contentDocument.querySelector("select");
           const optionValues = _.map(select.options, "value");
           if (optionValues.includes(programSlug)) {
             select.value = programSlug;
           }
-        }, 100);
+        });
       };
     }
   },

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -554,3 +554,11 @@ export const mapObj = R.curry((fn, obj) => R.compose(
   R.map(fn),
   R.toPairs
 )(obj));
+
+export const wait = (millis: number): Promise<void> => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, millis);
+  });
+};

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -555,10 +555,9 @@ export const mapObj = R.curry((fn, obj) => R.compose(
   R.toPairs
 )(obj));
 
-export const wait = (millis: number): Promise<void> => {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve();
-    }, millis);
-  });
-};
+/**
+ * Returns a promise which resolves after a number of milliseconds have elapsed
+ */
+export const wait = (millis: number): Promise<void> => (
+  new Promise(resolve => setTimeout(resolve, millis))
+);

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -36,6 +36,7 @@ import {
   highlight,
   sortedCourseRuns,
   mapObj,
+  wait,
 } from '../util/util';
 import {
   EDUCATION_LEVELS,
@@ -858,5 +859,22 @@ describe('utility functions', () => {
       );
       assert.deepEqual(edited, { baz_foo: 'baz_bar' });
     });
+  });
+
+  it('waits some milliseconds', done => {
+    let executed = false;
+    wait(30).then(() => {
+      executed = true;
+    });
+
+    setTimeout(() => {
+      assert.isFalse(executed);
+
+      setTimeout(() => {
+        assert.isTrue(executed);
+
+        done();
+      }, 20);
+    }, 20);
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Added a `wait` function which wraps around `setTimeout` and returns a promise which resolves when the time has elapsed.

#### How should this be manually tested?
Go to `/dashboard/?status=receipt&course_key=missing` and look at your network tab. Every three seconds there should be a dashboard refresh