### PR TITLE
Shown Coupons without code on order summary page

### DIFF
--- a/static/js/components/OrderSummary.js
+++ b/static/js/components/OrderSummary.js
@@ -70,9 +70,9 @@ class OrderSummary extends React.Component {
   render() {
     let { course, courseRun, checkout, checkoutStatus, couponCode, discount} = this.props;
     let discountInfo;
-    const message = couponCode ? `Discount from coupon ${couponCode}` : 'Discount from coupon';
 
     if (discount) {
+      const message = couponCode ? `Discount from coupon ${couponCode}` : 'Discount from coupon';
       discountInfo = [
         this.showAmount(message, this.getDiscountAmount()),
         <Cell col={10} tablet={6} phone={4} className="division-line" key="division"/>,

--- a/static/js/components/OrderSummary.js
+++ b/static/js/components/OrderSummary.js
@@ -68,15 +68,18 @@ class OrderSummary extends React.Component {
   }
 
   render() {
-    let { course, courseRun, checkout, checkoutStatus, couponCode} = this.props;
+    let { course, courseRun, checkout, checkoutStatus, couponCode, discount} = this.props;
     let discountInfo;
-    if (couponCode) {
+    const message = couponCode ? `Discount from coupon ${couponCode}` : 'Discount from coupon';
+
+    if (discount) {
       discountInfo = [
-        this.showAmount(`Discount from coupon ${couponCode}`, this.getDiscountAmount()),
+        this.showAmount(message, this.getDiscountAmount()),
         <Cell col={10} tablet={6} phone={4} className="division-line" key="division"/>,
         this.showAmount('Total', this.getFinalPrice())
       ];
     }
+
     return (
       <div>
         <Card shadow={1}>

--- a/static/js/components/OrderSummary_test.js
+++ b/static/js/components/OrderSummary_test.js
@@ -64,27 +64,32 @@ describe('OrderSummary', () => {
     );
   };
 
-  it('shows discount calculation if user has a coupon', () => {
-    let course = findCourse(course => (
-      course.runs.length > 0 &&
-      course.runs[0].status === STATUS_OFFERED
-    ));
-    let firstRun = course.runs[0];
-    const wrapper = renderOrderSummary({
-      courseRun: firstRun,
-      course: course,
-      discount: COURSE_PRICES_RESPONSE[1].price,
-      finalPrice: 0,
-      couponCode: '561KH'
-    });
+  for (let code of ['561KH', null, '']) {
+    it(`shows discount calculation if user has a coupon with code ${code}`, () => {
+      let course = findCourse(course => (
+        course.runs.length > 0 &&
+        course.runs[0].status === STATUS_OFFERED
+      ));
+      let firstRun = course.runs[0];
+      const wrapper = renderOrderSummary({
+        courseRun: firstRun,
+        course: course,
+        discount: COURSE_PRICES_RESPONSE[1].price,
+        finalPrice: 0,
+        couponCode: code
+      });
 
-    let descriptions = wrapper.find(".description");
-    assert.equal(descriptions.length, 3);
-    assert.equal(descriptions.children().nodes[1], 'Discount from coupon 561KH');
-    let amounts = wrapper.find(".amount");
-    assert.equal(amounts.length, 3);
-    assert.equal(amounts.children().nodes[1], `-$${COURSE_PRICES_RESPONSE[1].price}`);
-  });
+      let descriptions = wrapper.find(".description");
+      assert.equal(descriptions.length, 3);
+      assert.equal(
+        descriptions.children().nodes[1],
+        code ? `Discount from coupon ${code}` : 'Discount from coupon'
+      );
+      let amounts = wrapper.find(".amount");
+      assert.equal(amounts.length, 3);
+      assert.equal(amounts.children().nodes[1], `-$${COURSE_PRICES_RESPONSE[1].price}`);
+    });
+  }
 
   it('does not show discount calculation if no discount applies', () => {
     let course = findCourse(course => (

--- a/static/js/components/OrderSummary_test.js
+++ b/static/js/components/OrderSummary_test.js
@@ -69,7 +69,7 @@ describe('OrderSummary', () => {
     [null, 'null coupon code'],
     ['', 'blank coupon code']
   ].forEach(([code, codeDescription]) => {
-    it(`shows discount calculation if user has a coupon with code ${codeDescription}`, () => {
+    it(`shows discount calculation if user has a coupon with ${codeDescription}`, () => {
       let course = findCourse(course => (
         course.runs.length > 0 &&
         course.runs[0].status === STATUS_OFFERED

--- a/static/js/components/OrderSummary_test.js
+++ b/static/js/components/OrderSummary_test.js
@@ -64,8 +64,12 @@ describe('OrderSummary', () => {
     );
   };
 
-  for (let code of ['561KH', null, '']) {
-    it(`shows discount calculation if user has a coupon with code ${code}`, () => {
+  [
+    ['561KH', 'non-blank coupon code'],
+    [null, 'null coupon code'],
+    ['', 'blank coupon code']
+  ].forEach(([code, codeDescription]) => {
+    it(`shows discount calculation if user has a coupon with code ${codeDescription}`, () => {
       let course = findCourse(course => (
         course.runs.length > 0 &&
         course.runs[0].status === STATUS_OFFERED
@@ -89,7 +93,7 @@ describe('OrderSummary', () => {
       assert.equal(amounts.length, 3);
       assert.equal(amounts.children().nodes[1], `-$${COURSE_PRICES_RESPONSE[1].price}`);
     });
-  }
+  });
 
   it('does not show discount calculation if no discount applies', () => {
     let course = findCourse(course => (


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3125

#### What's this PR do?
Allow coupon without code display in order summary

#### How should this be manually tested?
Go to order summary on a course which has a coupon without code

@pdpinch 