### PR TITLE
Show recipients on email edit box

### DIFF
--- a/mail/serializers.py
+++ b/mail/serializers.py
@@ -7,6 +7,7 @@ from rest_framework import (
     serializers
 )
 from mail.models import AutomaticEmail
+from search.models import PercolateQuery
 
 
 class GenericMailSerializer(serializers.Serializer):
@@ -17,10 +18,23 @@ class GenericMailSerializer(serializers.Serializer):
     email_body = fields.CharField(label="Email Body", style={"base_template": "textarea.html"})
 
 
+class PercolateQuerySerializer(serializers.ModelSerializer):
+    """
+    PercolateQuerySerializer
+    """
+    class Meta:
+        model = PercolateQuery
+        fields = (
+            'original_query',
+            'query'
+        )
+
+
 class AutomaticEmailSerializer(serializers.ModelSerializer):
     """
     AutomaticEmailSerializer
     """
+    query = PercolateQuerySerializer()
     class Meta:
         model = AutomaticEmail
         fields = (
@@ -28,5 +42,6 @@ class AutomaticEmailSerializer(serializers.ModelSerializer):
             'email_subject',
             'email_body',
             'sender_name',
-            'id'
+            'id',
+            'query'
         )

--- a/mail/serializers.py
+++ b/mail/serializers.py
@@ -35,6 +35,7 @@ class AutomaticEmailSerializer(serializers.ModelSerializer):
     AutomaticEmailSerializer
     """
     query = PercolateQuerySerializer()
+
     class Meta:
         model = AutomaticEmail
         fields = (

--- a/mail/serializers_test.py
+++ b/mail/serializers_test.py
@@ -2,7 +2,7 @@
 Tests for the mail serializers
 """
 from mail.factories import AutomaticEmailFactory
-from mail.serializers import AutomaticEmailSerializer
+from mail.serializers import AutomaticEmailSerializer, PercolateQuerySerializer
 
 from search.base import MockedESTestCase
 
@@ -23,4 +23,5 @@ class AutomaticEmailSerializerTests(MockedESTestCase):
             "email_body": automatic.email_body,
             "sender_name": automatic.sender_name,
             "id": automatic.id,
+            "query": PercolateQuerySerializer(automatic.query).data
         }

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -148,7 +148,7 @@ export const convertEmailEdit = mapObj(([k, v]) => (
   [k.match(/^subject$|^body$/) ? `email_${k}` : k.replace(/^email_/, ""), v]
 ));
 
