### PR TITLE
Pdpinch/remove price

### DIFF
--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -102,7 +102,7 @@ export default class CourseListCard extends React.Component {
     }
 
     return <p className={priceMessageClassName}>
-      Courses in this program cost <strong>{ formatPrice(price) } USD each.</strong> {" "}
+      To get credit for the courses in this program, you must pay for a verified certificate from edx.org.
       If you want to audit courses for FREE and upgrade later,
       click Enroll then choose the audit option.
     </p>;

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -88,7 +88,7 @@ export default class CourseListCard extends React.Component {
 
   renderPriceMessage(): ?React$Element<*> {
     const { program } = this.props;
-    const { coupon, price } = this.getProgramCouponPrice();
+    const { coupon } = this.getProgramCouponPrice();
 
     // Special case: 100% off coupon
     if (coupon && isFreeCoupon(coupon) && coupon.content_type === COUPON_CONTENT_TYPE_PROGRAM) {

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -111,7 +111,7 @@ describe('CourseListCard', () => {
       assert.lengthOf(messageEl, 1);
       assert.include(
         messageEl.text(),
-        "Courses in this program cost $4000 USD each."
+        "you must pay for a verified certificate from edx.org."
       );
     });
 


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #3481 

#### What's this PR do?

Removes the course price information from the dashboard, for non-FA courses

#### How should this be manually tested?

Take a look at the dashboard for a non-FA program. 

#### Screenshots (if appropriate)

Coming soon
![image](https://user-images.githubusercontent.com/430126/29334834-bec4043c-81d6-11e7-93bb-678c6bf6e43c.png)




