### PR TITLE
Fix occasional null reference error when running snapshot_dashboard_states

### DIFF
--- a/static/js/containers/FinancialAidCalculator.js
+++ b/static/js/containers/FinancialAidCalculator.js
@@ -162,10 +162,15 @@ const FinancialAidCalculator = ({
   saveFinancialAid,
   submitFinancialAid,
   updateCalculatorEdit,
-  currentProgramEnrollment: { title, id },
+  currentProgramEnrollment,
   openConfirmSkipDialog,
   programs,
 }: CalculatorProps) => {
+  if (!currentProgramEnrollment) {
+    return null;
+  }
+  const { title, id } = currentProgramEnrollment;
+
   let program = programs.find(prog => prog.id === id);
   if (!program) {
     return null;


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #3373

#### What's this PR do?
Fixes a null reference error. This usually only visible via selenium since `currentProgramEnrollment` will be set by `localStorage` after the first time the user visits the page.

#### How should this be manually tested?
Run `./scripts/test/snapshot_dashboard_states.sh --learner` and verify that no exception occurs
