### PR TITLE
Fix selenium dashboard data expiration

### DIFF
--- a/selenium_tests/data_util.py
+++ b/selenium_tests/data_util.py
@@ -49,7 +49,7 @@ def create_user_for_login(is_staff=True, username=None):
             profile_params['user__username'] = username
         user = ProfileFactory.create(**profile_params).user
 
-    later = now_in_utc() + timedelta(minutes=5)
+    later = now_in_utc() + timedelta(weeks=5000)
     # Create a fake edX social auth to make this user look like they logged in via edX
     user.social_auth.create(
         provider=EdxOrgOAuth2.name,


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
This changes the expiration date for user data to be further into the future. Since the data is not recreated each time the tests run if there's a backup database, the expiration date may pass which causes the tests to fail locally.

#### How should this be manually tested?
Run `./scripts/test/run_selenium_tests_dev.sh`, wait 10 minutes then run it again.
