### PR TITLE
fix node sass issues on travis

### DIFF
--- a/travis/Dockerfile-travis-watch-build
+++ b/travis/Dockerfile-travis-watch-build
@@ -23,4 +23,8 @@ RUN chown -R mitodl:mitodl /src
 
 USER mitodl
 
+# this is just to get a warm cache, we delete node_modules afterwards to
+# avoid issues with native extensions (mainly node-sass)
 RUN yarn install --pure-lockfile
+
+RUN rm -rf node_modules


### PR DESCRIPTION
#### What are the relevant tickets?

none. 

#### What's this PR do?

This deletes `node_modules/` in `Dockerfile-travis-watch-build`. This dockerfile is used to build an image we push to docker hub to cache some of the build steps for getting the JavaScript envrionment set up (mainly it gives us yarn, a warm cache for yarn,  and an OS level dependency). The issue was coming up because we were leaving the `node_modules` directory around in this image, so that when we went to build the container for running the tests (using `Dockerfile-travis-watch`) we were running into a bug with yarn + node-sass, where yarn fails to rebuild the native extensions that sass uses when it should.

So! We now delete the `node_modules` directory from the `Dockerfile-travis-watch-build` image, so that when we run `yarn install --pure-lockfile` in `Dockerfile-travis-watch` we are doing a clean install, not a messy one over an existing `node_modules` directory (yarn caches things aggressively though, so it should still be pretty fast).

The issue came up today because I pushed updated images to docker hub (using the `travis/update_docker_hub.sh` script) and we upgraded `node_sass` since the last time I pushed updated images.

#### How should this be manually tested?

images built using the changes here have already been pushed to docker hub, so if JavaScript builds are passing we're good.