### PR TITLE
Remove unused watch link from nginx container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       - "8079:8079"
     links:
       - web
-      - watch
 
   python:
     build: .


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Removes link between nginx and watch containers. At some point the nginx container talked to watch, but this was removed in favor of the browser talking directly to watch.

#### How should this be manually tested?
Site should work
