### PR TITLE
Renamed send button to Save Changes on automatic email edit button

### DIFF
--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -68,7 +68,7 @@ type EmailDialogProps = {
   updateEmailFieldEdit:       () => void,
   renderRecipients?:          (filters: ?Array<Filter>) => React$Element<*>,
   updateEmailBody:            (e: Object) => void,
-  type:                       string
+  dialogType:                 string
 };
 
 export default class EmailCompositionDialog extends React.Component {
@@ -205,7 +205,7 @@ export default class EmailCompositionDialog extends React.Component {
       dialogVisibility,
       updateEmailFieldEdit,
       renderRecipients,
-      type
+      dialogType
     } = this.props;
     const { editorState } = this.state;
 
@@ -220,7 +220,7 @@ export default class EmailCompositionDialog extends React.Component {
           this.closeEmailComposeAndClear,
           this.closeEmailComposerAndSend,
           fetchStatus === FETCH_PROCESSING,
-          this.okButtonLabel(type)
+          this.okButtonLabel(dialogType)
         )
       }
       onRequestClose={this.closeEmailComposeAndClear}

--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -6,6 +6,7 @@ import { Editor } from 'react-draft-wysiwyg';
 // $FlowFixMe: Flow thinks this module isn't present for some reason
 import { EditorState, ContentState, convertFromHTML, Modifier } from 'draft-js';
 
+import { AUTOMATIC_EMAIL_ADMIN_TYPE } from './constants';
 import AutomaticEmailOptions from './AutomaticEmailOptions';
 import RecipientVariableButton from './RecipientVariableButton';
 import { FETCH_PROCESSING } from '../../actions';
@@ -67,6 +68,7 @@ type EmailDialogProps = {
   updateEmailFieldEdit:       () => void,
   renderRecipients?:          (filters: ?Array<Filter>) => React$Element<*>,
   updateEmailBody:            (e: Object) => void,
+  type:                       string
 };
 
 export default class EmailCompositionDialog extends React.Component {
@@ -190,6 +192,9 @@ export default class EmailCompositionDialog extends React.Component {
     />;
   });
 
+  okButtonLabel = (dialogType: string) => (
+    dialogType === AUTOMATIC_EMAIL_ADMIN_TYPE ? 'Save Changes' : 'Send'
+  );
 
   render() {
     if (!this.props.activeEmail) return null;
@@ -200,6 +205,7 @@ export default class EmailCompositionDialog extends React.Component {
       dialogVisibility,
       updateEmailFieldEdit,
       renderRecipients,
+      type
     } = this.props;
     const { editorState } = this.state;
 
@@ -214,7 +220,7 @@ export default class EmailCompositionDialog extends React.Component {
           this.closeEmailComposeAndClear,
           this.closeEmailComposerAndSend,
           fetchStatus === FETCH_PROCESSING,
-          'Send'
+          this.okButtonLabel(type)
         )
       }
       onRequestClose={this.closeEmailComposeAndClear}

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -17,6 +17,12 @@ import {
   TEST_EMAIL_CONFIG,
   INITIAL_TEST_EMAIL_STATE
 } from './test_constants';
+import {
+  AUTOMATIC_EMAIL_ADMIN_TYPE,
+  LEARNER_EMAIL_TYPE,
+  COURSE_EMAIL_TYPE,
+  SEARCH_EMAIL_TYPE
+} from './constants';
 
 describe('EmailCompositionDialog', () => {
   let sandbox, sendStub, closeStub, updateStub;
@@ -93,6 +99,24 @@ describe('EmailCompositionDialog', () => {
     TestUtils.Simulate.click(getDialog().querySelector('.save-button'));
     assert.isTrue(sendStub.called, "called send handler");
   });
+
+  it('should rename "send" button to "Save Changes"', () => {
+    renderDialog(
+      {inputs: {subject: 'abc', body: 'abc'}},
+      {type: AUTOMATIC_EMAIL_ADMIN_TYPE}
+    );
+    assert.equal(getDialog().querySelector('.save-button').textContent, "Save Changes");
+  });
+
+  for (let type of [LEARNER_EMAIL_TYPE, COURSE_EMAIL_TYPE, SEARCH_EMAIL_TYPE]) {
+    it(`should label primary button as"send" for composer type ${type}`, () => {
+      renderDialog(
+        {inputs: {subject: 'abc', body: 'abc'}},
+        {type: type}
+      );
+      assert.equal(getDialog().querySelector('.save-button').textContent, "Send");
+    });
+  }
 
   it('should fire the close handler when the "cancel" button is clicked', () => {
     renderDialog();

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -100,19 +100,19 @@ describe('EmailCompositionDialog', () => {
     assert.isTrue(sendStub.called, "called send handler");
   });
 
-  it('should rename "send" button to "Save Changes"', () => {
+  it('should show a "Save" label when the dialog is being used to edit an email', () => {
     renderDialog(
       {inputs: {subject: 'abc', body: 'abc'}},
-      {type: AUTOMATIC_EMAIL_ADMIN_TYPE}
+      {dialogType: AUTOMATIC_EMAIL_ADMIN_TYPE}
     );
     assert.equal(getDialog().querySelector('.save-button').textContent, "Save Changes");
   });
 
-  for (let type of [LEARNER_EMAIL_TYPE, COURSE_EMAIL_TYPE, SEARCH_EMAIL_TYPE]) {
-    it(`should label primary button as"send" for composer type ${type}`, () => {
+  for (let dialogType of [LEARNER_EMAIL_TYPE, COURSE_EMAIL_TYPE, SEARCH_EMAIL_TYPE]) {
+    it('should show a "Send" label when the dialog is being used to send an email', () => {
       renderDialog(
         {inputs: {subject: 'abc', body: 'abc'}},
-        {type: type}
+        {dialogType: dialogType}
       );
       assert.equal(getDialog().querySelector('.save-button').textContent, "Send");
     });

--- a/static/js/components/email/hoc.js
+++ b/static/js/components/email/hoc.js
@@ -120,7 +120,7 @@ export const withEmailDialog = R.curry(
             subheadingRenderer={emailConfig.renderSubheading}
             renderRecipients={emailConfig.renderRecipients}
             updateEmailBody={this.updateEmailBody}
-            type={activeEmailType}
+            dialogType={activeEmailType}
           />
         );
       }

--- a/static/js/components/email/hoc.js
+++ b/static/js/components/email/hoc.js
@@ -120,6 +120,7 @@ export const withEmailDialog = R.curry(
             subheadingRenderer={emailConfig.renderSubheading}
             renderRecipients={emailConfig.renderRecipients}
             updateEmailBody={this.updateEmailBody}
+            type={activeEmailType}
           />
         );
       }


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3182

#### What's this PR do?
it changes the label of edit email dialog which was previously `Send` but now it is renamed to `Save Changes`

#### How should this be manually tested?
Go to http://192.168.99.100:8079/automaticemails/ and try to edit email.

@pdpinch 
#### Screenshots (if appropriate)
<img width="1071" alt="screen shot 2017-05-22 at 3 07 22 pm" src="https://cloud.githubusercontent.com/assets/10431250/26304843/4cf59126-3f06-11e7-8c55-0bf91eee60cc.png">
