### PR TITLE
Add exam grade detail display

### DIFF
--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -70,6 +70,7 @@ const COURSE: Course = {
   runs: [],
   can_schedule_exam: false,
   has_exam: false,
+  proctorate_exams_grades: [],
 };
 
 const PROGRAM: AvailableProgram = {

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -23,6 +23,7 @@ import {
 import {
   formatPrice,
 } from '../../util/util';
+import type { GradeType } from '../../containers/DashboardPage';
 
 const priceMessageClassName = "price-message";
 
@@ -37,7 +38,7 @@ export default class CourseListCard extends React.Component {
     setEnrollSelectedCourseRun:      (r: CourseRun) => void,
     setEnrollCourseDialogVisibility: (bool: boolean) => void,
     setShowExpandedCourseStatus:     (n: number) => void,
-    setShowGradeDetailDialog:        (b: boolean, title: string) => void,
+    setShowGradeDetailDialog:        (b: boolean, t: GradeType, title: string) => void,
     ui:                              UIState,
     checkout:                        (s: string) => void,
   };

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -11,6 +11,7 @@ import ProgressMessage from './courses/ProgressMessage';
 import StatusMessages from './courses/StatusMessages';
 import type { Course, CourseRun, FinancialAidUserInfo } from '../../flow/programTypes';
 import type { UIState } from '../../reducers/ui';
+import type { GradeType } from '../../containers/DashboardPage';
 import type {
   CouponPrices,
   Coupon,
@@ -41,7 +42,7 @@ export default class CourseRow extends React.Component {
     ui:                              UIState,
     checkout:                        (s: string) => void,
     setShowExpandedCourseStatus:     (n: number) => void,
-    setShowGradeDetailDialog:        (b: boolean, title: string) => void,
+    setShowGradeDetailDialog:        (b: boolean, t: GradeType, title: string) => void,
   };
 
   // $FlowFixMe: CourseRun is sometimes an empty object

--- a/static/js/components/dashboard/courses/Grades.js
+++ b/static/js/components/dashboard/courses/Grades.js
@@ -17,6 +17,13 @@ import { hasPearsonExam } from './util';
 import GradeDetailPopup from './GradeDetailPopup';
 import type { DialogVisibilityState } from '../../../reducers/ui';
 import { GRADE_DETAIL_DIALOG } from '../../../constants';
+import type { GradeType } from '../../../containers/DashboardPage';
+import { EXAM_GRADE, EDX_GRADE } from '../../../containers/DashboardPage';
+
+export const gradeDetailPopupKey = (gradeType: GradeType, courseTitle: string) => (
+  `${GRADE_DETAIL_DIALOG}${gradeType}${courseTitle}`
+);
+
 
 const renderGrade = R.curry((caption, grade) => (
   <div className={`grade-display ${classify(caption)}`}>
@@ -70,7 +77,7 @@ const renderPassed = (course: Course) => {
 
 type CourseGradeProps = {
   course:                   Course,
-  setShowGradeDetailDialog: (b: boolean, t: string) => void,
+  setShowGradeDetailDialog: (b: boolean, g: GradeType, t: string) => void,
   dialogVisibility:         DialogVisibilityState,
 }
 
@@ -85,14 +92,28 @@ const Grades = (props: CourseGradeProps) => {
     <GradeDetailPopup
       course={course}
       setShowGradeDetailDialog={setShowGradeDetailDialog}
-      dialogVisibility={dialogVisibility[`${GRADE_DETAIL_DIALOG}${course.title}`] === true}
+      dialogVisibility={dialogVisibility[gradeDetailPopupKey(EDX_GRADE, course.title)] === true}
+      gradeType={EDX_GRADE}
     />
-    <div
-      className="grades"
-      onClick={() => setShowGradeDetailDialog(true, course.title)}
-    >
-      { renderEdXGrade(course) }
-      { renderExamGrade(course) }
+    <GradeDetailPopup
+      course={course}
+      setShowGradeDetailDialog={setShowGradeDetailDialog}
+      dialogVisibility={dialogVisibility[gradeDetailPopupKey(EXAM_GRADE, course.title)] === true}
+      gradeType={EXAM_GRADE}
+    />
+    <div className="grades">
+      <div
+        className="open-popup"
+        onClick={() => setShowGradeDetailDialog(true, EDX_GRADE, course.title)}
+      >
+        { renderEdXGrade(course) }
+      </div>
+      <div
+        className="open-popup"
+        onClick={() => setShowGradeDetailDialog(true, EXAM_GRADE, course.title)}
+      >
+        { renderExamGrade(course) }
+      </div>
       { renderFinalGrade(course) }
     </div>
     { renderPassed(course) }

--- a/static/js/components/dashboard/courses/Grades_test.js
+++ b/static/js/components/dashboard/courses/Grades_test.js
@@ -12,6 +12,7 @@ import {
   EXAM_GRADE_WEIGHT,
 } from '../../../lib/grades';
 import { STATUS_PASSED, STATUS_OFFERED, } from '../../../constants';
+import { EXAM_GRADE, EDX_GRADE } from '../../../containers/DashboardPage';
 
 describe('Course Grades', () => {
   let course, setShowGradeDetailDialogStub;
@@ -64,7 +65,6 @@ describe('Course Grades', () => {
     let expectation = _.round(
       // $FlowFixMe: flow doesnt like this
       (COURSE_GRADE_WEIGHT * course.runs[0].final_grade) +
-      // $FlowFixMe: flow doesnt like this
       (EXAM_GRADE_WEIGHT * (course.proctorate_exams_grades[0].percentage_grade * 100))
     );
     assert.equal(
@@ -131,8 +131,13 @@ describe('Course Grades', () => {
   });
 
   it('should call setShowGradeDetailDialog onClick', () => {
+    let examGrade = makeProctoredExamResult();
+    examGrade.passed = true;
+    course.proctorate_exams_grades.push(examGrade);
     let grades = renderGrades();
-    grades.find('.grades').simulate('click');
-    assert.ok(setShowGradeDetailDialogStub.calledWith(true));
+    grades.find('.open-popup').first().simulate('click');
+    assert.ok(setShowGradeDetailDialogStub.calledWith(true, EDX_GRADE, course.title));
+    grades.find('.open-popup').at(1).simulate('click');
+    assert.ok(setShowGradeDetailDialogStub.calledWith(true, EXAM_GRADE, course.title));
   });
 });

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -37,7 +37,6 @@ import {
   STATUS_PASSED,
   STATUS_CURRENTLY_ENROLLED,
   STATUS_PAID_BUT_NOT_ENROLLED,
-  GRADE_DETAIL_DIALOG,
 } from '../constants';
 import {
   setToastMessage,
@@ -110,9 +109,14 @@ import { getOwnDashboard, getOwnCoursePrices } from '../reducers/util';
 import { actions } from '../lib/redux_rest';
 import { wait } from '../util/util';
 import { CALCULATOR_DIALOG } from './FinancialAidCalculator';
+import { gradeDetailPopupKey } from '../components/dashboard/courses/Grades';
 
 const isFinishedProcessing = R.contains(R.__, [FETCH_SUCCESS, FETCH_FAILURE]);
 const PEARSON_TOS_DIALOG = "pearsonTOSDialogVisible";
+
+export type GradeType = 'EDX_GRADE' | 'EXAM_GRADE';
+export const EDX_GRADE: GradeType = 'EDX_GRADE';
+export const EXAM_GRADE: GradeType = 'EXAM_GRADE';
 
 class DashboardPage extends React.Component {
   static contextTypes = {
@@ -514,12 +518,12 @@ class DashboardPage extends React.Component {
     }
   }
 
-  setShowGradeDetailDialog = (open: boolean, courseTitle: string) => {
+  setShowGradeDetailDialog = (open: boolean, gradeType: GradeType, courseTitle: string) => {
     const { dispatch } = this.props;
     if (open) {
-      dispatch(showDialog(`${GRADE_DETAIL_DIALOG}${courseTitle}`));
+      dispatch(showDialog(gradeDetailPopupKey(gradeType, courseTitle)));
     } else {
-      dispatch(hideDialog(`${GRADE_DETAIL_DIALOG}${courseTitle}`));
+      dispatch(hideDialog(gradeDetailPopupKey(gradeType, courseTitle)));
     }
   };
 

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -87,7 +87,6 @@ import {
   TOAST_FAILURE,
   TOAST_SUCCESS,
   STATUS_CAN_UPGRADE,
-  GRADE_DETAIL_DIALOG,
 } from '../constants';
 import type { Program } from '../flow/programTypes';
 import {
@@ -101,7 +100,8 @@ import {
 import { actions } from '../lib/redux_rest';
 import EmailCompositionDialog from '../components/email/EmailCompositionDialog';
 import { makeRunEnrolled } from '../components/dashboard/courses/test_util';
-import Grades from '../components/dashboard/courses/Grades';
+import Grades, { gradeDetailPopupKey } from '../components/dashboard/courses/Grades';
+import { EDX_GRADE } from './DashboardPage';
 
 describe('DashboardPage', () => {
   let renderComponent, helper, listenForActions;
@@ -151,18 +151,19 @@ describe('DashboardPage', () => {
 
   it('should show a <Grades /> component, and open the dialog when clicked', () => {
     return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
-      wrapper.find(Grades).find('.grades').simulate('click');
+      wrapper.find(Grades).find('.open-popup').first().simulate('click');
       let state = helper.store.getState().ui;
-      let key = `${GRADE_DETAIL_DIALOG}${DASHBOARD_RESPONSE.programs[0].courses[0].title}`;
+      let key = gradeDetailPopupKey(EDX_GRADE, DASHBOARD_RESPONSE.programs[0].courses[0].title);
       assert.isTrue(state.dialogVisibility[key]);
     });
   });
 
   it('should close the <Grades /> dialog if you click outside', () => {
-    let key = `${GRADE_DETAIL_DIALOG}${DASHBOARD_RESPONSE.programs[0].courses[0].title}`;
+    let key = gradeDetailPopupKey(EDX_GRADE, DASHBOARD_RESPONSE.programs[0].courses[0].title);
+
     helper.store.dispatch(showDialog(key));
     return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
-      wrapper.find(Grades).find(Dialog).props().onRequestClose();
+      wrapper.find(Grades).find(Dialog).first().props().onRequestClose();
       let state = helper.store.getState().ui;
       assert.isFalse(state.dialogVisibility[key]);
     });

--- a/static/js/containers/LearnerPage.js
+++ b/static/js/containers/LearnerPage.js
@@ -31,8 +31,9 @@ import type { ProfileContainerProps } from './ProfileFormContainer';
 import type { CoursePrices, DashboardsState } from '../flow/dashboardTypes';
 import type { AllEmailsState } from '../flow/emailTypes';
 import { showDialog, hideDialog } from '../actions/ui';
-import { GRADE_DETAIL_DIALOG } from '../constants';
 import type { RestState } from '../flow/restTypes';
+import type { GradeType } from './DashboardPage';
+import { gradeDetailPopupKey } from '../components/dashboard/courses/Grades';
 
 const notFetchingOrFetched = R.compose(
   R.not, R.contains(R.__, [FETCH_PROCESSING, FETCH_SUCCESS, FETCH_FAILURE])
@@ -132,14 +133,15 @@ class LearnerPage extends React.Component<*, LearnerPageProps, *> {
       .replace(/^\|\s/, '');
   }
 
-  setShowGradeDetailDialog = (open: boolean, courseTitle: string) => {
+  setShowGradeDetailDialog = (open: boolean, gradeType: GradeType, courseTitle: string) => {
     const { dispatch } = this.props;
     if (open) {
-      dispatch(showDialog(`${GRADE_DETAIL_DIALOG}${courseTitle}`));
+      dispatch(showDialog(gradeDetailPopupKey(gradeType, courseTitle)));
     } else {
-      dispatch(hideDialog(`${GRADE_DETAIL_DIALOG}${courseTitle}`));
+      dispatch(hideDialog(gradeDetailPopupKey(gradeType, courseTitle)));
     }
   };
+
 
   render() {
     const {

--- a/static/js/containers/LearnerPage_test.js
+++ b/static/js/containers/LearnerPage_test.js
@@ -48,7 +48,6 @@ import { USER_PROFILE_RESPONSE, DASHBOARD_RESPONSE } from '../test_constants';
 import {
   HIGH_SCHOOL,
   DOCTORATE,
-  GRADE_DETAIL_DIALOG,
 } from '../constants';
 import {
   generateNewEducation,
@@ -76,7 +75,8 @@ import {
     RECEIVE_FETCH_COUPONS_SUCCESS,
     REQUEST_FETCH_COUPONS,
 } from '../actions/coupons';
-import Grades from '../components/dashboard/courses/Grades';
+import Grades, { gradeDetailPopupKey } from '../components/dashboard/courses/Grades';
+import { EDX_GRADE } from './DashboardPage';
 
 describe("LearnerPage", function() {
   this.timeout(10000);
@@ -1029,7 +1029,6 @@ describe("LearnerPage", function() {
       });
     });
 
-
     it('should show the staff learner info card, if the user has a staff role', () => {
       const smallDashboard = {"programs": DASHBOARD_RESPONSE.programs.slice(0,1), "isEdxDataFresh": true};
       helper.dashboardStub.returns(Promise.resolve(smallDashboard));
@@ -1046,9 +1045,9 @@ describe("LearnerPage", function() {
       SETTINGS.roles.push({ role: 'staff', permissions: [] });
       const actions = userActions.concat([REQUEST_DASHBOARD, RECEIVE_DASHBOARD_SUCCESS]);
       return renderComponent(`/learner/${username}`, actions).then(([wrapper]) => {
-        wrapper.find(Grades).find('.grades').at(0).simulate('click');
+        wrapper.find('.open-popup').at(0).simulate('click');
         let state = helper.store.getState().ui;
-        let key = `${GRADE_DETAIL_DIALOG}${DASHBOARD_RESPONSE.programs[0].courses[0].title}`;
+        let key = gradeDetailPopupKey(EDX_GRADE, DASHBOARD_RESPONSE.programs[0].courses[0].title);
         assert.isTrue(state.dialogVisibility[key]);
       });
     });
@@ -1056,11 +1055,11 @@ describe("LearnerPage", function() {
     it('should close the <Grades /> dialog if you click outside', () => {
       const username = SETTINGS.user.username;
       SETTINGS.roles.push({ role: 'staff', permissions: [] });
-      let key = `${GRADE_DETAIL_DIALOG}${DASHBOARD_RESPONSE.programs[0].courses[0].title}`;
+      let key = gradeDetailPopupKey(EDX_GRADE, DASHBOARD_RESPONSE.programs[0].courses[0].title);
       helper.store.dispatch(showDialog(key));
       const actions = userActions.concat([REQUEST_DASHBOARD, RECEIVE_DASHBOARD_SUCCESS]);
       return renderComponent(`/learner/${username}`, actions).then(([wrapper]) => {
-        wrapper.find(Grades).at(0).find(Dialog).props().onRequestClose();
+        wrapper.find(Grades).at(0).find(Dialog).at(0).props().onRequestClose();
         let state = helper.store.getState().ui;
         assert.isFalse(state.dialogVisibility[key]);
       });

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -90,6 +90,7 @@ export const makeCourse = (positionInProgram: number): Course => {
     title: `Title for course ${courseId}`,
     can_schedule_exam: false,
     has_exam: false,
+    proctorate_exams_grades: [],
   };
 };
 

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -55,7 +55,7 @@ export type Course = {
   id:                       number,
   position_in_program:      number,
   can_schedule_exam:        boolean,
-  proctorate_exams_grades?: Array<ProctoredExamResult>,
+  proctorate_exams_grades:  Array<ProctoredExamResult>,
   has_exam:                 boolean,
 };
 

--- a/static/js/lib/grades_test.js
+++ b/static/js/lib/grades_test.js
@@ -83,7 +83,6 @@ describe('Grades library', () => {
       assertIsJust(
         calculateFinalGrade(course),
         (COURSE_GRADE_WEIGHT * ((course.runs[0].final_grade): any)) +
-        // $FlowFixMe: Flow doesn't like this
         (EXAM_GRADE_WEIGHT * (course.proctorate_exams_grades[0].percentage_grade * 100))
       );
     });

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -583,11 +583,13 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
           "position_in_program": 0,
           "title": "Gio Course - failed, no grade",
           "description": "",
-          "id": 1
+          "id": 1,
+          "proctorate_exams_grades": []
         },
         {
           "prerequisites": "",
           "runs": [],
+          "proctorate_exams_grades": [],
           "position_in_program": 1,
           "title": "8.MechCx Advanced Introductory Classical Mechanics",
           "description": "",
@@ -599,7 +601,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
           "position_in_program": 2,
           "title": "EDX Demo course",
           "description": "",
-          "id": 3
+          "id": 3,
+          "proctorate_exams_grades": []
         },
         {
           "prerequisites": "",
@@ -607,7 +610,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
           "position_in_program": 3,
           "title": "Peter Course",
           "description": "",
-          "id": 4
+          "id": 4,
+          "proctorate_exams_grades": []
         }
       ],
       "financial_aid_availability": false,
@@ -635,7 +639,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
             }
           ],
           "description": null,
-          "prerequisites": null
+          "prerequisites": null,
+          "proctorate_exams_grades": []
         },
         {
           "id": 6,
@@ -656,7 +661,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
             }
           ],
           "description": "The demo course",
-          "prerequisites": ""
+          "prerequisites": "",
+          "proctorate_exams_grades": []
         },
         {
           "id": 7,
@@ -665,7 +671,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
           "runs": [
           ],
           "description": null,
-          "prerequisites": null
+          "prerequisites": null,
+          "proctorate_exams_grades": []
         },
         {
           "id": 6789,
@@ -686,7 +693,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
             }
           ],
           "description": "The demo course",
-          "prerequisites": ""
+          "prerequisites": "",
+          "proctorate_exams_grades": []
         },
         {
           "id": 8,
@@ -707,7 +715,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
             }
           ],
           "description": null,
-          "prerequisites": null
+          "prerequisites": null,
+          "proctorate_exams_grades": []
         },
         {
           "id": 10,
@@ -729,7 +738,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
             }
           ],
           "description": null,
-          "prerequisites": null
+          "prerequisites": null,
+          "proctorate_exams_grades": []
         },
         {
           "id": 1278,
@@ -771,7 +781,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
               "fuzzy_start_date": "Fall 2017",
               "course_end_date": "2016-09-09T10:20:10Z",
             }
-          ]
+          ],
+          "proctorate_exams_grades": []
         },
         {
           "id": 17,
@@ -789,7 +800,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
               "fuzzy_start_date": "Fall 2017",
               "course_end_date": "2016-09-09T10:20:10Z",
             }
-          ]
+          ],
+          "proctorate_exams_grades": []
         },
         {
           "id": 15,
@@ -806,7 +818,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
               "course_end_date": "2016-09-09T10:20:10Z",
               "course_id": "verified",
             }
-          ]
+          ],
+          "proctorate_exams_grades": []
         },
         {
           "id": 11,
@@ -827,7 +840,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
             }
           ],
           "description": null,
-          "prerequisites": null
+          "prerequisites": null,
+          "proctorate_exams_grades": []
         },
         {
           "id": 16,
@@ -844,7 +858,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
               "course_end_date": "2018-09-09T10:20:10Z",
               "enrollment_start_date": "2016-03-04T01:00:00Z",
             }
-          ]
+          ],
+          "proctorate_exams_grades": []
         }
       ],
       "title": "Master Program",
