### PR TITLE
Use MIDDLEWARE instead of MIDDLEWARE_CLASSES

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -118,7 +118,7 @@ if not DISABLE_WEBPACK_LOADER_STATS:
     INSTALLED_APPS += ('webpack_loader',)
 
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -138,7 +138,7 @@ if DEBUG:
     INSTALLED_APPS += (
         'nplusone.ext.django',
     )
-    MIDDLEWARE_CLASSES += (
+    MIDDLEWARE += (
         'nplusone.ext.django.NPlusOneMiddleware',
     )
 
@@ -567,7 +567,7 @@ MIDDLEWARE_FEATURE_FLAG_COOKIE_MAX_AGE_SECONDS = get_int('MIDDLEWARE_FEATURE_FLA
 
 
 if MIDDLEWARE_FEATURE_FLAG_QS_PREFIX:
-    MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + (
+    MIDDLEWARE = MIDDLEWARE + (
         'ui.middleware.QueryStringFeatureFlagMiddleware',
         'ui.middleware.CookieFeatureFlagMiddleware',
     )
@@ -577,9 +577,9 @@ if MIDDLEWARE_FEATURE_FLAG_QS_PREFIX:
 if DEBUG:
     INSTALLED_APPS += ('debug_toolbar', )
     # it needs to be enabled before other middlewares
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE = (
         'debug_toolbar.middleware.DebugToolbarMiddleware',
-    ) + MIDDLEWARE_CLASSES
+    ) + MIDDLEWARE
 
     def show_toolbar(request):
         """

--- a/micromasters/test.py
+++ b/micromasters/test.py
@@ -3,9 +3,10 @@ Test utilities
 """
 from unittest.mock import patch
 import django.test
+from django.utils.deprecation import MiddlewareMixin
 
 
-class FakeSiteMiddleware(object):
+class FakeSiteMiddleware(MiddlewareMixin):
     """
     A mock implementation of `wagtail.wagtailcore.middleware.SiteMiddleware`
     that doesn't make any database calls.
@@ -15,7 +16,7 @@ class FakeSiteMiddleware(object):
         return None
 
 
-class FakeRedirectMiddleware(object):
+class FakeRedirectMiddleware(MiddlewareMixin):
     """
     A mock implementation of `wagtail.wagtailredirects.middleware.RedirectMiddleware`
     that doesn't make any database calls.

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,7 +3,7 @@ codecov
 ddt
 django-debug-toolbar
 ipdb
-nplusone
+nplusone>=0.8.1
 pdbpp
 pip-tools
 pylint==1.7.1


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2565 

#### What's this PR do?
I made a PR to add support for MIDDLEWARE in nplusone. That was merged and all other middleware classes we use are already compatible with MIDDLEWARE.

#### How should this be manually tested?
Run `docker-compose build` to update dependencies. Make sure the site is viewable locally and there are no errors.
