### PR TITLE
Fixed alter_data enrolled status and edX data freshness

### DIFF
--- a/seed_data/lib.py
+++ b/seed_data/lib.py
@@ -328,7 +328,6 @@ def set_course_run_past(course_run, end_date=None, upgradeable=False, save=True,
 def set_course_run_current(course_run, enrollable_now=True,  # pylint: disable=too-many-arguments
                            enrollable_past=False, upgradeable=True, save=True, now=None):
     """Sets relevant CourseRun dates to be current relative to now"""
-    course_run.end_date = None
     if enrollable_now:
         course_run.enrollment_start, course_run.enrollment_end = \
             create_active_date_range(started_days_ago=10, days_until_end=5)
@@ -338,6 +337,7 @@ def set_course_run_current(course_run, enrollable_now=True,  # pylint: disable=t
     else:
         course_run.enrollment_start, course_run.enrollment_end = create_future_date_range()
     course_run.start_date = course_run.enrollment_start + timedelta(days=5)
+    course_run.end_date = course_run.start_date + timedelta(days=30)
     if enrollable_now and not upgradeable:
         course_run.upgrade_deadline = now - timedelta(days=1)
     else:

--- a/seed_data/management/commands/alter_data.py
+++ b/seed_data/management/commands/alter_data.py
@@ -34,6 +34,7 @@ from seed_data.lib import (
     clear_dashboard_data,
     is_fake_program_course_run,
     update_fake_course_run_edx_key,
+    ensure_cached_data_freshness,
 )
 
 
@@ -365,10 +366,12 @@ ADDITIONAL_PARAMS = {
 
 class Command(BaseCommand):
     """
-    Fine-tune course/program data (and associated enrollments/grades/etc) for a user.
+    Fine-tune course/program data (and associated enrollments/grades/etc) for a user, and set their
+    cached edX data to be considered 'fresh'.
     """
     help = """
-    Fine-tune course/program data (and associated enrollments/grades/etc) for a user.
+    Fine-tune course/program data (and associated enrollments/grades/etc) for a user, and set their
+    cached edX data to be considered 'fresh'.
     For detailed usage examples, run the command with '{0}' (ie: 'manage.py alter_data {0}')
     """.format(EXAMPLE_USAGE_COMMAND_NAME)
 
@@ -437,3 +440,5 @@ class Command(BaseCommand):
                 self.stdout.write(json.dumps(result, indent=2))
             elif result:
                 self.stdout.write(result)
+            # Ensure that the given user's edX data will be considered 'fresh'
+            ensure_cached_data_freshness(user=action_params['user'])


### PR DESCRIPTION
#### What are the relevant tickets?
No tickets. Fixes 2 minor `alter_data` command issues

#### What's this PR do?

1. Sets a course end date for current/ongoing courses (front end logic was recently changed in a way that shows vague output when an end date isn't set)
1. For the given users, sets cached edX data expiration one month in the future each time the `alter_data` script is invoked. Up until now, changing enrollment information via `alter_data` would often be undone by the 5 minute automatic refresh of edX data.

#### How should this be manually tested?

1. Run this management command, replacing the username with your own, and the `course-title` to any course title you wish: 
    ```
    ./manage.py alter_data set_to_enrolled --username=USERNAME --course-title='Analog Learning 100' --grade=75
    ```
    Visit `/dashboard` to see the course and make sure it is shown to be in progress.

1. Run the following, replacing the username with your own: 
    ```
    ./manage.py shell -c 'from dashboard.models import UserCacheRefreshTime; print(UserCacheRefreshTime.objects.filter(user__username="USERNAME").values("enrollment").first())'
    ```
    Note the timestamp. Now run any `alter_data` command besides the `examples` command (the one from the previous step will do fine). Run the command to get the enrollment timestamp again, and confirm that it has been reset to 1 month in the future

