### PR TITLE
Upgraded Wagtail to 1.10.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -34,4 +34,4 @@ social-auth-app-django==1.1.0
 robohash
 static3==0.5.1
 uwsgi
-wagtail==1.9
+wagtail==1.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,7 @@ unidecode==0.4.20         # via wagtail
 urllib3==1.21.1           # via elasticsearch
 uwsgi==2.0.15
 vine==1.1.3               # via amqp
-wagtail==1.9
+wagtail==1.10.1
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1       # via html5lib
 willow==0.4               # via wagtail


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Upgrades Wagtail to 1.10.1 as a requirement to upgrade Django to 1.11

#### How should this be manually tested?
We should check that the CMS works properly
