### PR TITLE
Upgrade to python 3.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.6.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35
+envlist = py36
 skip_missing_interpreters = True
 skipsdist = True
 

--- a/travis/Dockerfile-travis-web
+++ b/travis/Dockerfile-travis-web
@@ -1,4 +1,4 @@
-FROM mitodl/mm_web_travis
+FROM mitodl/mm_web_travis_next
 
 WORKDIR /tmp
 

--- a/travis/update-docker-hub.sh
+++ b/travis/update-docker-hub.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -eo pipefail
 
-docker build -t mitodl/mm_web_travis -f Dockerfile .
+docker build -t mitodl/mm_web_travis_next -f Dockerfile .
 docker build -t mitodl/mm_watch_travis -f travis/Dockerfile-travis-watch-build .
 
-docker push mitodl/mm_web_travis
+docker push mitodl/mm_web_travis_next
 docker push mitodl/mm_watch_travis


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3226 

#### What's this PR do?
Upgrades heroku runtime and Docker enviornment to python 3.6.1

#### How should this be manually tested?
No changes should be seen in functionality

#### Any background context you want to provide?
@aliceriot do we need to update the travis docker image after this PR?