### PR TITLE
Fixed jumbled text when entering text in search mail dialog in chrome

### DIFF
--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -84,8 +84,11 @@ export default class EmailCompositionDialog extends React.Component {
   }
 
   componentWillReceiveProps (nextProps: EmailDialogProps) {
-    if (!this.state.editorState.getCurrentContent().hasText()) {
-      this.setState(editorStateFromProps(nextProps));
+    let newState = editorStateFromProps(nextProps);
+    let newStateHasText = newState.editorState.getCurrentContent().hasText();
+
+    if (!this.state.editorState.getCurrentContent().hasText() && newStateHasText) {
+      this.setState(newState);
     }
   }
 

--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -165,8 +165,9 @@ export default class EmailCompositionDialog extends React.Component {
 
   onEditorStateChange = (editorState: EditorState) => {
     const { updateEmailBody } = this.props;
-    updateEmailBody(editorState);
-    this.setState({ editorState });
+    this.setState({ editorState }, () => {
+      updateEmailBody(editorState);
+    });
   };
 
   clearEditorState = () => {


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3365

#### What's this PR do?
Fixed jumbled text when user use tab on email composer

#### How should this be manually tested?
go to email compose and use tab to set subject and body

### Question
> why we are using `state` on this screen, why not  use action to update email state?

@pdpinch @aliceriot 