### PR TITLE
Fixed financial aid income dialog that was showing up twice

### DIFF
--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -287,8 +287,8 @@ const saveFinancialAid = R.curry((dispatch, current) => {
 const submitFinancialAid = R.curry((dispatch, current) => {
   const { income, currency, programId } = current;
   dispatch(addFinancialAid(income, currency, programId)).then(() => {
+    dispatch(hideDialog(INCOME_DIALOG));
     dispatch(clearCalculatorEdit());
-    dispatch(showDialog(INCOME_DIALOG));
   });
 });
 

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -275,6 +275,7 @@ describe('FinancialAidCalculator', () => {
         actions.prices.get.successType,
         RECEIVE_DASHBOARD_SUCCESS,
         CLEAR_CALCULATOR_EDIT,
+        HIDE_DIALOG,
       ], () => {
         wrapper.find('.pricing-actions').find('.calculate-cost-button').simulate('click');
         let calculator = document.querySelector('.financial-aid-calculator');


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3344

#### What's this PR do?
Remove a line of code which was casing to show income dialog twice.

#### How should this be manually tested?
Go to FA calculator and submit, a confirm dialog will appear. Submit it and you want see this dialog for second time.

@pdpinch 
#### Screenshots (if appropriate)
<img width="913" alt="screen shot 2017-07-18 at 4 55 06 pm" src="https://user-images.githubusercontent.com/10431250/28315908-effd5980-6bd9-11e7-96e4-0d013fbcfab3.png">

<img width="851" alt="screen shot 2017-07-18 at 4 55 11 pm" src="https://user-images.githubusercontent.com/10431250/28315909-f00e4952-6bd9-11e7-8e09-2b9e8fb17a84.png">

<img width="791" alt="screen shot 2017-07-18 at 4 55 19 pm" src="https://user-images.githubusercontent.com/10431250/28315910-f012bc4e-6bd9-11e7-8799-6237651166f9.png">
