### PR TITLE
Let user pay for a course if auditing

### DIFF
--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -116,14 +116,10 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
 
   // handle other 'in-progress' cases
   if (courseUpcomingOrCurrent(firstRun) || firstRun.status === STATUS_CAN_UPGRADE) {
-    if (hasPaidForAnyCourseRun(course)) {
-      messages.push({message: "You are auditing this course."});
-    } else {
-      messages.push({
-        message: "You are auditing. To get credit, you need to pay for the course.",
-        action: courseAction(firstRun, COURSE_ACTION_PAY)
-      });
-    }
+    messages.push({
+      message: "You are auditing. To get credit, you need to pay for the course.",
+      action: courseAction(firstRun, COURSE_ACTION_PAY)
+    });
     return S.Just(messages);
   }
 

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -138,15 +138,6 @@ describe('Course Status Messages', () => {
       assertIsNothing(calculateMessages(calculateMessagesProps));
     });
 
-    it('should say "auditing" if the user already paid, but has re-enrolled', () => {
-      makeRunCurrent(course.runs[0]);
-      makeRunPaid(course.runs[1]);
-      makeRunEnrolled(course.runs[0]);
-      assertIsJust(calculateMessages(calculateMessagesProps), [{
-        "message": "You are auditing this course."
-      }]);
-    });
-
     it('should nag unpaid auditors to pay', () => {
       makeRunCurrent(course.runs[0]);
       makeRunEnrolled(course.runs[0]);


### PR DESCRIPTION
#### What are the relevant tickets?
Fix  #3455

#### What's this PR do?
Show the same course status message when user is auditing a course, independently of previous enrollments for that course.

#### How should this be manually tested?
Run
```
./manage.py alter_data set_past_run_to_passed --username staff --program-title Analog --course-title 100
./manage.py alter_data set_to_needs_upgrade --username staff --program-title Analog --course-title 100
```
You should be able to enroll in the course again.
![screen shot 2017-08-15 at 4 12 40 pm](https://user-images.githubusercontent.com/7574259/29334204-a7963746-81d4-11e7-9198-c51721daba42.png)
