### PR TITLE
Move collectstatic into docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,6 @@ COPY . /src
 WORKDIR /src
 RUN chown -R mitodl:mitodl /src
 
-# Gather static
-RUN ./manage.py collectstatic --noinput
 RUN apt-get clean && apt-get purge
 USER mitodl
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
     command: >
       /bin/bash -c '
       sleep 3 &&
+      python3 manage.py collectstatic --noinput &&
       python3 manage.py migrate --no-input &&
       uwsgi uwsgi.ini'
     ports:

--- a/travis-docker-compose.yml
+++ b/travis-docker-compose.yml
@@ -38,7 +38,8 @@ services:
     command: >
       /bin/bash -c '
       sleep 3 &&
-      python3 manage.py migrate &&
+      python3 manage.py collectstatic --noinput &&
+      python3 manage.py migrate --no-input &&
       ./with_host.sh python3 manage.py runserver 0.0.0.0:8079'
     ports:
       - "8079:8079"


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3450 

#### What's this PR do?
Moves collectstatic step to docker-compose, which will allow us to do validation checks in `settings.py`

#### How should this be manually tested?
Clear `staticfiles` locally, restart docker-compose, then go to `/admin/` and verify that the page looks correct.