@@ -870,7 +885,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
           "position": 0,
           "course_start_date": "2016-01-01",
           "course_end_date": "2016-09-09T10:20:10Z",
-        }]
+        }],
+        "proctorate_exams_grades": []
       }],
       "id": 5
     },
@@ -904,7 +920,8 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
             }
           ],
           "description": "Course for Last program",
-          "prerequisites": ""
+          "prerequisites": "",
+          "proctorate_exams_grades": []
         },
       ],
       "financial_aid_availability": false,
@@ -929,8 +946,9 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
           "fuzzy_start_date": "",
           "current_grade": null,
           "title": "Digital Learning 100 - January 2015",
-          "status": STATUS_PAID_BUT_NOT_ENROLLED
-        }]
+          "status": STATUS_PAID_BUT_NOT_ENROLLED,
+        }],
+        "proctorate_exams_grades": []
       }],
       "financial_aid_availability": true,
       "id": 7

--- a/static/scss/dashboard/grades.scss
+++ b/static/scss/dashboard/grades.scss
@@ -9,7 +9,10 @@
     justify-content: flex-start;
     flex-direction: row;
     display: flex;
-    cursor: pointer;
+
+    .open-popup {
+      cursor: pointer;
+    }
   }
 
   .passed-course {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #3353

#### What's this PR do?

this adds a detail display for the exam grades, which opens if you click on the 'over-all' exam grade. the edx grade detail display may be opened by clicking on that 'over-all' grade.

#### How should this be manually tested?

If you have a course with edX grades and also exam grades you should see both on either `/learner` or on the dashboard. clicking on the exam grade should open the detail display for that, and the same for the edx grade. the best grade for each should be highlighted with a check and a little mark saying 'Passed'.