### PR TITLE
Remove geosuggest component, revert to dropdowns

### DIFF
--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -326,51 +326,6 @@ class EducationForm extends ProfileFormFields {
       }
     };
 
-    const schoolAddressMapping = {
-      locality: keySet("school_city"),
-      administrative_area_level_1: keySet("school_state_or_territory"),
-      country: keySet("school_country")
-    };
-
-    // Load geosuggest component only if Google Maps API is loaded.
-    let addressForm = () => {
-      if (window.google && window.google.maps) {
-        return <Cell col={12}>
-        {this.boundGeosuggest(schoolAddressMapping, keySet('location'), "School Location",
-          {
-            placeholder: "Anytown, Massachusetts, United States",
-            types: ["(cities)"]
-          }
-        )}
-      </Cell>;
-      } else {
-        return <Grid style={{padding:'0px', margin:'0px', width:'100%'}}>
-              <Cell col={4}>
-                <CountrySelectField
-                  stateKeySet={keySet('school_state_or_territory')}
-                  countryKeySet={keySet('school_country')}
-                  label='Country'
-                  topMenu={true}
-                  {...this.defaultInputComponentProps()}
-                />
-              </Cell>
-              <Cell col={4}>
-                <StateSelectField
-                  stateKeySet={keySet('school_state_or_territory')}
-                  countryKeySet={keySet('school_country')}
-                  label='State'
-                  topMenu={true}
-                  {...this.defaultInputComponentProps()}
-                />
-              </Cell>
-              <Cell col={4} key="school_city">
-                {this.boundTextField(keySet('school_city'), 'City')}
-              </Cell></Grid>;
-      }
-
-    };
-
-
     return <Grid className="profile-tab-grid">
       <Cell col={12} className="profile-form-title">
         {title}
