### PR TITLE
Upgrade pylint, treat warnings as errors

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -35,7 +35,7 @@ class HomePage(Page):
     content_panels = []
     subpage_types = ['ProgramPage']
 
-    def get_context(self, request):
+    def get_context(self, request, *args, **kwargs):
         programs = Program.objects.filter(live=True).select_related('programpage').order_by("id")
         js_settings = {
             "gaTrackingID": settings.GA_TRACKING_ID,
@@ -84,7 +84,7 @@ class ProgramChildPage(Page):
         """ Get the parent ProgramPage"""
         return ProgramPage.objects.ancestor_of(self).first()
 
-    def get_context(self, request):
+    def get_context(self, request, *args, **kwargs):
         context = get_program_page_context(self.parent_page(), request)
         context['child_page'] = self
         context['active_tab'] = self.title
@@ -199,7 +199,7 @@ class ProgramPage(Page):
         InlinePanel('semester_dates', label='Future Semester Dates'),
     ]
 
-    def get_context(self, request):
+    def get_context(self, request, *args, **kwargs):
         context = get_program_page_context(self, request)
         context['active_tab'] = 'about'
         return context
@@ -345,7 +345,7 @@ class FrequentlyAskedQuestion(Orderable):
     answer = RichTextField()
     slug = models.SlugField(unique=True, default=None, blank=True)
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
         if not self.slug:
             max_length = FrequentlyAskedQuestion._meta.get_field('slug').max_length
             slug = orig_slug = slugify(self.question)[:max_length]

--- a/courses/models.py
+++ b/courses/models.py
@@ -168,7 +168,7 @@ class CourseRun(models.Model):
     def __str__(self):
         return self.title
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
         """Overridden save method"""
         if not self.edx_course_key:
             self.edx_course_key = None

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -17,7 +17,7 @@ from backends import utils
 from backends.edxorg import EdxOrgOAuth2
 from dashboard.models import UserCacheRefreshTime
 from dashboard.api_edx_cache import CachedEdxDataApi
