### PR TITLE
Make status text consistent with acceptance of faxed FA documents.

### DIFF
--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -83,7 +83,7 @@ export default class FinancialAidCard extends React.Component {
     case FA_STATUS_DOCS_SENT:
       return <div className="documents-sent">
         <Icon name="done" key="icon" />
-        Documents mailed on {moment(dateDocumentsSent).format(DASHBOARD_FORMAT)}.
+        Documents mailed/faxed on {moment(dateDocumentsSent).format(DASHBOARD_FORMAT)}.
         We will review your documents as soon as possible.
       </div>;
     case FA_STATUS_PENDING_DOCS:

--- a/static/js/components/dashboard/FinancialAidCard_test.js
+++ b/static/js/components/dashboard/FinancialAidCard_test.js
@@ -240,7 +240,7 @@ describe("FinancialAidCard", () => {
         it(`shows the document sent date for status ${status}`, () => {
           let program = programWithStatus(status);
           let wrapper = renderCard({ program });
-          assert.include(wrapper.text(), 'Documents mailed on Mar 3, 2003');
+          assert.include(wrapper.text(), 'Documents mailed/faxed on Mar 3, 2003');
         });
       }
     });


### PR DESCRIPTION
#### What are the relevant tickets?
#3392

#### What's this PR do?
Changes wording for consistency with acceptance of both mailed and faxed financial aid documents.

#### How should this be manually tested?
Peer review, perhaps.