### PR TITLE
Add JSON output for course price and coupons API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ celerybeat-schedule
 
 # profiling
 recreate_index_*.profile
+
+# Selenium
+dashboard_states_output/

--- a/scripts/test/run_snapshot_dashboard_states.sh
+++ b/scripts/test/run_snapshot_dashboard_states.sh
@@ -17,5 +17,6 @@ then
 fi
 
 docker-compose run \
+   -e RUNNING_SELENIUM=true \
    -e WEBPACK_DEV_SERVER_HOST="$WEBPACK_SELENIUM_DEV_SERVER_HOST" \
    selenium ./manage.py snapshot_dashboard_states $@

--- a/selenium_tests/base.py
+++ b/selenium_tests/base.py
@@ -61,7 +61,8 @@ log = logging.getLogger(__name__)
 
 def _make_absolute_url(relative_url, absolute_base):
     """
-    Create an absolute URL for selenium testing given a relative URL
+    Create an absolute URL for selenium testing given a relative URL. This will also replace the host of absolute_base
+    with the host IP of this instance.
 
     Args:
         relative_url (str): A relative URL
@@ -344,9 +345,13 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
         """Helper function for WebDriverWait"""
         return CustomWebDriverWait(driver=self.selenium, timeout=5)
 
+    def make_absolute_url(self, relative_url):
+        """Make an absolute URL appropriate for selenium testing"""
+        return _make_absolute_url(relative_url, self.live_server_url)
+
     def get(self, relative_url):
         """Use self.live_server_url with a URL which will work for external services"""
-        new_url = _make_absolute_url(relative_url, self.live_server_url)
+        new_url = self.make_absolute_url(relative_url)
         self.selenium.get(new_url)
         self.wait().until(lambda driver: driver.find_element_by_tag_name("body"))
         self.assert_console_logs()

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -1,5 +1,6 @@
 """Management command to attach avatars to profiles"""
 import itertools
+import json
 import os
 import sys
 from urllib.parse import quote_plus
@@ -10,6 +11,7 @@ from django.core.management import (
 )
 from django.test import override_settings
 import pytest
+import requests
 
 from courses.factories import CourseRunFactory
 from courses.models import (
@@ -39,6 +41,8 @@ RUNNING_DASHBOARD_STATES = False
 # We are passing options via global variable because of the bizarre way this management command is structured. Since
 # pytest is used to invoke the tests, we don't have a good way to pass options to it directly.
 DASHBOARD_STATES_OPTIONS = None
+
+DUMP_DIRECTORY = "dashboard_states_output"
 
 
 def make_scenario(command):
@@ -184,10 +188,13 @@ class DashboardStates(SeleniumTestsBase):
     @classmethod
     def _make_filename(cls, num, name, use_mobile=False):
         """Format the filename without extension for dashboard states"""
-        return "dashboard_state_{num:03d}_{command}{mobile}".format(
-            num=num,
-            command=name,
-            mobile="_mobile" if use_mobile else "",
+        return os.path.join(
+            DUMP_DIRECTORY,
+            "dashboard_state_{num:03d}_{command}{mobile}".format(
+                num=num,
+                command=name,
+                mobile="_mobile" if use_mobile else "",
+            )
         )
 
     def _make_scenarios(self):
@@ -260,6 +267,11 @@ class DashboardStates(SeleniumTestsBase):
 
     def test_dashboard_states(self):
         """Iterate through all possible dashboard states and take screenshots of each one"""
+        try:
+            os.mkdir(DUMP_DIRECTORY)
+        except FileExistsError:
+            pass
+
         use_mobile = DASHBOARD_STATES_OPTIONS.get('mobile')
         if use_mobile:
             self.selenium.set_window_size(480, 854)
@@ -292,10 +304,21 @@ class DashboardStates(SeleniumTestsBase):
 
             filename = self._make_filename(num, name, use_mobile=use_mobile)
             self.take_screenshot(filename)
-            self.get("/api/v0/dashboard/{}/".format(self.edx_username))
-            text = self.selenium.execute_script('return document.querySelector(".response-info pre").innerText')
-            with open("{}.txt".format(filename), 'w') as f:
-                f.write(text)
+
+            # Get the API results and store them alongside the screenshots
+            sessionid = self.selenium.get_cookie('sessionid')['value']
+            for api_url, api_name in [
+                ("/api/v0/dashboard/{}/".format(self.edx_username), 'dashboard'),
+                ("/api/v0/coupons/", 'coupons'),
+                ("/api/v0/course_prices/{}/".format(self.edx_username), 'course_prices'),
+            ]:
+                absolute_url = self.make_absolute_url(api_url)
+                api_json = requests.get(absolute_url, cookies={'sessionid': sessionid}).json()
+                with open("{filename}.{api_name}.json".format(
+                    filename=filename,
+                    api_name=api_name,
+                ), 'w') as f:
+                    json.dump(api_json, f, indent="    ")
 
 
 class Command(BaseCommand):
@@ -338,6 +361,11 @@ class Command(BaseCommand):
             # This should only happen if the user is running in an environment without Docker, which isn't allowed
             # for this command.
             raise Exception('Missing environment variable WEBPACK_DEV_SERVER_HOST.')
+
+        if os.environ.get('RUNNING_SELENIUM') != 'true':
+            raise Exception(
+                "This management command must be run with ./scripts/tests/run_snapshot_dashboard_states.sh"
+            )
 
         # We need to use pytest here instead of invoking the tests directly so that the test database
         # is used. Using override_settings(DATABASE...) causes a warning message and is not reliable.

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -1,6 +1,5 @@
 """Management command to attach avatars to profiles"""
 import itertools
-import json
 import os
 import sys
 from urllib.parse import quote_plus
@@ -11,7 +10,6 @@ from django.core.management import (
 )
 from django.test import override_settings
 import pytest
-import requests
 
 from courses.factories import CourseRunFactory
 from courses.models import (
@@ -304,21 +302,7 @@ class DashboardStates(SeleniumTestsBase):
 
             filename = self._make_filename(num, name, use_mobile=use_mobile)
             self.take_screenshot(filename)
-
-            # Get the API results and store them alongside the screenshots
-            sessionid = self.selenium.get_cookie('sessionid')['value']
-            for api_url, api_name in [
-                ("/api/v0/dashboard/{}/".format(self.edx_username), 'dashboard'),
-                ("/api/v0/coupons/", 'coupons'),
-                ("/api/v0/course_prices/{}/".format(self.edx_username), 'course_prices'),
-            ]:
-                absolute_url = self.make_absolute_url(api_url)
-                api_json = requests.get(absolute_url, cookies={'sessionid': sessionid}).json()
-                with open("{filename}.{api_name}.json".format(
-                    filename=filename,
-                    api_name=api_name,
-                ), 'w') as f:
-                    json.dump(api_json, f, indent="    ")
+            self.store_api_results(filename)
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3321 
Fixes #3295 

#### What's this PR do?
 - Stores results for `course_prices` and `coupons` REST APIs. These are also now stored as `json` files to allow easier parsing
 - Added check so that if user runs the management command directly instead of via the script they will be told to use the script
 - Outputs dashboard states in a separate directory `dashboard_states_output/`

#### How should this be manually tested?
Run `./scripts/test/run_snapshot_dashboard_states.sh`. The output should now be in a separate directory and there should be three json files per png file.
