### PR TITLE
Allow learners to pay for exam attempts

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -438,11 +438,17 @@ def is_exam_schedulable(user, course):
 
 
 def get_future_exam_runs(user, course):
+    """
+    Return a list of first dates when exams can be scheduled
+    """
     exam_runs = ExamRun.get_schedulable_in_future(course)
     exam_authizations_queryset = ExamAuthorization.objects.filter(user=user, exam_run__in=exam_runs)
     return [exam_run.date_first_schedulable for exam_run in exam_runs if exam_authizations_queryset.exists()]
 
 
 def has_to_pay_for_course(mmtrack, course):
+    """
+    Determine if payment is required to for another exam attempt
+    """
     attempt_limit = mmtrack.get_payments_count_for_course(course) * ATTEMPTS_PER_PAID_RUN
     return ExamAuthorization.taken_exams().count() >= attempt_limit

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -439,11 +439,8 @@ def is_exam_schedulable(user, course):
 
 def get_future_exam_runs(user, course):
     exam_runs = ExamRun.get_schedulable_in_future(course)
-    schedulable_exam_runs = []
-    for exam_run in exam_runs:
-        if ExamAuthorization.objects.filter(user=user, exam_run__in=exam_runs).exists():
-            schedulable_exam_runs.append(exam_run.date_first_schedulable)
-    return schedulable_exam_runs
+    exam_authizations_queryset = ExamAuthorization.objects.filter(user=user, exam_run__in=exam_runs)
+    return [exam_run.date_first_schedulable for exam_run in exam_runs if exam_authizations_queryset.exists()]
 
 
 def has_to_pay_for_course(mmtrack, course):

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -447,10 +447,11 @@ def get_future_exam_runs(course):
         course (courses.models.Course): A course
 
     Returns:
-        list of strings: a list of dates when future exams become schedulable
+        list(str): a list of dates when future exams become schedulable
     """
-    exam_runs = ExamRun.get_schedulable_in_future(course).order_by('date_first_schedulable')
-    return [exam_run.date_first_schedulable for exam_run in exam_runs]
+
+    return (ExamRun.get_schedulable_in_future(course).
+            order_by('date_first_schedulable').values_list('date_first_schedulable', flat=True))
 
 
 def has_to_pay_for_exam(mmtrack, course):
@@ -464,4 +465,4 @@ def has_to_pay_for_exam(mmtrack, course):
         bool: if the user has to pay for another exam attempt
     """
     attempt_limit = mmtrack.get_payments_count_for_course(course) * ATTEMPTS_PER_PAID_RUN
-    return ExamAuthorization.objects.filter(user=mmtrack.user, course=course).count() >= attempt_limit
+    return ExamAuthorization.objects.filter(user=mmtrack.user, course=course, exam_taken=True).count() >= attempt_limit

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -17,7 +17,9 @@ from grades import api
 from grades.models import FinalGrade
 from grades.serializers import ProctoredExamGradeSerializer
 from exams.models import ExamAuthorization, ExamRun
-from exams.api import ATTEMPTS_PER_PAID_RUN
+
+# maximum number of exam attempts per payment
+ATTEMPTS_PER_PAID_RUN = 2
 
 log = logging.getLogger(__name__)
 

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -753,7 +753,7 @@ class CourseRunTest(CourseTests):
 
 @ddt.ddt
 @patch('dashboard.api.get_future_exam_runs', return_value=[])
-@patch('dashboard.api.has_to_pay_for_course', return_value=False)
+@patch('dashboard.api.has_to_pay_for_exam', return_value=False)
 class InfoCourseTest(CourseTests):
     """Tests for get_info_for_course"""
 

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -816,11 +816,14 @@ class InfoCourseTest(CourseTests):
             course,
             course_data_from_call,
             can_schedule_exam=False,
+            exams_schedulable_in_future=None,
+            has_to_pay=False,
             has_exam=False,
             proct_exams=None
     ):
         """Helper to format the course info"""
         proct_exams = proct_exams or []
+        exams_schedulable_in_future = exams_schedulable_in_future or []
         expected_data = {
             "id": course.pk,
             "title": course.title,
@@ -829,6 +832,8 @@ class InfoCourseTest(CourseTests):
             "prerequisites": course.prerequisites,
             "has_contact_email": bool(course.contact_email),
             "can_schedule_exam": can_schedule_exam,
+            "exams_schedulable_in_future": exams_schedulable_in_future,
+            "has_to_pay": has_to_pay,
             "proctorate_exams_grades": proct_exams,
             "has_exam": has_exam,
         }
