### PR TITLE
Complete freeze final grades task when cache refresh fails

### DIFF
--- a/grades/api.py
+++ b/grades/api.py
@@ -6,6 +6,8 @@ from collections import namedtuple
 
 from django.contrib.auth.models import User
 
+from django_redis import get_redis_connection
+
 from dashboard.api_edx_cache import CachedEdxUserData, CachedEdxDataApi
 from dashboard.models import CachedEnrollment
 from grades.exceptions import FreezeGradeFailedException
@@ -165,6 +167,8 @@ def freeze_user_final_grade(user, course_run, raise_on_exception=False):
     try:
         CachedEdxDataApi.update_all_cached_grade_data(user)
     except Exception as ex:  # pylint: disable=broad-except
+        con = get_redis_connection("redis")
+        con.lpush('{}'.format(course_run.edx_course_key), user.id)
         if not raise_on_exception:
             log.exception('Impossible to refresh the edX cache for user "%s"', user.username)
             return

--- a/grades/api.py
+++ b/grades/api.py
@@ -16,6 +16,7 @@ from grades.models import (
     FinalGradeStatus,
 )
 
+CACHE_KEY_FAILED_USERS_BASE_STR = "failed_users_{0}"
 
 log = logging.getLogger(__name__)
 
@@ -168,7 +169,7 @@ def freeze_user_final_grade(user, course_run, raise_on_exception=False):
         CachedEdxDataApi.update_all_cached_grade_data(user)
     except Exception as ex:  # pylint: disable=broad-except
         con = get_redis_connection("redis")
-        con.lpush('{}'.format(course_run.edx_course_key), user.id)
+        con.lpush(CACHE_KEY_FAILED_USERS_BASE_STR.format(course_run.edx_course_key), user.id)
         if not raise_on_exception:
             log.exception('Impossible to refresh the edX cache for user "%s"', user.username)
             return

--- a/grades/tasks.py
+++ b/grades/tasks.py
@@ -143,14 +143,13 @@ def freeze_course_run_final_grades(course_run_id):
 
     # find number of users for which cache could not be updated
     con = get_redis_connection("redis")
-    failed_users_count = con.llen(api.CACHE_KEY_FAILED_USERS_BASE_STR.format(course_run.edx_course_key))
+    failed_users_cache_key = api.CACHE_KEY_FAILED_USERS_BASE_STR.format(course_run.edx_course_key)
+    failed_users_count = con.llen(failed_users_cache_key)
 
     # get the list of users that failed authentication last run of the task
-    failed_users_list = list(map(int, con.lrange(
-        api.CACHE_KEY_FAILED_USERS_BASE_STR.format(course_run.edx_course_key), 0, failed_users_count)))
+    failed_users_list = list(map(int, con.lrange(failed_users_cache_key, 0, failed_users_count)))
     users_need_freeze = list(user_ids_qset)
-    users_left = [user_id for user_id in users_need_freeze if user_id not in failed_users_list]
-
+    users_left = list(set(users_need_freeze) - set(failed_users_list))
     # if there are no more users to be frozen, just complete the task
     if not users_left:
         log.info('Completing grading with %d users getting refresh cache errors', len(failed_users_list))
@@ -160,7 +159,7 @@ def freeze_course_run_final_grades(course_run_id):
     # if the task reaches this point, it means there are users still to be processed
 
     # clear the list for users for whom cache update failed
-    con.delete(api.CACHE_KEY_FAILED_USERS_BASE_STR.format(course_run.edx_course_key))
+    con.delete(failed_users_cache_key)
     # create an entry in with pending status ('pending' is the default status)
     CourseRunGradingStatus.create_pending(course_run=course_run)
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #2657

#### What's this PR do?
Counts the number of users where user authentication failed and completes the task in the next run of the task.

#### How should this be manually tested?
Make a past passed course run, set the freezable date

```from courses.models import *
course_run = CourseRun.objects.get(edx_course_key=course_key)

from datetime import timedelta
from micromasters.utils import now_in_utc
course_run.freeze_grade_date=now_in_utc()-timedelta(days=1)
course_run.save()
```

Try to freeze the grades. 
