### PR TITLE
Removed EXAMS_CARD_ENABLED logic so card always shows (#3002)

### DIFF
--- a/static/js/components/dashboard/FinalExamCard.js
+++ b/static/js/components/dashboard/FinalExamCard.js
@@ -236,10 +236,6 @@ export default class FinalExamCard extends React.Component<void, Props, void> {
       showPearsonTOSDialog
     } = this.props;
 
-    if (!SETTINGS.FEATURES.EXAMS) {
-      return null;
-    }
-
     switch (program.pearson_exam_status) {
     case PEARSON_PROFILE_ABSENT:
       return absentCard();

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -16,9 +16,7 @@ const _createSettings = () => ({
   es_page_size: 40,
   EXAMS_SSO_CLIENT_CODE: 'foobarcode',
   EXAMS_SSO_URL: 'http://foo.bar/baz',
-  FEATURES: {
-    EXAMS: true,
-  },
+  FEATURES: {}, // placeholder
   get username() {
     throw new Error("username was removed");
   }

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -14,4 +14,4 @@ class FeatureFlag(Enum):
     Members should have values of increasing powers of 2 (1, 2, 4, 8, ...)
 
     """
-    EXAMS = 1
+    EXAMS = 1  # DEPRECATED: unfortunately, empty enums aren't a Thing, so this has to stay for now

--- a/ui/views.py
+++ b/ui/views.py
@@ -22,7 +22,6 @@ from profiles.permissions import CanSeeIfNotPrivate
 from roles.models import Instructor, Staff
 from ui.decorators import require_mandatory_urls
 from ui.templatetags.render_bundle import public_path
-from ui.utils import FeatureFlag
 
 log = logging.getLogger(__name__)
 
@@ -62,12 +61,7 @@ class ReactView(View):  # pylint: disable=unused-argument
             "public_path": public_path(request),
             "EXAMS_SSO_CLIENT_CODE": settings.EXAMS_SSO_CLIENT_CODE,
             "EXAMS_SSO_URL": settings.EXAMS_SSO_URL,
-            "FEATURES": {
-                "EXAMS": (
-                    settings.FEATURES.get('EXAMS_CARD_ENABLED', False) or
-                    FeatureFlag.EXAMS in getattr(request, 'mm_feature_flags', [])
-                ),
-            },
+            "FEATURES": {},  # placeholder
         }
 
         return render(

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -270,7 +270,6 @@ class DashboardTests(ViewsTests):
     """
     Tests for dashboard views
     """
-    @override_settings(FEATURES={"EXAMS_CARD_ENABLED": False})
     def test_dashboard_settings(self):
         """
         Assert settings we pass to dashboard
@@ -329,9 +328,7 @@ class DashboardTests(ViewsTests):
                 'public_path': '/static/bundles/',
                 'EXAMS_SSO_CLIENT_CODE': 'itsacode',
                 'EXAMS_SSO_URL': 'url',
-                'FEATURES': {
-                    'EXAMS': False,
-                },
+                'FEATURES': {},
             }
             assert resp.context['is_public'] is False
             assert resp.context['has_zendesk_widget'] is True
@@ -668,7 +665,6 @@ class TestUsersPage(ViewsTests):
     Tests for user page
     """
 
-    @override_settings(FEATURES={"EXAMS_CARD_ENABLED": False})
     def test_users_logged_in(self):
         """
         Assert settings we pass to dashboard
@@ -728,9 +724,7 @@ class TestUsersPage(ViewsTests):
                     'public_path': '/static/bundles/',
                     'EXAMS_SSO_CLIENT_CODE': 'itsacode',
                     'EXAMS_SSO_URL': 'url',
-                    'FEATURES': {
-                        'EXAMS': False,
-                    },
+                    'FEATURES': {},
                 }
                 assert has_permission.called
 
@@ -743,7 +737,6 @@ class TestUsersPage(ViewsTests):
                     'zendesk_widget',
                 }
 
-    @override_settings(FEATURES={"EXAMS_CARD_ENABLED": False})
     def test_users_anonymous(self):
         """
         Assert settings we pass to dashboard
@@ -798,9 +791,7 @@ class TestUsersPage(ViewsTests):
                     'public_path': '/static/bundles/',
                     'EXAMS_SSO_CLIENT_CODE': 'itsacode',
                     'EXAMS_SSO_URL': 'url',
-                    'FEATURES': {
-                        'EXAMS': False,
-                    },
+                    'FEATURES': {},
                 }
                 assert has_permission.called
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3002 

#### What's this PR do?
Removes the feature flag and ensures the exam card is always visible.

#### How should this be manually tested?
Setup an exam authorization for yourself and ensure `FEATURE_EXAMS_CARD_ENABLED` is not in your `.env`. Verify the card still appears for you.
