### PR TITLE
bump yarn version to the latest pre-release (fixes the node-sass issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   },
   "engines": {
     "node": "6.2.0",
-    "yarn": "0.24.5"
+    "yarn": "0.27.0"
   },
   "scripts": {
     "postinstall": "./webpack_if_prod.sh",


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

bump the yarn version to the [latest pre-release](https://github.com/yarnpkg/yarn/releases/tag/v0.27.0)

[this pr](https://github.com/yarnpkg/yarn/pull/3704) recently merged and, from my testing, it appears to fix the issue we were seeing with node-sass! :tada: 

#### How should this be manually tested?

build should be good on heroku, no issues locally, etc. you will need to delete your `node_modules` directly to start off, and then after that you should be able to run a `--pure-lockfile` install over it as many times as you want without the `node-sass` error popping up. YAY!