### PR TITLE
Prevent users from creating coupons on non-financial aid programs

### DIFF
--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -534,7 +534,10 @@ class CouponTests(MockedESTestCase):
     def setUpTestData(cls):
         """Create a set of course runs for testing"""
         super().setUpTestData()
-        cls.run1 = CourseRunFactory.create(course__program__live=True)
+        cls.run1 = CourseRunFactory.create(
+            course__program__live=True,
+            course__program__financial_aid_availability=True,
+        )
         cls.program = cls.run1.course.program
         cls.run2 = CourseRunFactory.create(course=cls.run1.course)
         cls.runs = [cls.run1, cls.run2]
@@ -640,7 +643,11 @@ class PickCouponTests(MockedESTestCase):
     @classmethod
     def _create_coupons(cls, user):
         """Create some coupons"""
-        course = CourseRunFactory.create(course__program__live=True).course
+        course_run = CourseRunFactory.create(
+            course__program__financial_aid_availability=True,
+            course__program__live=True,
+        )
+        course = course_run.course
         ProgramEnrollment.objects.create(program=course.program, user=user)
         coupon1_auto = CouponFactory.create(
             coupon_type=Coupon.DISCOUNTED_PREVIOUS_COURSE,

--- a/ecommerce/factories.py
+++ b/ecommerce/factories.py
@@ -98,7 +98,7 @@ class CouponFactory(DjangoModelFactory):
     class Meta:
         model = Coupon
 
-    content_object = SubFactory(ProgramFactory)
+    content_object = SubFactory(ProgramFactory, financial_aid_availability=True)
 
     class Params:  # pylint: disable=missing-docstring
         percent = Trait(

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -351,6 +351,9 @@ class Coupon(TimestampedModel, AuditableModel):
                 "coupon must be for a course if coupon_type is {}".format(self.DISCOUNTED_PREVIOUS_COURSE)
             )
 
+        if not self.program.financial_aid_availability:
+            raise ValidationError("coupons are only allowed for programs with financial aid")
+
     @classmethod
     def get_audit_class(cls):
         return CouponAudit

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -17,7 +17,8 @@ class SerializerTests(TestCase):
         """
         Test coupon serializer
         """
-        coupon = CouponFactory.create(content_object=CourseRunFactory.create().course.program)
+        course_run = CourseRunFactory.create(course__program__financial_aid_availability=True)
+        coupon = CouponFactory.create(content_object=course_run.course.program)
         assert CouponSerializer(coupon).data == {
             'amount': str(coupon.amount),
             'amount_type': coupon.amount_type,
@@ -32,7 +33,8 @@ class SerializerTests(TestCase):
         """
         Test coupon serializer
         """
-        coupon = CouponFactory.create(content_object=CourseRunFactory.create().course)
+        course_run = CourseRunFactory.create(course__program__financial_aid_availability=True)
+        coupon = CouponFactory.create(content_object=course_run.course)
         assert CouponSerializer(coupon).data == {
             'amount': str(coupon.amount),
             'amount_type': coupon.amount_type,
@@ -47,6 +49,7 @@ class SerializerTests(TestCase):
         """
         Test coupon serializer
         """
+        course_run = CourseRunFactory.create(course__program__financial_aid_availability=True)
         with self.assertRaises(ValidationError) as ex:
-            CouponFactory.create(content_object=CourseRunFactory.create())
+            CouponFactory.create(content_object=course_run)
         assert ex.exception.args[0]['__all__'][0].args[0] == 'content_object must be of type Course or Program'

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -480,7 +480,7 @@ class CouponTests(MockedESTestCase):
             provider=EdxOrgOAuth2.name,
             uid='user',
         )
-        run = CourseRunFactory.create()
+        run = CourseRunFactory.create(course__program__financial_aid_availability=True)
         cls.coupon = CouponFactory.create(content_object=run.course.program)
         UserCoupon.objects.create(coupon=cls.coupon, user=cls.user)
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3340 

#### What's this PR do?
Prevents coupons from being created for non-financial aid programs.

#### How should this be manually tested?
Create a coupon in the Django admin for a non-financial aid program and see the error message