-const findTerms = (tree) => {
+export const findTerms = (tree) => {
   if (tree.hasOwnProperty("term") && !tree.term.hasOwnProperty("program.id")) {
     return [tree.term];
   }
@@ -159,12 +159,11 @@ const findTerms = (tree) => {
       .map(obj => findTerms(obj))
     );
   }
-  return undefined;
+  return [];
 };
 
 export const getFilters  = (root: Object) => {
-  let terms = R.filter(obj => obj !== undefined, findTerms(root));
-
+  let terms = findTerms(root);
   return _.map(terms, (term: Object) => ({
     'id': Object.keys(term)[0],
     'name': Object.keys(term)[0],

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import R from 'ramda';
+import _ from 'lodash';
 
 import {
   sendCourseTeamMail,
@@ -10,7 +11,7 @@ import {
 import { makeProfileImageUrl, mapObj } from '../../util/util';
 import type { Profile } from '../../flow/profileTypes';
 import type { Course } from '../../flow/programTypes';
-import type { EmailConfig, EmailState, Filter } from '../../flow/emailTypes';
+import type { AutomaticEmail, EmailConfig, EmailState, Filter } from '../../flow/emailTypes';
 import { actions } from '../../lib/redux_rest.js';
 import { SEARCH_FACET_FIELD_LABEL_MAP } from '../../constants';
 import { makeCountryNameTranslations } from '../LearnerSearch';
@@ -147,9 +148,57 @@ export const convertEmailEdit = mapObj(([k, v]) => (
   [k.match(/^subject$|^body$/) ? `email_${k}` : k.replace(/^email_/, ""), v]
 ));
 
+const findTerms = (tree) => {
+  if (tree.hasOwnProperty("term") && !tree.term.hasOwnProperty("program.id")) {
+    return [tree.term];
+  }
+  if (R.any(_.isObject, Object.values(tree))) {
+    return R.flatten(
+      Object.values(tree)
+      .filter(_.isObject)
+      .map(obj => findTerms(obj))
+    );
+  }
+  return undefined;
+};
+
+export const getFilters  = (root: Object) => {
+  let terms = R.filter(obj => obj !== undefined, findTerms(root));
+
+  return _.map(terms, (term: Object) => ({
+    'id': Object.keys(term)[0],
+    'name': Object.keys(term)[0],
+    'value': term[Object.keys(term)[0]]
+  }));
+};
+
 export const AUTOMATIC_EMAIL_ADMIN_CONFIG: EmailConfig = {
-  title: 'Edit Message',
+  title: 'Edit Email Campaign',
   editEmail: actions.automaticEmails.patch,
-  emailOpenParams: R.compose(R.objOf('inputs'), convertEmailEdit),
   emailSendParams: R.compose(convertEmailEdit, R.prop('inputs')),
+
+  emailOpenParams: (emailOpenParams: AutomaticEmail) => ({
+    inputs: {
+      subject: emailOpenParams.email_subject,
+      body: emailOpenParams.email_body,
+      sendAutomaticEmails: emailOpenParams.enabled,
+    },
+    filters: getFilters(emailOpenParams.query.original_query.post_filter)
+  }),
+
+  renderRecipients: (filters?: Array<Filter>) => {
+    if (!filters || filters.length <= 0) {
+      return null;
+    }
+    return (
+      <div className="sk-selected-filters-display">
+        <div className="sk-selected-filters-title">
+          Recipients
+        </div>
+        <div className="sk-selected-filters">
+          {renderFilterOptions(filters)}
+        </div>
+      </div>
+    );
+  }
 };

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -148,26 +148,35 @@ export const convertEmailEdit = mapObj(([k, v]) => (
   [k.match(/^subject$|^body$/) ? `email_${k}` : k.replace(/^email_/, ""), v]
 ));
 
-export const findTerms = (tree) => {
+export const findFilters = (tree) => {
   if (tree.hasOwnProperty("term") && !tree.term.hasOwnProperty("program.id")) {
     return [tree.term];
   }
+
+  if (tree.hasOwnProperty("range")) {
+    return [tree.range];
+  }
+
   if (R.any(_.isObject, Object.values(tree))) {
     return R.flatten(
       Object.values(tree)
       .filter(_.isObject)
-      .map(obj => findTerms(obj))
+      .map(obj => findFilters(obj))
     );
   }
   return [];
 };
 
+const serializeValue = (value: Object|string) => (
+  _.isObject(value) ? `${value.gte} - ${value.lte}` : value
+);
+
 export const getFilters  = (root: Object) => {
-  let terms = findTerms(root);
+  let terms = findFilters(root);
   return _.map(terms, (term: Object) => ({
     'id': Object.keys(term)[0],
     'name': Object.keys(term)[0],
-    'value': term[Object.keys(term)[0]]
+    'value': serializeValue(term[Object.keys(term)[0]])
   }));
 };
 

--- a/static/js/components/email/lib_test.js
+++ b/static/js/components/email/lib_test.js
@@ -18,6 +18,7 @@ import {
   LEARNER_EMAIL_CONFIG,
   AUTOMATIC_EMAIL_ADMIN_CONFIG,
   convertEmailEdit,
+  getFilters,
 } from './lib';
 import {
   START_EMAIL_EDIT,
@@ -75,6 +76,28 @@ describe('Specific email config', () => {
       </MuiThemeProvider>
     );
   };
+
+  const queryFilters = `{
+    "bool": {
+      "must":[
+        { 
+          "nested": {
+            "path": "program.enrollments",
+            "filter": {
+              "term": {
+                "program.enrollments.payment_status": "Paid"
+              }
+            }
+          }
+        },
+        {
+          "term": {
+            "program.id":1
+          }
+        }
+      ]
+    }
+  }`;
 
   describe('for the learner email', () => {
     let wrapper,
@@ -227,6 +250,15 @@ describe('Specific email config', () => {
         ].forEach(obj => {
           assert.deepEqual(convertEmailEdit(convertEmailEdit(obj)), obj);
         });
+      });
+
+      it('should return filters', () => {
+        let filters = getFilters(JSON.parse(queryFilters));
+        assert.deepEqual(filters, [{
+          "id": "program.enrollments.payment_status",
+          "name": "program.enrollments.payment_status",
+          "value": "Paid"
+        }]);
       });
     });
   });

--- a/static/js/components/email/lib_test.js
+++ b/static/js/components/email/lib_test.js
@@ -19,6 +19,7 @@ import {
   AUTOMATIC_EMAIL_ADMIN_CONFIG,
   convertEmailEdit,
   getFilters,
+  findTerms,
 } from './lib';
 import {
   START_EMAIL_EDIT,
@@ -259,6 +260,43 @@ describe('Specific email config', () => {
           "name": "program.enrollments.payment_status",
           "value": "Paid"
         }]);
+      });
+
+      describe('getFilters', () => {
+        it('should return filters', () => {
+          let filters = getFilters(JSON.parse(queryFilters));
+          assert.deepEqual(filters, [{
+            "id": "program.enrollments.payment_status",
+            "name": "program.enrollments.payment_status",
+            "value": "Paid"
+          }]);
+        });
+      });
+
+      describe('findTerms', () => {
+        it('should return filters', () => {
+          let filters = findTerms(JSON.parse(queryFilters));
+          assert.equal(filters.length, 1);
+          assert.deepEqual(filters, [{
+            "program.enrollments.payment_status": "Paid"
+          }]);
+        });
+
+        it('should ignore program.id and return empty list when no filter selected', () => {
+          const query = `{
+            "bool": {
+              "must":[
+                {
+                  "term": {
+                    "program.id":1
+                  }
+                }
+              ]
+            }
+          }`;
+          let filters = findTerms(JSON.parse(query));
+          assert.equal(filters.length, 0);
+        });
       });
     });
   });

