### PR TITLE
upgrade iso-3166-2.js to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "iflow-lodash": "^1.1.16",
     "iflow-react-router": "^1.1.16",
     "imports-loader": "^0.7.1",
-    "iso-3166-2": "https://github.com/mitodl/iso-3166-2.js#56e303c367fc1bed0784fe70d41c18b674cd1352",
+    "iso-3166-2": "1.0.0",
     "isomorphic-fetch": "2.2.1",
     "jquery": "^3.2.1",
     "jsdom": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3291,9 +3291,9 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
-"iso-3166-2@https://github.com/mitodl/iso-3166-2.js#56e303c367fc1bed0784fe70d41c18b674cd1352":
-  version "0.6.0"
-  resolved "https://github.com/mitodl/iso-3166-2.js#56e303c367fc1bed0784fe70d41c18b674cd1352"
+iso-3166-2@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/iso-3166-2/-/iso-3166-2-1.0.0.tgz#20c5cda527b56bfc7409c6802d9bff0119086131"
 
 isobject@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #3430 with an updated package instead of a fork

#### What's this PR do?

Upgrade iso-3166-2.js to 1.0.0 which includes English names for Israeli districts

This update includes a breaking change: failed lookups now return null instead of {}. Hopefully tests will pass. 

#### How should this be manually tested?

Go to the profile and set your country to be Israel. Confirm that the drop-down of states/territories has English names instead of Arabic of Hebrew. 

