### PR TITLE
Use Geosuggest React component for Profile education and employment forms

### DIFF
--- a/app.json
+++ b/app.json
@@ -98,7 +98,7 @@
     },
     "GOOGLE_API_KEY": {
       "description": "API key for accessing Google services",
-      "required": false
+      "required": true
     },
     "MAILGUN_KEY": {
       "description": "The token for authenticating against the Mailgun API"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   db:
     image: postgres
@@ -50,6 +50,8 @@ services:
       EXAMS_SFTP_HOST: sftp
       EXAMS_SFTP_USERNAME: odl
       EXAMS_SFTP_PASSWORD: 123
+      DOCKER_HOST: ${DOCKER_HOST:-missing}
+      WEBPACK_DEV_SERVER_HOST: ${WEBPACK_DEV_SERVER_HOST:-localhost}
     env_file: .env
 
   web:
@@ -83,6 +85,8 @@ services:
       - yarn-cache:/home/mitodl/.cache/yarn
     environment:
       NODE_ENV: 'development'
+      DOCKER_HOST: ${DOCKER_HOST:-missing}
+      CONTAINER_NAME: 'watch'
     env_file: .env
 
   celery:

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "fetch-mock": "^5.11.0",
     "file-loader": "^0.11.1",
     "flow-bin": "^0.43.1",
+    "fuse-js-latest": "^2.6.2",
     "history": "^4.6.0",
     "iflow-lodash": "^1.1.16",
     "iflow-react-router": "^1.1.16",

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -18,8 +18,6 @@ import {
 import ProfileFormFields from '../util/ProfileFormFields';
 import ConfirmDeletion from './ConfirmDeletion';
 import SelectField from './inputs/SelectField';
-import CountrySelectField from './inputs/CountrySelectField';
-import StateSelectField from './inputs/StateSelectField';
 import { educationEntriesByDate } from '../util/sorting';
 import { dialogActions } from './inputs/util';
 import {
@@ -326,6 +324,12 @@ class EducationForm extends ProfileFormFields {
       }
     };
 
+    const schoolAddressMapping = {
+      locality: keySet("school_city"),
+      administrative_area_level_1: keySet("school_state_or_territory"),
+      country: keySet("school_country")
+    };
+
     return <Grid className="profile-tab-grid">
       <Cell col={12} className="profile-form-title">
         {title}
@@ -338,26 +342,13 @@ class EducationForm extends ProfileFormFields {
       <Cell col={12}>
         {this.boundDateField(keySet('graduation_date'), 'Graduation Date', true, true)}
       </Cell>
-      <Cell col={4}>
-        <CountrySelectField
-          stateKeySet={keySet('school_state_or_territory')}
-          countryKeySet={keySet('school_country')}
-          label='Country'
-          topMenu={true}
-          {...this.defaultInputComponentProps()}
-        />
-      </Cell>
-      <Cell col={4}>
-        <StateSelectField
-          stateKeySet={keySet('school_state_or_territory')}
-          countryKeySet={keySet('school_country')}
-          label='State'
-          topMenu={true}
-          {...this.defaultInputComponentProps()}
-        />
-      </Cell>
-      <Cell col={4} key="school_city">
-        {this.boundTextField(keySet('school_city'), 'City')}
+      <Cell col={12}>
+        {this.boundGeosuggest(schoolAddressMapping, keySet('location'), "School Location",
+          {
+            placeholder: "Anytown, Massachusetts, United States",
+            types: ["geocode"]
+          }
+        )}
       </Cell>
     </Grid>;
   };

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -18,8 +18,6 @@ import ProfileFormFields from '../util/ProfileFormFields';
 import { dialogActions } from './inputs/util';
 import ConfirmDeletion from './ConfirmDeletion';
 import SelectField from './inputs/SelectField';
-import CountrySelectField from './inputs/CountrySelectField';
-import StateSelectField from './inputs/StateSelectField';
 import INDUSTRIES from '../data/industries';
 import { formatMonthDate } from '../util/date';
 import type { Option } from '../flow/generalTypes';
@@ -130,6 +128,12 @@ class EmploymentForm extends ProfileFormFields {
     let id = _.get(profile, keySet("id"));
     let title = id !== undefined ? 'Edit Employment' : 'Add Employment';
 
+    const employerAddressMapping = {
+      locality: keySet("city"),
+      administrative_area_level_1: keySet("state_or_territory"),
+      country: keySet("country")
+    };
+
     return (
       <Grid className="profile-tab-grid">
         <Cell col={12} className="profile-form-title">
@@ -137,25 +141,6 @@ class EmploymentForm extends ProfileFormFields {
         </Cell>
         <Cell col={12}>
           {this.boundTextField(keySet('company_name'), 'Name of Employer')}
-        </Cell>
-        <Cell col={4}>
-          <CountrySelectField
-            stateKeySet={keySet('state_or_territory')}
-            countryKeySet={keySet('country')}
-            label='Country'
-            {...this.defaultInputComponentProps()}
-          />
-        </Cell>
-        <Cell col={4}>
-          <StateSelectField
-            stateKeySet={keySet('state_or_territory')}
-            countryKeySet={keySet('country')}
-            label='State or Territory'
-            {...this.defaultInputComponentProps()}
-          />
-        </Cell>
-        <Cell col={4}>
-          {this.boundTextField(keySet('city'), 'City')}
         </Cell>
         <Cell col={12}>
           <SelectField
@@ -177,6 +162,14 @@ class EmploymentForm extends ProfileFormFields {
           <span className={`end-date-hint ${this.addSpaceForError(keySet('end_date'))}`}>
             Leave blank if this is a current position
           </span>
+        </Cell>
+        <Cell col={12}>
+          {this.boundGeosuggest(employerAddressMapping, keySet('location'), "Employer Location",
+            {
+              placeholder: "Anytown, Massachusetts, United States",
+              types: ["geocode"]
+            }
+          )}
         </Cell>
       </Grid>
     );

--- a/static/js/containers/LearnerPage_test.js
+++ b/static/js/containers/LearnerPage_test.js
@@ -367,8 +367,8 @@ describe("LearnerPage", function() {
           "field_of_study": "Philosophy",
           "school_name": "Harvard",
           "school_city": "Cambridge",
-          "school_state_or_territory": "US-MA",
-          "school_country": "US",
+          "school_state_or_territory": "AF-KAN",
+          "school_country": "AF",
           "online_degree": false
         });
         helper.profileGetStub.
@@ -512,8 +512,8 @@ describe("LearnerPage", function() {
             },
             school_name: "A School",
             school_country: "AF",
-            school_state_or_territory: "AF-BAL",
-            school_city: "FoobarVille"
+            school_state_or_territory: "AF-KAN",
+            school_city: "Anytown"
           };
           expectedProfile.education.push(entry);
 
@@ -526,18 +526,15 @@ describe("LearnerPage", function() {
             START_PROFILE_EDIT,
             SET_EDUCATION_DIALOG_INDEX,
             SET_EDUCATION_DIALOG_VISIBILITY,
-            SET_EDUCATION_DIALOG_VISIBILITY,
             SET_EDUCATION_DEGREE_LEVEL,
-            SET_EDUCATION_DEGREE_LEVEL,
-            UPDATE_PROFILE_VALIDATION,
             REQUEST_PATCH_USER_PROFILE,
             RECEIVE_PATCH_USER_PROFILE_SUCCESS,
-            CLEAR_PROFILE_EDIT,
+            CLEAR_PROFILE_EDIT
           ];
-          for (let i = 0; i < 8; i++) {
+          for (let i = 0; i < 6; i++) {
             expectedActions.push(UPDATE_PROFILE);
           }
-          for (let i = 0; i < 7; i++) {
+          for (let i = 0; i < 6; i++) {
             expectedActions.push(UPDATE_PROFILE_VALIDATION);
           }
           for (let i = 0; i < 3; i++) {
@@ -569,9 +566,7 @@ describe("LearnerPage", function() {
             modifyTextField(inputs[3], "1999");
 
             // set country, state, and city
-            modifyEducationSelect('.country', "Afghanistan");
-            modifyEducationSelect('.state', "Balkh");
-            modifyTextField(inputs[6], "FoobarVille");
+            modifyTextField(inputs[4], "Anytown, Qandahar, Afghanistan");
             let save = dialog.querySelector('.save-button');
             ReactTestUtils.Simulate.click(save);
           });
@@ -751,9 +746,9 @@ describe("LearnerPage", function() {
               month: "01",
               day: undefined
             },
-            city: "FoobarVille",
+            city: "Anytown",
             country: "AF",
-            state_or_territory: "AF-BAL",
+            state_or_territory: "AF-KAN",
           };
           updatedProfile.work_history.push(entry);
 
@@ -764,14 +759,12 @@ describe("LearnerPage", function() {
 
           let expectedActions = [
             START_PROFILE_EDIT,
-            UPDATE_PROFILE,
             SET_WORK_DIALOG_INDEX,
             SET_WORK_DIALOG_VISIBILITY,
-            UPDATE_PROFILE_VALIDATION,
             REQUEST_PATCH_USER_PROFILE,
             RECEIVE_PATCH_USER_PROFILE_SUCCESS
           ];
-          for (let i = 0; i < 10; i++) {
+          for (let i = 0; i < 9; i++) {
             expectedActions.push(UPDATE_PROFILE);
             expectedActions.push(UPDATE_PROFILE_VALIDATION);
           }
@@ -797,22 +790,19 @@ describe("LearnerPage", function() {
             // company name
             modifyTextField(inputs[0], "FoobarCorp");
 
-            // country, state, city
-            modifyWorkSelect('.country', "Afghanistan");
-            modifyWorkSelect('.state-or-territory', "Balkh");
-            modifyTextField(inputs[3], "FoobarVille");
-
             // industry
             modifyWorkSelect('.industry', "Accounting");
 
             // position
-            modifyTextField(inputs[5], "Assistant Foobar");
+            modifyTextField(inputs[2], "Assistant Foobar");
 
             // start date, end date
-            modifyTextField(inputs[6], "12");
-            modifyTextField(inputs[7], "2001");
-            modifyTextField(inputs[8], "01");
-            modifyTextField(inputs[9], "2002");
+            modifyTextField(inputs[3], "12");
+            modifyTextField(inputs[4], "2001");
+            modifyTextField(inputs[5], "01");
+            modifyTextField(inputs[6], "2002");
+            // country, state, city
+            modifyTextField(inputs[7], "Anytown, Kandahar, Afghanistan");
 
             let button = dialog.querySelector(".save-button");
             ReactTestUtils.Simulate.click(button);

--- a/static/js/lib/location.js
+++ b/static/js/lib/location.js
@@ -1,6 +1,63 @@
 import R from 'ramda';
 import iso3166 from 'iso-3166-2';
+import Fuse from 'fuse-js-latest';
 
-export const codeToCountryName = (code: string) =>  R.pathOr(
-  "", ['name'], iso3166.country(R.defaultTo("", code))
+const notAvailable = "Not Available";
+
+/**
+ * Gets the name of a country given its code
+ * @param code Country code
+ */
+export const codeToCountryName =  R.compose(
+  R.pathOr("", ['name']),
+  iso3166.country,
+  R.defaultTo("")
 );
+
+/**
+ * Gets the code for a country given its name
+ * @param name Country name
+ */
+export const nameToCountryCode = R.compose(
+  R.pathOr("", ['code']),
+  iso3166.country,
+  R.defaultTo("")
+);
+
+/**
+ * Gets the name of a state/territory given its ISO3166 code (as in 'US-MA')
+ * @param code ISO3166 code ('US-MA', 'US-CO', etc).
+ */
+export const codeToStateName = R.compose(
+  R.pathOr(notAvailable, ['name']),
+  iso3166.subdivision,
+  R.defaultTo("")
+);
+
+/**
+ * Get a list of subregion objects for a country, each with a 'code' and 'name' property.
+ * @param country Country code
+ */
+export const getSubcodes = (country:string) => (
+  R.map(function(key) {
+    return {"code": key, "name": iso3166.data[country]["sub"][key]["name"]};
+  }, Object.keys(iso3166.data[country]["sub"]))
+);
+
+/**
+ * Gets the ISO3166 code for a state/territory given a country and state name.
+ * If no exact match is found for a state name, try a fuzzy match.
+ * Return a notAvailable value if no match can be found either way.
+ * @param country Country code
+ * @param name State/territory name
+ */
+export const nameToStateCode = (country: string, name: string) =>  {
+  let statecode = iso3166.subdivision(R.defaultTo("", country), R.defaultTo("", name));
+  if (!R.isEmpty(statecode)) {
+    return statecode['code'];
+  } else {
+    const fuse = new Fuse(getSubcodes(country), {keys: ["name"], threshold:0.4, tokenize: true});
+    const fuzzymatches = fuse.search(R.defaultTo("", name));
+    return R.isEmpty(fuzzymatches) ? notAvailable : fuzzymatches[0]["code"];
+  }
+};

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -420,7 +420,7 @@ describe('Profile validation functions', () => {
       assert.deepEqual(educationValidation(clone), {
         education: [{
           school_name: 'School name is required',
-          school_city: 'City is required'
+          location: 'Location must contain city, state, country'
         }, {}]
       });
     });
@@ -450,7 +450,7 @@ describe('Profile validation functions', () => {
       clone.work_history[0].city = '';
       assert.deepEqual(employmentValidation(clone), {
         work_history: [{
-          city: 'City is required',
+          location: 'Location must contain city, state, country',
           company_name: 'Name of Employer is required'
         },{}]
       });
@@ -589,7 +589,7 @@ describe('Profile validation functions', () => {
       profile = _.cloneDeep(USER_PROFILE_RESPONSE);
       _.set(profile, ['work_history', 0, 'country'], '');
       let expectation = [false, EMPLOYMENT_STEP, {
-        work_history: [{country: "Country is required"}, {}]
+        work_history: [{location: "Location must contain city, state, country"}, {}]
       }];
       assert.deepEqual(validateProfileComplete(profile), expectation);
     });

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -200,8 +200,8 @@ export class GoogleMapsStub {
     address_components: [
       {long_name: "123 Main Street", short_name: "123 Main St", types: ["street_address"]},
       {long_name: "Anytown", short_name: "Anytown", types: ["locality"]},
-      {long_name: "RandoState", short_name: "RS", types: ["administrative_area_level_1"]},
-      {long_name: "United States", short_name: "USA", types: ["country"]},
+      {long_name: "Kandahar", short_name: "Kandahar", types: ["administrative_area_level_1"]},
+      {long_name: "Afghanistan", short_name: "AF", types: ["country"]},
     ],
     geometry: {
       location: {

--- a/static/scss/geosuggest.scss
+++ b/static/scss/geosuggest.scss
@@ -29,4 +29,17 @@
 
 .geosuggest__suggests {
   border: 1px solid rgb(224, 224, 224);
+  bottom: 50%;
+  top: initial;
+}
+
+.geosuggest__suggests--hidden {
+  max-height: 0;
+  overflow: hidden;
+  border-width: 0;
+}
+
+.geosuggest__item--active {
+  background: #267dc0;
+  color: #fff;
 }

--- a/ui/views.py
+++ b/ui/views.py
@@ -70,7 +70,7 @@ class ReactView(View):  # pylint: disable=unused-argument
             context={
                 "has_zendesk_widget": True,
                 "is_public": False,
-                "google_maps_api": False,
+                "google_maps_api": True,
                 "js_settings_json": json.dumps(js_settings),
                 "ga_tracking_id": "",
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2665,6 +2665,10 @@ function.prototype.name@^1.0.0:
     function-bind "^1.1.0"
     is-callable "^1.1.2"
 
+fuse-js-latest@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/fuse-js-latest/-/fuse-js-latest-2.6.2.tgz#2b907cf881287bb454c56cb186743b1d87d9da35"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/2384

#### What's this PR do?
Replaces the city, state, and country input fields for the profile education and employment dialogs with a Geosuggest component input field.

#### How should this be manually tested?
Add and edit employment and education entries on your profile.  Start typing in a city (like 'Boston'), you should see some suggestions start to appear below the input field. Choose one and save.  Then go back to edit the entry and make sure that the value you selected is there.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
