### PR TITLE
Use is_passing in MMTrack

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -144,7 +144,7 @@ class MMTrack:
         if not self.certificates.has_verified_cert(edx_course_key):
             return False
         certificate = self.certificates.get_verified_cert(edx_course_key)
-        return certificate.status == 'downloadable'
+        return certificate.is_passing
 
     @property
     def final_grade_qset(self):

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -557,14 +557,12 @@ class MMTrackTest(MockedESTestCase):
         assert mmtrack.has_paid_for_any_in_program() is True
 
     @ddt.data(
-        ("verified", "downloadable", True, True),
-        ("audit", "downloadable", False, False),
-        ("verified", "generating", True, True),
-        ("verified", "notpassing", False, False),
-        ("verified", "unverified", False, False),
+        ("verified", True, True),
+        ("audit", False, False),
+        ("verified", False, False),
     )
     @ddt.unpack
-    def test_has_passing_certificate(self, certificate_type, status, is_passing, expected_result):
+    def test_has_passing_certificate(self, certificate_type, is_passing, expected_result):
         """
         Test for has_passing_certificate method with different type of certificates
         """
@@ -573,7 +571,6 @@ class MMTrackTest(MockedESTestCase):
             "username": "staff",
             "course_id": course_key,
             "certificate_type": certificate_type,
-            "status": status,
             "is_passing": is_passing,
             "download_url": "http://www.example.com/demo.pdf",
             "grade": "0.98"

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -572,6 +572,7 @@ class MMTrackTest(MockedESTestCase):
             "course_id": course_key,
             "certificate_type": certificate_type,
             "is_passing": is_passing,
+            "status": "downloadable",
             "download_url": "http://www.example.com/demo.pdf",
             "grade": "0.98"
         }

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -557,14 +557,14 @@ class MMTrackTest(MockedESTestCase):
         assert mmtrack.has_paid_for_any_in_program() is True
 
     @ddt.data(
-        ("verified", "downloadable", True),
-        ("audit", "downloadable", False),
-        ("verified", "generating", False),
-        ("verified", "notpassing", False),
-        ("verified", "unverified", False),
+        ("verified", "downloadable", True, True),
+        ("audit", "downloadable", False, False),
+        ("verified", "generating", True, True),
+        ("verified", "notpassing", False, False),
+        ("verified", "unverified", False, False),
     )
     @ddt.unpack
-    def test_has_passing_certificate(self, certificate_type, status, expected_result):
+    def test_has_passing_certificate(self, certificate_type, status, is_passing, expected_result):
         """
         Test for has_passing_certificate method with different type of certificates
         """
@@ -574,6 +574,7 @@ class MMTrackTest(MockedESTestCase):
             "course_id": course_key,
             "certificate_type": certificate_type,
             "status": status,
+            "is_passing": is_passing,
             "download_url": "http://www.example.com/demo.pdf",
             "grade": "0.98"
         }
@@ -608,6 +609,7 @@ class MMTrackTest(MockedESTestCase):
             "course_id": self.crun_fa.edx_course_key,
             "certificate_type": "verified",
             "status": "downloadable",
+            "is_passing": True,
             "download_url": "http://www.example.com/demo.pdf",
             "grade": "0.98"
         }

--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ django-server-status==0.3.2
 django-storages-redux==1.3.2
 django-webpack-loader==0.4.1
 djangorestframework==3.5.2
-edx-api-client==0.3.0
+edx-api-client==0.4.0
 edx-opaque-keys==0.4
 elasticsearch-dsl==2.1.0
 elasticsearch==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@
 #
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
-appdirs==1.4.3            # via setuptools
 asn1crypto==0.22.0        # via cryptography
 beautifulsoup4==4.5.3     # via wagtail
 billiard==3.3.0.23        # via celery
@@ -30,7 +29,7 @@ django-treebeard==4.1.0   # via wagtail
 django-webpack-loader==0.4.1
 django==1.10.5
 djangorestframework==3.5.2
-edx-api-client==0.3.0
+edx-api-client==0.4.0
 edx-opaque-keys==0.4
 elasticsearch-dsl==2.1.0
 elasticsearch==2.3.0
@@ -45,7 +44,7 @@ jsonfield==1.0.3
 kombu==3.0.37             # via celery, django-server-status
 newrelic==2.82.0.62
 oauthlib==2.0.2           # via requests-oauthlib, social-auth-core
-packaging==16.8           # via cryptography, setuptools
+packaging==16.8           # via cryptography
 paramiko==2.1.2           # via pysftp
 pbr==2.0.0                # via stevedore
 pexpect==4.2.1            # via ipython
@@ -74,7 +73,7 @@ requests-oauthlib==0.8.0  # via social-auth-core
 requests==2.11.1
 robohash==1.0
 simplegeneric==0.8.1      # via ipython
-six==1.10.0               # via cryptography, django-role-permissions, django-server-status, edx-api-client, edx-opaque-keys, elasticsearch-dsl, faker, html5lib, packaging, prompt-toolkit, python-dateutil, setuptools, social-auth-app-django, social-auth-core, stevedore, traitlets
+six==1.10.0               # via cryptography, django-role-permissions, django-server-status, edx-api-client, edx-opaque-keys, elasticsearch-dsl, faker, html5lib, packaging, prompt-toolkit, python-dateutil, social-auth-app-django, social-auth-core, stevedore, traitlets
 social-auth-app-django==1.1.0
 social-auth-core==1.2.0   # via social-auth-app-django
 static3==0.5.1
@@ -88,6 +87,3 @@ wagtail==1.9
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5         # via html5lib
 willow==0.4               # via wagtail
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools                # via cryptography, html5lib, ipython


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #2539

#### What's this PR do?
Change MMTrack `has_passing_certificate` to use `is_passing` property of the certificate coming from edx.

#### How should this be manually tested?
should be covered in dashboard/utils_test.py