-from micromasters.celery import async
+from micromasters.celery import app
 from micromasters.utils import (
     chunks,
     now_in_utc,
@@ -34,7 +34,7 @@ LOCK_EXPIRE = 60 * 60 * 2  # Lock expires in 2 hrs
 lock_id = '{0}-lock'.format(uuid.uuid4())
 
 
-@async.task
+@app.task
 def batch_update_user_data():
     """
     Create sub tasks to update user data like enrollments,
@@ -81,7 +81,7 @@ def batch_update_user_data():
             release_lock()
 
 
-@async.task(rate_limit=PARALLEL_RATE_LIMIT)
+@app.task(rate_limit=PARALLEL_RATE_LIMIT)
 def batch_update_user_data_subtasks(students):
     """
     Update user data like enrollments, certificates and grades from edX platform.

--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -315,7 +315,7 @@ class UserCourseEnrollmentTest(MockedESTestCase, APITestCase):
         assert PossiblyImproperlyConfigured.__name__ in resp.data[0]
 
         # if the error from the call to edX is is not HTTPError, the user gets a normal json error
-        mock_edx_enr.side_effect = ValueError()  # pylint: disable=redefined-variable-type
+        mock_edx_enr.side_effect = ValueError()
         resp = self.client.post(self.url, {'course_id': self.course_id}, format='json')
         assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         # the response has a structure like {"error": "<message>"}

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -361,7 +361,7 @@ class Coupon(TimestampedModel, AuditableModel):
         """
         return serialize_model_object(self)
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
         """Override save to do certain validations"""
         self.full_clean()
         super().save(*args, **kwargs)

--- a/exams/factories.py
+++ b/exams/factories.py
@@ -17,6 +17,7 @@ from exams.models import (
     ExamRun,
 )
 from micromasters.factories import UserFactory
+from micromasters.utils import as_datetime
 from profiles.factories import ProfileFactory
 
 FAKE = faker.Factory.create()
@@ -54,7 +55,8 @@ class ExamRunFactory(DjangoModelFactory):
         lambda exam_run: exam_run.date_first_eligible + timedelta(days=20)
     )
     date_grades_available = factory.LazyAttribute(
-        lambda exam_run: exam_run.date_last_eligible
+        # Convert date to datetime
+        lambda exam_run: as_datetime(exam_run.date_last_eligible)
     )
     authorized = False
 

--- a/exams/pearson/utils_test.py
+++ b/exams/pearson/utils_test.py
@@ -49,7 +49,7 @@ class PearsonUtilsTest(SimpleTestCase):
         """Tests parse_or_default uses parsed value or default"""
         assert utils.parse_or_default(int, None)('5') == 5
         assert utils.parse_or_default(int, None)('') is None
-        assert utils.parse_or_default(int, 4)('') is 4
+        assert utils.parse_or_default(int, 4)('') == 4
 
     @patch('mail.api.MailgunClient')
     def test_email_processing_failures(self, mailgun_client_mock):  # pylint: disable=no-self-use

--- a/exams/tasks.py
+++ b/exams/tasks.py
@@ -24,7 +24,7 @@ from exams.utils import (
     exponential_backoff,
     validate_profile,
 )
-from micromasters.celery import async
+from micromasters.celery import app
 from micromasters.utils import now_in_utc
 
 PEARSON_CDD_FILE_PREFIX = "cdd-%Y%m%d%H_"
@@ -37,7 +37,7 @@ PEARSON_FILE_ENCODING = "utf-8"
 log = logging.getLogger(__name__)
 
 
-@async.task(bind=True, max_retries=3)
+@app.task(bind=True, max_retries=3)
 def export_exam_profiles(self):
     """
     Sync any outstanding profiles
@@ -116,7 +116,7 @@ def export_exam_profiles(self):
         log.exception('Unexpected exception updating ExamProfile.status')
 
 
-@async.task(bind=True, max_retries=3)
+@app.task(bind=True, max_retries=3)
 def export_exam_authorizations(self):
     """
     Sync any outstanding profiles
@@ -175,7 +175,7 @@ def export_exam_authorizations(self):
             log.exception('Unexpected exception updating ExamProfile.status')
 
 
-@async.task
+@app.task
 def batch_process_pearson_zip_files():
     """
     Fetch zip files from pearsons sftp periodically.
@@ -194,7 +194,7 @@ def batch_process_pearson_zip_files():
         log.exception('Retryable error during SFTP operation')
 
 
-@async.task
+@app.task
 def update_exam_run(exam_run_id):
     """
     An updated ExamRun means all authorizations should be updated
@@ -210,7 +210,7 @@ def update_exam_run(exam_run_id):
     api.update_authorizations_for_exam_run(exam_run)
 
 
-@async.task
+@app.task
 def authorize_exam_runs():
     """
     Check for outstanding exam runs

--- a/financialaid/admin.py
+++ b/financialaid/admin.py
@@ -25,7 +25,7 @@ class FinancialAidAdmin(admin.ModelAdmin):
     """Admin for FinancialAid"""
     model = FinancialAid
 
-    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument, arguments-differ
         return False
 
     def save_model(self, request, obj, form, change):
@@ -40,10 +40,10 @@ class FinancialAidAuditAdmin(admin.ModelAdmin):
     model = FinancialAidAudit
     readonly_fields = get_field_names(FinancialAidAudit)
 
-    def has_add_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def has_add_permission(self, *args, **kwargs):  # pylint: disable=unused-argument, arguments-differ
         return False
 
-    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument, arguments-differ
         return False
 
 

--- a/financialaid/models.py
+++ b/financialaid/models.py
@@ -46,7 +46,7 @@ class TierProgram(TimestampedModel):
         return 'tier "{0}" for program "{1}"'.format(self.tier.name, self.program.title)
 
     @transaction.atomic
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
         """
         Override the save to enforce the existence of only one `current` = True
         per program and tier
@@ -77,7 +77,7 @@ class FinancialAid(TimestampedModel, AuditableModel):
     justification = models.TextField(null=True)
     country_of_residence = models.TextField()
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
         """
         Override save to make sure only one FinancialAid object exists for a User and the associated Program
         """

--- a/financialaid/tasks.py
+++ b/financialaid/tasks.py
@@ -6,10 +6,10 @@ import requests
 from financialaid.api import update_currency_exchange_rate
 from financialaid.constants import get_currency_exchange_rate_api_request_url
 from financialaid.exceptions import ExceededAPICallsException, UnexpectedAPIErrorException
-from micromasters.celery import async
+from micromasters.celery import app
 
 
-@async.task
+@app.task
 def sync_currency_exchange_rates():
     """
     Updates all CurrencyExchangeRate objects to reflect latest exchange rates from

--- a/grades/admin.py
+++ b/grades/admin.py
@@ -13,7 +13,7 @@ class FinalGradeAdmin(admin.ModelAdmin):
     list_display = ('id', 'grade', 'user', 'course_run', )
     ordering = ('course_run',)
 
-    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument, arguments-differ
         return False
 
     def save_model(self, request, obj, form, change):
@@ -31,10 +31,10 @@ class FinalGradeAuditAdmin(admin.ModelAdmin):
     ordering = ('final_grade', 'id', )
     list_filter = ('final_grade__course_run__edx_course_key', )
 
-    def has_add_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def has_add_permission(self, *args, **kwargs):  # pylint: disable=unused-argument, arguments-differ
         return False
 
-    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument, arguments-differ
         return False
 
 
@@ -51,7 +51,7 @@ class ProctoredExamGradeAdmin(admin.ModelAdmin):
     list_display = ('id', 'user', 'course', )
     ordering = ('course', 'user')
 
-    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument, arguments-differ
         return False
 
     def save_model(self, request, obj, form, change):
@@ -69,10 +69,10 @@ class ProctoredExamGradeAuditAdmin(admin.ModelAdmin):
     ordering = ('proctored_exam_grade', 'id', )
     list_filter = ('proctored_exam_grade__course__title', )
 
-    def has_add_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def has_add_permission(self, *args, **kwargs):  # pylint: disable=unused-argument, arguments-differ
         return False
 
-    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument, arguments-differ
         return False
 
 admin.site.register(models.FinalGrade, FinalGradeAdmin)

--- a/grades/models.py
+++ b/grades/models.py
@@ -117,7 +117,7 @@ class FinalGrade(TimestampedModel, AuditableModel):
             course_id=self.course_run.edx_course_key
         )
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
         """Overridden method to run validation"""
         self.full_clean()
         return super().save(*args, **kwargs)