@@ -854,7 +859,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_no_runs(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_no_runs(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """test for get_info_for_course for course with no runs"""
         self.assert_course_equal(
             self.course_noruns,
@@ -865,17 +872,24 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_with_contact_email(self, mock_schedulable, mock_format):  # pylint: disable=no-self-use
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_with_contact_email(
+            self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):  # pylint: disable=no-self-use
         """test that get_info_for_course indicates that a course has a contact_email """
         course = CourseFactory.create(contact_email="abc@example.com")
         course_info = api.get_info_for_course(course, self.mmtrack)
         assert course_info['has_contact_email'] is True
         assert mock_format.called is False
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.is_exam_schedulable')
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
     @ddt.data((True), (False))
-    def test_info_returns_exam_schedulable(self, boolean, mock_schedulable):
+    def test_info_returns_exam_schedulable(self, boolean, mock_future_exams, mock_has_to_pay, mock_schedulable):
         """test that get_info_for_course returns whether the exam is schedulable"""
         course = CourseFactory.create(contact_email=None)
         mock_schedulable.return_value = boolean
@@ -883,7 +897,9 @@ class InfoCourseTest(CourseTests):
         assert course_info['can_schedule_exam'] == boolean
 
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_returns_has_exam(self, mock_schedulable):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_returns_has_exam(self, mock_future_exams, mock_has_to_pay, mock_schedulable):
         """test that get_info_for_course returns whether the course has an exam module or not"""
         course = CourseFactory.create(contact_email=None)
         self.assert_course_equal(
@@ -900,7 +916,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_without_contact_email(self, mock_schedulable, mock_format):  # pylint: disable=no-self-use
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_without_contact_email(self,  mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):  # pylint: disable=no-self-use
         """test that get_info_for_course indicates that a course has no contact_email """
         course = CourseFactory.create(contact_email=None)
         course_info = api.get_info_for_course(course, self.mmtrack)
@@ -910,7 +928,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_not_enrolled_offered(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_not_enrolled_offered(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """test for get_info_for_course for course with with an offered run"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -929,7 +949,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_not_enrolled_but_paid(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_not_enrolled_but_paid(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """test for get_info_for_course for course with with a paid but not enrolled run"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -953,7 +975,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_not_passed_offered(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_not_passed_offered(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """test for get_info_for_course for course with a run not passed and another offered"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -974,7 +998,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_not_enrolled_not_passed_not_offered(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_not_enrolled_not_passed_not_offered(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """test for get_info_for_course for course with run not passed and nothing offered"""
         self.mmtrack.configure_mock(**{'has_passed_course.return_value': False})
         with patch(
@@ -993,7 +1019,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_grade(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_grade(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """test for get_info_for_course for course with a course current and another not passed"""
         self.mmtrack.configure_mock(**{'has_passed_course.return_value': False})
         with patch(
@@ -1012,7 +1040,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_check_but_not_passed(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_check_but_not_passed(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """
         test for get_info_for_course in case a check if the course has been passed is required
         """
@@ -1033,7 +1063,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_missed_deadline(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_missed_deadline(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """
         test for get_info_for_course with a missed upgrade deadline
         """
@@ -1053,7 +1085,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_check_but_not_passed_no_next(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_check_but_not_passed_no_next(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """
         test for get_info_for_course in case a check if the course has been passed
         is required for the course, the course has not been passed and there is no next run
@@ -1075,7 +1109,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_check_passed(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_check_passed(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """
         test for get_info_for_course in case a check if the course has been passed
         is required for the course and the course has been passed
@@ -1101,7 +1137,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_will_attend(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_will_attend(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """test for get_info_for_course for course with enrolled run that will happen in the future"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1118,7 +1156,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_upgrade(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_upgrade(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """test for get_info_for_course for course with a run that needs to be upgraded"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1135,7 +1175,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_upgrade_in_past(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_upgrade_in_past(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """
         test for get_info_for_course for course with a run
         that needs to be upgraded but before a current enrolled one
@@ -1156,7 +1198,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_default_should_not_happen(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_default_should_not_happen(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """
         test for get_info_for_course for course with a run with an
         unexpected state but that can be offered
@@ -1176,7 +1220,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_default_should_not_happen_no_next(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_default_should_not_happen_no_next(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """test for get_info_for_course with no next and weird status"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1193,7 +1239,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_read_cert_for_all_no_next(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_info_read_cert_for_all_no_next(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """
         test for get_info_for_course in case the less recent course is flagged to be checked if passed
         """
@@ -1219,7 +1267,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_course_run_end_date_mixed(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_course_run_end_date_mixed(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """
         Test with a mix of end_date being None and also a valid date
         """
@@ -1259,7 +1309,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_course_with_proctorate_exam(self, mock_schedulable, mock_format):
+    @patch('dashboard.api.get_future_exam_runs', return_value=[])
+    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
+    def test_course_with_proctorate_exam(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
         """
         Test with proctorate exam results
         """

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1588,3 +1588,20 @@ class ExamSchedulableTests(MockedESTestCase):
         exam_auth = ExamAuthorizationFactory.create(exam_run=exam_run, course=exam_run.course)
 
         assert api.is_exam_schedulable(exam_auth.user, exam_auth.course) is (not is_past and not is_future)
+
+
+@ddt.ddt
+class FutureExamRunsTests(MockedESTestCase):
+    """Tests future schedulable exam runs"""
+
+    @ddt.data(
+        (False, True, 1),
+        (True, False, 0),
+        (False, False, 0),
+    )
+    @ddt.unpack
+    def test_get_future_exam_runs(self, is_past, is_future, result):
+        """test get_future_exam_runs"""
+        exam_run = ExamRunFactory.create(scheduling_past=is_past, scheduling_future=is_future)
+
+        assert len(api.get_future_exam_runs(exam_run.course)) == result

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1605,3 +1605,26 @@ class FutureExamRunsTests(MockedESTestCase):
         exam_run = ExamRunFactory.create(scheduling_past=is_past, scheduling_future=is_future)
 
         assert len(api.get_future_exam_runs(exam_run.course)) == result
+
+
+@ddt.ddt
+class ExamAttemptsTests(CourseTests):
+    """Tests exam attempts for user"""
+
+    def setUp(self):
+        super().setUp()
+        self.mmtrack.user = self.user
+
+    @ddt.data(
+        (1, 1, False),
+        (2, 1, True),
+        (3, 1, True),
+        (3, 2, False),
+    )
+    @ddt.unpack
+    def test_has_to_pay(self, num_of_taken_exams, num_of_payments, result):
+        """Test has_to_pay_for_exam"""
+        self.mmtrack.get_payments_count_for_course.return_value = num_of_payments
+        for _ in range(num_of_taken_exams):
+            ExamAuthorizationFactory.create(user=self.user, course=self.course, exam_taken=True)
+        assert api.has_to_pay_for_exam(self.mmtrack, self.course) is result

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -752,6 +752,8 @@ class CourseRunTest(CourseTests):
 
 
 @ddt.ddt
+@patch('dashboard.api.get_future_exam_runs', return_value=[])
+@patch('dashboard.api.has_to_pay_for_course', return_value=False)
 class InfoCourseTest(CourseTests):
     """Tests for get_info_for_course"""
 
@@ -859,9 +861,7 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_no_runs(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_no_runs(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with no runs"""
         self.assert_course_equal(
             self.course_noruns,
@@ -869,13 +869,13 @@ class InfoCourseTest(CourseTests):
         )
         assert mock_format.called is False
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
     def test_info_with_contact_email(
-            self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):  # pylint: disable=no-self-use
+            self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):  # pylint: disable=no-self-use
         """test that get_info_for_course indicates that a course has a contact_email """
         course = CourseFactory.create(contact_email="abc@example.com")
         course_info = api.get_info_for_course(course, self.mmtrack)
@@ -886,20 +886,18 @@ class InfoCourseTest(CourseTests):
         assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.is_exam_schedulable')
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
     @ddt.data((True), (False))
-    def test_info_returns_exam_schedulable(self, boolean, mock_future_exams, mock_has_to_pay, mock_schedulable):
+    def test_info_returns_exam_schedulable(self, boolean, mock_schedulable, mock_future_exams, mock_has_to_pay):
         """test that get_info_for_course returns whether the exam is schedulable"""
         course = CourseFactory.create(contact_email=None)
         mock_schedulable.return_value = boolean
         course_info = api.get_info_for_course(course, self.mmtrack)
         assert course_info['can_schedule_exam'] == boolean
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_returns_has_exam(self, mock_future_exams, mock_has_to_pay, mock_schedulable):
+    def test_info_returns_has_exam(self, mock_schedulable, mock_future_exams, mock_has_to_pay):
         """test that get_info_for_course returns whether the course has an exam module or not"""
         course = CourseFactory.create(contact_email=None)
         self.assert_course_equal(
@@ -913,24 +911,25 @@ class InfoCourseTest(CourseTests):
             has_exam=True
         )
         assert mock_schedulable.call_count == 2
+        assert mock_has_to_pay.call_count == 2
+        assert mock_future_exams.call_count == 2
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_without_contact_email(self,  mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):  # pylint: disable=no-self-use
+    def test_info_without_contact_email(
+            self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):  # pylint: disable=no-self-use
         """test that get_info_for_course indicates that a course has no contact_email """
         course = CourseFactory.create(contact_email=None)
         course_info = api.get_info_for_course(course, self.mmtrack)
         assert course_info['has_contact_email'] is False
         assert mock_format.called is False
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_not_enrolled_offered(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_not_enrolled_offered(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with with an offered run"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -946,12 +945,12 @@ class InfoCourseTest(CourseTests):
             )
         mock_format.assert_called_once_with(self.course_run, api.CourseStatus.OFFERED, self.mmtrack, position=1)
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_not_enrolled_but_paid(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_not_enrolled_but_paid(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with with a paid but not enrolled run"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -972,12 +971,12 @@ class InfoCourseTest(CourseTests):
             position=1
         )
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_not_passed_offered(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_not_passed_offered(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with a run not passed and another offered"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -995,12 +994,13 @@ class InfoCourseTest(CourseTests):
         # one for the course that is current run
         mock_format.assert_any_call(self.course_run, api.CourseStatus.OFFERED, self.mmtrack, position=2)
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_not_enrolled_not_passed_not_offered(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_not_enrolled_not_passed_not_offered(
+            self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with run not passed and nothing offered"""
         self.mmtrack.configure_mock(**{'has_passed_course.return_value': False})
         with patch(
@@ -1016,12 +1016,12 @@ class InfoCourseTest(CourseTests):
         mock_format.assert_any_call(self.course_run, api.CourseStatus.NOT_PASSED, self.mmtrack, position=1)
         mock_format.assert_any_call(self.course_run_ver, api.CourseStatus.NOT_PASSED, self.mmtrack, position=2)
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_grade(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_grade(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with a course current and another not passed"""
         self.mmtrack.configure_mock(**{'has_passed_course.return_value': False})
         with patch(
@@ -1037,12 +1037,12 @@ class InfoCourseTest(CourseTests):
         mock_format.assert_any_call(self.course_run, api.CourseStatus.CURRENTLY_ENROLLED, self.mmtrack, position=1)
         mock_format.assert_any_call(self.course_run_ver, api.CourseStatus.NOT_PASSED, self.mmtrack, position=2)
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_check_but_not_passed(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_check_but_not_passed(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay,):
         """
         test for get_info_for_course in case a check if the course has been passed is required
         """
@@ -1060,12 +1060,12 @@ class InfoCourseTest(CourseTests):
         mock_format.assert_any_call(self.course_run_ver, api.CourseStatus.NOT_PASSED, self.mmtrack, position=1)
         mock_format.assert_any_call(self.course_run, api.CourseStatus.OFFERED, self.mmtrack, position=2)
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_missed_deadline(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_missed_deadline(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course with a missed upgrade deadline
         """
@@ -1082,12 +1082,13 @@ class InfoCourseTest(CourseTests):
         mock_format.assert_any_call(self.course_run_ver, api.CourseStatus.MISSED_DEADLINE, self.mmtrack, position=1)
         mock_format.assert_any_call(self.course_run, api.CourseStatus.OFFERED, self.mmtrack, position=2)
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_check_but_not_passed_no_next(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_check_but_not_passed_no_next(
+            self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course in case a check if the course has been passed
         is required for the course, the course has not been passed and there is no next run
@@ -1106,12 +1107,12 @@ class InfoCourseTest(CourseTests):
         mock_format.assert_called_once_with(
             self.course_run_past, api.CourseStatus.NOT_PASSED, self.mmtrack, position=1)
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_check_passed(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_check_passed(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course in case a check if the course has been passed
         is required for the course and the course has been passed
@@ -1134,12 +1135,12 @@ class InfoCourseTest(CourseTests):
             position=1
         )
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_will_attend(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_will_attend(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with enrolled run that will happen in the future"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1153,12 +1154,12 @@ class InfoCourseTest(CourseTests):
             )
         mock_format.assert_called_once_with(self.course_run, api.CourseStatus.WILL_ATTEND, self.mmtrack, position=1)
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_upgrade(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_upgrade(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with a run that needs to be upgraded"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1172,12 +1173,12 @@ class InfoCourseTest(CourseTests):
             )
         mock_format.assert_called_once_with(self.course_run, api.CourseStatus.CAN_UPGRADE, self.mmtrack, position=1)
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_upgrade_in_past(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_upgrade_in_past(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course for course with a run
         that needs to be upgraded but before a current enrolled one
@@ -1195,12 +1196,12 @@ class InfoCourseTest(CourseTests):
         mock_format.assert_any_call(self.course_run, api.CourseStatus.CURRENTLY_ENROLLED, self.mmtrack, position=1)
         mock_format.assert_any_call(self.course_run_ver, api.CourseStatus.CAN_UPGRADE, self.mmtrack, position=2)
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_default_should_not_happen(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_default_should_not_happen(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course for course with a run with an
         unexpected state but that can be offered
@@ -1217,12 +1218,13 @@ class InfoCourseTest(CourseTests):
             )
         assert mock_format.call_count == 0
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_default_should_not_happen_no_next(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_default_should_not_happen_no_next(
+            self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course with no next and weird status"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1236,12 +1238,12 @@ class InfoCourseTest(CourseTests):
             )
         assert mock_format.call_count == 0
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_info_read_cert_for_all_no_next(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_info_read_cert_for_all_no_next(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course in case the less recent course is flagged to be checked if passed
         """
@@ -1264,12 +1266,12 @@ class InfoCourseTest(CourseTests):
             position=2
         )
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_course_run_end_date_mixed(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_course_run_end_date_mixed(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """
         Test with a mix of end_date being None and also a valid date
         """
@@ -1306,12 +1308,12 @@ class InfoCourseTest(CourseTests):
             )
         mock_format.assert_called_once_with(run1, api.CourseStatus.OFFERED, self.mmtrack, position=1)
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    @patch('dashboard.api.get_future_exam_runs', return_value=[])
-    @patch('dashboard.api.has_to_pay_for_course', return_value=False)
-    def test_course_with_proctorate_exam(self, mock_future_exams, mock_has_to_pay, mock_schedulable, mock_format):
+    def test_course_with_proctorate_exam(self, mock_schedulable, mock_format, mock_future_exams, mock_has_to_pay):
         """
         Test with proctorate exam results
         """
@@ -1327,6 +1329,8 @@ class InfoCourseTest(CourseTests):
         )
         assert mock_format.called is False
         assert mock_schedulable.call_count == 1
+        assert mock_has_to_pay.call_count == 1
+        assert mock_future_exams.call_count == 1
         self.mmtrack.get_course_proctorate_exam_results.assert_called_once_with(self.course_noruns)
 
 

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -219,6 +219,16 @@ class MMTrack:
             order__status=Order.FULFILLED, order__user=self.user, course_key=course_key
         ).values('order_id').distinct().count()
 
+    def get_payments_count_for_course(self, course):
+        """
+        Get the total count of payments for given course
+        Args:
+           course (courses.models.Course): a course
+        Returns:
+            int: count of paid course runs
+        """
+        return sum([self.get_course_paid_count(course_run.edx_course_key) for course_run in course.courserun_set.all()])
+
     def has_paid_for_any_in_program(self):
         """
         Returns true if a user has paid for any course run in the program

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -208,7 +208,7 @@ class MMTrack:
 
     def get_course_paid_count(self, course_key):
         """
-        Gets the count of paid course runs for the course
+        Gets the count of payments for given course run
 
         Args:
             edx_course_key (str): an edX course run key

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -223,11 +223,14 @@ class MMTrack:
         """
         Get the total count of payments for given course
         Args:
-           course (courses.models.Course): a course
+            course (courses.models.Course): a course
         Returns:
             int: count of paid course runs
         """
-        return sum([self.get_course_paid_count(course_run.edx_course_key) for course_run in course.courserun_set.all()])
+        return sum([
+            self.get_course_paid_count(course_run.edx_course_key)
+            for course_run in course.courserun_set.only('edx_course_key')
+        ])
 
     def has_paid_for_any_in_program(self):
         """

--- a/exams/api.py
+++ b/exams/api.py
@@ -13,6 +13,7 @@ from dashboard.models import (
     ProgramEnrollment,
 )
 from dashboard.utils import get_mmtrack
+from dashboard.api import has_to_pay_for_exam
 from exams.exceptions import ExamAuthorizationException
 from exams.models import (
     ExamAuthorization,
@@ -101,9 +102,8 @@ def authorize_for_exam_run(mmtrack, course_run, exam_run):
         )
         raise ExamAuthorizationException(errors_message)
 
-    # if they have run out of attempt, they don't get authorizaed
-    attempt_limit = mmtrack.get_course_paid_count(course_run.edx_course_key) * ATTEMPTS_PER_PAID_RUN
-    if ExamAuthorization.taken_exams().count() >= attempt_limit:
+    # if they have run out of attempts, they don't get authorized
+    if has_to_pay_for_exam(mmtrack, course_run.course):
         errors_message = MESSAGE_NO_ATTEMPTS_TEMPLATE.format(
             user=mmtrack.user.username,
             course_id=course_run.edx_course_key

--- a/exams/api.py
+++ b/exams/api.py
@@ -35,7 +35,6 @@ MESSAGE_NO_ATTEMPTS_TEMPLATE = (
     'course id is "{course_id}". No attempts remaining.'
 )
 
-ATTEMPTS_PER_PAID_RUN = 2
 
 log = logging.getLogger(__name__)
 

--- a/exams/api_test.py
+++ b/exams/api_test.py
@@ -18,6 +18,7 @@ from dashboard.factories import (
     ProgramEnrollmentFactory,
 )
 from dashboard.utils import get_mmtrack
+from dashboard.api import ATTEMPTS_PER_PAID_RUN
 from ecommerce.factories import LineFactory
 from exams.api import (
     authorize_for_exam_run,
@@ -27,7 +28,6 @@ from exams.api import (
     sso_digest,
     MESSAGE_NOT_ELIGIBLE_TEMPLATE,
     MESSAGE_NOT_PASSED_OR_EXIST_TEMPLATE,
-    ATTEMPTS_PER_PAID_RUN,
 )
 from exams.exceptions import ExamAuthorizationException
 from exams.factories import (

--- a/exams/models.py
+++ b/exams/models.py
@@ -41,6 +41,23 @@ class ExamRun(TimestampedModel):
             date_last_schedulable__gte=now,
         )
 
+    @classmethod
+    def get_schedulable_in_future(cls, course):
+        """
+        Get a QuerySet with currently schedulable exam runs
+
+        Args:
+            course (courses.models.Course): the course to find exam runs for
+
+        Returns:
+            django.db.models.query.QuerySet: A Queryset filtered to currently schedulable exam runs
+        """
+        now = now_in_utc()
+        return cls.objects.filter(
+            course=course,
+            date_first_schedulable__gte=now
+        )
+
     def __str__(self):
         return 'Exam run for course "{}" with exam series code "{}"'.format(
             self.course.title,

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -69,6 +69,8 @@ const COURSE: Course = {
   position_in_program: 1,
   runs: [],
   can_schedule_exam: false,
+  exams_schedulable_in_future: [],
+  has_to_pay: false,
   has_exam: false,
   proctorate_exams_grades: [],
 };

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -48,7 +48,7 @@ export const formatMessage = (message: Message, index?: number) => (
   </div>
 );
 
-const formatDate = date => (
+export const formatDate = date => (
   moment(date).format(COURSE_CARD_FORMAT)
 );
 
@@ -143,25 +143,26 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
                 action: courseAction(firstRun, COURSE_ACTION_PAY)
               };
             } else {
-              messageBox['message'] = `You did not pass the exam, but you can try again.
-               Click above to reschedule an exam with Pearson.`;
+              messageBox['message'] = "You did not pass the exam, but you can try again. " +
+                "Click above to reschedule an exam with Pearson.";
             }
           } else if (R.isEmpty(course.exams_schedulable_in_future)) {
             // no info about future exam runs
-            messageBox['message'] = `You did not pass the exam. There are currently no exams
-             available for scheduling. Please check back later.`;
+            messageBox['message'] = "You did not pass the exam. There are currently no exams " +
+             "available for scheduling. Please check back later.";
           } else {
             // can not schedule now, but some time in the future
             if (course.has_to_pay) {
               messageBox = {
-                message: `You did not pass the exam. If you want to re-take the exam, you need
-                 to pay again. You can sign up to re-take the exam starting
-                  on ${formatDate(course.exams_schedulable_in_future[0])}`,
+                message: "You did not pass the exam. If you want to re-take the exam, you need " +
+                "to pay again. You can sign up to re-take the exam starting " +
+                `on ${formatDate(course.exams_schedulable_in_future[0])}`,
                 action: courseAction(firstRun, COURSE_ACTION_PAY)
               };
             } else {
-              messageBox['message'] = `You can sign up to re-take the exam starting
-               on ${formatDate(course.exams_schedulable_in_future[0])}.`;
+              messageBox['message'] = "You did not pass the exam, but you can try again. " +
+                "You can sign up to re-take the exam starting on " +
+                `on ${formatDate(course.exams_schedulable_in_future[0])}.`;
             }
           }
         } else { // no past exam attempts

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -146,7 +146,11 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
               messageBox['message'] = `You did not pass the exam, but you can try again.
                Click above to reschedule an exam with Pearson.`;
             }
-          } else if (course.exams_schedulable_in_future) {
+          } else if (R.isEmpty(course.exams_schedulable_in_future)) {
+            // no info about future exam runs
+            messageBox['message'] = `You did not pass the exam. There are currently no exams
+             available for scheduling. Please check back later.`;
+          } else {
             // can not schedule now, but some time in the future
             if (course.has_to_pay) {
               messageBox = {
@@ -159,9 +163,6 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
               messageBox['message'] = `You can sign up to re-take the exam starting
                on ${formatDate(course.exams_schedulable_in_future[0])}.`;
             }
-          } else {
-            messageBox['message'] = `You did not pass the exam. There are currently no exams
-             available for scheduling. Please check back later.`;
           }
         } else { // no past exam attempts
           messageBox['message'] = "The edX course is complete, but you need to pass the final exam.";

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -136,19 +136,19 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
       if (exams && ! passedExam) {
         let messageBox = {};
         if (failedExam) {
-          messageBox['message'] = "You did not pass the exam, but you can try again. ";
           if (course.can_schedule_exam) { // if can schedule exam now
-            if(course.has_to_pay) {
+            if (course.has_to_pay) {
               messageBox = {
                 message: "You did not pass the exam. If you want to re-take the exam, you need to pay again.",
                 action: courseAction(firstRun, COURSE_ACTION_PAY)
               };
             } else {
-              messageBox['message'] = R.concat(messageBox['message'],"Click above to reschedule an exam with Pearson.");
+              messageBox['message'] = `You did not pass the exam, but you can try again.
+               Click above to reschedule an exam with Pearson.`;
             }
           } else if (course.exams_schedulable_in_future) {
-              // can not schedule now, but some time in the future
-            if(course.has_to_pay) {
+            // can not schedule now, but some time in the future
+            if (course.has_to_pay) {
               messageBox = {
                 message: `You did not pass the exam. If you want to re-take the exam, you need
                  to pay again. You can sign up to re-take the exam starting
@@ -156,10 +156,12 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
                 action: courseAction(firstRun, COURSE_ACTION_PAY)
               };
             } else {
-              messageBox['message'] = `You can sign up to re-take the exam starting on ${formatDate(course.exams_schedulable_in_future[0])}.`;
+              messageBox['message'] = `You can sign up to re-take the exam starting
+               on ${formatDate(course.exams_schedulable_in_future[0])}.`;
             }
           } else {
-            messageBox['message'] =  "You did not pass the exam. There are currently no exams available for scheduling. Please check back later.";
+            messageBox['message'] = `You did not pass the exam. There are currently no exams
+             available for scheduling. Please check back later.`;
           }
         } else { // no past exam attempts
           messageBox['message'] = "The edX course is complete, but you need to pass the final exam.";

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -48,7 +48,7 @@ export const formatMessage = (message: Message, index?: number) => (
   </div>
 );
 
-export const formatDate = date => (
+export const formatDate = (date: ?string) => (
   moment(date).format(COURSE_CARD_FORMAT)
 );
 

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -89,6 +89,8 @@ export const makeCourse = (positionInProgram: number): Course => {
     position_in_program: positionInProgram,
     title: `Title for course ${courseId}`,
     can_schedule_exam: false,
+    exams_schedulable_in_future: [],
+    has_to_pay: false,
     has_exam: false,
     proctorate_exams_grades: [],
   };

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -55,6 +55,8 @@ export type Course = {
   id:                       number,
   position_in_program:      number,
   can_schedule_exam:        boolean,
+  exams_schedulable_in_future: Array<string>,
+  has_to_pay:               boolean,
   proctorate_exams_grades:  Array<ProctoredExamResult>,
   has_exam:                 boolean,
 };

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -49,16 +49,16 @@ export type ProctoredExamResult = {
 };
 
 export type Course = {
-  runs:                     Array<CourseRun>,
-  title:                    string,
-  has_contact_email:        boolean,
-  id:                       number,
-  position_in_program:      number,
-  can_schedule_exam:        boolean,
-  exams_schedulable_in_future: Array<string>,
-  has_to_pay:               boolean,
-  proctorate_exams_grades:  Array<ProctoredExamResult>,
-  has_exam:                 boolean,
+  runs:                         Array<CourseRun>,
+  title:                        string,
+  has_contact_email:            boolean,
+  id:                           number,
+  position_in_program:          number,
+  can_schedule_exam:            boolean,
+  exams_schedulable_in_future:  Array<string>,
+  has_to_pay:                   boolean,
+  proctorate_exams_grades:      Array<ProctoredExamResult>,
+  has_exam:                     boolean,
 };
 
 export type ProgramPageCourse = {

--- a/static/js/lib/grades.js
+++ b/static/js/lib/grades.js
@@ -57,6 +57,11 @@ export const hasPassingExamGrade = R.compose(
   R.propOr([], 'proctorate_exams_grades')
 );
 
+export const hasFailingExamGrade = R.compose(
+  R.any(R.propEq('passed', false)),
+  R.propOr([], 'proctorate_exams_grades')
+);
+
 export const hasPassedCourseRun = R.compose(
   R.any(R.propEq('status', STATUS_PASSED)),
   R.propOr([], 'runs')

--- a/static/js/lib/grades_test.js
+++ b/static/js/lib/grades_test.js
@@ -7,6 +7,7 @@ import {
   getLargestEdXGrade,
   calculateFinalGrade,
   hasPassingExamGrade,
+  hasFailingExamGrade,
   hasPassedCourseRun,
   passedCourse,
 
@@ -108,6 +109,32 @@ describe('Grades library', () => {
       assert.isFalse(hasPassingExamGrade(course));
     });
   });
+
+  describe('hasFailingExamGrade', () => {
+    let course;
+
+    beforeEach(() => {
+      course = {
+        proctorate_exams_grades:  [1,2].map(makeProctoredExamResult)
+      };
+    });
+    it('should return true if the user has any failing exam grades', () => {
+      course.proctorate_exams_grades[0].passed = false;
+      assert.isTrue(hasFailingExamGrade(course));
+    });
+
+    it('should return false otherwise', () => {
+      course.proctorate_exams_grades.forEach(grade => {
+        grade.passed = true;
+      });
+      assert.isFalse(hasFailingExamGrade(course));
+    });
+    it('should return false if no grades', () => {
+      course.proctorate_exams_grades = [];
+      assert.isFalse(hasFailingExamGrade(course));
+    });
+  });
+
 
   describe('hasPassedCourseRun', () => {
     let course;

--- a/static/scss/dashboard/course-status-messages.scss
+++ b/static/scss/dashboard/course-status-messages.scss
@@ -4,7 +4,7 @@
   .status-message {
     background-color: $bg-warm;
     border: 1px solid $dashboard-button-disable;
-    padding: 13px 0 15px 18px;
+    padding: 13px 18px 15px 18px;
     border-radius: 2px;
 
     .dashboard-button {


### PR DESCRIPTION
#### What are the relevant tickets?
Fix  #3441

#### What's this PR do?
Shows a different course status message based on the state of `ExamRun`s and grades for exams.

#### How should this be manually tested?

#### Case 1: Has failed exam attempt, can schedule next one.
login as a learner enrolled in FA program like 'Digital Learning'. Run alter_data command for your user to have passed a course run:
`./manage.py alter_data set_past_run_to_passed --username username --course-title 'Digital Learning 100'`
Then in the django shell set up the exam:
```
from courses.models import *
from django.contrib.auth.models import User
from exams.factories import ExamRunFactory
from exams.models import *

c=Course.objects.filter(title='Digital Learning 100')[0]

exam_run=ExamRunFactory.create(course=c, authorized=True)

user = User.objects.filter(username='username')[0]

au=ExamAuthorizationFactory.create(user=user, course=c, exam_run=exam_run, status= 'success', exam_taken=True)

exam_profile= ExamProfileFactory.create(status='success', profile=user.profile)
```
And the failed grade:
```
from grades.factories import *
from micromasters.utils import now_in_utc
from datetime import timedelta

exam_grade = ProctoredExamGradeFactory.create(user=user, course=c, exam_run=exam_run, passed=False, percentage_grade=0.1)
exam_run.date_grades_available=now_in_utc()-timedelta(days=1)
exam_run.save()

```

<img width="630" alt="screen shot 2017-08-07 at 11 42 02 pm" src="https://user-images.githubusercontent.com/7574259/29055390-4039fa3e-7bca-11e7-8958-f54aca2363a9.png">

#### Case 2: Has failed exam attempt, no current exam runs, has exam run that can be scheduled in the future.
Change the exam run to be schedulable in the future:
```
exam_run.date_first_schedulable=now_in_utc()+timedelta(days=1)
exam_run.save()
```
<img width="652" alt="screen shot 2017-08-07 at 11 47 34 pm" src="https://user-images.githubusercontent.com/7574259/29055522-f4332894-7bca-11e7-9f2b-3aebab4ce202.png">

#### Case 3: No information about current or future exam runs.
```
exam_run.date_last_schedulable=now_in_utc()-timedelta(days=1)
exam_run.save()
```
![screen shot 2017-08-08 at 12 06 33 pm](https://user-images.githubusercontent.com/7574259/29082005-4008f084-7c32-11e7-8908-ef2d02d8767e.png)

### Case 4: One payment and 2 failed exam attempts
Create another failed exam grade
![screen shot 2017-08-08 at 12 30 11 pm](https://user-images.githubusercontent.com/7574259/29083062-7589bbf0-7c35-11e7-9ad5-2426098a1614.png)

#### Case 5: The same as case 4, but can schedule exam only in the future
Change the exam run to be schedulable in the future:
```
exam_run.date_first_schedulable=now_in_utc()+timedelta(days=1)
exam_run.save()
```
![screen shot 2017-08-08 at 12 35 16 pm](https://user-images.githubusercontent.com/7574259/29083284-3a9f982e-7c36-11e7-8bf4-c4a71d45190f.png)

#### Case 6:  no current or future exam runs
```
exam_run.date_last_schedulable=now_in_utc()-timedelta(days=1)
exam_run.date_first_schedulable=now_in_utc()-timedelta(days=3)
exam_run.save()
```
It probably does not make sense to show the disabled 'Pay Now' button, since we do not mention that the user has to pay in the message.
![screen shot 2017-08-08 at 1 45 53 pm](https://user-images.githubusercontent.com/7574259/29086279-0d9a29b6-7c40-11e7-8716-6c1a11aca6d3.png)




