### PR TITLE
Use test database when running snapshot_dashboard_states

### DIFF
--- a/selenium_tests/base.py
+++ b/selenium_tests/base.py
@@ -109,6 +109,9 @@ class CustomWebDriverWait(WebDriverWait):
 class SeleniumTestsBase(StaticLiveServerTestCase):
     """Base class for selenium tests"""
 
+    # Password used by all created users
+    PASSWORD = 'pass'
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -155,21 +158,6 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
         recreate_index()
 
         self.user = self.create_user()
-        self.password = "pass"
-        self.user.set_password(self.password)
-        self.user.save()
-
-        # Update profile to pass validation so we don't get redirected to the signup page
-        profile = self.user.profile
-        profile.phone_number = '+1-800-888-8888'
-        profile.country = 'US'
-        profile.state_or_territory = 'US-MA'
-        profile.postal_code = '02142'
-        profile.filled_out = True
-        profile.agreed_to_terms_of_service = True
-        profile.save()
-
-        self.edx_username = self.user.social_auth.get(provider=EdxOrgOAuth2.name).uid
 
         # Create a live program with valid prices and financial aid
         run = CourseRunFactory.create(
@@ -296,7 +284,7 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
         self.get("admin/")
         self.wait().until(lambda driver: driver.find_element_by_id("id_username"))
         self.selenium.find_element_by_id("id_username").send_keys(user.username)
-        self.selenium.find_element_by_id("id_password").send_keys(self.password)
+        self.selenium.find_element_by_id("id_password").send_keys(self.PASSWORD)
         self.selenium.find_element_by_css_selector("input[type=submit]").click()
         # This is the 'Welcome, username' box on the upper right
         self.wait().until(lambda driver: driver.find_element_by_id("user-tools"))
@@ -359,11 +347,15 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
         print(self.selenium.find_element_by_tag_name("body").get_attribute("innerHTML"))
 
     @classmethod
-    def create_user(cls):
+    def create_user(cls, username=None):
         """Create a user with a profile and fake edX social auth data"""
         with mute_signals(post_save):
             profile = ProfileFactory.create(filled_out=True)
         user = profile.user
+
+        if username is not None:
+            user.username = username
+            user.save()
 
         # Create a fake edX social auth to make this user look like they logged in via edX
         later = now_in_utc() + timedelta(minutes=5)
@@ -383,6 +375,20 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
             certificate=later,
             current_grade=later,
         )
+
+        user.set_password(cls.PASSWORD)
+        user.save()
+
+        # Update profile to pass validation so we don't get redirected to the signup page
+        profile = user.profile
+        profile.phone_number = '+1-800-888-8888'
+        profile.country = 'US'
+        profile.state_or_territory = 'US-MA'
+        profile.postal_code = '02142'
+        profile.filled_out = True
+        profile.agreed_to_terms_of_service = True
+        profile.save()
+
         return user
 
     def num_elements_on_page(self, selector, driver=None):
@@ -390,3 +396,8 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
         script = "return document.querySelectorAll({selector!r}).length".format(selector=selector)
         driver = driver or self.selenium
         return driver.execute_script(script)
+
+    @property
+    def edx_username(self):
+        """Get the edx username for self.user"""
+        return self.user.social_auth.get(provider=EdxOrgOAuth2.name).uid

--- a/selenium_tests/base.py
+++ b/selenium_tests/base.py
@@ -328,6 +328,10 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
                 continue
             if "__webpack_hmr" in message:
                 continue
+            if "Warning: Accessing PropTypes via the main React package is deprecated." in message:
+                continue
+            if "Warning: ReactTelephoneInput: React.createClass is deprecated" in message:
+                continue
 
             # warnings (e.g. deprecations) should not fail the tests
             if entry['level'] in ["WARNING"]:

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -1,57 +1,219 @@
 """Management command to attach avatars to profiles"""
+import itertools
 import os
 import sys
-import unittest
+from urllib.parse import quote_plus
 
 from django.core.management import (
     BaseCommand,
     call_command,
 )
-from django.test.utils import override_settings
+import pytest
 
-from courses.models import Program
+from courses.factories import CourseRunFactory
+from courses.models import (
+    Course,
+    CourseRun,
+    Program,
+)
 from dashboard.models import ProgramEnrollment
+from ecommerce.models import (
+    Coupon,
+    UserCoupon,
+)
+from exams.factories import ExamRunFactory
+from grades.factories import ProctoredExamGradeFactory
 from seed_data.management.commands.alter_data import EXAMPLE_COMMANDS
 from selenium_tests.base import SeleniumTestsBase
 
 
