### PR TITLE
Created management command to make exam grade adjustments

### DIFF
--- a/grades/factories.py
+++ b/grades/factories.py
@@ -18,6 +18,7 @@ from courses.factories import (
     CourseRunFactory,
 )
 from exams.factories import ExamRunFactory
+from exams.pearson.constants import EXAM_GRADE_PASS, EXAM_GRADE_FAIL
 from grades.constants import FinalGradeStatus
 from grades.models import (
     FinalGrade,
@@ -49,7 +50,7 @@ class ProctoredExamGradeFactory(DjangoModelFactory):
     # this assumes that the max score is 100
     passing_score = 60.0
     score = LazyAttribute(lambda x: x.percentage_grade * 100)
-    grade = LazyAttribute(lambda x: 'Pass' if x.passed else 'Fail')
+    grade = LazyAttribute(lambda x: EXAM_GRADE_PASS if x.passed else EXAM_GRADE_FAIL)
     client_authorization_id = FuzzyText()
     row_data = {"From factory": True}
     passed = Faker('boolean')

--- a/grades/management/commands/adjust_exam_grades_from_csv.py
+++ b/grades/management/commands/adjust_exam_grades_from_csv.py
@@ -1,0 +1,119 @@
+"""
+Freezes final grades for a course
+"""
+import csv
+import argparse
+from collections import namedtuple
+from django.core.management import BaseCommand, CommandError
+
+from grades.models import ProctoredExamGrade
+
+
+class ParsingError(CommandError):
+    """Custom class for parsing exceptions"""
+    pass
+
+
+class GradeRowParser:
+    """Parser for rows of grade adjustment information in a CSV"""
+    RowProps = namedtuple('RowProps', ['exam_grade_id', 'score'])
+    default_col_names = dict(
+        exam_grade_id='proctoredexam_id',
+        score='score',
+    )
+
+    def __init__(self, col_names=None):
+        """
+        Args:
+            col_names (dict): Mapping of RowProps property name to the name of the column in the CSV
+        """
+        col_names = col_names or {}
+        self.col_names = self.RowProps(**{**self.default_col_names, **col_names})
+
+    def parse_and_validate_row(self, row):
+        """Parses a row of grade adjustment info and makes sure it doesn't contain bad data"""
+        try:
+            parsed_row = self.RowProps(
+                exam_grade_id=int(row[self.col_names.exam_grade_id]),
+                score=float(row[self.col_names.score]),
+            )
+        except KeyError as e:
+            raise ParsingError('Row is missing a required column: {}'.format(str(e)))
+        except ValueError as e:
+            raise ParsingError('Row has an invalid value: {}'.format(str(e)))
+
+        if parsed_row.score < 0.0 or parsed_row.score > 100.0:
+            row_identifier = '{}: {}'.format(self.col_names.exam_grade_id, parsed_row.exam_grade_id)
+            raise ParsingError('[{}] "score" value must be between 0 and 100'.format(row_identifier))
+        return parsed_row
+
+    def parse_exam_grade_adjustments(self, csv_reader):
+        """
+        Parses all rows of grade adjustment info from a CSV and yields each ProctoredExamGrade object
+        with its associated grade adjustment row from the CSV
+
+        Args:
+            csv_reader (csv.DictReader): A DictReader instance
+
+        Returns:
+            tuple(ProctoredExamGrade, RowProps):
+                A tuple containing a ProctoredExamGrade and its associated parsed CSV row
+        """
+        parsed_row_dict = {}
+        for row in csv_reader:
+            parsed_row = self.parse_and_validate_row(row)
+            parsed_row_dict[parsed_row.exam_grade_id] = parsed_row
+        exam_grade_query = ProctoredExamGrade.objects.filter(id__in=parsed_row_dict.keys())
+        if exam_grade_query.count() < len(parsed_row_dict):
+            bad_exam_grade_ids = set(parsed_row_dict.keys()) - set(exam_grade_query.values_list('id', flat=True))
+            raise ParsingError(
+                'Some exam grade IDs do not match any ProctoredExamGrade records: {}'.format(bad_exam_grade_ids)
+            )
+        for exam_grade in exam_grade_query.all():
+            yield exam_grade, parsed_row_dict[exam_grade.id]
+
+
+class Command(BaseCommand):
+    """Parses a csv with exam grade adjustment information and changes the appropriate grades"""
+    help = "Parses a csv with exam grade adjustment information and changes the appropriate grades"
+
+    def add_arguments(self, parser):
+        parser.add_argument('csvfile', type=argparse.FileType('r'), help='')
+        parser.add_argument(
+            '--grade-id-col-name',
+            default=GradeRowParser.default_col_names['exam_grade_id'],
+            help='Name of the column that contains the proctored exam grade id')
+        parser.add_argument(
+            '--score-col-name',
+            default=GradeRowParser.default_col_names['score'],
+            help='Name of the column that contains the score value'
+        )
+
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument,too-many-locals
+        col_names = dict(
+            exam_grade_id=kwargs.get('grade_id_col_name'),
+            score=kwargs.get('score_col_name'),
+        )
+        csvfile = kwargs.get('csvfile')
+        reader = csv.DictReader(csvfile.read().splitlines(), delimiter='\t')
+        grade_row_parser = GradeRowParser(col_names=col_names)
+
+        total_rows = 0
+        grades_changed = 0
+        grades_unchanged = 0
+
+        for exam_grade, parsed_adjustment_row in grade_row_parser.parse_exam_grade_adjustments(reader):
+            if exam_grade.score != parsed_adjustment_row.score:
+                exam_grade.set_score(parsed_adjustment_row.score)
+                exam_grade.save_and_log(None)
+                grades_changed = grades_changed + 1
+            else:
+                grades_unchanged = grades_unchanged + 1
+            total_rows = total_rows + 1
+
+        result_messages = ['Total rows: {}'.format(total_rows)]
+        if grades_changed:
+            result_messages.append('Grades changed: {}'.format(grades_changed))
+        if grades_unchanged:
+            result_messages.append('Grades found with no change in score: {}'.format(grades_unchanged))
+        self.stdout.write(self.style.SUCCESS('\n'.join(result_messages)))

--- a/grades/models.py
+++ b/grades/models.py
@@ -12,6 +12,7 @@ from courses.models import (
     CourseRun,
 )
 from exams.models import ExamRun
+from exams.pearson.constants import EXAM_GRADE_PASS, EXAM_GRADE_FAIL
 from grades.constants import FinalGradeStatus
 from micromasters.models import (
     AuditableModel,
@@ -230,6 +231,18 @@ class ProctoredExamGrade(TimestampedModel, AuditableModel):
         """
         now = now_in_utc()
         return cls.objects.filter(user=user, course=course, exam_run__date_grades_available__lte=now)
+
+    def set_score(self, new_score):
+        """
+        Sets a value for the score field, then sets related fields based on that value
+
+        Args:
+            new_score (float): The new score value
+        """
+        self.score = new_score
+        self.percentage_grade = self.score / 100.0
+        self.passed = self.score >= self.passing_score
+        self.grade = EXAM_GRADE_PASS if self.passed else EXAM_GRADE_FAIL
 
     def to_dict(self):
         return serialize_model_object(self)


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #3309 

#### What's this PR do?
Creates a management command that can adjust exam grades based on data in a csv

#### How should this be manually tested?
This gist will help: https://gist.github.com/gsidebo/8c3252a4d8f0b9f7bd67ffa3ba2782f6

It contains a script for ensuring that a set of users have exam grades, and an example csv for the grade adjustments. Once you have a set of users with exam grades, download that csv to your project root and change the `proctoredexam_id` column values to match the `ProctoredExamGrade.id` values for your users (the `user_id` column in this csv is ignored - the only column that matters for matching to our records is `proctoredexam_id`). Run the management command with this file (e.g.: `./manage.py adjust_exam_grades_from_csv "./test_grade_adjust.csv"`), then check the exam scores in the database to make sure that the adjustments worked. 

You can also mess with the csv (change scores to be invalid, change id's to something nonexistent, etc) to see how it handles errors

#### Any background context you want to provide?
The csv's that we get from DEDP are tab-delimited
