### PR TITLE
Fix coupon selenium screenshots

### DIFF
--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -24,10 +24,7 @@ from ecommerce.models import (
 )
 from exams.factories import ExamRunFactory
 from financialaid.factories import FinancialAidFactory
-from financialaid.models import (
-    FinancialAid,
-    FinancialAidStatus,
-)
+from financialaid.models import FinancialAidStatus
 from grades.factories import ProctoredExamGradeFactory
 from seed_data.management.commands.alter_data import EXAMPLE_COMMANDS
 from selenium_tests.base import SeleniumTestsBase

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -24,7 +24,10 @@ from ecommerce.models import (
 )
 from exams.factories import ExamRunFactory
 from financialaid.factories import FinancialAidFactory
-from financialaid.models import FinancialAidStatus
+from financialaid.models import (
+    FinancialAid,
+    FinancialAidStatus,
+)
 from grades.factories import ProctoredExamGradeFactory
 from seed_data.management.commands.alter_data import EXAMPLE_COMMANDS
 from selenium_tests.base import SeleniumTestsBase
@@ -134,8 +137,10 @@ class DashboardStates(SeleniumTestsBase):
 
     def with_coupon(self, amount_type, is_program, is_free):
         """Add a course-level coupon"""
-        call_command("alter_data", 'set_to_offered', '--username', 'staff', '--course-title', 'Analog Learning 200')
-        course = Course.objects.get(title='Analog Learning 200')
+        # Set up financial aid and use Digital Learning since coupons are only allowed for financial aid programs
+        self.with_financial_aid(FinancialAidStatus.AUTO_APPROVED, True)
+
+        course = Course.objects.get(title='Digital Learning 200')
         if is_program:
             content_object = course.program
         else:
@@ -153,6 +158,16 @@ class DashboardStates(SeleniumTestsBase):
             content_object=content_object, coupon_type=Coupon.STANDARD, amount_type=amount_type, amount=amount,
         )
         UserCoupon.objects.create(user=self.user, coupon=coupon)
+
+    def with_coupon_no_financial_aid_application(self):
+        """Coupon without a financial aid application"""
+        self.with_coupon(Coupon.PERCENT_DISCOUNT, True, False)
+        FinancialAid.objects.all().delete()
+
+    def with_coupon_pending_financial_aid(self):
+        """Coupon with a non-terminal financial aid application"""
+        self.with_coupon(Coupon.PERCENT_DISCOUNT, True, False)
+        FinancialAid.objects.update(status=FinancialAidStatus.PENDING_MANUAL_APPROVAL)
 
     def with_financial_aid(self, status, is_enrolled):
         """Set the status of user's financial aid"""
@@ -173,6 +188,7 @@ class DashboardStates(SeleniumTestsBase):
             user=self.user,
             status=status,
             tier_program__program=program,
+            tier_program__discount_amount=50,
         )
 
     @classmethod
@@ -248,6 +264,8 @@ class DashboardStates(SeleniumTestsBase):
         )
 
         # Other misc scenarios
+        yield (self.with_coupon_no_financial_aid_application, 'with_coupon_no_financial_aid_application')
+        yield (self.with_coupon_pending_financial_aid, 'with_coupon_pending_financial_aid')
         yield (self.pending_enrollment, 'pending_enrollment')
         yield (self.contact_course, 'contact_course')
         yield (self.missed_payment_can_reenroll, 'missed_payment_can_reenroll')
@@ -279,12 +297,12 @@ class DashboardStates(SeleniumTestsBase):
         scenarios = self._make_scenarios()
         scenarios_with_numbers = enumerate(scenarios)
 
-        suffix = DASHBOARD_STATES_OPTIONS.get('suffix')
-        if suffix is not None:
+        match = DASHBOARD_STATES_OPTIONS.get('match')
+        if match is not None:
             scenarios_with_numbers = (
                 (num, (run_scenario, name))
                 for (num, (run_scenario, name)) in scenarios_with_numbers
-                if self._make_filename(num, name).endswith(suffix)
+                if match in self._make_filename(num, name)
             )
 
         for num, (run_scenario, name) in scenarios_with_numbers:
@@ -313,9 +331,9 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--suffix",
-            dest="suffix",
-            help="Runs only scenarios matching the given suffix",
+            "--match",
+            dest="match",
+            help="Runs only scenarios matching the given string",
             required=False,
         )
         parser.add_argument(

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -162,12 +162,12 @@ class DashboardStates(SeleniumTestsBase):
     def with_coupon_no_financial_aid_application(self):
         """Coupon without a financial aid application"""
         self.with_coupon(Coupon.PERCENT_DISCOUNT, True, False)
-        FinancialAid.objects.all().delete()
+        self.user.financialaid_set.update(status=FinancialAidStatus.RESET)
 
     def with_coupon_pending_financial_aid(self):
         """Coupon with a non-terminal financial aid application"""
         self.with_coupon(Coupon.PERCENT_DISCOUNT, True, False)
-        FinancialAid.objects.update(status=FinancialAidStatus.PENDING_MANUAL_APPROVAL)
+        self.user.financialaid_set.update(status=FinancialAidStatus.PENDING_MANUAL_APPROVAL)
 
     def with_financial_aid(self, status, is_enrolled):
         """Set the status of user's financial aid"""


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #3340 

#### What's this PR do?
Changes `dashboard_snapshot_states` to create coupons for financial aid programs. Currently this creates coupons for a non-financial aid program, which is an invalid state since there can't be coupons in non-financial aid programs.

#### How should this be manually tested?
Run `./scripts/test/run_snapshot_dashboard_states.sh --match coupon` and look at the screenshots. Some values are incorrect, see #3342 for the issue to fix it.
