### PR TITLE
Add financial aid screenshots

### DIFF
--- a/selenium_tests/base.py
+++ b/selenium_tests/base.py
@@ -373,6 +373,10 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
 
     def take_screenshot(self, name=None, output_base64=False):
         """Helper method to take a screenshot and put it in a temp directory"""
+        width = self.selenium.get_window_size()['width']
+        height = self.selenium.execute_script("return document.body.scrollHeight")
+        self.selenium.set_window_size(width, height)
+
         if name is None:
             name = self._testMethodName
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3277

#### What's this PR do?
 - Adds screenshots for each financial aid state
 - More descriptive filenames for other scenarios
 - Take screenshot of entire page height
 - Add `--mobile` flag to do mobile form factor screenshots

#### How should this be manually tested?
Run `./manage.py snapshot_dashboard_states --mobile`. There should be extra financial aid related screenshots, the filenames should be more descriptive than before and they should be suffixed with mobile. All screenshots should have a width of 480 pixels.