### PR TITLE
Geocode location text when user clicks 'Save' immediately after typing location

### DIFF
--- a/static/js/lib/location_test.js
+++ b/static/js/lib/location_test.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import { codeToCountryName } from './location';
+import { codeToCountryName, codeToStateName, nameToStateCode } from './location';
 
 describe('location', () => {
   describe('codeToCountryName', () => {
@@ -13,4 +13,36 @@ describe('location', () => {
       });
     });
   });
+
+  describe('codeToStateName', () => {
+    it('should return a valid state name for a code', () => {
+      [
+        ['US-MA', 'Massachusetts'],
+        ['AF-KAN', 'Kandahār'],
+        [null, 'Not Available'],
+        ['', 'Not Available']
+      ].forEach(([stateCode, state]) => {
+        assert.equal(codeToStateName(stateCode), state);
+      });
+    });
+  });
+
+  describe('stateNametoCode', () => {
+    it('should return a valid state code for a name', () => {
+      [
+        ['Massachusetts', 'US', 'US-MA', ],
+        ['Qandahar', 'AF', 'AF-KAN'],
+        ['', 'US', 'Not Available'],
+        [null, 'US', 'Not Available'],
+      ].forEach(([state, country, stateCode]) => {
+        assert.equal(nameToStateCode(country, state), stateCode);
+      });
+    });
+  });
+
 });
+
+
+
+
+

--- a/static/js/lib/validation/profile.js
+++ b/static/js/lib/validation/profile.js
@@ -271,7 +271,7 @@ const educationKeys: (e: EducationEntry) => string[] = R.ifElse(
   isHighSchool, R.compose(excludeFieldOfStudy, R.keys), R.keys
 );
 
