### PR TITLE
Added redirect of mm.mit.edu to micromasters.mit.edu

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -6,6 +6,12 @@ server {
 }
 
 server {
+    listen 8079;
+    server_name mm.mit.edu;
+    return 301 https://micromasters.mit.edu$request_uri;
+}
+
+server {
     listen 8079 default_server;
     root /src;
 

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -45,6 +45,12 @@ http {
     }
 
     server {
+        listen <%= ENV["PORT"] %>;
+        server_name mm.mit.edu;
+        return 301 https://micromasters.mit.edu$request_uri;
+    }
+
+    server {
         listen <%= ENV["PORT"] %> default_server;
         server_name _;
         root /app;


### PR DESCRIPTION
In order to allow for a short URL to use in marketing material we are
adding support for the `mm` subdomain. This PR adds a redirect to the
full `micromasters` subdomain to address issues with things like the
OAUTH callback and any potential weirdness with cloudfront.

#### What are the relevant tickets?
(Required)

#### What's this PR do?
Redirects `mm.mit.edu` to `micromasters.mit.edu`

#### How should this be manually tested?
Modify your /etc/hosts file to map `mm.mit.edu` to your localhost and try to visit that subdomain to verify that you get redirected to the production site.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
