### PR TITLE
Updated logging level for Sentry client in Celery

### DIFF
--- a/micromasters/celery.py
+++ b/micromasters/celery.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 client = Client(**settings.RAVEN_CONFIG)
 
-register_logger_signal(client, loglevel=settings.LOG_LEVEL)
+register_logger_signal(client, loglevel=logging.ERROR)
 
 # The register_signal function can also take an optional argument
 # `ignore_expected` which causes exception classes specified in Task.throws


### PR DESCRIPTION
The Sentry logger signal handler got set to match the app logging level which is causing
erroneous messages to be logged to Sentry.

#### What are the relevant tickets?
N/A

#### What's this PR do?
Raises the logging level for Sentry messages in Celery tasks.

#### How should this be manually tested?
Verify that sentry log messages aren't being fired for non-error messages in Celery tasks.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
