### PR TITLE
use our fork of iso-3166-2.js with English names for Israel's districts

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "iflow-lodash": "^1.1.16",
     "iflow-react-router": "^1.1.16",
     "imports-loader": "^0.7.1",
-    "iso-3166-2": "https://github.com/mitodl/iso-3166-2.js#3466fbed3fe7b961d1548e4272b992f41f97677a",
+    "iso-3166-2": "https://github.com/mitodl/iso-3166-2.js#56e303c367fc1bed0784fe70d41c18b674cd1352",
     "isomorphic-fetch": "2.2.1",
     "jquery": "^3.2.1",
     "jsdom": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "iflow-lodash": "^1.1.16",
     "iflow-react-router": "^1.1.16",
     "imports-loader": "^0.7.1",
-    "iso-3166-2": "^0.6.0",
+    "iso-3166-2": "https://github.com/mitodl/iso-3166-2.js#3466fbed3fe7b961d1548e4272b992f41f97677a",
     "isomorphic-fetch": "2.2.1",
     "jquery": "^3.2.1",
     "jsdom": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3291,9 +3291,9 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
-"iso-3166-2@git+https://github.com/mitodl/iso-3166-2.js.git#3466fbed3fe7b961d1548e4272b992f41f97677a", "iso-3166-2@https://github.com/mitodl/iso-3166-2.js#3466fbed3fe7b961d1548e4272b992f41f97677a":
+"iso-3166-2@https://github.com/mitodl/iso-3166-2.js#56e303c367fc1bed0784fe70d41c18b674cd1352":
   version "0.6.0"
-  resolved "https://github.com/mitodl/iso-3166-2.js#3466fbed3fe7b961d1548e4272b992f41f97677a"
+  resolved "https://github.com/mitodl/iso-3166-2.js#56e303c367fc1bed0784fe70d41c18b674cd1352"
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -5433,32 +5433,7 @@ request-promise-native@^1.0.3:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.0"
 
-request@2, request@2.79.0, request@^2.79.0:
-  version "2.79.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.11.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~2.0.6"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    qs "~6.3.0"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "~0.4.1"
-    uuid "^3.0.0"
-
-request@^2.81.0:
+request@2, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -5483,6 +5458,31 @@ request@^2.81.0:
     stringstream "~0.0.4"
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
+    uuid "^3.0.0"
+
+request@2.79.0:
+  version "2.79.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.11.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~2.0.6"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    qs "~6.3.0"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
 require-directory@^2.1.1:
@@ -6039,7 +6039,7 @@ style-loader@^0.18.1:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
-supports-color@3.1.2, supports-color@^3.1.0:
+supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -6049,7 +6049,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.1.0, supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3291,9 +3291,9 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
-iso-3166-2@^0.6.0:
+"iso-3166-2@git+https://github.com/mitodl/iso-3166-2.js.git#3466fbed3fe7b961d1548e4272b992f41f97677a", "iso-3166-2@https://github.com/mitodl/iso-3166-2.js#3466fbed3fe7b961d1548e4272b992f41f97677a":
   version "0.6.0"
-  resolved "https://registry.yarnpkg.com/iso-3166-2/-/iso-3166-2-0.6.0.tgz#e97462df35177d7dd15a5f5a955599297ef7cc43"
+  resolved "https://github.com/mitodl/iso-3166-2.js#3466fbed3fe7b961d1548e4272b992f41f97677a"
 
 isobject@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #3430 

#### What's this PR do?

Uses mitodl/iso-3166-2.js with English names for Israel's districts. 

#### How should this be manually tested?

Go to the learner profile, change the country to Israel and confirm that the district names are in English, not Arabic or Hebrew. 

For the English names, see 
https://github.com/mitodl/iso-3166-2.js/blob/3466fbed3fe7b961d1548e4272b992f41f97677a/data.csv#L1851

#### Any background context you want to provide?

There is a PR open on the upstream repository, but no one has responded to it.

See https://github.com/olahol/iso-3166-2.js/pull/20
