### PR TITLE
Fixed bug involving poorly configured TierPrograms used for testing

### DIFF
--- a/courses/factories.py
+++ b/courses/factories.py
@@ -15,7 +15,7 @@ class ProgramFactory(DjangoModelFactory):
     title = fuzzy.FuzzyText(prefix="Program ")
     live = factory.Faker('boolean')
     description = fuzzy.FuzzyText()
-    price = fuzzy.FuzzyDecimal(low=100, high=12345)
+    price = fuzzy.FuzzyDecimal(low=500, high=2000)
 
     class Meta:
         model = Program


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3262

#### What's this PR do?
Fixes bug involving poorly configured TierPrograms used for testing (noticed primarily in the running of `seed_db`)

#### How should this be manually tested?
Unseed/seed the db, go to the dashboard, check out the tiers created for Digital Learning

#### Where should the reviewer start?
`financialaid/factories.py`

#### Any background context you want to provide?
I noticed this problem a while ago and created a small script in a Jupyter notebook that adjusted `TierProgram`s to be properly configured. I ported that over to `TierProgramFactory.create_properly_configured_batch`
