### PR TITLE
Fixed mail dialog rich text editor jumbling up letters

### DIFF
--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -165,8 +165,8 @@ export default class EmailCompositionDialog extends React.Component {
 
   onEditorStateChange = (editorState: EditorState) => {
     const { updateEmailBody } = this.props;
-    this.setState({ editorState });
     updateEmailBody(editorState);
+    this.setState({ editorState });
   };
 
   clearEditorState = () => {


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3254

#### What's this PR do?
On chrome/firefox OSX, Email composer rich text editor was reversing first 2 characters, this occur on first time after opening email composer. After that it worked fine. 
I fixed that behaviour

#### How should this be manually tested?
go to email composer and type text like `hello world`

@pdpinch 

#### Screenshots (if appropriate)

<img width="825" alt="screen shot 2017-06-08 at 4 14 13 pm" src="https://user-images.githubusercontent.com/10431250/26926118-c0ad5bb4-4c65-11e7-80fb-ab235fb1344e.png">
