### PR TITLE
Dashboard API: displayed final grade for course with missed deadline status but user has final grades in system

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -418,7 +418,10 @@ def format_courserun_for_dashboard(course_run, status_for_user, mmtrack, positio
             formatted_run['current_grade'] = mmtrack.get_current_grade(course_run.edx_course_key)
     # any other status but "offered" should have the current grade
     elif status_for_user != CourseStatus.OFFERED:
-        formatted_run['current_grade'] = mmtrack.get_current_grade(course_run.edx_course_key)
+        if mmtrack.has_final_grade(course_run.edx_course_key):
+            formatted_run['final_grade'] = mmtrack.get_final_grade_percent(course_run.edx_course_key)
+        else:
+            formatted_run['current_grade'] = mmtrack.get_current_grade(course_run.edx_course_key)
 
     return formatted_run
 

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -154,6 +154,7 @@ class FormatRunTest(CourseTests):
             'get_final_grade_percent.return_value': 99.99,
             'get_current_grade.return_value': 33.33,
             'has_paid.return_value': False,
+            'has_final_grade.return_value': False
         })
         self.crun = self.create_run(
             start=self.now+timedelta(weeks=52),
@@ -311,6 +312,25 @@ class FormatRunTest(CourseTests):
         # test that a weird status raises here
         with self.assertRaises(ImproperlyConfigured):
             api.format_courserun_for_dashboard(crun, 'foo_status', self.mmtrack)
+
+    def test_has_final_grade_not_enrolled(self):
+        """
+        Test a special case where user has a final grade and he missed the
+        deadline and neither he is enrolled in course nor he has paid
+        """
+        self.mmtrack.configure_mock(**{
+            'get_final_grade_percent.return_value': 99.99,
+            'has_paid.return_value': False,
+            'has_final_grade.return_value': True
+        })
+        self.expected_ret_data.update({
+            'status': api.CourseStatus.MISSED_DEADLINE,
+            'final_grade': 99.99
+        })
+        self.assertEqual(
+            api.format_courserun_for_dashboard(self.crun, api.CourseStatus.MISSED_DEADLINE, self.mmtrack),
+            self.expected_ret_data
+        )
 
 
 @ddt.ddt


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3327

#### What's this PR do?
Added final grade in api when user is neither enrolled nor paid for course but he has a final grade in system, plus course deadline has passed

#### How should this be manually tested?
create a course in existing program who's deadline is passed and then create a final grade and check it in dashboard api

```url
http://192.168.99.100:8079/api/v0/dashboard/(username)/
```

@pdpinch 
#### Screenshots (if appropriate)
<img width="742" alt="screen shot 2017-07-19 at 7 13 47 pm" src="https://user-images.githubusercontent.com/10431250/28371443-7417b526-6cb6-11e7-8d8c-d9dccea1dfae.png">