--- a/grades/tasks.py
+++ b/grades/tasks.py
@@ -11,7 +11,7 @@ from django.core.cache import caches
 from courses.models import CourseRun
 from grades import api
 from grades.models import CourseRunGradingStatus
-from micromasters.celery import async
+from micromasters.celery import app
 from micromasters.utils import chunks
 
 
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 cache_redis = caches['redis']
 
 
-@async.task
+@app.task
 def find_course_runs_and_freeze_grades():
     """
     Async task that takes care of finding all the course
@@ -38,7 +38,7 @@ def find_course_runs_and_freeze_grades():
         freeze_course_run_final_grades.delay(run.id)
 
 
-@async.task
+@app.task
 def freeze_course_run_final_grades(course_run_id):
     """
     Async task manager to freeze all the users' final grade in a course run
@@ -104,7 +104,7 @@ def freeze_course_run_final_grades(course_run_id):
     cache_redis.set(cache_id, results.id, None)
 
 
-@async.task
+@app.task
 def freeze_users_final_grade_async(user_ids, course_run_id):
     """
     Async task to freeze the final grade in a course run for a list of users.

--- a/mail/admin.py
+++ b/mail/admin.py
@@ -13,10 +13,10 @@ class FinancialAidEmailAuditAdmin(admin.ModelAdmin):
     model = FinancialAidEmailAudit
     readonly_fields = get_field_names(FinancialAidEmailAudit)
 
-    def has_add_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def has_add_permission(self, *args, **kwargs):  # pylint: disable=unused-argument, arguments-differ
         return False
 
-    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument, arguments-differ
         return False
 
 

--- a/micromasters/celery.py
+++ b/micromasters/celery.py
@@ -26,9 +26,9 @@ class CustomCelery(Celery):
         register_logger_signal(client)
         register_signal(client)
 
-async = CustomCelery('micromasters')
+app = CustomCelery('micromasters')
 
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
-async.config_from_object('django.conf:settings')
-async.autodiscover_tasks(lambda: settings.INSTALLED_APPS)  # pragma: no cover
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)  # pragma: no cover

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -325,7 +325,7 @@ MAILGUN_BCC_TO_EMAIL = get_var('MAILGUN_BCC_TO_EMAIL', 'no-reply@micromasters.mi
 
 # e-mail configurable admins
 ADMIN_EMAIL = get_var('MICROMASTERS_ADMIN_EMAIL', '')
-if ADMIN_EMAIL is not '':
+if ADMIN_EMAIL != '':
     ADMINS = (('Admins', ADMIN_EMAIL),)
 else:
     ADMINS = ()

--- a/micromasters/utils.py
+++ b/micromasters/utils.py
@@ -209,6 +209,19 @@ def safely_remove_file(file_path):
             pass
 
 
+def as_datetime(date):
+    """
+    Convert date to datetime set to midnight with a UTC timezone
+
+    Args:
+        date (datetime.date): A date object
+
+    Returns:
+        datetime.datetime: A datetime object for midnight of that date, UTC
+    """
+    return datetime.datetime.combine(date, datetime.datetime.min.time()).replace(tzinfo=pytz.utc)
+
+
 def now_in_utc():
     """
     Get the current time in UTC

