### PR TITLE
fix the email validation

### DIFF
--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -361,7 +361,7 @@ let emailMessages: ErrorMessages = {
 
 const emailBodyValid = R.ifElse(
   R.test(/<a.*>.*<\/a>/),
-  R.compose(R.not, R.test(/<a\s.*href=("|')(?!http|https)/)),
+  R.compose(R.not, R.test(/<a\s.*href=("|')(?!http|https|mailto:)/)),
   R.T,
 );
 
@@ -369,7 +369,7 @@ export const emailValidation = (emailInputs: EmailInputs): ValidationErrors => {
   let errors = findErrors(emailInputs, R.keys(emailMessages), emailMessages);
 
   if (!R.has('body', errors) && !emailBodyValid(emailInputs.body)) {
-    errors['body'] = "All link URLs must start with 'http' or 'https'";
+    errors['body'] = "All link URLs must start with 'http', 'https', or 'mailto:'";
   }
   return errors;
 };

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -665,12 +665,13 @@ describe('Email validation', () => {
       ['<a href="foo.bar">my bad link :(</a>', true],
       ['<a href="http://foo.bar">my good link :)</a>', false],
       ['<a href="https://foo.bar">my better link :D</a>', false],
+      ['<a href="mailto:me@example.com">EMAIL ME!!!!</a>', false],
     ].forEach(([bodyText, shouldFail]) => {
       let inputs = _.clone(email);
       inputs.body = bodyText;
       assert.deepEqual(
         emailValidation(inputs),
-        shouldFail ? { body: "All link URLs must start with 'http' or 'https'" } : {}
+        shouldFail ? { body: "All link URLs must start with 'http', 'https', or 'mailto:'" } : {}
       );
     });
   });


### PR DESCRIPTION
#### What are the relevant tickets?

closes #3360

#### What's this PR do?

this fixes the email validation so the user can save an email with a `mailto` link in it.

#### How should this be manually tested?

If you create an email and add a `mailto` link you should be able to save the email. You should still be unable to save a link which does not begin with `http|https` (e.g. `wikipedia.org/wiki/Potato`).