### PR TITLE
Allow user to enroll in a course if FA pending

### DIFF
--- a/static/js/components/CourseEnrollmentDialog.js
+++ b/static/js/components/CourseEnrollmentDialog.js
@@ -28,6 +28,7 @@ export default class CourseEnrollmentDialog extends React.Component {
     course:                   Course,
     courseRun:                CourseRun,
     hasUserApplied:           boolean,
+    pendingFinancialAid:      boolean,
     addCourseEnrollment:      (courseId: string) => Promise<*>,
     checkout:                 Function,
     financialAidAvailability: boolean,
@@ -60,9 +61,19 @@ export default class CourseEnrollmentDialog extends React.Component {
   };
 
   render() {
-    const { open, setVisibility, course, hasUserApplied } = this.props;
+    const { open, setVisibility, course, hasUserApplied, pendingFinancialAid } = this.props;
     let message, payButton, auditButton;
-    if (hasUserApplied) {
+    if (pendingFinancialAid){
+      message = `Your Personalized Course Price is still pending approval, but you can
+        sign up now to audit the course for FREE, and then pay later. (Payment is required
+        to get credit for the MicroMasters certificate.)`;
+      payButton = (
+        <Button key="pay" disabled
+          colored className="dashboard-button pay-button">
+          Pay Now
+        </Button>
+      );
+    } else if (hasUserApplied){
       message = `You can pay now, or you can audit the course for FREE
         and upgrade later. (Payment is required to get credit for the
         MicroMasters certificate.)`;

--- a/static/js/components/CourseEnrollmentDialog.js
+++ b/static/js/components/CourseEnrollmentDialog.js
@@ -63,7 +63,7 @@ export default class CourseEnrollmentDialog extends React.Component {
   render() {
     const { open, setVisibility, course, hasUserApplied, pendingFinancialAid } = this.props;
     let message, payButton, auditButton;
-    if (pendingFinancialAid){
+    if (pendingFinancialAid) {
       message = `Your Personalized Course Price is still pending approval, but you can
         sign up now to audit the course for FREE, and then pay later. (Payment is required
         to get credit for the MicroMasters certificate.)`;
@@ -73,7 +73,7 @@ export default class CourseEnrollmentDialog extends React.Component {
           Pay Now
         </Button>
       );
-    } else if (hasUserApplied){
+    } else if (hasUserApplied) {
       message = `You can pay now, or you can audit the course for FREE
         and upgrade later. (Payment is required to get credit for the
         MicroMasters certificate.)`;

--- a/static/js/components/CourseEnrollmentDialog_test.js
+++ b/static/js/components/CourseEnrollmentDialog_test.js
@@ -32,7 +32,8 @@ describe("CourseEnrollmentDialog", () => {
     courseRun = makeRun(1),
     course = makeCourse(1),
     open = true,
-    financialAidAvailability = true
+    financialAidAvailability = true,
+    pendingFinancialAid = false
   ) => {
     mount(
       <MuiThemeProvider muiTheme={getMuiTheme()}>
@@ -45,6 +46,7 @@ describe("CourseEnrollmentDialog", () => {
           checkout={checkoutStub}
           financialAidAvailability={financialAidAvailability}
           hasUserApplied={hasUserApplied}
+          pendingFinancialAid={pendingFinancialAid}
         />
       </MuiThemeProvider>,
       {
@@ -72,6 +74,16 @@ describe("CourseEnrollmentDialog", () => {
     const payButton = ((wrapper.querySelector('.pay-button'): any): HTMLButtonElement);
     assert.equal(payButton.textContent, "Pay Now");
     assert.isFalse(payButton.disabled);
+    const auditButton = getEl(wrapper, '.audit-button');
+    assert.equal(auditButton.textContent, "Audit for Free & Pay Later");
+  });
+  it('can render with pendingFinancialAid = true', () => {
+    const wrapper = renderDialog(
+      true,  makeRun(1), makeCourse(1), true, true, true
+    );
+    const payButton = ((wrapper.querySelector('.pay-button'): any): HTMLButtonElement);
+    assert.equal(payButton.textContent, "Pay Now");
+    assert.isTrue(payButton.disabled);
     const auditButton = getEl(wrapper, '.audit-button');
     assert.equal(auditButton.textContent, "Audit for Free & Pay Later");
   });

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -80,11 +80,7 @@ export default class CourseAction extends React.Component {
   }
 
   renderEnrollButton(run: CourseRun, actionType: string): React$Element<*> {
-    let buttonProps = {};
 
-    if (this.hasPendingFinancialAid()) {
-      buttonProps.disabled = true;
-    }
 
     return (
       <div className="course-action">
@@ -93,7 +89,6 @@ export default class CourseAction extends React.Component {
           component={Button}
           spinning={run.status === STATUS_PENDING_ENROLLMENT}
           onClick={() => this.handleEnrollButtonClick(run)}
-          {...buttonProps}
         >
           { actionType === COURSE_ACTION_REENROLL ? 'Re-Enroll' : 'Enroll' }
         </SpinnerButton>

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -15,9 +15,6 @@ import {
   STATUS_OFFERED,
   STATUS_CAN_UPGRADE,
   STATUS_PENDING_ENROLLMENT,
-  FA_PENDING_STATUSES,
-  FA_TERMINAL_STATUSES,
-  FA_ALL_STATUSES,
   COURSE_ACTION_PAY,
   COURSE_ACTION_ENROLL,
   COURSE_ACTION_REENROLL,
@@ -170,63 +167,6 @@ describe('CourseAction', () => {
       let button = wrapper.find(Button);
       assert.isTrue(button.props().disabled);
       assert.equal(button.props().children, 'Pay Now');
-    });
-
-    it('shows a disabled enroll button if and only if a user is pending approval', () => {
-      let firstRun = alterFirstRun(course, {
-        enrollment_start_date: now.toISOString(),
-      });
-
-      FA_ALL_STATUSES.forEach(status => {
-        const wrapper = renderCourseAction({
-          courseRun: firstRun,
-          financialAid: {
-            ...FINANCIAL_AID_PARTIAL_RESPONSE,
-            has_user_applied: true,
-            application_status: status,
-          },
-          hasFinancialAid: true,
-          actionType: COURSE_ACTION_ENROLL,
-        });
-        let button = wrapper.find(SpinnerButton);
-
-        if (FA_PENDING_STATUSES.includes(status)) {
-          assert.isTrue(button.props().disabled);
-          // we don't show a spinner in this case, only for API loads or when waiting for Cybersource callback
-          assert.isFalse(button.props().spinning);
-        } else {
-          assert.isUndefined(button.props().disabled);
-        }
-        assert.include(button.props().children, 'Enroll');
-      });
-    });
-
-    it('shows a disabled pay button if and only if a user has not been approved yet', () => {
-      let firstRun = alterFirstRun(course, {
-        enrollment_start_date: now.toISOString(),
-        status: STATUS_CAN_UPGRADE,
-      });
-
-      FA_ALL_STATUSES.forEach(status => {
-        const wrapper = renderCourseAction({
-          courseRun: firstRun,
-          financialAid: {
-            ...FINANCIAL_AID_PARTIAL_RESPONSE,
-            has_user_applied: true,
-            application_status: status,
-          },
-          hasFinancialAid: true,
-          actionType: COURSE_ACTION_PAY,
-        });
-        let payButton = wrapper.find(Button);
-
-        if (FA_TERMINAL_STATUSES.includes(status)) {
-          assert.isUndefined(payButton.props().disabled);
-        } else {
-          assert.isTrue(payButton.props().disabled);
-        }
-        assert.equal(payButton.children().text(), 'Pay Now');
-      });
     });
 
     it('pay button redirects to checkout', () => {

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -28,6 +28,7 @@ import {
   COUPON_CONTENT_TYPE_COURSE,
   COUPON_CONTENT_TYPE_PROGRAM,
   FA_TERMINAL_STATUSES,
+  FA_PENDING_STATUSES,
   TOAST_SUCCESS,
   TOAST_FAILURE,
   STATUS_OFFERED,
@@ -613,11 +614,17 @@ class DashboardPage extends React.Component {
       this.shouldSkipFinancialAid() ||
       program.financial_aid_user_info.has_user_applied
     );
+    let pendingFinancialAid = (
+      program.financial_aid_availability &&
+      program.financial_aid_user_info.has_user_applied &&
+      FA_PENDING_STATUSES.includes(program.financial_aid_user_info.application_status)
+    );
 
     return <CourseEnrollmentDialog
       course={course}
       courseRun={courseRun}
       hasUserApplied={hasUserApplied}
+      pendingFinancialAid={pendingFinancialAid}
       financialAidAvailability={program.financial_aid_availability}
       checkout={this.dispatchCheckout}
       open={ui.enrollCourseDialogVisibility}

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -640,8 +640,8 @@ describe('DashboardPage', () => {
       });
     });
     R.forEach((faStatus) => {
-      let expected_disabled = FA_PENDING_STATUSES.includes(faStatus);
-      it(`${faStatus} status ${expected_disabled?"disables":"does not disable"} pay now button`, () => {
+      let expectedDisabled = FA_PENDING_STATUSES.includes(faStatus);
+      it(`${faStatus} status ${expectedDisabled ? "disables" : "does not disable"} pay now button`, () => {
         let course = makeCourse();
         course.runs[0].enrollment_start_date = moment().subtract(2, 'days');
         dashboardResponse.programs[0].courses = [course];
@@ -661,7 +661,7 @@ describe('DashboardPage', () => {
             enrollButton.simulate('click');
           }).then((state) => {
             assert.isTrue(state.ui.enrollCourseDialogVisibility);
-            assert.equal(document.querySelector('.pay-button').disabled, expected_disabled);
+            assert.equal(document.querySelector('.pay-button').disabled, expectedDisabled);
           });
         });
       });

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -639,17 +639,19 @@ describe('DashboardPage', () => {
         });
       });
     });
-    R.forEach((fa_status) => {
-      it(`shows course enrollment dialog ${fa_status}`, () => {
+    R.forEach((faStatus) => {
+      let expected_disabled = FA_PENDING_STATUSES.includes(faStatus);
+      it(`${faStatus} status ${expected_disabled?"disables":"does not disable"} pay now button`, () => {
         let course = makeCourse();
         course.runs[0].enrollment_start_date = moment().subtract(2, 'days');
         dashboardResponse.programs[0].courses = [course];
         dashboardResponse.programs[0].financial_aid_availability = true;
         dashboardResponse.programs[0].financial_aid_user_info = {
-          application_status: fa_status,
+          application_status: faStatus,
           date_documents_sent: '2016-01-01',
           has_user_applied: true,
         };
+
 
         helper.dashboardStub.returns(Promise.resolve(dashboardResponse));
         return renderComponent('/dashboard', DASHBOARD_SUCCESS_ACTIONS).then(([wrapper]) => {
@@ -659,11 +661,11 @@ describe('DashboardPage', () => {
             enrollButton.simulate('click');
           }).then((state) => {
             assert.isTrue(state.ui.enrollCourseDialogVisibility);
-            assert.isTrue(document.querySelector('.pay-button').disabled);
+            assert.equal(document.querySelector('.pay-button').disabled, expected_disabled);
           });
         });
       });
-    }, FA_PENDING_STATUSES);
+    }, FA_ALL_STATUSES);
   });
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3411

#### What's this PR do?
Remove the logic for disabling the Enroll button, enabling the user to get to the `CourseEnrollmentDialog`, where the user has the option of auditing the course while waiting for FA application to get approved.

#### How should this be manually tested?
Set a course in a program to `offered`. Set your FinancialAid to 'pending' or other `FA_PENDING_STATUSES`. And try to enroll in that course.