--- a/micromasters/utils_test.py
+++ b/micromasters/utils_test.py
@@ -29,6 +29,7 @@ from financialaid.factories import (
 )
 from micromasters.exceptions import PossiblyImproperlyConfigured
 from micromasters.utils import (
+    as_datetime,
     chunks,
     custom_exception_handler,
     dict_with_keys,
@@ -295,6 +296,12 @@ class UtilTests(unittest.TestCase):
             'a': 1,
         }
         assert dict_with_keys(source_dict, ['a', 'b']) == source_dict
+
+
+def test_as_datetime():
+    """as_datetime should convert a date to datetime at midnight, UTC"""
+    a_while_ago = datetime.date(2016, 3, 4)
+    assert as_datetime(a_while_ago) == datetime.datetime(2016, 3, 4, tzinfo=pytz.UTC)
 
 
 def test_now_in_utc():

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -188,7 +188,7 @@ class Profile(models.Model):
     updated_on = models.DateTimeField(blank=True, null=True, auto_now=True)
 
     @transaction.atomic
-    def save(self, *args, update_image=False, **kwargs):
+    def save(self, *args, update_image=False, **kwargs):  # pylint: disable=arguments-differ
         """Set the student_id number to the PK number and update thumbnails if necessary"""
         if update_image:
             if self.image:

--- a/profiles/models_test.py
+++ b/profiles/models_test.py
@@ -61,7 +61,7 @@ class StudentIdTests(MockedESTestCase):
             user = UserFactory()
         profile = Profile(user=user)
         assert profile.student_id is None
-        assert profile.pretty_printed_student_id is ''
+        assert profile.pretty_printed_student_id == ''
 
 
 class ImageTests(MockedESTestCase):

--- a/profiles/permissions.py
+++ b/profiles/permissions.py
@@ -21,14 +21,14 @@ class CanEditIfOwner(BasePermission):
     Only owner of a profile has permission to edit the profile.
     """
 
-    def has_object_permission(self, request, view, profile):
+    def has_object_permission(self, request, view, obj):
         """
         Only allow editing for owner of the profile.
         """
         if request.method in SAFE_METHODS:
             return True
 
-        return profile.user == request.user
+        return obj.user == request.user
 
 
 class CanSeeIfNotPrivate(BasePermission):

--- a/pylintrc
+++ b/pylintrc
@@ -19,4 +19,4 @@ ignored-modules=
 	six.moves,
 
 [MESSAGES CONTROL]
-disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors, line-too-long, no-self-use
+disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors, line-too-long, no-self-use, len-as-condition, no-else-return

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,9 @@ norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.e
 pep8ignore =
    */migrations/* ALL
 pep8maxlinelength = 119
+filterwarnings =
+    error
+    ignore::DeprecationWarning
+    ignore::django.utils.deprecation.RemovedInDjango20Warning
+    ignore::PendingDeprecationWarning
+    ignore:Failed to load HostKeys

--- a/roles/models.py
+++ b/roles/models.py
@@ -41,14 +41,14 @@ class Role(models.Model):
         unique_together = ('user', 'program', 'role',)
 
     @transaction.atomic
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
         """
         Overridden method to run a preventive validation before saving the object.
         """
         self.full_clean()
         super(Role, self).save(*args, **kwargs)
 
-    def full_clean(self, *args, **kwargs):
+    def full_clean(self, *args, **kwargs):  # pylint: disable=arguments-differ
         """
         Overridden method to run a preventive validation.
         """

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -6,7 +6,7 @@ Celery tasks for search
 
 from dashboard.models import ProgramEnrollment
 from mail.api import send_automatic_emails as _send_automatic_emails
-from micromasters.celery import async
+from micromasters.celery import app
 from search.indexing_api import (
     get_default_alias,
     index_program_enrolled_users as _index_program_enrolled_users,
@@ -19,7 +19,7 @@ from search.indexing_api import (
 from search.models import PercolateQuery
 
 
-@async.task
+@app.task
 def remove_program_enrolled_user(program_enrollment_id):
     """
     Remove program-enrolled user from index
