### PR TITLE
Fixed Pearson exam date parsing bug

### DIFF
--- a/exams/management/commands/simulate_sftp_responses.py
+++ b/exams/management/commands/simulate_sftp_responses.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from exams.pearson.constants import (
-    PEARSON_DATETIME_FORMAT,
+    PEARSON_DEFAULT_DATETIME_FORMAT,
     PEARSON_FILE_TYPES,
 )
 from exams.pearson import sftp
@@ -116,7 +116,7 @@ class Command(BaseCommand):
                     'ClientAuthorizationID': aid,
                     'ClientCandidateID': cid,
                     'Status': status,
-                    'Date': now.strftime(PEARSON_DATETIME_FORMAT),
+                    'Date': now.strftime(PEARSON_DEFAULT_DATETIME_FORMAT),
                     'Message': 'Invalid ExamSeriesCode' if error else '',
                 })
 
@@ -150,7 +150,7 @@ class Command(BaseCommand):
                 writer.writerow({
                     'ClientCandidateID': cid,
                     'Status': 'Error' if error else 'Accepted',
-                    'Date': now.strftime(PEARSON_DATETIME_FORMAT),
+                    'Date': now.strftime(PEARSON_DEFAULT_DATETIME_FORMAT),
                     'Message': 'Invalid Address' if error else '',
                 })
 

--- a/exams/pearson/constants.py
+++ b/exams/pearson/constants.py
@@ -2,8 +2,12 @@
 from types import SimpleNamespace
 
 # Pearson TSV constants
-PEARSON_DATE_FORMAT = "%Y/%m/%d"
-PEARSON_DATETIME_FORMAT = "%Y/%m/%d %H:%M:%S"
+PEARSON_DATETIME_FORMATS = [
+    "%Y/%m/%d %H:%M:%S",
+    "%m/%d/%Y %H:%M:%S"
+]
+PEARSON_DEFAULT_DATETIME_FORMAT = PEARSON_DATETIME_FORMATS[0]
+PEARSON_DEFAULT_DATE_FORMAT = PEARSON_DEFAULT_DATETIME_FORMAT.split(' ')[0]
 
 PEARSON_FILE_TYPES = SimpleNamespace(
     EAC='eac',

--- a/exams/pearson/utils_test.py
+++ b/exams/pearson/utils_test.py
@@ -21,11 +21,22 @@ class PearsonUtilsTest(SimpleTestCase):
         assert utils.is_zip_file('file.not') is False
         assert utils.is_zip_file('file') is False
 
-    def test_parse_datetime(self):
+    def test_parse_datetime_valid(self):
         """
         Tests that datetimes format correctly according to Pearson spec
         """
-        assert utils.parse_datetime('2016/05/15 15:02:55') == FIXED_DATETIME
+        parsed_datetimes = map(
+            utils.parse_datetime,
+            ['2016/05/15 15:02:55', '05/15/2016 15:02:55']
+        )
+        assert all(parsed_datetime == FIXED_DATETIME for parsed_datetime in parsed_datetimes)
+
+    def test_parse_datetime_invalid(self):
+        """
+        Tests that an improperly-formatted datetime will result in an exception
+        """
+        with self.assertRaises(UnparsableRowException):
+            utils.parse_datetime('bad/date/format')
 
     @ddt.data(
         ('true', True),

--- a/exams/pearson/writers.py
+++ b/exams/pearson/writers.py
@@ -10,8 +10,8 @@ import phonenumbers
 import pycountry
 
 from exams.pearson.constants import (
-    PEARSON_DATE_FORMAT,
-    PEARSON_DATETIME_FORMAT,
+    PEARSON_DEFAULT_DATE_FORMAT,
+    PEARSON_DEFAULT_DATETIME_FORMAT,
     PEARSON_DIALECT_OPTIONS,
     PEARSON_STATE_SUPPORTED_COUNTRIES,
 )
@@ -52,14 +52,14 @@ class BaseTSVWriter(object):
         """
         Formats a date to Pearson's required format
         """
-        return date.strftime(PEARSON_DATE_FORMAT)
+        return date.strftime(PEARSON_DEFAULT_DATE_FORMAT)
 
     @classmethod
     def format_datetime(cls, dt):
         """
         Formats a datetime to Pearson's required format
         """
-        return dt.strftime(PEARSON_DATETIME_FORMAT)
+        return dt.strftime(PEARSON_DEFAULT_DATETIME_FORMAT)
 
     @classmethod
     def get_field_mapper(cls, field):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3251 

#### What's this PR do?
Fixes Pearson exam date parsing bug. Pearson has apparently been giving us 2 different datetime formats in exam results

#### How should this be manually tested?
Unit test passage is a good sign, but I'll post a code snippet below to show how I tested this manually
