### PR TITLE
Fix duplicate social auth creation during log in

### DIFF
--- a/backends/urls.py
+++ b/backends/urls.py
@@ -2,12 +2,12 @@
 from django.conf.urls import url
 
 from social_django import views
-from social_django.urls import extra
+from social_django.urls import (
+    app_name,  # pylint: disable=unused-import
+    extra,
+)
 
 from backends.views import complete
-
-
-app_name = 'social'
 
 urlpatterns = [
     # authentication / association

--- a/backends/urls.py
+++ b/backends/urls.py
@@ -9,13 +9,18 @@ from social_django.urls import (
 
 from backends.views import complete
 
+
+# These four endpoints were originally copied from social_django.urls. 'complete' is a modified view which
+# we are substituting to log out the user to workaround social auth creation issues.
 urlpatterns = [
-    # authentication / association
-    url(r'^login/(?P<backend>[^/]+){0}$'.format(extra), views.auth,
-        name='begin'),
     # Override default complete view to force logout before login
     url(r'^complete/(?P<backend>[^/]+)/$', complete,
         name='complete'),
+
+    # These three go to views in social_core
+    # authentication / association
+    url(r'^login/(?P<backend>[^/]+){0}$'.format(extra), views.auth,
+        name='begin'),
     # disconnection
     url(r'^disconnect/(?P<backend>[^/]+){0}$'.format(extra), views.disconnect,
         name='disconnect'),

--- a/backends/urls.py
+++ b/backends/urls.py
@@ -1,0 +1,27 @@
+"""URLs module"""
+from django.conf import settings
+from django.conf.urls import url
+
+from social_core.utils import setting_name
+from social_django import views
+
+from backends.views import complete
+
+
+extra = getattr(settings, setting_name('TRAILING_SLASH'), True) and '/' or ''
+
+app_name = 'social'
+
+urlpatterns = [
+    # authentication / association
+    url(r'^login/(?P<backend>[^/]+){0}$'.format(extra), views.auth,
+        name='begin'),
+    # Override default complete view to force logout before login
+    url(r'^complete/(?P<backend>[^/]+)/$', complete,
+        name='complete'),
+    # disconnection
+    url(r'^disconnect/(?P<backend>[^/]+){0}$'.format(extra), views.disconnect,
+        name='disconnect'),
+    url(r'^disconnect/(?P<backend>[^/]+)/(?P<association_id>[^/]+){0}$'
+        .format(extra), views.disconnect, name='disconnect_individual'),
+]

--- a/backends/urls.py
+++ b/backends/urls.py
@@ -1,14 +1,11 @@
 """URLs module"""
-from django.conf import settings
 from django.conf.urls import url
 
-from social_core.utils import setting_name
 from social_django import views
+from social_django.urls import extra
 
 from backends.views import complete
 
-
-extra = getattr(settings, setting_name('TRAILING_SLASH'), True) and '/' or ''
 
 app_name = 'social'
 

--- a/backends/urls.py
+++ b/backends/urls.py
@@ -2,8 +2,8 @@
 from django.conf.urls import url
 
 from social_django import views
-from social_django.urls import (
-    app_name,  # pylint: disable=unused-import
+from social_django.urls import (  # pylint: disable=unused-import
+    app_name,
     extra,
 )
 

--- a/backends/views.py
+++ b/backends/views.py
@@ -11,10 +11,17 @@ from social_django.utils import psa
 @psa('social:complete')
 def complete(request, *args, **kwargs):
     """Override this method so we can force user to be logged out."""
+    # This view overrides the behavior of the default 'complete' endpoint in order
+    # to log out the user first. If user 1 is already logged in and user 2 is logged in on edX,
+    # social_core can get confused on which User should get the SocialAuth object.
     if request.user.is_authenticated():
         key = "{}_state".format(request.backend.name)
         backend_state = request.session.get(key)
         logout(request)
+        # logout will clear the session, this preserves the backend session state. We need to do
+        # this so that this workflow will validate correctly (EdxOrgOAuth2.validate_state).
+        # key is the same one used in EdxOrgAuth2.get_session_state().
         request.session[key] = backend_state
 
+    # Continue with social_core pipeline
     return social_complete(request, *args, **kwargs)

--- a/backends/views.py
+++ b/backends/views.py
@@ -1,3 +1,4 @@
+"""Views related to social auth"""
 from django.contrib.auth import logout
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt

--- a/backends/views.py
+++ b/backends/views.py
@@ -1,0 +1,19 @@
+from django.contrib.auth import logout
+from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_exempt
+from social_django.views import complete as social_complete
+from social_django.utils import psa
+
+
+@never_cache
+@csrf_exempt
+@psa('social:complete')
+def complete(request, *args, **kwargs):
+    """Override this method so we can force user to be logged out."""
+    if request.user.is_authenticated():
+        key = "{}_state".format(request.backend.name)
+        backend_state = request.session.get(key)
+        logout(request)
+        request.session[key] = backend_state
+
+    return social_complete(request, *args, **kwargs)

--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -3,7 +3,6 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
-from social_django import views as social_views
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls

--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
+from social_django import views as social_views
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
@@ -18,7 +19,7 @@ if settings.DEBUG:
     ]
 
 urlpatterns += [
-    url('', include('social_django.urls', namespace='social')),
+    url(r'', include('backends.urls')),
     url(r'^admin/', include(admin.site.urls)),
     url('', include('courses.urls')),
     url('', include('dashboard.urls')),


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3432 

#### What's this PR do?
Logs out the user in the social auth `complete` view before they log in. The root cause of #3299 was that the new social auth object was created for a new edX account, but it was attached to the currently logged in user even if that user isn't necessarily related to the edX user.

#### How should this be manually tested?
- First, log out in MM and edX.
- Go to edX and create a user with username `social_auth_1` and email `social_auth_1@example.com`. Log in on MM. Don't worry about filling out the profile.
 - Open the browser console and type `SETTINGS.user.username`. You should see `social_auth_1`.
- Log out on edX (but stay logged in on MM). Create a user with username `social_auth_2` and email `social_auth_2@example.com` on edX. On MM go to `/login/edxorg/`. You should see an empty profile.
 - Open the browser console and type `SETTINGS.user.username`. You should see `social_auth_2`.
 - Open the Django shell. Run these commands:

        from django.contrib.auth.models import User
        
        def print_auth(user):
            print(user.username, user.social_auth.values_list('uid, 'provider'))
        
        print_auth(User.objects.get(username='social_auth_1'))
        print_auth(User.objects.get(username='social_auth_2'))

For the last two lines you should see:

    social_auth_1 <QuerySet [('social_auth_1', 'edxorg')]>
    social_auth_2 <QuerySet [('social_auth_2', 'edxorg')]>

- Now, go to edX and log out there (stay logged in on MM). Log in as the first user (`social_auth_1@example.com`). On MM go to `/login/edxorg/`.
- In your browser console type `SETTINGS.user.username`. You should see `social_auth_1`.
- In your Django shell run the last two lines again:

        print_auth(User.objects.get(username='social_auth_1'))
        print_auth(User.objects.get(username='social_auth_2'))

You should have this output (same as before):

    social_auth_1 <QuerySet [('social_auth_1', 'edxorg')]>
    social_auth_2 <QuerySet [('social_auth_2', 'edxorg')]>