### PR TITLE
fix automatic email editing

### DIFF
--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -190,6 +190,7 @@ export const AUTOMATIC_EMAIL_ADMIN_CONFIG: EmailConfig = {
       subject: emailOpenParams.email_subject,
       body: emailOpenParams.email_body,
       sendAutomaticEmails: emailOpenParams.enabled,
+      id: emailOpenParams.id,
     },
     filters: getFilters(emailOpenParams.query.original_query.post_filter)
   }),

--- a/static/js/containers/AutomaticEmailPage.js
+++ b/static/js/containers/AutomaticEmailPage.js
@@ -83,7 +83,7 @@ class AutomaticEmailPage extends React.Component {
     const { dispatch, automaticEmails: { emailsInFlight }} = this.props;
 
     if (! emailsInFlight.has(email.id)) {
-      let updatedEmail = R.evolve({enabled: R.not}, email);
+      let updatedEmail = R.evolve({enabled: R.not, query: R.always(undefined)}, email);
       dispatch(toggleEmailPatchInFlight(email.id));
       dispatch(actions.automaticEmails.patch(updatedEmail)).then(() => {
         dispatch(toggleEmailPatchInFlight(email.id));


### PR DESCRIPTION
#### What are the relevant tickets?

closes #3350 
closes #3351 

#### What's this PR do?

this fixes the editing for automatic emails. basically, the ID was accidentally ommitted. that isn't great.

#### How should this be manually tested?

I added a test that should fail on master. But also, you should just confirm yourself that things aren't working on master. go to `/automaticemails` and try to edit one. When you click 'save' you should get an error in the JS console. The branch should restore the functionality.

To test that the test I added fails on master you can do:

```
git cc ap/fix-automatic-emails -- static/js/containers/AutomaticEmailPage_test.js
```

and confirm that there's a failing test. then check out my branch and confirm all tests are passing.

Also, for the 'toggling' functionality, confirm that you can toggle the 'active' state for any automatic email that shows up on the page. If you toggle an email, you should not see any change in 'filters' that show up in the recipients thingy (if you open the email editor dialog again after toggling it).