### PR TITLE
Mail search now skips users without a profile

### DIFF
--- a/mail/api.py
+++ b/mail/api.py
@@ -22,6 +22,7 @@ from mail.models import (
 )
 from mail.utils import filter_recipient_variables
 from micromasters.utils import chunks
+from profiles.models import Profile
 from search.api import (
     adjust_search_for_percolator,
     search_percolate_queries,
@@ -377,15 +378,15 @@ def get_mail_vars(emails):
         generator of dict:
             A dictionary of template variables which includes email so we can tell who is who
     """
-    queryset = User.objects.filter(email__in=emails).values(
-        'email',
-        'profile__mail_id',
-        'profile__preferred_name',
+    queryset = Profile.objects.filter(user__email__in=emails).values(
+        'user__email',
+        'mail_id',
+        'preferred_name',
     ).iterator()
     return (
         {
-            'email': values['email'],
-            'mail_id': values['profile__mail_id'].hex,
-            'preferred_name': values['profile__preferred_name'],
+            'email': values['user__email'],
+            'mail_id': values['mail_id'].hex,
+            'preferred_name': values['preferred_name'],
         } for values in queryset
     )

--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -684,3 +684,12 @@ class RecipientVariablesTests(MockedESTestCase):
     def test_missing_email(self):
         """get_mail_vars should skip missing emails without erroring"""
         assert list(get_mail_vars(['missing@email.com'])) == []
+
+    def test_missing_profile(self):
+        """get_mail_vars should skip User objects without a Profile"""
+        with mute_signals(post_save):
+            profile = ProfileFactory.create()
+        user = profile.user
+        profile.delete()
+
+        assert list(get_mail_vars([user.email])) == []


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3239 

#### What's this PR do?
Changes the mail search filter to skip users where `Profile` is `None`. For the linked sentry issue there were two users who had two `User` objects each and only one had a `Profile`. I'm not sure what caused this but it seems like only the one with a `Profile` is valid.

#### How should this be manually tested?
For some fake user with a valid profile, create another `User` object with the same `email`. On master you should get a 500 error when attempting to send email, and the error should not be there in this branch.