+# We need to have pytest skip DashboardStates when collecting tests to run, but we also want to run it as a test
+# when invoked by this command so we can take advantage of Selenium and the test database infrastructure. This
+# defaults the test to being skipped. When the management command runs it changes this flag to True to
+# invoke the test.
+RUNNING_DASHBOARD_STATES = False
+
+
+def make_scenario(command):
+    """Make lambda from ExampleCommand"""
+    return lambda: call_command("alter_data", command.command, *command.args)
+
+
+def bind_args(func, *args, **kwargs):
+    """Helper function to bind the args to the closure"""
+    return lambda: func(*args, **kwargs)
+
+
+@pytest.mark.skipif(
+    'not RUNNING_DASHBOARD_STATES',
+    reason='DashboardStates test suite is only meant to be run via management command',
+)
 class DashboardStates(SeleniumTestsBase):
     """Runs through each dashboard state taking a snapshot"""
+    def create_exams(self, edx_passed, exam_passed, is_offered):
+        """Create an exam and mark it and the related course as passed or not passed"""
+        if edx_passed:
+            call_command(
+                "alter_data", 'set_to_passed', '--username', 'staff',
+                '--course-title', 'Analog Learning 200', '--grade', '75',
+            )
+        else:
+            call_command(
+                "alter_data", 'set_to_failed', '--username', 'staff',
+                '--course-title', 'Analog Learning 200', '--grade', '45',
+            )
+        course = Course.objects.get(title='Analog Learning 200')
+        exam_run = ExamRunFactory.create(course=course, eligibility_past=True, scheduling_past=True)
+        for _ in range(2):
+            ProctoredExamGradeFactory.create(
+                user=self.user,
+                course=course,
+                exam_run=exam_run,
+                passed=False,
+            )
+        ProctoredExamGradeFactory.create(
+            user=self.user,
+            course=course,
+            exam_run=exam_run,
+            passed=exam_passed,
+        )
+        if is_offered:
+            CourseRunFactory.create(course=course)
+
+    def with_prev_passed_run(self):
+        """Add a passed run to a failed course. The course should then be passed"""
+        call_command(
+            "alter_data", 'set_to_failed', '--username', 'staff',
+            '--course-title', 'Analog Learning 200', '--grade', '45',
+        )
+        call_command(
+            "alter_data", 'set_past_run_to_passed', '--username', 'staff',
+            '--course-title', 'Analog Learning 200',
+        )
+
+    def pending_enrollment(self):
+        """
+        Mark a course run as offered, then use the CyberSource redirect URL to view the pending enrollment status
+        """
+        run = CourseRun.objects.get(title='Analog Learning 100 - August 2015')
+        call_command(
+            'alter_data', 'set_to_offered', '--username', 'staff',
+            '--course-run-title', 'Analog Learning 100 - August 2015',
+        )
+        run.refresh_from_db()
+        return "/dashboard?status=receipt&course_key={}".format(quote_plus(run.edx_course_key))
+
+    def contact_course(self):
+        """Show a contact course team link"""
+        call_command(
+            "alter_data", 'set_to_passed', '--username', 'staff',
+            '--course-title', 'Analog Learning 200', '--grade', '75',
+        )
+        course = Course.objects.get(title='Analog Learning 200')
+        course.contact_email = 'example@example.com'
+        course.save()
+
+    def missed_payment_can_reenroll(self):
+        """User has missed payment but they can re-enroll"""
+        call_command(
+            "alter_data", 'set_to_needs_upgrade', '--username', 'staff',
+            '--course-title', 'Analog Learning 200', '--missed-deadline',
+        )
+        course = Course.objects.get(title='Analog Learning 200')
+        CourseRunFactory.create(course=course)
+
+    def with_coupon(self, amount_type, is_program, is_free):
+        """Add a course-level coupon"""
+        call_command("alter_data", 'set_to_offered', '--username', 'staff', '--course-title', 'Analog Learning 200')
+        course = Course.objects.get(title='Analog Learning 200')
+        if is_program:
+            content_object = course.program
+        else:
+            content_object = course
+
+        if amount_type == Coupon.FIXED_DISCOUNT or amount_type == Coupon.FIXED_PRICE:
+            amount = 50
+        else:
+            if is_free:
+                amount = 1
+            else:
+                amount = 0.25
+
+        coupon = Coupon.objects.create(
+            content_object=content_object, coupon_type=Coupon.STANDARD, amount_type=amount_type, amount=amount,
+        )
+        UserCoupon.objects.create(user=self.user, coupon=coupon)
+
     def test_dashboard_states(self):
         """Iterate through all possible dashboard states and take screenshots of each one"""
-        self.user = self.create_user()
-        self.user.username = 'staff'
-        self.user.set_password(self.password)
-        self.user.save()
-
-        # Update profile to pass validation so we don't get redirected to the signup page
-        profile = self.user.profile
-        profile.phone_number = '+93-23-232-3232'
-        profile.filled_out = True
-        profile.agreed_to_terms_of_service = True
-        profile.save()
+        self.user = self.create_user('staff')
 
         self.get("/admin")
         self.login_via_admin(self.user)
         call_command("seed_db")
 
         db_path = self.dump_db()
