### PR TITLE
Added redux-asserts flow types

### DIFF
--- a/flow-typed/npm/redux-asserts_v0.x.x.js
+++ b/flow-typed/npm/redux-asserts_v0.x.x.js
@@ -1,0 +1,18 @@
+import type { Action, Dispatch, Reducer } from 'redux'
+
+declare module 'redux-asserts' {
+  declare type State = any;
+  declare type StateFunc = ((state: State) => State);
+
+  declare type TestStore = {
+    dispatch: Dispatch,
+    getState: () => State,
+    subscribe: (listener: () => void) => () => void,
+    replaceReducer: (reducer: Reducer<any, any>) => void,
+    createListenForActions: (stateFunc?: StateFunc) => ((actions: Array<string>, () => void) => Promise<State>),
+    createDispatchThen: (stateFunc?: StateFunc) => (
+      (action: Action, expectedActions: Array<string>) => Promise<State>
+    )
+  }
+  declare export default function configureTestStore(reducerFunc?: (state: State) => State): TestStore;
+}

--- a/static/js/store/configureStore.js
+++ b/static/js/store/configureStore.js
@@ -77,10 +77,6 @@ export const configureMainTestStore = (reducer: Reducer<*,*>) => {
   );
 };
 
-export const signupDialogStore = (test: boolean = false) => {
-  if (test) {
-    return configureTestStore({ signupDialog: INITIAL_SIGNUP_STATE });
-  } else {
-    return configureStore({ signupDialog: INITIAL_SIGNUP_STATE });
-  }
+export const signupDialogStore = () => {
+  return configureStore({ signupDialog: INITIAL_SIGNUP_STATE });
 };

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -30,13 +30,9 @@ import rootReducer from '../reducers';
 import DashboardRouter from '../DashboardRouter';
 import { testRoutes } from './test_utils';
 import { configureMainTestStore } from '../store/configureStore';
-import type { Action } from '../flow/reduxTypes';
-import type { TestStore } from '../flow/reduxTypes';
 import type { Sandbox } from '../flow/sinonTypes';
 
 export default class IntegrationTestHelper {
-  listenForActions: (a: Array<string>, f: Function) => Promise<*>;
-  dispatchThen: (a: Action) => Promise<*>;
   sandbox: Sandbox;
   store: TestStore;
   browserHistory: History;


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3451 

#### What's this PR do?
Adds flow types for our `redux-asserts` library. It lets us make sure that the function in `listenForActions` doesn't have anything returned from it, for example

#### How should this be manually tested?
No testing needed
