### PR TITLE
Small styling tweaks on the Send Email form

### DIFF
--- a/static/scss/email-composition-dialog.scss
+++ b/static/scss/email-composition-dialog.scss
@@ -97,7 +97,7 @@
       }
 
       .subheading-section {
-        padding-bottom: 20px;
+        margin: 10px 0 20px 10px;
 
         .subheading-to {
           padding: 0 10px;
@@ -225,8 +225,12 @@
   display: flex;
 
   .custom-toolbar-button {
-    width: 130px;
+    font-size: 14px;
+    padding: 0 9px;
+    background: $bg-med-gray;
+    color: $font-gray;
     height: 30px;
+    width: auto;
   }
 
   .insert {


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
This tweaks the visual style of the email macros buttons on the Send Email form... 

![image](https://cloud.githubusercontent.com/assets/20047260/26174802/897db56a-3b1e-11e7-9747-ffc9afbaeb47.png)

and also tweaks the margins for the # of recipients text:

![image](https://cloud.githubusercontent.com/assets/20047260/26174832/a002e0c6-3b1e-11e7-956d-89aef95d0c92.png)

