### PR TITLE
Add no-sequences eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,6 +52,7 @@
     "mocha/no-top-level-hooks": [2],
     "mocha/no-identical-title": [2],
     "mocha/no-nested-tests": [2],
+    "no-sequences": [2],
   },
   "env": {
     "es6": true,

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -679,7 +679,7 @@ describe('DashboardPage', () => {
       let checkoutStub = helper.sandbox.stub(storeActions, 'checkout').returns(() => promise);
 
       program.financial_aid_availability = false;
-      program.description = "Not passed program",
+      program.description = "Not passed program";
       program.courses[0].runs = [{
         ...program.courses[0].runs[0],
         course_start_date: "2016-09-22T11:48:27Z",

--- a/static/js/entry/zendesk_widget.js
+++ b/static/js/entry/zendesk_widget.js
@@ -5,6 +5,7 @@ import R from 'ramda';
 import { wait } from '../util/util';
 
 // Start of odl Zendesk Widget script
+/* eslint-disable no-sequences */
 /*<![CDATA[*/
 window.zEmbed || function (e, t) {
   let n, o, d, i, s, a = [],
@@ -31,7 +32,7 @@ window.zEmbed || function (e, t) {
     o.close();
 }("https://assets.zendesk.com/embeddable_framework/main.js", "odl.zendesk.com");
  /*]]>*/
-
+/* eslint-enable no-sequences */
 
 // This will execute when Zendesk's Javascript is finished executing, and the
 // Web Widget API is available to be used. Zendesk's various iframes may *not*


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Adds an eslint rule forbidding statements like `a = 3, b = 4`. Comma expressions within `let` are still allowed.

#### How should this be manually tested?
N/A
