### PR TITLE
upgrade react telephone input component

### DIFF
--- a/js_test.sh
+++ b/js_test.sh
@@ -50,7 +50,7 @@ if [[ $(
     grep -v 'ignored, nothing could be mapped' |
     grep -v "This browser doesn't support the \`onScroll\` event" |
     grep -v "Warning: Accessing PropTypes via the main React package is deprecated" |
-    grep -v "Warning: ReactTelephoneInput: React.createClass is deprecated" |
+    grep -v "Warning: A Component: React.createClass is deprecated" |
     wc -l |
     awk '{print $1}'
     ) -ne 0 ]]  # is file empty?

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "react-slick": "^0.14.4",
     "react-swipeable": "^4.0.0",
     "react-tap-event-plugin": "^2.0.1",
-    "react-telephone-input": "^4.0.1",
+    "react-telephone-input": "^4.1.1",
     "react-test-renderer": "^15.5.4",
     "react-tooltip": "^3.1.6",
     "react-virtualized-select": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1596,7 +1596,15 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.1, create-react-class@^15.5.2, create-react-class@^15.5.3, create-react-class@^15.5.x:
+create-react-class@^15.5.1, create-react-class@^15.5.2, create-react-class@^15.5.3, create-react-class@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
+create-react-class@^15.5.x:
   version "15.5.3"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.5.3.tgz#fb0f7cae79339e9a179e194ef466efa3923820fe"
   dependencies:
@@ -5141,13 +5149,15 @@ react-tap-event-plugin@^2.0.1:
   dependencies:
     fbjs "^0.8.6"
 
-react-telephone-input@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/react-telephone-input/-/react-telephone-input-4.0.1.tgz#9ff2004e4d27f9e7d3a00f014949fc6415d1867d"
+react-telephone-input@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/react-telephone-input/-/react-telephone-input-4.1.1.tgz#5150b54f5c78b332c4d415d757ea9faf5e184afe"
   dependencies:
     classnames "^2.1.2"
     country-telephone-data "0.4.2"
+    create-react-class "^15.6.0"
     lodash "^4.17.4"
+    prop-types "^15.5.10"
     react-onclickoutside "5.3.1"
 
 react-test-renderer@^15.5.4:


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

this updates `react-telephone-input` to the latest version. the most recent version fixes a warning we were seeing in the JS console, because previously it used `React.createClass`, which is a soon-to-be deprecated API. Now it is fixed, so we may upgrade and all that.

#### How should this be manually tested?

The tests should pass without error, and the telephone input component should behave as before.