### PR TITLE
Fixed broken cms migrations

### DIFF
--- a/cms/migrations/0006_change_homepage_title.py
+++ b/cms/migrations/0006_change_homepage_title.py
@@ -19,5 +19,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(set_default_homepage_text),
+        migrations.RunPython(set_default_homepage_text, reverse_code=migrations.RunPython.noop),
     ]


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket

#### What's this PR do?
Fixes wagtail-related migrations so they're reversible

#### How should this be manually tested?
If you're OK nuking your CMS data, you can do this:

```
./manage.py migrate cms zero
./manage.py migrate cms
```
If you go to `/cms` after that, you should be able to click the "Pages" link and see the standard home page with the correct title

#### Any background context you want to provide?
I was caught in migration hell yesterday trying to fix wagtail-related migrations. The point of this fix wasn't to make the two migrations perfectly reversible; the point was to get wagtail to stop complaining when rolling back those two migrations and to make the forward migrations idempotent
