### PR TITLE
Fix wait timeout

### DIFF
--- a/static/js/actions/course_enrollments.js
+++ b/static/js/actions/course_enrollments.js
@@ -9,7 +9,7 @@ import { showEnrollPayLaterSuccess } from './ui';
 export const showEnrollPayLaterSuccessMessage = (courseId: string): Dispatcher<*> => {
   return (dispatch: Dispatch) => {
     dispatch(showEnrollPayLaterSuccess(courseId));
-    return wait(900).then(() => {
+    return wait(9000).then(() => {
       dispatch(showEnrollPayLaterSuccess(null));
     });
   };

--- a/static/js/actions/course_enrollments_test.js
+++ b/static/js/actions/course_enrollments_test.js
@@ -1,6 +1,7 @@
 // @flow
 import { assert } from 'chai';
 import configureTestStore from 'redux-asserts';
+import sinon from 'sinon';
 
 import { showEnrollPayLaterSuccessMessage } from './course_enrollments';
 import {
@@ -8,26 +9,34 @@ import {
   SHOW_ENROLL_PAY_LATER_SUCCESS,
 } from './ui';
 import rootReducer from '../reducers';
+import * as util from '../util/util';
 
 describe('show and hide enroll pay later success alert', () => {
-  let store, dispatchThen;
+  let store, sandbox, dispatchThen;
 
   beforeEach(() => {
     store = configureTestStore(rootReducer);
     dispatchThen = store.createDispatchThen(state => state.ui);
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   it('should set and reset enroll pay later dialog', () => {
+    let waitPromise = Promise.resolve();
+    let waitStub = sandbox.stub(util, 'wait').returns(waitPromise);
+
     return dispatchThen(
       showEnrollPayLaterSuccessMessage('foo/bar/baz'),
       [SHOW_ENROLL_PAY_LATER_SUCCESS]
     ).then((state) => {
       assert.equal(state.showEnrollPayLaterSuccess, 'foo/bar/baz');
-      return dispatchThen(
-        showEnrollPayLaterSuccess(null),
-        [SHOW_ENROLL_PAY_LATER_SUCCESS]
-      ).then((state) => {
-        assert.deepEqual(state.showEnrollPayLaterSuccess, null);
+
+      sinon.assert.calledWith(waitStub, 9000);
+      return waitPromise.then(() => {
+        assert.deepEqual(store.getState().ui.showEnrollPayLaterSuccess, null);
       });
     });
   });

--- a/static/js/actions/course_enrollments_test.js
+++ b/static/js/actions/course_enrollments_test.js
@@ -4,10 +4,7 @@ import configureTestStore from 'redux-asserts';
 import sinon from 'sinon';
 
 import { showEnrollPayLaterSuccessMessage } from './course_enrollments';
-import {
-  showEnrollPayLaterSuccess,
-  SHOW_ENROLL_PAY_LATER_SUCCESS,
-} from './ui';
+import { SHOW_ENROLL_PAY_LATER_SUCCESS } from './ui';
 import rootReducer from '../reducers';
 import * as util from '../util/util';
 


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes the timeout for the enroll success message. It was 9 seconds but it was inadvertently changed to 900 milliseconds in https://github.com/mitodl/micromasters/pull/3195

#### How should this be manually tested?
Enroll in a course. The success message should stay up for about 9 seconds
