### PR TITLE
Raise an exception if there are two social auth objects

### DIFF
--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -97,7 +97,9 @@ def batch_update_user_data_subtasks(students):
             log.exception('edX data refresh task: unable to get user "%s"', user_id)
             continue
 
-        if not UserSocialAuth.objects.filter(user=user).exists():
+        try:
+            UserSocialAuth.objects.get(user=user)
+        except:
             log.exception('user "%s" does not have python social auth object', user.username)
             continue
 

--- a/profiles/api.py
+++ b/profiles/api.py
@@ -12,12 +12,12 @@ log = logging.getLogger(__name__)
 
 def get_social_auth(user):
     """
-    returns social auth object for user
+    Returns social auth object for user
 
     Args:
          user (django.contrib.auth.models.User):  A Django user
     """
-    return user.social_auth.filter(provider=EdxOrgOAuth2.name).latest('id')
+    return user.social_auth.get(provider=EdxOrgOAuth2.name)
 
 
 def get_social_username(user):

--- a/profiles/api_test.py
+++ b/profiles/api_test.py
@@ -3,6 +3,10 @@ Tests for profile functions
 """
 
 from unittest.mock import Mock
+
+from django.core.exceptions import MultipleObjectsReturned
+from testfixtures import LogCapture
+
 from backends.edxorg import EdxOrgOAuth2
 
 from profiles.api import get_social_username, get_social_auth
@@ -53,17 +57,31 @@ class SocialTests(MockedESTestCase):
 
     def test_two_social(self):
         """
-        get_social_username should return latest social user name if
-        there are two social edX accounts for a user
+        get_social_username should return None if there are two social edX accounts for a user
         """
-        new_social_auth = UserSocialAuthFactory.create(user=self.user, uid='other name')
-        assert get_social_username(self.user) == new_social_auth.uid
+        self.user.social_auth.create(
+            provider=EdxOrgOAuth2.name,
+            uid='other name',
+        )
+
+        with LogCapture() as log_capture:
+            assert get_social_username(self.user) is None
+            log_capture.check(
+                (
+                    'profiles.api',
+                    'ERROR',
+                    'Unexpected error retrieving social auth username: get() returned more than '
+                    'one UserSocialAuth -- it returned 2!'
+                )
+            )
 
     def test_get_social_auth(self):
         """
         Tests that get_social_auth returns a user's edX social auth object, and if multiple edX social auth objects
-        exists, it returns the most recently created
+        exists, it raises an exception
         """
         assert get_social_auth(self.user) == self.user.social_auth.get(provider=EdxOrgOAuth2.name)
-        new_social_auth = UserSocialAuthFactory.create(user=self.user, uid='other name')
-        assert get_social_auth(self.user) == new_social_auth
+        UserSocialAuthFactory.create(user=self.user, uid='other name')
+        with self.assertRaises(MultipleObjectsReturned) as ex:
+            get_social_auth(self.user)
+        assert ex.exception.args[0] == 'get() returned more than one UserSocialAuth -- it returned 2!'

--- a/profiles/api_test.py
+++ b/profiles/api_test.py
@@ -59,10 +59,7 @@ class SocialTests(MockedESTestCase):
         """
         get_social_username should return None if there are two social edX accounts for a user
         """
-        self.user.social_auth.create(
-            provider=EdxOrgOAuth2.name,
-            uid='other name',
-        )
+        UserSocialAuthFactory.create(user=self.user, uid='other name')
 
         with LogCapture() as log_capture:
             assert get_social_username(self.user) is None
@@ -82,6 +79,5 @@ class SocialTests(MockedESTestCase):
         """
         assert get_social_auth(self.user) == self.user.social_auth.get(provider=EdxOrgOAuth2.name)
         UserSocialAuthFactory.create(user=self.user, uid='other name')
-        with self.assertRaises(MultipleObjectsReturned) as ex:
+        with self.assertRaises(MultipleObjectsReturned):
             get_social_auth(self.user)
-        assert ex.exception.args[0] == 'get() returned more than one UserSocialAuth -- it returned 2!'


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #3299 

#### What's this PR do?
Changes behavior to raise an exception if there is more than one social auth per user. This should only be merged after #3444 is merged and the existing duplicate social auth accounts are removed.

#### How should this be manually tested?
N/A
