### PR TITLE
Fixed issue when a user have more the one social auth objects

### DIFF
--- a/dashboard/api_edx_cache.py
+++ b/dashboard/api_edx_cache.py
@@ -12,7 +12,6 @@ from requests.exceptions import HTTPError
 
 from backends import utils
 from backends.exceptions import InvalidCredentialStored
-from backends.edxorg import EdxOrgOAuth2
 from courses.models import CourseRun
 from dashboard import models
 from micromasters.utils import now_in_utc

--- a/dashboard/api_edx_cache.py
+++ b/dashboard/api_edx_cache.py
@@ -16,7 +16,7 @@ from backends.edxorg import EdxOrgOAuth2
 from courses.models import CourseRun
 from dashboard import models
 from micromasters.utils import now_in_utc
-from profiles.api import get_social_username
+from profiles.api import get_social_username, get_social_auth
 from search import tasks
 
 log = logging.getLogger(__name__)
@@ -342,7 +342,7 @@ class CachedEdxDataApi:
             None
         """
         # get the credentials for the current user for edX
-        user_social = user.social_auth.get(provider=EdxOrgOAuth2.name)
+        user_social = get_social_auth(user)
         utils.refresh_user_token(user_social)
         # create an instance of the client to query edX
         edx_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL)

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -14,7 +14,6 @@ from edx_api.client import EdxApi
 from social_django.models import UserSocialAuth
 
 from backends import utils
-from backends.edxorg import EdxOrgOAuth2
 from dashboard.models import UserCacheRefreshTime
 from dashboard.api_edx_cache import CachedEdxDataApi
 from micromasters.celery import app

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -22,6 +22,7 @@ from micromasters.utils import (
     chunks,
     now_in_utc,
 )
+from profiles.api import get_social_auth
 
 
 log = logging.getLogger(__name__)
@@ -97,15 +98,13 @@ def batch_update_user_data_subtasks(students):
             log.exception('edX data refresh task: unable to get user "%s"', user_id)
             continue
 
-        try:
-            UserSocialAuth.objects.get(user=user)
-        except:
+        if not UserSocialAuth.objects.filter(user=user).exists():
             log.exception('user "%s" does not have python social auth object', user.username)
             continue
 
         # get the credentials for the current user for edX
         try:
-            user_social = user.social_auth.get(provider=EdxOrgOAuth2.name)
+            user_social = get_social_auth(user)
         except:
             log.exception('user "%s" does not have edX credentials', user.username)
             continue

--- a/dashboard/tasks_test.py
+++ b/dashboard/tasks_test.py
@@ -85,6 +85,24 @@ class TasksTest(MockedESTestCase):
 
     @mock.patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cache_if_expired', new_callable=mock.MagicMock)
     @mock.patch('backends.utils.refresh_user_token', autospec=True)
+    def test_student_enrollments_called_task_when_multiple_social(self, mocked_refresh, mocked_refresh_cache):
+        """
+        Assert get_student_enrollments is actually called in happy path when user
+        has more the one social auth objects
+        """
+        self.user1.social_auth.create(
+            provider=EdxOrgOAuth2.name,
+            uid="{}_edx1".format(self.user1.username),
+            extra_data=self.social_infos
+        )
+        batch_update_user_data_subtasks.s([self.students[0]]).apply(args=()).get()
+        assert mocked_refresh.call_count == 1
+        for user, cache_type in product([self.user1], CachedEdxDataApi.SUPPORTED_CACHES):
+            mocked_refresh_cache.assert_any_call(user, mock.ANY, cache_type)
+            mocked_refresh.assert_any_call(user.social_auth.filter(provider=EdxOrgOAuth2.name).latest('id'))
+
+    @mock.patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cache_if_expired', new_callable=mock.MagicMock)
+    @mock.patch('backends.utils.refresh_user_token', autospec=True)
     def test_subtask_user_does_not_exist(self, mocked_refresh, mocked_refresh_cache):
         """
         Test if the user has been deleted between the select and the run of the task,

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -23,7 +23,7 @@ from dashboard.permissions import CanReadIfStaffOrSelf
 from dashboard.api import get_user_program_info
 from dashboard.api_edx_cache import CachedEdxDataApi
 from micromasters.exceptions import PossiblyImproperlyConfigured
-from profiles.api import get_social_username
+from profiles.api import get_social_username, get_social_auth
 
 
 log = logging.getLogger(__name__)

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -53,7 +53,7 @@ class UserDashboard(APIView):
         # get the credentials for the current user for edX
         edx_client = None
         if user == request.user:
-            user_social = request.user.social_auth.get(provider=EdxOrgOAuth2.name)
+            user_social = get_social_auth(request.user)
             try:
                 utils.refresh_user_token(user_social)
             except utils.InvalidCredentialStored as exc:
@@ -98,7 +98,7 @@ class UserCourseEnrollment(APIView):
         if course_id is None:
             raise ValidationError('course id missing in the request')
         # get the credentials for the current user for edX
