### PR TITLE
Add test for filters being displayed when there are zero hits

### DIFF
--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -7,6 +7,7 @@ import axios from 'axios';
 import { Utils as SearchkitUtils } from 'searchkit';
 
 import IntegrationTestHelper from '../util/integration_test_helper';
+import { wait } from '../util/util';
 import {
   PROGRAMS,
   ELASTICSEARCH_RESPONSE,
@@ -460,6 +461,39 @@ describe('LearnerSearchPage', function () {
           "Degree: High school",
           "Company: Microsoft",
         ]);
+      });
+    });
+  });
+
+  it('shows filters and the textbox even if there are no results', () => {
+    const query = {
+      "courses": ["Digital Learning 200"],
+      "final-grade": {"min": 50, "max": 100},
+      "payment_status": ["Paid"],
+      "semester": ["2016 - Spring"],
+      "num-courses-passed": {},
+      "grade-average": {"min": 47, "max": 100},
+      "birth_location": ["US"],
+      "country": [["US"], ["US-ME"]],
+      "education_level": ["hs"],
+      "company_name": ["Microsoft"]
+    };
+
+    const noHitsResponse = {
+      hits: {
+        'total': 0,
+        'max_score': null,
+        'hits': []
+      }
+    };
+    replySpy.returns(Promise.resolve([200, noHitsResponse]));
+    return renderSearch().then(([wrapper]) => {
+      const searchkit = wrapper.find("SearchkitProvider").props().searchkit;
+      searchkit.searchFromUrlQuery(query);
+
+      return wait(1000).then(() => {
+        assert(wrapper.find('.sk-search-box'), 'Unable to find textbox');
+        assert.equal(wrapper.find('.filter-visibility-toggle').length, 9);
       });
     });
   });

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -7,7 +7,6 @@ import axios from 'axios';
 import { Utils as SearchkitUtils } from 'searchkit';
 
 import IntegrationTestHelper from '../util/integration_test_helper';
-import { wait } from '../util/util';
 import {
   PROGRAMS,
   ELASTICSEARCH_RESPONSE,
@@ -491,10 +490,8 @@ describe('LearnerSearchPage', function () {
       const searchkit = wrapper.find("SearchkitProvider").props().searchkit;
       searchkit.searchFromUrlQuery(query);
 
-      return wait(1000).then(() => {
-        assert(wrapper.find('.sk-search-box'), 'Unable to find textbox');
-        assert.equal(wrapper.find('.filter-visibility-toggle').length, 9);
-      });
+      assert(wrapper.find('.sk-search-box'), 'Unable to find textbox');
+      assert.equal(wrapper.find('.filter-visibility-toggle').length, 9);
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3193 

#### What's this PR do?
Tests for the fix made in #3184. No matter what filters are enabled or what text is in the textbox we should not show an error screen

#### How should this be manually tested?
Revert the commit for #3184 and run the test locally. It should fail
