### PR TITLE
Fix JS race condition in tests

### DIFF
--- a/static/js/containers/AutomaticEmailPage_test.js
+++ b/static/js/containers/AutomaticEmailPage_test.js
@@ -36,7 +36,7 @@ describe('AutomaticEmailPage', () => {
 
   afterEach(() => {
     helper.cleanup();
-  }); 
+  });
 
   const baseActions = [
     REQUEST_GET_USER_PROFILE,
@@ -85,6 +85,7 @@ describe('AutomaticEmailPage', () => {
   });
 
   it('shows a placeholder if there is no data', () => {
+    // clear the previous automatic email mock set in IntegrationTestHelper
     fetchMock.restore();
     fetchMock.mock('/api/v0/mail/automatic_email/', () => (
       { body: JSON.stringify([]) }

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -19,6 +19,7 @@ import {
 import IntegrationTestHelper from '../util/integration_test_helper';
 import {
   REQUEST_DASHBOARD,
+  RECEIVE_DASHBOARD_SUCCESS,
   UPDATE_COURSE_STATUS,
   CLEAR_DASHBOARD,
 } from '../actions/dashboard';
@@ -323,8 +324,15 @@ describe('DashboardPage', () => {
             it(`only if status is ${status}`, () => {
               program.financial_aid_user_info.application_status = status;
               let expectedSkip = !FA_TERMINAL_STATUSES.includes(status);
-              let actions = expectedSkip ? expectedActions : DASHBOARD_SUCCESS_ACTIONS;
-              return renderComponent('/dashboard', actions).then(() => {
+              // Extra actions dispatched to refresh the dashboard
+              let expectedActionsWithDashboardRequest = expectedActions.concat([
+                REQUEST_DASHBOARD,
+                RECEIVE_DASHBOARD_SUCCESS,
+                actions.prices.get.requestType,
+                actions.prices.get.successType,
+              ]);
+              let _actions = expectedSkip ? expectedActionsWithDashboardRequest : DASHBOARD_SUCCESS_ACTIONS;
+              return renderComponent('/dashboard', _actions).then(() => {
                 let aid = helper.store.getState().financialAid;
                 if (expectedSkip) {
                   assert.equal(aid.fetchSkipStatus, storeActions.FETCH_SUCCESS);

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -174,6 +174,13 @@ describe('DashboardPage', () => {
       SET_TIMEOUT_ACTIVE,
       UPDATE_COURSE_STATUS,
     ]);
+    let waitResolve, waitPromise, waitStub;
+    beforeEach(() => {
+      waitPromise = new Promise(resolve => {
+        waitResolve = resolve;
+      });
+      waitStub = helper.sandbox.stub(util, 'wait').returns(waitPromise);
+    });
 
     it('shows the order status toast when the query param is set for a cancellation', () => {
       return renderComponent('/dashboard?status=cancel', SUCCESS_WITH_TOAST_ACTIONS).then(() => {
@@ -365,14 +372,6 @@ describe('DashboardPage', () => {
     });
 
     describe('fake timer tests', function() {
-      let waitStub, waitResolve, waitPromise;
-      beforeEach(() => {
-        waitPromise = new Promise(resolve => {
-          waitResolve = resolve;
-        });
-        waitStub = helper.sandbox.stub(util, 'wait').returns(waitPromise);
-      });
-
       it('refetches the dashboard after 3 seconds if 2 minutes has not passed', () => {
         let course = findCourse(course =>
           course.runs.length > 0 &&

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -177,6 +177,8 @@ describe('DashboardPage', () => {
     let waitResolve, waitPromise, waitStub;
     beforeEach(() => {
       waitPromise = new Promise(resolve => {
+        // Note that most tests here won't call waitResolve at all so the promise won't resolve. The only tests
+        // that should are tests testing the order receipt 3 second timeout functionality.
         waitResolve = resolve;
       });
       waitStub = helper.sandbox.stub(util, 'wait').returns(waitPromise);

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -32,10 +32,21 @@ if (!Object.entries) {
   entries.shim();
 }
 
+import fetchMock from 'fetch-mock';
 let localStorageMock = require('./util/test_utils').localStorageMock;
 beforeEach(() => { // eslint-disable-line mocha/no-top-level-hooks
   window.localStorage = localStorageMock();
   window.sessionStorage = localStorageMock();
+
+  // Uncomment to diagnose stray API calls. Also see relevant block in afterEach
+  /*
+  fetchMock.restore();
+  fetchMock.catch((...args) => {
+    console.log("ERROR: Unmatched request: ", args);
+    console.trace();
+    process.exit(1);
+  });
+  */
 });
 
 // cleanup after each test run
@@ -49,6 +60,13 @@ afterEach(function () { // eslint-disable-line mocha/no-top-level-hooks
   window.localStorage.reset();
   window.sessionStorage.reset();
   window.location = 'http://fake/';
+
+  // Comment next line to diagnose stray API calls. Also see relevant block in beforeEach
+  fetchMock.restore();
+  // Uncomment this to diagnose stray API calls
+  // This adds a 200 ms delay between tests. Since fetchMock is still enabled at this point the next unmatched
+  // fetch attempt which occurs within 200 ms after the test finishes will cause a warning.
+  // return require('./util/util').wait(200);
 });
 
 // required for interacting with react-mdl components

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -42,7 +42,6 @@ export default class IntegrationTestHelper {
   browserHistory: History;
 
   constructor() {
-    fetchMock.restore();
     this.sandbox = sinon.sandbox.create();
     this.store = configureMainTestStore((...args) => {
       // uncomment to listen on dispatched actions


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3399

#### What's this PR do?
This is caused by a test in `DashboardPage_test.js` which didn't wait for all actions which were dispatched. This caused a fetch to happen after the sandbox was cleared, which meant that `fetchMock` handled it instead without any mock for that endpoint. This:
 - fixes the test to listen for the additional actions
 - Moves `fetchMock.restore()` into `global_init` `afterEach` so we aren't listening for actions in between tests anymore
 - adds commented out code to aid in debugging this issue in the future

#### How should this be manually tested?
N/A