-        for num, example_command in enumerate(EXAMPLE_COMMANDS):
+
+        # Generate scenarios from all alter_data example commands
+        scenarios = [
+            (make_scenario(command), command.command) for command in EXAMPLE_COMMANDS
+            # Complicated to handle, and this is the same as the previous command anyway
+            if "--course-run-key" not in command.args
+        ]
+
+        # Add scenarios for every combination of passed/failed course and exam
+        for tup in itertools.product([True, False], repeat=3):
+            edx_passed, exam_passed, is_passed = tup
+
+            scenarios.append((
+                bind_args(self.create_exams, edx_passed, exam_passed, is_passed),
+                'create_exams_{}_{}_{}'.format(edx_passed, exam_passed, is_passed),
+            ))
+
+        # Also test for two different passing and failed runs on the same course
+        scenarios.append((self.with_prev_passed_run, 'failed_with_prev_passed_run'))
+
+        # Add scenarios for coupons
+        coupon_scenarios = [
+            (Coupon.FIXED_PRICE, True, False),
+            (Coupon.FIXED_PRICE, False, False),
+            (Coupon.FIXED_DISCOUNT, True, False),
+            (Coupon.FIXED_DISCOUNT, False, False),
+            (Coupon.PERCENT_DISCOUNT, True, False),
+            (Coupon.PERCENT_DISCOUNT, False, False),
+            (Coupon.PERCENT_DISCOUNT, True, True),
+            (Coupon.PERCENT_DISCOUNT, False, True),
+        ]
+        scenarios.extend([
+            (bind_args(self.with_coupon, *args), "coupon_{}_{}_{}".format(*args))
+            for args in coupon_scenarios
+        ])
+
+        # Other misc scenarios
+        scenarios.append((self.pending_enrollment, 'pending_enrollment'))
+        scenarios.append((self.contact_course, 'contact_course'))
+        scenarios.append((self.missed_payment_can_reenroll, 'missed_payment_can_reenroll'))
+
+        for num, (run_scenario, name) in enumerate(scenarios):
             self.restore_db(db_path)
 
             ProgramEnrollment.objects.create(user=self.user, program=Program.objects.get(title='Analog Learning'))
 
-            if "--course-run-key" in example_command.args:
-                # Complicated to handle, and this is the same as the previous command anyway
-                continue
-            call_command("alter_data", example_command.command, *example_command.args)
-            self.get("/dashboard")
+            new_url = run_scenario()
+            if new_url is None:
+                new_url = '/dashboard'
+            self.get(new_url)
             self.wait().until(lambda driver: driver.find_element_by_class_name('course-list'))
             self.selenium.execute_script('document.querySelector(".course-list").scrollIntoView()')
-            self.take_screenshot("dashboard_state_{num:03d}_{command}".format(
+            filename = "dashboard_state_{num:03d}_{command}".format(
                 num=num,
-                command=example_command.command,
-            ))
+                command=name,
+            )
+            self.take_screenshot(filename)
+            self.get("/api/v0/dashboard/{}/".format(self.edx_username))
+            text = self.selenium.execute_script('return document.querySelector(".response-info pre").innerText')
+            with open("{}.txt".format(filename), 'w') as f:
+                f.write(text)
 
 
 class Command(BaseCommand):
@@ -62,11 +224,16 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         os.environ['DJANGO_LIVE_TEST_SERVER_ADDRESS'] = '0.0.0.0:8286'
-        with override_settings(
-            ELASTICSEARCH_INDEX='testindex',
-            DEBUG=False,
-        ):
-            suite = unittest.TestLoader().loadTestsFromTestCase(DashboardStates)
-            result = unittest.TextTestRunner(verbosity=2).run(suite)
-            if not result.wasSuccessful():
-                sys.exit(1)
+        os.environ['ELASTICSEARCH_INDEX'] = 'testindex'
+        os.environ['DEBUG'] = 'False'
+        os.environ['DISABLE_WEBPACK_LOADER_STATS'] = 'True'
+        os.environ['USE_WEBPACK_DEV_SERVER'] = 'True'
+        if not os.environ.get('WEBPACK_DEV_SERVER_HOST'):
+            raise Exception(
+                'Missing environment variable WEBPACK_DEV_SERVER_HOST. Please set this to the IP address of your '
+                'webpack dev server (omit the port number).'
+            )
+
+        global RUNNING_DASHBOARD_STATES  # pylint: disable=global-statement
+        RUNNING_DASHBOARD_STATES = True
+        sys.exit(pytest.main(args=["{}::DashboardStates".format(__file__), "-s"]))


### PR DESCRIPTION
#### What are the relevant tickets?
None, related to #3241 

#### What's this PR do?
 - Runs the dashboard state collection in the test database instead of the regular database
 - Also changes behavior to run against the webpack dev server. This requires the user to set `WEBPACK_DEV_SERVER_HOST` to the IP address of where their watch container runs
 - Adds scenarios to take screenshots regarding exams, a mixed passed/failed set of runs on a course, and coupons
 - Adds a dump of the dashboard API JSON alongside the screenshot

#### How should this be manually tested?
Run the management command and verify that your dev environment has not been affected
