### PR TITLE
Added check for exam attempts

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -206,6 +206,19 @@ class MMTrack:
             return self.has_final_grade_paid_on_edx(edx_course_key)
         return self.has_verified_enrollment(edx_course_key)
 
+    def get_course_paid_count(self, course_key):
+        """
+        Gets the count of paid course runs for the course
+
+        Args:
+            edx_course_key (str): an edX course run key
+        Returns:
+            int: count of paid course runs
+        """
+        return Line.objects.filter(
+            order__status=Order.FULFILLED, order__user=self.user, course_key=course_key
+        ).values('order_id').distinct().count()
+
     def has_paid_for_any_in_program(self):
         """
         Returns true if a user has paid for any course run in the program

--- a/exams/models.py
+++ b/exams/models.py
@@ -180,6 +180,11 @@ class ExamAuthorization(TimestampedModel):
     exam_taken = models.BooleanField(default=False)
     exam_no_show = models.BooleanField(default=False)
 
+    @classmethod
+    def taken_exams(cls):
+        """Returns a QuerySet for taken exams"""
+        return cls.objects.filter(exam_taken=True)
+
     def __str__(self):
         return 'Exam Authorization "{0}" with status "{1}" for user {2}'.format(
             self.id,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2286 

#### What's this PR do?
Adds a check to not generate more authorizations if a user has reached their limit of exam attempts for how many times they've paid.

#### How should this be manually tested?

The tests added should pass, otherwise you can test by:

For an FA course:
- Create an `ExamRun` for the course with all dates in the past.
- Create two `ExamRunAuthorization`s for the past `ExamRun`
- Create a second `ExamRun` for the course with `date_first_eligible` in the past and `date_last_eligible` in the future.
- Enroll in the current course run for that course
- Create a passing `FinalGrade` for the current course run of that course
- Verify you have no `ExamAuthorization` record for that course
- Pay for the course
- Verify do not have a third `ExamAuthorization` record for that course