--- a/static/js/components/email/lib_test.js
+++ b/static/js/components/email/lib_test.js
@@ -276,7 +276,7 @@ describe('Specific email config', () => {
       describe('findFilters', () => {
         it('should return an empty list if passed an empty object', () => {
           let filters = findFilters({});
-          assert.equal(filters.length, 0);
+          assert.deepEqual(filters, []);
         });
 
         it('should return an empty list if passed an object without any "term" and "range" key on it', () => {
@@ -290,7 +290,7 @@ describe('Specific email config', () => {
             }
           }`;
           let filters = findFilters(JSON.parse(query));
-          assert.equal(filters.length, 0);
+          assert.deepEqual(filters, []);
         });
 
         it('should return a list of filters defined at the top-level', () => {
@@ -319,7 +319,11 @@ describe('Specific email config', () => {
             }
           }`;
           let filters = findFilters(JSON.parse(query));
-          assert.equal(filters.length, 3);
+          assert.deepEqual(filters, [
+            { "program.grade_average": { "gte": 0, "lte": 81 } },
+            { "profile.birth_country": "US" },
+            { "profile.country": "US" },
+          ]);
         });
 
         it('should return a list of filters which are nested in the object', () => {
@@ -364,7 +368,12 @@ describe('Specific email config', () => {
             }
           }`;
           let filters = findFilters(JSON.parse(query));
-          assert.equal(filters.length, 4);
+          assert.deepEqual(filters, [
+            { "program.enrollments.course_title": "Digital Learning 100" },
+            { "program.enrollments.final_grade": { "gte": 0, "lte": 89 } },
+            { "program.enrollments.payment_status": "Paid" },
+            { "program.enrollments.semester": "2016 - Summer" },
+          ]);
         });
 
         it('should return a list of filters which are nested at different levels', () => {
@@ -416,7 +425,11 @@ describe('Specific email config', () => {
             }
           }`;
           let filters = findFilters(JSON.parse(query));
-          assert.equal(filters.length, 3);
+          assert.deepEqual(filters, [
+            { "program.enrollments.course_title": "Digital Learning 100" },
+            { "profile.education.degree_name": "b" },
+            { "profile.work_history.company_name": "Volvo" },
+          ]);
         });
 
         it('should ignore program.id', () => {
@@ -432,7 +445,7 @@ describe('Specific email config', () => {
             }
           }`;
           let filters = findFilters(JSON.parse(query));
-          assert.equal(filters.length, 0);
+          assert.deepEqual(filters, []);
         });
       });
     });

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -35,6 +35,7 @@ export const SEARCH_FACET_FIELD_LABEL_MAP = {
   'profile.education.degree_name': 'Degree',
   'profile.work_history.company_name': 'Company',
   'num-courses-passed': '# of Courses Passed',
+  'program.enrollments.final_grade': 'Final Grade'
 };
 
 // NOTE: these need to be kept in sync with ui/url_utils.py

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -50,4 +50,5 @@ export type AutomaticEmail = {
   email_body:     string,
   sender_name:    string,
   id:             number,
+  query:          Object
 };

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -1009,6 +1009,28 @@ export const EDX_CHECKOUT_RESPONSE = deepFreeze({
 });
 /* eslint-enable max-len */
 
+const queryFilters = `{
+  "bool": {
+    "must":[
+      { 
+        "nested": {
+          "path": "program.enrollments",
+          "filter": {
+            "term": {
+              "program.enrollments.payment_status": "Paid"
+            }
+          }
+        }
+      },
+      {
+        "term": {
+          "program.id":1
+        }
+      }
+    ]
+  }
+}`;
+
 export const GET_AUTOMATIC_EMAILS_RESPONSE = [
   {
     enabled: true,
@@ -1016,6 +1038,11 @@ export const GET_AUTOMATIC_EMAILS_RESPONSE = [
     email_body: 'such a great email, literally so great',
     sender_name: 'Simone de Beauvoir',
     id: 1,
+    query: {
+      original_query: {
+        post_filter: {...JSON.parse(queryFilters)}
+      }
+    }
   },
   {
     enabled: false,
@@ -1023,5 +1050,10 @@ export const GET_AUTOMATIC_EMAILS_RESPONSE = [
     email_body: 'this one was not as good :(',
     sender_name: 'Jean-Paul Sartre',
     id: 2,
+    query: {
+      original_query: {
+        post_filter: {...JSON.parse(queryFilters)}
+      }
+    }
   }
 ];


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3202

#### What's this PR do?
Adds filters/recipients to automatic email page

#### How should this be manually tested?
(Required)
- on learners search page select as much filters u can
- create an automatic email from learner search page.
- open the automatic email page and press edit 
- you will see the filters 

#### Screenshots (if appropriate)

<img width="1280" alt="screen shot 2017-05-31 at 12 10 51 am" src="https://cloud.githubusercontent.com/assets/10431250/26600543/e951cf90-4595-11e7-9be1-4347bc922b62.png">