-        user_social = request.user.social_auth.get(provider=EdxOrgOAuth2.name)
+        user_social = get_social_auth(request.user)
         try:
             utils.refresh_user_token(user_social)
         except utils.InvalidCredentialStored as exc:

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -17,7 +17,6 @@ from django.shortcuts import get_object_or_404
 from edx_api.client import EdxApi
 from rest_framework.exceptions import ValidationError
 
-from backends.edxorg import EdxOrgOAuth2
 from courses.models import (
     CourseRun,
     Program,

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -46,7 +46,7 @@ from financialaid.models import (
     TierProgram
 )
 from micromasters.utils import now_in_utc
-from profiles.api import get_social_username
+from profiles.api import get_social_username, get_social_auth
 
 
 ISO_8601_FORMAT = '%Y-%m-%dT%H:%M:%SZ'

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -305,7 +305,7 @@ def enroll_user_on_success(order):
     Returns:
          None
     """
-    user_social = order.user.social_auth.get(provider=EdxOrgOAuth2.name)
+    user_social = get_social_auth(order.user)
     enrollments_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL).enrollments
 
     exceptions = []

--- a/profiles/api.py
+++ b/profiles/api.py
@@ -10,6 +10,14 @@ from backends.edxorg import EdxOrgOAuth2
 log = logging.getLogger(__name__)
 
 
+def get_social_auth(user):
+    """
+    returns social auth object for user
+    Args:
+         user (django.contrib.auth.models.User):  A Django user
+    """
+    return get_social_auth(order.user)
+
 def get_social_username(user):
     """
     Get social auth edX username for a user, or else return None.
@@ -22,7 +30,7 @@ def get_social_username(user):
         return None
 
     try:
-        return user.social_auth.get(provider=EdxOrgOAuth2.name).uid
+        return get_social_auth(order.user).uid
     except ObjectDoesNotExist:
         return None
     except Exception as ex:  # pylint: disable=broad-except

--- a/profiles/api.py
+++ b/profiles/api.py
@@ -16,7 +16,7 @@ def get_social_auth(user):
     Args:
          user (django.contrib.auth.models.User):  A Django user
     """
-    return get_social_auth(order.user)
+    return user.social_auth.filter(provider=EdxOrgOAuth2.name).latest('id')
 
 def get_social_username(user):
     """
@@ -30,7 +30,7 @@ def get_social_username(user):
         return None
 
     try:
-        return get_social_auth(order.user).uid
+        return get_social_auth(user).uid
     except ObjectDoesNotExist:
         return None
     except Exception as ex:  # pylint: disable=broad-except

--- a/profiles/api.py
+++ b/profiles/api.py
@@ -13,10 +13,12 @@ log = logging.getLogger(__name__)
 def get_social_auth(user):
     """
     returns social auth object for user
+
     Args:
          user (django.contrib.auth.models.User):  A Django user
     """
     return user.social_auth.filter(provider=EdxOrgOAuth2.name).latest('id')
+
 
 def get_social_username(user):
     """

--- a/profiles/api_test.py
+++ b/profiles/api_test.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock
 
 from django.db.models.signals import post_save
 from factory.django import mute_signals
-from testfixtures import LogCapture
 
 from backends.edxorg import EdxOrgOAuth2
 from profiles.api import get_social_username
@@ -64,21 +63,12 @@ class SocialTests(MockedESTestCase):
 
     def test_two_social(self):
         """
-        get_social_username should return None if there are two social edX accounts for a user
+        get_social_username should return latest social user name if
+        there are two social edX accounts for a user
         """
-
+        social_username = 'other name'
         self.user.social_auth.create(
             provider=EdxOrgOAuth2.name,
-            uid='other name',
+            uid=social_username,
         )
-
-        with LogCapture() as log_capture:
-            assert get_social_username(self.user) is None
-            log_capture.check(
-                (
-                    'profiles.api',
-                    'ERROR',
-                    'Unexpected error retrieving social auth username: get() returned more than '
-                    'one UserSocialAuth -- it returned 2!'
-                )
-            )
+        assert get_social_username(self.user) == social_username


### PR DESCRIPTION
#### What are the relevant tickets?
fixed https://github.com/mitodl/micromasters/issues/3299

#### What's this PR do?
Allow users to have more the one social auth objects, previously application was throwing error when user have more the one social auth objects

#### How should this be manually tested?
- This PR changes the query on social auth table, Instead of looking for one object it filter out all objects of a user and the picks the latest.
- To test it create a duplicate social object you can create it manually, then see exceptions on console
- previously app was throwing exception when it was running `micromasters/dashboard/tasks.py`
- now it wont throw
- you will see dashboard like this
<img width="983" alt="screen shot 2017-07-25 at 7 00 01 pm" src="https://user-images.githubusercontent.com/10431250/28575844-8da21be4-716b-11e7-861f-2e023be53dc2.png">
- switch to my branch `fix/aq/duplicate_social_auth` and things will be fine.


@pdpinch 