-const schoolLocationIsValid = extraErrorCheck('location', 'Location must contain city, state, country', entry => (
+const schoolLocationIsValid = extraErrorCheck('location', 'City, state/territory, and country are required.', entry => (
   isNilOrEmptyString(entry.school_city) ||
   isNilOrEmptyString(entry.school_state_or_territory) ||
   isNilOrEmptyString(entry.school_country)
@@ -313,7 +313,7 @@ const endDateNotInFuture = extraErrorCheck('end_date', 'End date cannot be in th
   moment(entry.end_date).isAfter(moment(), 'month')
 ));
 
-const workLocationIsValid = extraErrorCheck('location', 'Location must contain city, state, country', entry => (
+const workLocationIsValid = extraErrorCheck('location', 'City, state/territory, and country are required.', entry => (
   isNilOrEmptyString(entry.city) || isNilOrEmptyString(entry.state_or_territory) || isNilOrEmptyString(entry.country)
 ));
 

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -420,7 +420,7 @@ describe('Profile validation functions', () => {
       assert.deepEqual(educationValidation(clone), {
         education: [{
           school_name: 'School name is required',
-          location: 'Location must contain city, state, country',
+          location: 'City, state/territory, and country are required.',
           school_city: 'City is required'
         }, {}]
       });
@@ -451,7 +451,7 @@ describe('Profile validation functions', () => {
       clone.work_history[0].city = '';
       assert.deepEqual(employmentValidation(clone), {
         work_history: [{
-          location: 'Location must contain city, state, country',
+          location: 'City, state/territory, and country are required.',
           city: 'City is required',
           company_name: 'Name of Employer is required'
         },{}]
@@ -592,7 +592,7 @@ describe('Profile validation functions', () => {
       _.set(profile, ['work_history', 0, 'country'], '');
       let expectation = [false, EMPLOYMENT_STEP, {
         work_history: [{
-          location: "Location must contain city, state, country",
+          location: "City, state/territory, and country are required.",
           country: "Country is required"
         }, {}]
       }];

--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -254,10 +254,15 @@ const profileFields = (addressMapping: AddressComponentKeyMapping, components: G
         countryCode = nameToCountryCode(component.long_name);
         _.set(profile, keySet, countryCode);
       }
+    } else {
+      _.set(profile, keySet, '');
+      if (gmapType === 'administrative_area_level_1') {
+        stateKey = [keySet, ''];
+      }
     }
   });
   // Modify state code to be '<country code>-<state code>
-  if (countryCode !== null && stateKey !== []) {
+  if (countryCode !== null && stateKey.length > 0) {
     _.set(profile, stateKey[0], nameToStateCode(countryCode, stateKey[1]));
   }
 
@@ -270,6 +275,16 @@ const pathHasValue = R.flip(R.pathSatisfies(hasValue, R.__));
 const allPathsHaveValue = (addressMapping) => (
   R.compose(R.all(R.__, R.values(addressMapping)), pathHasValue)
 );
+
+class MicroGeosuggest extends Geosuggest {
+  //Override the default onInputBlur behavior of Geosuggest
+  onInputBlur = () => {
+    this.selectSuggest(this.state.activeSuggest);
+    if (!this.state.ignoreBlur) {
+      this.hideSuggests();
+    }
+  };
+}
 
 export function boundGeosuggest(
   addressMapping: AddressComponentKeyMapping,
@@ -341,9 +356,9 @@ export function boundGeosuggest(
 
   return (
     <div className={`bound-geosuggest ${validationErrorSelector(errors, keySet)}`}>
-      <Geosuggest id={id}
+      <MicroGeosuggest id={id}
         initialValue={initial} label={label} placeholder={placeholder} types={types}
-        onSuggestSelect={onSuggestSelect} onBlur={onBlur}
+        onSuggestSelect={onSuggestSelect} autoActivateFirstSuggest={true} onBlur={onBlur}
       />
       <span className="validation-error-text">
         {_.get(errors, keySet)}

--- a/static/js/util/profile_edit_test.js
+++ b/static/js/util/profile_edit_test.js
@@ -642,6 +642,50 @@ describe('Profile Editing utility functions', () => {
       assert.equal(that.props.profile.country, "US");
     });
 
+    it('populates profile info on geosuggest select but without any state', () => {
+      gmaps.geocodeResults = [{
+        address_components: [
+          {long_name: "Golden", short_name: "Golden", types: ["locality"]},
+          {long_name: "United States", short_name: "US", types: ["country"]},
+        ],
+        geometry: {
+          location: {
+            lat: () => 48.859,
+            lng: () => 2.207,
+          }
+        }
+      }];
+      gmaps.geocode = gmaps.sandbox.stub().callsArgWith(1, gmaps.geocodeResults, 'OK');
+      const wrapper = renderGeosuggest();
+      typeText(wrapper, "Golden");
+      const item = wrapper.find("li.geosuggest__item").first();
+      item.simulate('click');
+      assert.equal(that.props.profile.city, "Golden");
+      assert.equal(that.props.profile.state_or_territory, "Not Available");
+      assert.equal(that.props.profile.country, "US");
+    });
+
+    it('populates geosuggest text with 1st autocomplete suggestion on blur', () => {
+      gmaps.autocompleteSuggestions = [{
+        "description": "Golden, Colorado, United States",
+        "id": "691b237b0322f28988f3ce03e321ff72a12167fd",
+        "matched_substrings": [{"length": 5, "offset": 0}],
+        "place_id": "ChIJD7fiBh9u5kcRYJSMaMOCCwQ",
+        "reference": "CjQlAAAA_KB6EEceSTfkteSSF6U0",
+        "terms": [
+          {offset: 0, value: "Golden"},
+          {offset: 8, value: "Colorado"},
+          {offset: 17, value: "United States"},
+        ],
+        "types": ["locality", "political", "geocode"]
+      }];
+      gmaps.getPlacePredictions = gmaps.sandbox.stub().callsArgWith(1, gmaps.autocompleteSuggestions);
+      const wrapper = renderGeosuggest();
+      typeText(wrapper, "Golden");
+      wrapper.find('input').simulate('blur');
+      assert.equal(wrapper.find('input').get(0).value, "Golden, Colorado, United States");
+    });
+
     it('populates statecode via fuzzy match on geosuggest select', () => {
       gmaps.geocodeResults = [{
         address_components: [


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/micromasters/issues/3369

#### What's this PR do?
Enables 'autoActivateFirstSuggest' on the React Geosuggest component and overrides its default 'onInputBlur' behavior so that it will geocode the text even if the user clicks save immediately after typing.
I also changed the validation message if the input is invalid/empty to 'City, state/territory, and country are required.'

#### How should this be manually tested?
Add/edit an education or employment entry.  In the location field, manually type a location like 'Boston, MA, USA'.  Then click the 'Save' button immediately afterward without clicking Tab or Enter.  You should not get a validation error message about the location.
