### PR TITLE
Added factories to produce social auth for Users

### DIFF
--- a/grades/api_test.py
+++ b/grades/api_test.py
@@ -7,7 +7,6 @@ from unittest.mock import patch, MagicMock
 import ddt
 from django.core.exceptions import ImproperlyConfigured
 
-from backends.edxorg import EdxOrgOAuth2
 from courses.factories import CourseRunFactory
 from dashboard.api_edx_cache import CachedEdxUserData, UserCachedRunData
 from dashboard.factories import (
@@ -23,7 +22,7 @@ from financialaid.factories import (
 from grades import api
 from grades.exceptions import FreezeGradeFailedException
 from grades.models import FinalGrade, FinalGradeStatus
-from micromasters.factories import UserFactory
+from micromasters.factories import SocialUserFactory, UserFactory
 from micromasters.utils import now_in_utc
 from search.base import MockedESTestCase
 
@@ -39,12 +38,7 @@ class GradeAPITests(MockedESTestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.user = UserFactory.create()
-        cls.user.social_auth.create(
-            provider=EdxOrgOAuth2.name,
-            uid="{}_edx".format(cls.user.username),
-            extra_data={"access_token": "fooooootoken"}
-        )
+        cls.user = SocialUserFactory.create()
 
         cls.run_fa = CourseRunFactory.create(
             freeze_grade_date=now_in_utc()-timedelta(days=1),

--- a/micromasters/factories.py
+++ b/micromasters/factories.py
@@ -2,9 +2,40 @@
 Factory for Users
 """
 from django.contrib.auth.models import User
-from factory import Sequence
+from factory import (
+    Sequence,
+    SubFactory,
+    LazyAttribute,
+)
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
+from social_django.models import UserSocialAuth
+from backends.edxorg import EdxOrgOAuth2
+from micromasters.utils import pop_matching_keys_from_dict
+
+
+def extract_related_model_kwargs(orig_kwargs, related_model_prop_name):
+    """
+    Extracts a set of factory kwargs that refer to a related model, removes the model prefix from the keys,
+    and returns the dictionary.
+    Ex. usage:
+        user_factory_kwargs = dict(username='user_0', social_auth__provider='edx', social_auth__uid='user_0')
+        extract_related_model_kwargs(user_factory_kwargs, 'social_auth')
+        #> dict(provider='edx', uid='user_0')
+
+    Args:
+        orig_kwargs (dict): A dict of kwargs being passed to a factory generation method
+        related_model_prop_name (str): The model name as it should appear in kwargs (e.g.: 'user', 'social_auth')
+
+    Returns:
+        dict: A dict of kwargs related to a specific model (without the model prefix)
+    """
+    related_model_prefix = '{}__'.format(related_model_prop_name)
+    extracted_kwargs = pop_matching_keys_from_dict(
+        orig_kwargs,
+        lambda key: key.startswith(related_model_prefix)
+    )
+    return {k.replace(related_model_prefix, '', 1): v for k, v in extracted_kwargs.items()}
 
 
 class UserFactory(DjangoModelFactory):
@@ -14,3 +45,27 @@ class UserFactory(DjangoModelFactory):
 
     class Meta:
         model = User
+
+
+class UserSocialAuthFactory(DjangoModelFactory):
+    """Factory for UserSocialAuth"""
+    user = SubFactory(UserFactory)
+    provider = EdxOrgOAuth2.name
+    extra_data = {"access_token": "fooooootoken"}
+    uid = LazyAttribute(lambda social_auth: '{}_edx'.format(social_auth.user.username))
+
+    class Meta:
+        model = UserSocialAuth
+
+
+class SocialUserFactory(UserFactory):
+    """Factory for Users which should also have a social_auth object created for them"""
+    @classmethod
+    def create(cls, *args, **kwargs):
+        """
+        Overrides the default .create() method so that a UserSocialAuth records can be created
+        """
+        social_kwargs = extract_related_model_kwargs(kwargs, 'social_auth')
+        created_obj = super().create(*args, **kwargs)
+        UserSocialAuthFactory.create(user=created_obj, **social_kwargs)
+        return created_obj

--- a/micromasters/factories_test.py
+++ b/micromasters/factories_test.py
@@ -1,0 +1,44 @@
+"""Tests for top level micromasters factory functionality"""
+
+from micromasters.factories import extract_related_model_kwargs
+
+
+def test_extract_related_model_kwargs():
+    """Tests that extract_related_model_kwargs produces the right result and side effect"""
+    factory_kwargs = dict(
+        username='joe',
+        email='a@b.com',
+        social_auth__provider='edx',
+        social_auth__uid='joe',
+    )
+    related_model_kwargs = extract_related_model_kwargs(factory_kwargs, 'social_auth')
+    assert related_model_kwargs == dict(
+        provider='edx',
+        uid='joe',
+    )
+    assert factory_kwargs == dict(
+        username='joe',
+        email='a@b.com',
+    )
+
+    related_model_kwargs = extract_related_model_kwargs(factory_kwargs, 'non_existent_model_name')
+    assert related_model_kwargs == {}
+    assert factory_kwargs == dict(
+        username='joe',
+        email='a@b.com',
+    )
+
+
+def test_extract_related_model_kwargs_prefix():
+    """Tests that extract_related_model_kwargs only replaces a kwarg prefix"""
+    factory_kwargs = dict(
+        some_param='value',
+        user__username='joe',
+        user__other_user__username='joe'
+    )
+    related_model_kwargs = extract_related_model_kwargs(factory_kwargs, 'user')
+    assert set(related_model_kwargs.keys()) == {
+        'username',
+        'other_user__username'
+    }
+    assert set(factory_kwargs.keys()) == {'some_param'}

--- a/micromasters/utils.py
+++ b/micromasters/utils.py
@@ -48,6 +48,40 @@ def dict_with_keys(dictionary, keys):
     return {key: dictionary[key] for key in keys}
 
 
+def pop_keys_from_dict(dict_to_pop, keys):
+    """
+    Removes a set of keys from a dict and returns a dict of all the removed key-value pairs.
+    Ex. usage:
+        pop_keys_from_dict({'a': 1, 'b': 2, 'c': 3}, ['a', 'c'])
+        #> {'a': 1, 'c': 3}
+
+    Args:
+        dict_to_pop (dict): A dictionary
+        keys (list(str)): List of keys to remove and return
+
+    Returns:
+        dict: The key-value pairs removed from the dict
+    """
+    return {key: dict_to_pop.pop(key) for key in keys if key in dict_to_pop}
+
+
+def pop_matching_keys_from_dict(dict_to_pop, filter_func):
+    """
+    Removes keys from a dict that pass some filter function, and returns a dict of all the removed key-value pairs.
+    Ex. usage:
+        pop_matching_keys_from_dict({'a': 1, 'b': 2, 'c': 3}, lambda k: k in ['a','b'])
+        #> {'a': 1, 'b': 2}
+
+    Args:
+        dict_to_pop (dict): A dictionary
+        filter_func (callable): A filter function that will be applied to each key
+
+    Returns:
+        dict: The key-value pairs removed from the dict
+    """
+    return pop_keys_from_dict(dict_to_pop, filter(filter_func, dict_to_pop.copy()))
+
+
 def load_json_from_file(project_rel_filepath):
     """
     Loads JSON data from a file

--- a/micromasters/utils_test.py
+++ b/micromasters/utils_test.py
@@ -41,6 +41,8 @@ from micromasters.utils import (
     remove_falsey_values,
     safely_remove_file,
     serialize_model_object,
+    pop_keys_from_dict,
+    pop_matching_keys_from_dict,
 )
 from search.base import MockedESTestCase
 
@@ -309,3 +311,28 @@ def test_now_in_utc():
     now = now_in_utc()
     assert is_near_now(now)
     assert now.tzinfo == pytz.UTC
+
+
+def test_pop_keys_from_dict():
+    """pop_keys_from_dict should remove keys from a source dict and return a dict of removed key-values"""
+    orig_dict = dict(a=1, b=2, c=3, d=4)
+    new_dict = pop_keys_from_dict(orig_dict, ['a', 'd'])
+    assert new_dict == dict(a=1, d=4)
+    assert orig_dict == dict(b=2, c=3)
+    new_dict = pop_keys_from_dict(orig_dict, ['non-existent key'])
+    assert new_dict == {}
+    assert orig_dict == dict(b=2, c=3)
+
+
+def test_pop_matching_keys_from_dict():
+    """
+    test_pop_matching_keys_from_dict should remove matching keys from a source dict and return a dict
+    of removed key-values
+    """
+    orig_dict = dict(a=1, b=2, c=3, d=4)
+    new_dict = pop_matching_keys_from_dict(orig_dict, lambda k: k in ['a', 'd'])
+    assert new_dict == dict(a=1, d=4)
+    assert orig_dict == dict(b=2, c=3)
+    new_dict = pop_matching_keys_from_dict(orig_dict, lambda k: k == 'non-existent key')
+    assert new_dict == {}
+    assert orig_dict == dict(b=2, c=3)

--- a/profiles/factories.py
+++ b/profiles/factories.py
@@ -22,7 +22,7 @@ from factory.fuzzy import (
     FuzzyText,
 )
 import faker
-from micromasters.factories import UserFactory
+from micromasters.factories import UserFactory, SocialUserFactory
 from profiles.models import Employment, Profile, Education
 
 
@@ -115,6 +115,19 @@ class ProfileFactory(DjangoModelFactory):
         """
         with mute_signals(post_save):
             return super().create_batch(*args, **kwargs)
+
+
+class SocialProfileFactory(ProfileFactory):
+    """Factory for Profiles which should also have a social_auth object created for them"""
+    user = SubFactory(SocialUserFactory)
+
+    @classmethod
+    def create(cls, *args, **kwargs):
+        """
+        Overrides the default .create() method to turn off save signals
+        """
+        with mute_signals(post_save):
+            return super().create(*args, **kwargs)
 
 
 class EmploymentFactory(DjangoModelFactory):

--- a/profiles/permissions_test.py
+++ b/profiles/permissions_test.py
@@ -5,12 +5,13 @@ from unittest.mock import Mock
 from django.http import Http404
 from django.db.models.signals import post_save
 from factory.django import mute_signals
+import ddt
 
-from backends.edxorg import EdxOrgOAuth2
 from courses.factories import ProgramFactory
 from dashboard.models import ProgramEnrollment
 from micromasters.factories import UserFactory
-from profiles.factories import ProfileFactory
+from profiles.api import get_social_auth
+from profiles.factories import ProfileFactory, SocialProfileFactory
 from profiles.models import Profile
 from profiles.permissions import (
     CanEditIfOwner,
@@ -65,6 +66,7 @@ class CanEditIfOwnerTests(MockedESTestCase):
             assert not perm.has_object_permission(request, None, profile)
 
 
+@ddt.ddt
 class CanSeeIfNotPrivateTests(MockedESTestCase):
     """
     Tests for CanSeeIfNotPrivate permissions
@@ -72,253 +74,150 @@ class CanSeeIfNotPrivateTests(MockedESTestCase):
 
     def setUp(self):
         super(CanSeeIfNotPrivateTests, self).setUp()
-        with mute_signals(post_save):
-            self.other_user = other_user = UserFactory.create()
-            username = "{}_edx".format(other_user.username)
-            social_auth = other_user.social_auth.create(
-                provider=EdxOrgOAuth2.name,
-                uid=username
-            )
-            self.other_user_id = social_auth.uid
-            ProfileFactory.create(user=other_user, verified_micromaster_user=False)
+        self.user = SocialProfileFactory.create(verified_micromaster_user=False).user
+        self.perm = CanSeeIfNotPrivate()
 
-        with mute_signals(post_save):
-            self.profile_user = profile_user = UserFactory.create()
-            username = "{}_edx".format(profile_user.username)
-            social_auth = profile_user.social_auth.create(
-                provider=EdxOrgOAuth2.name,
-                uid=username
-            )
-            self.profile_user_id = social_auth.uid
+    def get_social_auth_uid(self, user):
+        """Helper method to get social_auth uid for a user"""
+        return get_social_auth(user).uid
 
     def test_cant_view_if_privacy_is_private(self):
         """
         Users are not supposed to view private profiles.
         """
-        perm = CanSeeIfNotPrivate()
+        new_profile = SocialProfileFactory.create(account_privacy=Profile.PRIVATE)
 
-        with mute_signals(post_save):
-            ProfileFactory.create(user=self.profile_user, account_privacy=Profile.PRIVATE)
-
-        request = Mock(user=self.other_user)
-        view = Mock(kwargs={'user': self.profile_user_id})
+        request = Mock(user=self.user)
+        view = Mock(kwargs={'user': self.get_social_auth_uid(new_profile.user)})
 
         with self.assertRaises(Http404):
-            perm.has_permission(request, view)
+            self.perm.has_permission(request, view)
 
-    def test_cant_view_public_to_mm_if_anonymous_user(self):
+    @ddt.data(Profile.PUBLIC_TO_MM, Profile.PRIVATE)
+    def test_cant_view_if_anonymous_user(self, account_privacy_setting):
         """
         Anonymous are not supposed to view public_to_mm or private profiles.
         """
-        perm = CanSeeIfNotPrivate()
-        with mute_signals(post_save):
-            ProfileFactory.create(user=self.profile_user, account_privacy=Profile.PUBLIC_TO_MM)
+        new_profile = SocialProfileFactory.create(account_privacy=account_privacy_setting)
 
         request = Mock(user=Mock(is_anonymous=Mock(return_value=True)))
-        view = Mock(kwargs={'user': self.profile_user_id})
+        view = Mock(kwargs={'user': self.get_social_auth_uid(new_profile.user)})
 
         with self.assertRaises(Http404):
-            perm.has_permission(request, view)
+            self.perm.has_permission(request, view)
 
-    def test_cant_view_private_mm_if_anonymous_user(self):
+    def test_can_view_public_if_anonymous_user(self):
         """
-        Anonymous are not supposed to view private profiles.
+        Anonymous can view public profiles.
         """
-        perm = CanSeeIfNotPrivate()
-        with mute_signals(post_save):
-            ProfileFactory.create(user=self.profile_user, account_privacy=Profile.PRIVATE)
+        new_profile = SocialProfileFactory.create(account_privacy=Profile.PUBLIC)
 
         request = Mock(user=Mock(is_anonymous=Mock(return_value=True)))
-        view = Mock(kwargs={'user': self.profile_user_id})
+        view = Mock(kwargs={'user': self.get_social_auth_uid(new_profile.user)})
 
-        with self.assertRaises(Http404):
-            perm.has_permission(request, view)
-
-    def test_cant_view_public_if_anonymous_user(self):
-        """
-        Anonymous are not supposed to view private profiles.
-        """
-        perm = CanSeeIfNotPrivate()
-        with mute_signals(post_save):
-            ProfileFactory.create(user=self.profile_user, account_privacy=Profile.PUBLIC)
-
-        request = Mock(user=Mock(is_anonymous=Mock(return_value=True)))
-        view = Mock(kwargs={'user': self.profile_user_id})
-
-        assert perm.has_permission(request, view) is True
+        assert self.perm.has_permission(request, view) is True
 
     def test_cant_view_if_non_verified_mm_user(self):
         """
         Non verified micromaster users are not supposed to view public_to_mm profiles.
         """
-        perm = CanSeeIfNotPrivate()
-        with mute_signals(post_save):
-            ProfileFactory.create(user=self.profile_user, account_privacy=Profile.PUBLIC_TO_MM)
+        new_profile = SocialProfileFactory.create(account_privacy=Profile.PUBLIC_TO_MM)
 
-        request = Mock(user=self.other_user)
-        view = Mock(kwargs={'user': self.profile_user_id})
+        request = Mock(user=self.user)
+        view = Mock(kwargs={'user': self.get_social_auth_uid(new_profile.user)})
 
         with self.assertRaises(Http404):
-            perm.has_permission(request, view)
+            self.perm.has_permission(request, view)
 
     def test_cant_view_if_privacy_weird(self):
         """
         Users can not open profiles with ambiguous account_privacy settings.
         """
-        perm = CanSeeIfNotPrivate()
-        with mute_signals(post_save):
-            ProfileFactory.create(user=self.profile_user, account_privacy='weird_setting')
+        new_profile = SocialProfileFactory.create(account_privacy='weird_setting')
 
-        request = Mock(user=self.other_user)
-        view = Mock(kwargs={'user': self.profile_user_id})
+        request = Mock(user=self.user)
+        view = Mock(kwargs={'user': self.get_social_auth_uid(new_profile.user)})
 
         with self.assertRaises(Http404):
-            perm.has_permission(request, view)
+            self.perm.has_permission(request, view)
 
     def test_can_view_own_profile(self):
         """
         Users are allowed to view their own profile.
         """
-        perm = CanSeeIfNotPrivate()
-        request = Mock(user=self.other_user)
-        view = Mock(kwargs={'user': self.other_user_id})
+        request = Mock(user=self.user)
+        view = Mock(kwargs={'user': self.get_social_auth_uid(self.user)})
 
-        assert perm.has_permission(request, view) is True
+        assert self.perm.has_permission(request, view) is True
 
     def test_users_can_view_public_profile(self):
         """
         Users are allowed to view public profile.
         """
-        perm = CanSeeIfNotPrivate()
-        with mute_signals(post_save):
-            ProfileFactory.create(user=self.profile_user, account_privacy=Profile.PUBLIC)
+        new_profile = SocialProfileFactory.create(account_privacy=Profile.PUBLIC)
 
-        request = Mock(user=self.other_user)
-        view = Mock(kwargs={'user': self.profile_user_id})
-        assert perm.has_permission(request, view) is True
+        request = Mock(user=self.user)
+        view = Mock(kwargs={'user': self.get_social_auth_uid(new_profile.user)})
+        assert self.perm.has_permission(request, view) is True
 
     def test_can_view_if_verified_mm_user(self):
         """
         Verified MM users are allowed to view public_to_mm profile.
         """
-        perm = CanSeeIfNotPrivate()
-        with mute_signals(post_save):
-            ProfileFactory.create(user=self.profile_user, account_privacy=Profile.PUBLIC_TO_MM)
-            program = ProgramFactory.create()
-            ProgramEnrollment.objects.create(
-                program=program,
-                user=self.profile_user,
-            )
-
-        with mute_signals(post_save):
-            user = UserFactory.create()
-            username = "{}_edx".format(user.username)
-            user.social_auth.create(
-                provider=EdxOrgOAuth2.name,
-                uid=username
-            )
-            ProfileFactory.create(user=user, verified_micromaster_user=True)
+        new_user = SocialProfileFactory.create(account_privacy=Profile.PUBLIC_TO_MM).user
+        verified_user = SocialProfileFactory.create(verified_micromaster_user=True).user
+        program = ProgramFactory.create()
+        for user in [new_user, verified_user]:
             ProgramEnrollment.objects.create(
                 program=program,
                 user=user,
             )
 
-        request = Mock(user=user)
-        view = Mock(kwargs={'user': self.profile_user_id})
-        assert perm.has_permission(request, view) is True
+        request = Mock(user=verified_user)
+        view = Mock(kwargs={'user': self.get_social_auth_uid(new_user)})
+        assert self.perm.has_permission(request, view) is True
 
     def test_view_public_to_mm_when_no_common_programs(self):
         """
         Users are not allowed to view public_to_mm profile if there are no common programs.
         """
-        perm = CanSeeIfNotPrivate()
-        with mute_signals(post_save):
-            ProfileFactory.create(user=self.profile_user, account_privacy=Profile.PUBLIC_TO_MM)
+        new_user = SocialProfileFactory.create(account_privacy=Profile.PUBLIC_TO_MM).user
+        verified_user = SocialProfileFactory.create(verified_micromaster_user=True).user
 
-        with mute_signals(post_save):
-            user = UserFactory.create()
-            username = "{}_edx".format(user.username)
-            user.social_auth.create(
-                provider=EdxOrgOAuth2.name,
-                uid=username
-            )
-            ProfileFactory.create(user=user, verified_micromaster_user=True)
-
-        request = Mock(user=user)
-        view = Mock(kwargs={'user': self.profile_user_id})
+        request = Mock(user=verified_user)
+        view = Mock(kwargs={'user': self.get_social_auth_uid(new_user)})
         with self.assertRaises(Http404):
-            perm.has_permission(request, view)
+            self.perm.has_permission(request, view)
 
-    def test_staff_can_see_profile(self):
+    @ddt.data(Staff.ROLE_ID, Instructor.ROLE_ID)
+    def test_roles_can_see_profile(self, role_to_set):
         """
-        Staff can see private profile of user with same program
+        Staff and Instructors can see private profile of user with same program
         """
-        # Create a private profile for profile user
-        ProfileFactory.create(
-            user=self.profile_user,
+        # Create a private profile
+        new_user = SocialProfileFactory.create(
             verified_micromaster_user=False,
             account_privacy=Profile.PRIVATE,
-        )
-
-        # Assign profile user to a program
+        ).user
         program = ProgramFactory.create()
         ProgramEnrollment.objects.create(
             program=program,
-            user=self.profile_user,
+            user=new_user,
         )
 
-        # Make self.other_user a staff of that program
+        # Make self.unverified_user a staff of that program
         role = Role.objects.create(
-            user=self.other_user,
+            user=self.user,
             program=program,
-            role=Staff.ROLE_ID,
+            role=role_to_set,
         )
+        request = Mock(user=self.user)
+        view = Mock(kwargs={'user': self.get_social_auth_uid(new_user)})
 
-        perm = CanSeeIfNotPrivate()
-        request = Mock(user=self.other_user)
-        view = Mock(kwargs={'user': self.profile_user_id})
-
-        assert perm.has_permission(request, view) is True
+        assert self.perm.has_permission(request, view) is True
 
         # Change role.program and assert that user no longer has permission to see private profile
         role.program = ProgramFactory.create()
         role.save()
         with self.assertRaises(Http404):
-            perm.has_permission(request, view)
-
-    def test_instructor_can_see_profile(self):
-        """
-        Instructors can see private profile of user with same program
-        """
-        # Create a private profile for profile user
-        ProfileFactory.create(
-            user=self.profile_user,
-            verified_micromaster_user=False,
-            account_privacy=Profile.PRIVATE,
-        )
-
-        # Assign profile user to a program
-        program = ProgramFactory.create()
-        ProgramEnrollment.objects.create(
-            program=program,
-            user=self.profile_user,
-        )
-
-        # Make self.other_user an instructor of that program
-        role = Role.objects.create(
-            user=self.other_user,
-            program=program,
-            role=Instructor.ROLE_ID,
-        )
-
-        perm = CanSeeIfNotPrivate()
-        request = Mock(user=self.other_user)
-        view = Mock(kwargs={'user': self.profile_user_id})
-
-        assert perm.has_permission(request, view) is True
-
-        # Change role.program and assert that user no longer has permission to see private profile
-        role.program = ProgramFactory.create()
-        role.save()
-        with self.assertRaises(Http404):
-            perm.has_permission(request, view)
+            self.perm.has_permission(request, view)

--- a/profiles/util_test.py
+++ b/profiles/util_test.py
@@ -5,16 +5,13 @@ from io import BytesIO
 from unittest import TestCase
 from unittest.mock import patch
 
-from django.db.models.signals import post_save
 from django.test import TestCase as DjangoTestCase
-from factory.django import mute_signals
 
 from factory.fuzzy import FuzzyInteger
 from PIL import Image
 
-from backends.edxorg import EdxOrgOAuth2
 from profiles import util
-from profiles.factories import ProfileFactory
+from profiles.factories import SocialProfileFactory
 
 
 class SplitNameTests(TestCase):
@@ -149,18 +146,6 @@ class FullNameTests(DjangoTestCase):
     """
     Tests for profile full name function.
     """
-    def create_profile(self, **kwargs):
-        """
-        Create a profile and social auth
-        """
-        with mute_signals(post_save):
-            profile = ProfileFactory.create(**kwargs)
-            profile.user.social_auth.create(
-                provider=EdxOrgOAuth2.name,
-                uid="{}_edx".format(profile.user.username)
-            )
-            return profile
-
     def test_full_name_no_profile(self):
         """
         test full name of user when no profile.
@@ -173,7 +158,7 @@ class FullNameTests(DjangoTestCase):
         """
         first = "Tester"
         last = "KK"
-        profile = self.create_profile(first_name=first, last_name=last)
+        profile = SocialProfileFactory.create(first_name=first, last_name=last)
         assert util.full_name(profile.user) == "{} {}".format(first, last)
 
     def test_full_name_when_last_name_empty(self):
@@ -182,7 +167,7 @@ class FullNameTests(DjangoTestCase):
         """
         first = "Tester"
         last = ""
-        profile = self.create_profile(first_name=first, last_name=last)
+        profile = SocialProfileFactory.create(first_name=first, last_name=last)
         assert util.full_name(profile.user) == "{name} ".format(name=first)
 
     def test_full_name_when_first_name_empty(self):
@@ -191,5 +176,5 @@ class FullNameTests(DjangoTestCase):
         """
         first = ""
         last = "Tester"
-        profile = self.create_profile(first_name=first, last_name=last)
+        profile = SocialProfileFactory.create(first_name=first, last_name=last)
         assert util.full_name(profile.user) == "{} {}".format(profile.user.username, last)

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -17,7 +17,6 @@ from rolepermissions.shortcuts import available_perm_status
 from wagtail.wagtailimages.models import Image
 from wagtail.wagtailimages.tests.utils import get_test_image_file
 
-from backends.edxorg import EdxOrgOAuth2
 from cms.factories import (
     FacultyFactory,
     InfoLinksFactory,
@@ -28,8 +27,9 @@ from cms.models import HomePage, ProgramPage
 from cms.serializers import ProgramPageSerializer
 from courses.factories import ProgramFactory, CourseFactory
 from micromasters.serializers import serialize_maybe_user
+from micromasters.factories import UserSocialAuthFactory
 from profiles.api import get_social_username
-from profiles.factories import ProfileFactory
+from profiles.factories import ProfileFactory, SocialProfileFactory
 from roles.models import Role
 from search.base import MockedESTestCase
 from ui.url_utils import DASHBOARD_URL, TERMS_OF_SERVICE_URL
@@ -43,18 +43,11 @@ class ViewsTests(MockedESTestCase):
         """
         Create and login a user
         """
-        with mute_signals(post_save):
-            profile = ProfileFactory.create(
-                agreed_to_terms_of_service=True,
-                filled_out=True,
-            )
-        profile.user.social_auth.create(
-            provider='not_edx',
+        profile = SocialProfileFactory.create(
+            agreed_to_terms_of_service=True,
+            filled_out=True,
         )
-        profile.user.social_auth.create(
-            provider=EdxOrgOAuth2.name,
-            uid="{}_edx".format(profile.user.username),
-        )
+        UserSocialAuthFactory.create(user=profile.user, provider='not_edx')
         self.client.force_login(profile.user)
         return profile
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #3166 

#### What's this PR do?
Adds factories to produce social auth for Users, and changes a lot of test cases to use those factories

#### How should this be manually tested?
No manual testing needed

#### Where should the reviewer start?
`micromasters/factories.py` and `profiles/factories.py`

#### Any background context you want to provide?
- Here's some example usage for the new factories:
    ```python
    # Create a user with a social auth provider 'abc'
    SocialUserFactory.create(username='user_0', social_auth__provider='abc')
    # Same as above, but create a Profile instead of a User
    SocialProfileFactory.create(first_name='Joe', user__username='user_0', user__social_auth__provider='abc')
    ```
- There are a bunch of other test cases that manually add social_auth records on their own, but this PR has enough lines as it is
