### PR TITLE
Specify course_end_date for makeRun

### DIFF
--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -73,6 +73,7 @@ export const makeRun = (position: number): CourseRun => {
     course_id: `course-v1:${runId}`,
     title: `Run ${runId}`,
     position: position,
+    course_end_date: moment().subtract(1, 'day').format(),
     status: STATUS_OFFERED,
     has_paid: false,
   };


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
This defines `course_end_date` for `makeRun` to avoid a race condition with `courseUpcomingOrCurrent` comparing now to now because we were passing `undefined` to `moment()`.

#### How should this be manually tested?
Tests should pass

#### What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/xfS6qmMpQuGSk/giphy.gif)