@@ -30,7 +30,7 @@ def remove_program_enrolled_user(program_enrollment_id):
     _remove_program_enrolled_user(program_enrollment_id)
 
 
-@async.task
+@app.task
 def index_program_enrolled_users(program_enrollment_ids):
     """
     Index program enrollments
@@ -47,7 +47,7 @@ def index_program_enrolled_users(program_enrollment_ids):
         _send_automatic_emails(program_enrollment)
 
 
-@async.task
+@app.task
 def index_users(user_ids):
     """
     Index users' ProgramEnrollment documents
@@ -63,7 +63,7 @@ def index_users(user_ids):
         _send_automatic_emails(program_enrollment)
 
 
-@async.task
+@app.task
 def index_percolate_queries(percolate_query_ids):
     """
     Index percolate queries
@@ -75,7 +75,7 @@ def index_percolate_queries(percolate_query_ids):
     _index_percolate_queries(PercolateQuery.objects.filter(id__in=percolate_query_ids))
 
 
-@async.task
+@app.task
 def delete_percolate_query(percolate_query_id):
     """
     Delete a percolate query in Elasticsearch

--- a/seed_data/lib.py
+++ b/seed_data/lib.py
@@ -205,7 +205,7 @@ class CachedEnrollmentHandler(CachedHandler):
     def set_edx_key(cls, obj, course_run):
         obj.data['course_details']['course_id'] = course_run.edx_course_key
 
-    def build_data_property(self, course_run, verified=True, **kwargs):
+    def build_data_property(self, course_run, verified=True, **kwargs):  # pylint: disable=arguments-differ
         return {
             'user': self.username,
             'mode': 'verified' if verified else 'not verified',
@@ -227,7 +227,7 @@ class CachedCertificateHandler(CachedHandler):
     def set_edx_key(cls, obj, course_run):
         obj.data['course_id'] = course_run.edx_course_key
 
-    def build_data_property(self, course_run, grade=DEFAULT_GRADE, **kwargs):
+    def build_data_property(self, course_run, grade=DEFAULT_GRADE, **kwargs):  # pylint: disable=arguments-differ
         return {
             'username': self.username,
             'course_id': course_run.edx_course_key,
@@ -245,7 +245,7 @@ class CachedCurrentGradeHandler(CachedHandler):
     def set_edx_key(cls, obj, course_run):
         obj.data['course_key'] = course_run.edx_course_key
 
-    def build_data_property(self, course_run, grade=DEFAULT_GRADE, **kwargs):
+    def build_data_property(self, course_run, grade=DEFAULT_GRADE, **kwargs):  # pylint: disable=arguments-differ
         return {
             'course_key': course_run.edx_course_key,
             'username': self.username,

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,7 +6,7 @@ ipdb
 nplusone
 pdbpp
 pip-tools
-pylint==1.6.5
+pylint==1.7.1
 pylint-django==0.7.2
 pytest
 pytest-cov


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3230 

#### What's this PR do?
Upgrades pylint and fixes errors from new rules. This also changes pylintrc to treat warnings as errors and ignores warnings which are due to deprecation errors or due to the sftp exam code

#### How should this be manually tested?
N/A
