### PR TITLE
Use city, state, country fields if Google Maps API is unavailable

### DIFF
--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -18,6 +18,8 @@ import {
 import ProfileFormFields from '../util/ProfileFormFields';
 import ConfirmDeletion from './ConfirmDeletion';
 import SelectField from './inputs/SelectField';
+import CountrySelectField from './inputs/CountrySelectField';
+import StateSelectField from './inputs/StateSelectField';
 import { educationEntriesByDate } from '../util/sorting';
 import { dialogActions } from './inputs/util';
 import {
@@ -330,6 +332,45 @@ class EducationForm extends ProfileFormFields {
       country: keySet("school_country")
     };
 
+    // Load geosuggest component only if Google Maps API is loaded.
+    let addressForm = () => {
+      if (window.google && window.google.maps) {
+        return <Cell col={12}>
+        {this.boundGeosuggest(schoolAddressMapping, keySet('location'), "School Location",
+          {
+            placeholder: "Anytown, Massachusetts, United States",
+            types: ["(cities)"]
+          }
+        )}
+      </Cell>;
+      } else {
+        return <Grid style={{padding:'0px', margin:'0px', width:'100%'}}>
+              <Cell col={4}>
+                <CountrySelectField
+                  stateKeySet={keySet('school_state_or_territory')}
+                  countryKeySet={keySet('school_country')}
+                  label='Country'
+                  topMenu={true}
+                  {...this.defaultInputComponentProps()}
+                />
+              </Cell>
+              <Cell col={4}>
+                <StateSelectField
+                  stateKeySet={keySet('school_state_or_territory')}
+                  countryKeySet={keySet('school_country')}
+                  label='State'
+                  topMenu={true}
+                  {...this.defaultInputComponentProps()}
+                />
+              </Cell>
+              <Cell col={4} key="school_city">
+                {this.boundTextField(keySet('school_city'), 'City')}
+              </Cell></Grid>;
+      }
+
+    };
+
+
     return <Grid className="profile-tab-grid">
       <Cell col={12} className="profile-form-title">
         {title}
@@ -342,14 +383,7 @@ class EducationForm extends ProfileFormFields {
       <Cell col={12}>
         {this.boundDateField(keySet('graduation_date'), 'Graduation Date', true, true)}
       </Cell>
-      <Cell col={12}>
-        {this.boundGeosuggest(schoolAddressMapping, keySet('location'), "School Location",
-          {
-            placeholder: "Anytown, Massachusetts, United States",
-            types: ["geocode"]
-          }
-        )}
-      </Cell>
+      {addressForm()}
     </Grid>;
   };
 

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -18,6 +18,8 @@ import ProfileFormFields from '../util/ProfileFormFields';
 import { dialogActions } from './inputs/util';
 import ConfirmDeletion from './ConfirmDeletion';
 import SelectField from './inputs/SelectField';
+import CountrySelectField from './inputs/CountrySelectField';
+import StateSelectField from './inputs/StateSelectField';
 import INDUSTRIES from '../data/industries';
 import { formatMonthDate } from '../util/date';
 import type { Option } from '../flow/generalTypes';
@@ -134,6 +136,42 @@ class EmploymentForm extends ProfileFormFields {
       country: keySet("country")
     };
 
+    let addressForm = () => {
+      // Use the Geosuggest component only if Google Maps API is loaded.
+      if (window.google && window.google.maps) {
+        return <Cell col={12}>
+                {this.boundGeosuggest(employerAddressMapping, keySet('location'), "Employer Location",
+                  {
+                    placeholder: "Anytown, Massachusetts, United States",
+                    types: ["(cities)"]
+                  }
+                )}
+              </Cell>;
+      } else {
+        return <Grid style={{padding:'0px', margin:'0px', width: '100%'}}>
+                <Cell col={4}>
+                  <CountrySelectField
+                    stateKeySet={keySet('state_or_territory')}
+                    countryKeySet={keySet('country')}
+                    label='Country'
+                    {...this.defaultInputComponentProps()}
+                  />
+                </Cell>
+                <Cell col={4}>
+                  <StateSelectField
+                    stateKeySet={keySet('state_or_territory')}
+                    countryKeySet={keySet('country')}
+                    label='State or Territory'
+                    {...this.defaultInputComponentProps()}
+                  />
+                </Cell>
+                <Cell col={4}>
+                  {this.boundTextField(keySet('city'), 'City')}
+                </Cell>
+               </Grid>;
+      }
+    };
+
     return (
       <Grid className="profile-tab-grid">
         <Cell col={12} className="profile-form-title">
@@ -163,14 +201,7 @@ class EmploymentForm extends ProfileFormFields {
             Leave blank if this is a current position
           </span>
         </Cell>
-        <Cell col={12}>
-          {this.boundGeosuggest(employerAddressMapping, keySet('location'), "Employer Location",
-            {
-              placeholder: "Anytown, Massachusetts, United States",
-              types: ["geocode"]
-            }
-          )}
-        </Cell>
+        {addressForm()}
       </Grid>
     );
   }

--- a/static/js/lib/location.js
+++ b/static/js/lib/location.js
@@ -39,11 +39,13 @@ export const codeToStateName = R.compose(
  * Get a list of subregion objects for a country, each with a 'code' and 'name' property.
  * @param country Country code
  */
-export const getSubcodes = (country:string) => (
-  R.map(function(key) {
-    return {"code": key, "name": iso3166.data[country]["sub"][key]["name"]};
-  }, Object.keys(iso3166.data[country]["sub"]))
-);
+export const getSubcodes = (country:string) => {
+  if (country in iso3166.data && "sub" in iso3166.data[country]) {
+    return R.map(function (key) {
+      return {"code": key, "name": iso3166.data[country]["sub"][key]["name"]};
+    }, Object.keys(iso3166.data[country]["sub"]));
+  } else return [];
+};
 
 /**
  * Gets the ISO3166 code for a state/territory given a country and state name.

--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -252,8 +252,12 @@ const educationMessages: ErrorMessages = {
   'graduation_date': 'Please enter a valid graduation date',
   'field_of_study': 'Field of study is required',
   'online_degree': 'Online Degree is required',
-  'school_name': 'School name is required'
+  'school_name': 'School name is required',
+  'school_city': 'City is required',
+  'school_state_or_territory': 'State is required',
+  'school_country': 'Country is required'
 };
+
 
 const isHighSchool: (e: EducationEntry) => boolean = R.compose(
   R.equals(HIGH_SCHOOL), R.prop('degree_name')
@@ -289,6 +293,9 @@ const workMessages: ErrorMessages = {
   'industry': 'Industry is required',
   'company_name': 'Name of Employer is required',
   'start_date': 'Please enter a valid start date',
+  'city': 'City is required',
+  'country': 'Country is required',
+  'state_or_territory': 'State or Territory is required',
 };
 
 // functions to perform extra checks

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -420,7 +420,8 @@ describe('Profile validation functions', () => {
       assert.deepEqual(educationValidation(clone), {
         education: [{
           school_name: 'School name is required',
-          location: 'Location must contain city, state, country'
+          location: 'Location must contain city, state, country',
+          school_city: 'City is required'
         }, {}]
       });
     });
@@ -451,6 +452,7 @@ describe('Profile validation functions', () => {
       assert.deepEqual(employmentValidation(clone), {
         work_history: [{
           location: 'Location must contain city, state, country',
+          city: 'City is required',
           company_name: 'Name of Employer is required'
         },{}]
       });
@@ -589,7 +591,10 @@ describe('Profile validation functions', () => {
       profile = _.cloneDeep(USER_PROFILE_RESPONSE);
       _.set(profile, ['work_history', 0, 'country'], '');
       let expectation = [false, EMPLOYMENT_STEP, {
-        work_history: [{location: "Location must contain city, state, country"}, {}]
+        work_history: [{
+          location: "Location must contain city, state, country",
+          country: "Country is required"
+        }, {}]
       }];
       assert.deepEqual(validateProfileComplete(profile), expectation);
     });


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/3348

#### What's this PR do?
Checks to see if the Google Maps API is loaded in the window. If it is, the GeoSuggest component is rendered.  If not, state and country dropdowns plus the city text field are rendered.

#### How should this be manually tested?
Edit/add an education and work history entry, you should get the geosuggest component. Temporarily comment out the script tag in base.html that loads Google Maps, then reload the page and repeat - should get the city field plus state/country dropdowns.