@@ -383,7 +338,27 @@ class EducationForm extends ProfileFormFields {
       <Cell col={12}>
         {this.boundDateField(keySet('graduation_date'), 'Graduation Date', true, true)}
       </Cell>
-      {addressForm()}
+      <Cell col={4}>
+        <CountrySelectField
+          stateKeySet={keySet('school_state_or_territory')}
+          countryKeySet={keySet('school_country')}
+          label='Country'
+          topMenu={true}
+          {...this.defaultInputComponentProps()}
+        />
+      </Cell>
+      <Cell col={4}>
+        <StateSelectField
+          stateKeySet={keySet('school_state_or_territory')}
+          countryKeySet={keySet('school_country')}
+          label='State'
+          topMenu={true}
+          {...this.defaultInputComponentProps()}
+        />
+      </Cell>
+      <Cell col={4} key="school_city">
+        {this.boundTextField(keySet('school_city'), 'City')}
+      </Cell>
     </Grid>;
   };
 

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -130,48 +130,6 @@ class EmploymentForm extends ProfileFormFields {
     let id = _.get(profile, keySet("id"));
     let title = id !== undefined ? 'Edit Employment' : 'Add Employment';
 
-    const employerAddressMapping = {
-      locality: keySet("city"),
-      administrative_area_level_1: keySet("state_or_territory"),
-      country: keySet("country")
-    };
-
-    let addressForm = () => {
-      // Use the Geosuggest component only if Google Maps API is loaded.
-      if (window.google && window.google.maps) {
-        return <Cell col={12}>
-                {this.boundGeosuggest(employerAddressMapping, keySet('location'), "Employer Location",
-                  {
-                    placeholder: "Anytown, Massachusetts, United States",
-                    types: ["(cities)"]
-                  }
-                )}
-              </Cell>;
-      } else {
-        return <Grid style={{padding:'0px', margin:'0px', width: '100%'}}>
-                <Cell col={4}>
-                  <CountrySelectField
-                    stateKeySet={keySet('state_or_territory')}
-                    countryKeySet={keySet('country')}
-                    label='Country'
-                    {...this.defaultInputComponentProps()}
-                  />
-                </Cell>
-                <Cell col={4}>
-                  <StateSelectField
-                    stateKeySet={keySet('state_or_territory')}
-                    countryKeySet={keySet('country')}
-                    label='State or Territory'
-                    {...this.defaultInputComponentProps()}
-                  />
-                </Cell>
-                <Cell col={4}>
-                  {this.boundTextField(keySet('city'), 'City')}
-                </Cell>
-               </Grid>;
-      }
-    };
-
     return (
       <Grid className="profile-tab-grid">
         <Cell col={12} className="profile-form-title">
@@ -179,6 +137,25 @@ class EmploymentForm extends ProfileFormFields {
         </Cell>
         <Cell col={12}>
           {this.boundTextField(keySet('company_name'), 'Name of Employer')}
+        </Cell>
+        <Cell col={4}>
+          <CountrySelectField
+            stateKeySet={keySet('state_or_territory')}
+            countryKeySet={keySet('country')}
+            label='Country'
+            {...this.defaultInputComponentProps()}
+          />
+        </Cell>
+        <Cell col={4}>
+          <StateSelectField
+            stateKeySet={keySet('state_or_territory')}
+            countryKeySet={keySet('country')}
+            label='State or Territory'
+            {...this.defaultInputComponentProps()}
+          />
+        </Cell>
+        <Cell col={4}>
+          {this.boundTextField(keySet('city'), 'City')}
         </Cell>
         <Cell col={12}>
           <SelectField
@@ -201,7 +178,6 @@ class EmploymentForm extends ProfileFormFields {
             Leave blank if this is a current position
           </span>
         </Cell>
-        {addressForm()}
       </Grid>
     );
   }

--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -25,7 +25,6 @@ import {
   USER_PROFILE_RESPONSE,
 } from '../test_constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
-import { GoogleMapsStub } from '../util/test_utils';
 import { makeStrippedHtml } from '../util/util';
 import * as api from '../lib/api';
 import {
@@ -191,16 +190,6 @@ describe("ErrorMessage", () => {
     });
 
     describe('user page', () => {
-      let gmaps;
-
-      beforeEach(() => {
-        gmaps = new GoogleMapsStub();
-      });
-
-      afterEach(() => {
-        gmaps.cleanup();
-      });
-
       it('should show an error for profile GET', () => {
         let fourOhFour = {
           errorStatusCode: 404,

--- a/static/js/components/PersonalTab_test.js
+++ b/static/js/components/PersonalTab_test.js
@@ -10,10 +10,9 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import PersonalTab from './PersonalTab';
 import { PROGRAMS, USER_PROFILE_RESPONSE } from '../test_constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
-import { GoogleMapsStub } from '../util/test_utils';
 
 describe("PersonalTab", () => {
-  let helper, gmaps;
+  let helper;
   let renderPersonalTab = (selectedProgram = null, props = {}) => {
     let { store } = helper;
     return mount(
@@ -38,12 +37,10 @@ describe("PersonalTab", () => {
 
   beforeEach(() => {
     helper = new IntegrationTestHelper();
-    gmaps = new GoogleMapsStub();
   });
 
   afterEach(() => {
     helper.cleanup();
-    gmaps.cleanup();
   });
 
   it('should show a list of programs to enroll in for the learner page', () => {

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -45,7 +45,6 @@ import {
   EMPLOYMENT_STEP,
 } from '../constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
-import { GoogleMapsStub } from '../util/test_utils';
 import { SUCCESS_ACTIONS } from './test_util';
 import { actions } from '../lib/redux_rest';
 
@@ -58,18 +57,16 @@ const REDIRECT_ACTIONS = SUCCESS_ACTIONS.concat([
 ]);
 
 describe('App', function() {
-  let listenForActions, renderComponent, helper, gmaps;
+  let listenForActions, renderComponent, helper;
 
   beforeEach(() => {
     helper = new IntegrationTestHelper();
-    gmaps = new GoogleMapsStub();
     listenForActions = helper.listenForActions.bind(helper);
     renderComponent = helper.renderComponent.bind(helper);
   });
 
   afterEach(() => {
     helper.cleanup();
-    gmaps.cleanup();
   });
 
   it('clears profile, ui, and enrollments after unmounting', () => {

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -36,12 +36,12 @@ import {
 } from '../constants';
 import IntegrationTestHelper from '../util/integration_test_helper';
 import * as api from '../lib/api';
-import { GoogleMapsStub, activeDialog } from '../util/test_utils';
+import { activeDialog } from '../util/test_utils';
 
 describe("ProfilePage", function() {
   this.timeout(5000);  // eslint-disable-line no-invalid-this
 
-  let listenForActions, renderComponent, helper, gmaps;
+  let listenForActions, renderComponent, helper;
   let addProgramEnrollmentStub, patchUserProfileStub;
 
   let profileSteps = [
@@ -71,7 +71,6 @@ describe("ProfilePage", function() {
 
   beforeEach(() => {
     helper = new IntegrationTestHelper();
-    gmaps = new GoogleMapsStub();
     listenForActions = helper.listenForActions.bind(helper);
     renderComponent = helper.renderComponent.bind(helper);
     patchUserProfileStub = helper.sandbox.stub(api, 'patchUserProfile');
@@ -81,7 +80,6 @@ describe("ProfilePage", function() {
 
   afterEach(() => {
     helper.cleanup();
-    gmaps.cleanup();
   });
 
   let confirmSaveButtonBehavior = (updatedProfile, pageElements, additionalActions = []) => {

--- a/static/js/flow/profileTypes.js
+++ b/static/js/flow/profileTypes.js
@@ -21,38 +21,6 @@ export type DateEdit = {
   year: ?string,
 };
 
-// https://developers.google.com/maps/documentation/geocoding/intro#Types
-export type GoogleMapsAddressComponent = {
-  long_name:  string,
-  short_name: string,
-  types:      string[]
-}
-
-export type AddressComponentKeyMapping = {
-  street_address?:              string[],
-  route?:                       string[],
-  intersection?:                string[],
-  political?:                   string[],
-  country?:                     string[],
-  administrative_area_level_1?: string[],
-  administrative_area_level_2?: string[],
-  administrative_area_level_3?: string[],
-  administrative_area_level_4?: string[],
-  administrative_area_level_5?: string[],
-  colloquial_area?:             string[],
-  locality?:                    string[],
-  ward?:                        string[],
-  sublocality?:                 string[],
-  neighborhood?:                string[],
-  premise?:                     string[],
-  subpremise?:                  string[],
-  postal_code?:                 string[],
-  natural_feature?:             string[],
-  airport?:                     string[],
-  park?:                        string[],
-  point_of_interest?:           string[],
-};
-
 export type WorkHistoryEntry = {
   id?:                  ?number,
   position:             string,

--- a/static/js/lib/location.js
+++ b/static/js/lib/location.js
@@ -1,9 +1,6 @@
 // @flow
 import R from 'ramda';
 import iso3166 from 'iso-3166-2';
-import Fuse from 'fuse-js-latest';
-
-const notAvailable = "Not Available";
 
 /**
  * Gets the name of a country given its code
@@ -14,53 +11,3 @@ export const codeToCountryName =  R.compose(
   iso3166.country,
   R.defaultTo("")
 );
-
-/**
- * Gets the code for a country given its name
- * @param name Country name
- */
-export const nameToCountryCode = R.compose(
-  R.pathOr("", ['code']),
-  iso3166.country,
-  R.defaultTo("")
-);
-
-/**
- * Gets the name of a state/territory given its ISO3166 code (as in 'US-MA')
- * @param code ISO3166 code ('US-MA', 'US-CO', etc).
- */
-export const codeToStateName = R.compose(
-  R.pathOr(notAvailable, ['name']),
-  iso3166.subdivision,
-  R.defaultTo("")
-);
-
-/**
- * Get a list of subregion objects for a country, each with a 'code' and 'name' property.
- * @param country Country code
- */
-export const getSubcodes = (country:string) => {
-  if (country in iso3166.data && "sub" in iso3166.data[country]) {
-    return R.map(function (key) {
-      return {"code": key, "name": iso3166.data[country]["sub"][key]["name"]};
-    }, Object.keys(iso3166.data[country]["sub"]));
-  } else return [];
-};
-
-/**
- * Gets the ISO3166 code for a state/territory given a country and state name.
- * If no exact match is found for a state name, try a fuzzy match.
- * Return a notAvailable value if no match can be found either way.
- * @param country Country code
- * @param name State/territory name
- */
-export const nameToStateCode = (country: string, name: string) =>  {
-  let statecode = iso3166.subdivision(R.defaultTo("", country), R.defaultTo("", name));
-  if (!R.isEmpty(statecode)) {
-    return statecode['code'];
-  } else {
-    const fuse = new Fuse(getSubcodes(country), {keys: ["name"], threshold:0.4, tokenize: true});
-    const fuzzymatches = fuse.search(R.defaultTo("", name));
-    return R.isEmpty(fuzzymatches) ? notAvailable : fuzzymatches[0]["code"];
-  }
-};

--- a/static/js/lib/location_test.js
+++ b/static/js/lib/location_test.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import { codeToCountryName, codeToStateName, nameToStateCode } from './location';
+import { codeToCountryName } from './location';
 
 describe('location', () => {
   describe('codeToCountryName', () => {
@@ -13,36 +13,4 @@ describe('location', () => {
       });
     });
   });
-
-  describe('codeToStateName', () => {
-    it('should return a valid state name for a code', () => {
-      [
-        ['US-MA', 'Massachusetts'],
-        ['AF-KAN', 'Kandahār'],
-        [null, 'Not Available'],
-        ['', 'Not Available']
-      ].forEach(([stateCode, state]) => {
-        assert.equal(codeToStateName(stateCode), state);
-      });
-    });
-  });
-
-  describe('stateNametoCode', () => {
-    it('should return a valid state code for a name', () => {
-      [
-        ['Massachusetts', 'US', 'US-MA', ],
-        ['Qandahar', 'AF', 'AF-KAN'],
-        ['', 'US', 'Not Available'],
-        [null, 'US', 'Not Available'],
-      ].forEach(([state, country, stateCode]) => {
-        assert.equal(nameToStateCode(country, state), stateCode);
-      });
-    });
-  });
-
 });
-
-
-
-
-

--- a/static/js/util/ProfileFormFields.js
+++ b/static/js/util/ProfileFormFields.js
@@ -7,7 +7,6 @@ import {
   boundTextField,
   boundRadioGroupField,
   boundCheckbox,
-  boundGeosuggest,
   boundTelephoneInput,
 } from './profile_edit';
 
@@ -20,7 +19,6 @@ export default class ProfileFormFields extends React.Component {
     this.boundDateField = boundDateField.bind(this);
     this.boundRadioGroupField = boundRadioGroupField.bind(this);
     this.boundCheckbox = boundCheckbox.bind(this);
-    this.boundGeosuggest = boundGeosuggest.bind(this);
     this.boundTelephoneInput = boundTelephoneInput.bind(this);
   }
 
@@ -29,7 +27,6 @@ export default class ProfileFormFields extends React.Component {
   boundDateField: Function;
   boundRadioGroupField: Function;
   boundCheckbox: Function;
-  boundGeosuggest: Function;
   boundTelephoneInput: Function;
 
   defaultInputComponentProps = (): Object => {

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -16,7 +16,6 @@ import type {
   Program
 } from '../flow/programTypes';
 import type { Action } from '../flow/reduxTypes';
-import type { Sandbox } from '../flow/sinonTypes';
 import type { Store } from 'redux';
 import App from '../containers/App';
 import DashboardPage from '../containers/DashboardPage';
@@ -177,73 +176,6 @@ export const localStorageMock = (init: any = {}) => {
     reset: reset,
   };
 };
-
-export class GoogleMapsStub {
-  sandbox: Sandbox;
-  getPlacePredictions: any;
-  geocode: any;
-
-  autocompleteSuggestions = [{
-    "description": "Paris, France",
-    "id": "691b237b0322f28988f3ce03e321ff72a12167fd",
-    "matched_substrings": [{"length": 5, "offset": 0}],
-    "place_id": "ChIJD7fiBh9u5kcRYJSMaMOCCwQ",
-    "reference": "CjQlAAAA_KB6EEceSTfkteSSF6U0",
-    "terms": [
-      {offset: 0, value: "Paris"},
-      {offset: 7, value: "France"},
-    ],
-    "types": ["locality", "political", "geocode"]
-  }];
-
-  geocodeResults = [{
-    address_components: [
-      {long_name: "123 Main Street", short_name: "123 Main St", types: ["street_address"]},
-      {long_name: "Anytown", short_name: "Anytown", types: ["locality"]},
-      {long_name: "Kandahar", short_name: "Kandahar", types: ["administrative_area_level_1"]},
-      {long_name: "Afghanistan", short_name: "AF", types: ["country"]},
-    ],
-    geometry: {
-      location: {
-        lat: () => 48.859,
-        lng: () => 2.207,
-      }
-    }
-  }];
-
-  constructor() {
-    this.sandbox = sinon.sandbox.create();
-    this.getPlacePredictions = this.sandbox.stub().callsArgWith(1, this.autocompleteSuggestions);
-    this.geocode = this.sandbox.stub().callsArgWith(1, this.geocodeResults, 'OK');
-
-    const that = this;
-    class FakeAutocompleteService {
-      getPlacePredictions = that.getPlacePredictions;
-    }
-    class FakeGeocoder {
-      geocode = that.geocode;
-    }
-
-    let google = {
-      maps: {
-        Geocoder: FakeGeocoder,
-        GeocoderStatus: {
-          OK: 'OK'
-        },
-        places: {
-          AutocompleteService: FakeAutocompleteService
-        }
-      }
-    };
-
-    window.google = google;
-  }
-
-  cleanup() {
-    this.sandbox.restore();
-    delete window.google;
-  }
-}
 
 export  const getEl = (div: any, selector: string): HTMLElement => {
   let el: HTMLElement = (div.querySelector(selector): any);

--- a/ui/views.py
+++ b/ui/views.py
@@ -72,7 +72,7 @@ class ReactView(View):  # pylint: disable=unused-argument
             context={
                 "has_zendesk_widget": True,
                 "is_public": False,
-                "google_maps_api": True,
+                "google_maps_api": False,
                 "js_settings_json": json.dumps(js_settings),
                 "ga_tracking_id": "",
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1596,17 +1596,9 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.1, create-react-class@^15.5.2, create-react-class@^15.5.3, create-react-class@^15.6.0:
+create-react-class@^15.5.1, create-react-class@^15.5.2, create-react-class@^15.5.3, create-react-class@^15.5.x, create-react-class@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
-create-react-class@^15.5.x:
-  version "15.5.3"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.5.3.tgz#fb0f7cae79339e9a179e194ef466efa3923820fe"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
@@ -5441,7 +5433,32 @@ request-promise-native@^1.0.3:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.0"
 
-request@2, request@^2.79.0, request@^2.81.0:
+request@2, request@2.79.0, request@^2.79.0:
+  version "2.79.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.11.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~2.0.6"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    qs "~6.3.0"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "~0.4.1"
+    uuid "^3.0.0"
+
+request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -5466,31 +5483,6 @@ request@2, request@^2.79.0, request@^2.81.0:
     stringstream "~0.0.4"
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
-    uuid "^3.0.0"
-
-request@2.79.0:
-  version "2.79.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.11.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~2.0.6"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    qs "~6.3.0"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
 require-directory@^2.1.1:
@@ -6047,7 +6039,7 @@ style-loader@^0.18.1:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
-supports-color@3.1.2:
+supports-color@3.1.2, supports-color@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -6057,7 +6049,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.0, supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/micromasters/issues/3409

#### What's this PR do?
Reverts address fields on education and employment forms to the original state and country dropdowns plus city text input.

#### How should this be manually tested?
Add or edit an education entry and employment entry on your profile page.  You should get dropdowns for state and country plus a text field for city.  Fill them in and save.  Then re-open to make sure the changes were saved correctly.

