### PR TITLE
fix potentially flaky JS thingy in the program factory

### DIFF
--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -98,7 +98,6 @@ const PEARSON_STATUSES = [
   PEARSON_PROFILE_IN_PROGRESS,
   PEARSON_PROFILE_INVALID,
   PEARSON_PROFILE_SCHEDULABLE,
-  "",
 ];
 
 export const makeProgram = (): Program => {


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

removed the `""` empty string from the array of possible choices for `pearson_exam_status` in the `makeProgram` factory. this could be chosen, rarely, and would cause a test in `StatusMessage_test` to fail.

#### How should this be manually tested?

make sure it makes sense and nothing is failing?