### PR TITLE
implement new preferred name behavior

### DIFF
--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -77,7 +77,7 @@ def update_profile_from_edx(backend, user, response, is_new, *args, **kwargs):  
     name = user_profile_edx.get('name', "")
     user_profile.edx_name = name
     user_profile.first_name, user_profile.last_name = split_name(name)
-    user_profile.preferred_name = user_profile.first_name
+    user_profile.preferred_name = name
     user_profile.edx_bio = user_profile_edx.get('bio')
     user_profile.country = user_profile_edx.get('country')
     user_profile.edx_requires_parental_consent = user_profile_edx.get('requires_parental_consent')

--- a/backends/pipeline_api_test.py
+++ b/backends/pipeline_api_test.py
@@ -193,7 +193,7 @@ class EdxPipelineApiTest(MockedESTestCase):
             ('edx_name', mocked_content['name']),
             ('first_name', first_name),
             ('last_name', last_name),
-            ('preferred_name', first_name),
+            ('preferred_name', mocked_content['name']),
             ('edx_bio', mocked_content['bio']),
             ('country', mocked_content['country']),
             ('edx_requires_parental_consent', mocked_content['requires_parental_consent']),

--- a/static/js/components/LearnerInfoCard.js
+++ b/static/js/components/LearnerInfoCard.js
@@ -16,11 +16,17 @@ import {
 import { mstr } from '../lib/sanctuary';
 import type { Profile } from '../flow/profileTypes';
 
+const showLegalNameIfStaff = profile => {
+  return hasAnyStaffRole(SETTINGS.roles)
+    ? <div className="legal-name">{`(Legal name: ${profile.first_name} ${profile.last_name})`}</div>
+    : null;
+};
+
 export default class LearnerInfoCard extends React.Component {
   props: {
-    profile: Profile,
+    profile:                  Profile,
     toggleShowPersonalDialog: () => void,
-    toggleShowAboutMeDialog: () => void,
+    toggleShowAboutMeDialog:  () => void,
     openLearnerEmailComposer: () => void,
   };
 
@@ -122,6 +128,7 @@ export default class LearnerInfoCard extends React.Component {
           <ProfileImage profile={profile} editable={true} />
           <div className="col user-info">
             <div className="profile-title">{getPreferredName(profile)}</div>
+            { showLegalNameIfStaff(profile) }
             <div className="profile-company-name">{mstr(getEmployer(profile))}</div>
             {this.renderEmailLink()}
           </div>

--- a/static/js/components/LearnerInfoCard_test.js
+++ b/static/js/components/LearnerInfoCard_test.js
@@ -98,6 +98,27 @@ describe('LearnerInfoCard', () => {
     );
   });
 
+  it('should not show legal name if the user is not staff', () => {
+    let wrapper = renderInfoCard();
+    assert.equal(wrapper.find('.legal-name').length, 0);
+  });
+
+  it('should show legal name if the user is staff', () => {
+    SETTINGS.user.username = "My user";
+    SETTINGS.roles = [{
+      "role": "staff",
+      "program": 1
+    }];
+    let wrapper = renderInfoCard({
+      profile: {
+        ...USER_PROFILE_RESPONSE,
+        first_name: 'FIRST',
+        last_name: 'LAST'
+      }
+    });
+    assert.equal(wrapper.find('.legal-name').text(), '(Legal name: FIRST LAST)');
+  });
+
   describe('email link', () => {
     let originalUsername = SETTINGS.user.username;
 

--- a/static/js/components/PersonalForm.js
+++ b/static/js/components/PersonalForm.js
@@ -80,8 +80,7 @@ export default class PersonalForm extends ProfileFormFields {
       <section>
         <h2 className="sr-only">Personal Information</h2>
         <p className="alert-info" role="alert">
-          Please fill out this form using your legal name
-          and truthful information.
+          Please provide your legal name, and truthful information.
         </p>
         <Grid className="profile-form-grid">
           <Cell col={6}>
@@ -91,6 +90,9 @@ export default class PersonalForm extends ProfileFormFields {
             {this.boundTextField(["last_name"], "Family name")}
           </Cell>
           {this.showRomanizedFields()}
+          <p className="alert-info" role="alert">
+            Do you prefer to use a name different that your legal name entered above? If so enter it below.
+          </p>
           <Cell col={12}>
             {this.boundTextField(["preferred_name"], "Nickname / Preferred name")}
           </Cell>

--- a/static/js/components/search/LearnerResult.js
+++ b/static/js/components/search/LearnerResult.js
@@ -12,9 +12,9 @@ import { canAdvanceSearchProgram } from '../../lib/roles';
 import ProfileImage from '../../containers/ProfileImage';
 import LearnerChip from '../LearnerChip';
 import {
-  getUserDisplayName,
   getLocation,
   highlight,
+  getPreferredName,
 } from '../../util/util';
 import { SearchkitComponent } from 'searchkit';
 import type { SearchResult } from '../../flow/searchTypes';
@@ -64,7 +64,7 @@ class LearnerResult extends SearchkitComponent {
           onMouseEnter={() => setLearnerChipVisibility(profile.username)}
         >
           <span className="display-name">
-            { highlight(getUserDisplayName(profile), this.searchkit.state.q) }
+            { highlight(getPreferredName(profile), this.searchkit.state.q) }
           </span>
           <span className="user-name">
             { highlight(profile.username, this.searchkit.state.q) }

--- a/static/js/components/search/LearnerResult_test.js
+++ b/static/js/components/search/LearnerResult_test.js
@@ -22,7 +22,7 @@ import {
 } from '../../actions/ui';
 import IntegrationTestHelper from '../../util/integration_test_helper';
 import {
-  getUserDisplayName,
+  getPreferredName,
 } from '../../util/util';
 import {
   USER_PROFILE_RESPONSE,
@@ -72,9 +72,9 @@ describe('LearnerResult', () => {
     props
   );
 
-  it("should include the user's name", () => {
+  it("should include the user's preferred name", () => {
     let result = renderLearnerResult().find(".learner-name").find(".display-name");
-    assert.equal(result.text(), getUserDisplayName(USER_PROFILE_RESPONSE));
+    assert.equal(result.text(), getPreferredName(USER_PROFILE_RESPONSE));
   });
 
   it("should include the username", () => {
@@ -227,8 +227,6 @@ describe('LearnerResult', () => {
       }
     );
     assert.deepEqual(result.find(".display-name .highlight").map(node => node.text()), [
-      'query',
-      'qÜery',
       'Query',
     ]);
     assert.equal(result.find(".user-name .highlight").text(), "query");

--- a/static/js/containers/LearnerPage.js
+++ b/static/js/containers/LearnerPage.js
@@ -80,10 +80,9 @@ class LearnerPage extends React.Component<*, LearnerPageProps, *> {
     } = this.props;
     let profilePath = [username, 'profile'];
 
-    let first = R.pathOr('', profilePath.concat('preferred_name'), profiles);
-    let last = R.pathOr('', profilePath.concat('last_name'), profiles);
+    let name = R.pathOr('', profilePath.concat('preferred_name'), profiles);
 
-    return `${first} ${last} | MITx MicroMasters Profile`
+    return `${name} | MITx MicroMasters Profile`
       .trim()
       .replace(/^\|\s/, '');
   }

--- a/static/js/containers/ProfileImage.js
+++ b/static/js/containers/ProfileImage.js
@@ -112,7 +112,7 @@ class ProfileImage extends React.Component {
           )}
           <img
             src={imageUrl}
-            alt={`Profile image for ${getPreferredName(profile, false)}`}
+            alt={`Profile image for ${getPreferredName(profile)}`}
             className={`rounded-profile-image ${imageSizeClass}`}
           />
           { userPrivilegeCheck(profile, this.cameraIcon) }

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -263,11 +263,12 @@ export function makeProfileImageUrl(profile: Profile, useSmall: ?boolean): strin
 }
 
 /**
- * Returns the preferred name or else the username
+ * Returns the preferred name, else first last, or else the username
  */
-export function getPreferredName(profile: Profile, last: boolean = true): string {
-  let first = profile.preferred_name || profile.first_name || profile.username;
-  return last && profile.last_name && !profile.preferred_name ? `${first} ${profile.last_name}` : first;
+export function getPreferredName(profile: Profile): string {
+  return profile.preferred_name || (profile.first_name && profile.last_name
+    ? `${profile.first_name} ${profile.last_name}` 
+    : profile.username);
 }
 
 export const getRomanizedName = (profile: Profile): string => (

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -138,38 +138,23 @@ describe('utility functions', () => {
       assert.equal('jane preferred', getPreferredName(profile));
     });
 
-    it('uses first_name if preferred_name is not available', () => {
+    it('uses ${first_name} ${last_name} if preferred_name is not available', () => {
       profile.preferred_name = undefined;
       assert.equal('jane doe', getPreferredName(profile));
     });
 
-    it('uses the username if first_name and preferred_name are not available', () => {
+    it('uses the username if preferred_name and first_name are not available', () => {
       profile.preferred_name = undefined;
       profile.first_name = undefined;
-      assert.equal('jane_username doe', getPreferredName(profile));
+      assert.equal('jane_username', getPreferredName(profile));
     });
 
-    it('shows the last name by default', () => {
-      assert.equal('First Last', getPreferredName({
-        first_name: 'First',
-        last_name: 'Last'
-      }));
-    });
-
-    it('does not show the last name if `last === false`', () => {
-      assert.equal('First', getPreferredName({
-        preferred_name: 'First',
-        last_name: 'Last',
-      }, false));
-    });
-
-    [true, false].forEach(bool => {
-      it(`shows just the first name if 'last === ${bool}' and 'profile.last_name === undefined'`, () => {
-        assert.equal('First', getPreferredName({preferred_name: 'First'}, bool));
-      });
+    it('uses the username if preferred_name and last_name are not available', () => {
+      profile.preferred_name = undefined;
+      profile.last_name = undefined;
+      assert.equal('jane_username', getPreferredName(profile));
     });
   });
-
 
   describe('getRomanizedName', () => {
     it('returns romanized First Last', () => {

--- a/static/scss/user-page.scss
+++ b/static/scss/user-page.scss
@@ -7,6 +7,12 @@
     font-weight: 400;
   }
 
+  .legal-name {
+    font-size: 13px;
+    color: $font-gray-light;
+    margin-top: 15px;
+  }
+
   .profile-company-name {
     font-size: 18px;
     color: #98989a;


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #2879 

#### What's this PR do?

this changes some stuff around the preferred name to be in line with what the issue says.

we:

- pre-populate the preferred name field (at account creation) with `${first} ${last}`, where `first` and `last` are the user's first and last names on edX (currently we do the same thing, but with just the first name).
- change the behavior of the `getPreferredName` utility function to always prefer to return the preferred name, then, `${first} ${last}`, and then `username`
- display the preferred name instead of the legal name in searchkit results
- show the legal name (with a little informative message) on the learner page if the current user is a staff user
- I think that's it?

#### How should this be manually tested?

Make sure that the changes described above have actually been implemented! It's helpful to change your preferred name to something like `PREFERRED` and your `first` and `last` to something equally distinctive to facilitate testing.