### PR TITLE
Use specific hash seed

### DIFF
--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -9,6 +9,7 @@ from django.core.management import (
     call_command,
 )
 from django.test import override_settings
+from faker.generator import random
 import pytest
 
 from courses.factories import CourseRunFactory
@@ -354,6 +355,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        random.seed(12345)
         if options.get('list_scenarios'):
             self.stdout.write('Scenarios:\n')
             for num, (_, name) in enumerate(DashboardStates()._make_scenarios()):  # pylint: disable=protected-access


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3341 

#### What's this PR do?
Sets the hash seed for the faker library so it generates the same random-ish values each time

#### How should this be manually tested?
Run this command:

    ./scripts/test/run_snapshot_dashboard_states.sh --match 000

Then rename `output/dashboard_states` to `output/old`. Then rerun the above command. Look at the `png` file in the `old` directory, then look at the one in `dashboard_states`. They should be bit for bit identical
