### PR TITLE
See Certificates links for non FA courses

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -3,13 +3,13 @@ Apis for the dashboard
 """
 import datetime
 import logging
+from urllib.parse import urljoin
+import pytz
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 from django.urls import reverse
-import pytz
-from urllib.parse import urljoin
 
 from backends.exceptions import InvalidCredentialStored
 from courses.models import Program

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -490,7 +490,7 @@ def get_certificate_url(mmtrack, course):
             if best_grade.has_certificate:
                 url = "/certificate/{}".format(final_grades.first().certificate.hash)
         elif mmtrack.has_passing_certificate(course_key):
-            download_url = mmtrack.certificates.get_verified_cert(course_key).dowload_url
+            download_url = mmtrack.certificates.get_verified_cert(course_key).download_url
             if download_url:
                 url = urljoin(settings.EDXORG_BASE_URL, download_url)
     return url

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -4,11 +4,12 @@ Apis for the dashboard
 import datetime
 import logging
 
-from urllib.parse import urljoin
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
-from django.conf import settings
+from django.urls import reverse
 import pytz
+from urllib.parse import urljoin
 
 from backends.exceptions import InvalidCredentialStored
 from courses.models import Program
@@ -488,7 +489,7 @@ def get_certificate_url(mmtrack, course):
         course_key = best_grade.course_run.edx_course_key
         if mmtrack.financial_aid_available:
             if best_grade.has_certificate:
-                url = "/certificate/{}".format(final_grades.first().certificate.hash)
+                url = reverse('certificate', args=[final_grades.first().certificate.hash])
         elif mmtrack.has_passing_certificate(course_key):
             download_url = mmtrack.certificates.get_verified_cert(course_key).download_url
             if download_url:

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -489,7 +489,7 @@ def get_certificate_url(mmtrack, course):
         course_key = best_grade.course_run.edx_course_key
         if mmtrack.financial_aid_available:
             if best_grade.has_certificate:
-                url = reverse('certificate', args=[final_grades.first().certificate.hash])
+                url = reverse('certificate', args=[best_grade.certificate.hash])
         elif mmtrack.has_passing_certificate(course_key):
             download_url = mmtrack.certificates.get_verified_cert(course_key).download_url
             if download_url:

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -4,11 +4,11 @@ Apis for the dashboard
 import datetime
 import logging
 
+from urllib.parse import urljoin
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
-import pytz
-from urllib.parse import urljoin
 from django.conf import settings
+import pytz
 
 from backends.exceptions import InvalidCredentialStored
 from courses.models import Program

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -11,6 +11,7 @@ from unittest.mock import (
 
 import ddt
 from django.core.exceptions import ImproperlyConfigured
+from django.conf import settings
 from rest_framework import status as http_status
 
 from backends.exceptions import InvalidCredentialStored
@@ -26,6 +27,7 @@ from dashboard import (
 )
 from dashboard.api_edx_cache import CachedEdxDataApi
 from dashboard.factories import CachedEnrollmentFactory, CachedCurrentGradeFactory, UserCacheRefreshTimeFactory
+from dashboard.models import CachedCertificate
 from dashboard.utils import MMTrack
 from exams.models import ExamProfile
 from exams.factories import ExamRunFactory, ExamAuthorizationFactory
@@ -1667,6 +1669,7 @@ class ExamAttemptsTests(CourseTests):
         assert api.has_to_pay_for_exam(self.mmtrack, self.course) is result
 
 
+@ddt.ddt
 class GetCertificateForCourse(CourseTests):
     """Tests get_certificate_url for a course"""
 
@@ -1696,3 +1699,30 @@ class GetCertificateForCourse(CourseTests):
         FinalGradeFactory.create(user=self.user, course_run=self.course_run, grade=0.8, passed=True)
         self.mmtrack.get_passing_final_grades_for_course.return_value = FinalGrade.objects.filter(user=self.user)
         assert api.get_certificate_url(self.mmtrack, self.course) == ''
+
+    @ddt.data(
+        ("verified", True, True),
+        ("audit", False, False),
+        ("verified", False, False),
+        ("audit", True, False),
+    )
+    @ddt.unpack
+    def test_edx_course_certificate(self, certificate_type, is_passing, has_url):
+        """Test edx certificate url for non FA courses"""
+        FinalGradeFactory.create(user=self.user, course_run=self.course_run, grade=0.8, passed=True)
+        self.mmtrack.get_passing_final_grades_for_course.return_value = FinalGrade.objects.filter(user=self.user)
+        self.mmtrack.financial_aid_available = False
+        self.mmtrack.has_passing_certificate.return_value = (certificate_type == "verified") and is_passing
+
+        cert_json = {
+            "username": "staff",
+            "course_id": self.course_run.edx_course_key,
+            "certificate_type": certificate_type,
+            "is_passing": is_passing,
+            "status": "downloadable",
+            "download_url": "/certificates/user/course_key",
+            "grade": "0.98"
+        }
+        self.mmtrack.certificates = CachedCertificate.deserialize_edx_data([cert_json])
+        certificate_url = (settings.EDXORG_BASE_URL + "certificates/user/course_key") if has_url else ""
+        assert api.get_certificate_url(self.mmtrack, self.course) == certificate_url

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1673,6 +1673,8 @@ class GetCertificateForCourse(CourseTests):
     def setUp(self):
         super().setUp()
         self.mmtrack.user = self.user
+        self.mmtrack.financial_aid_available = True
+
         self.course_run = self.create_run(course=self.course)
 
     def test_get_certificate_url(self):

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -309,7 +309,7 @@ class MMTrack:
         """
         return self.final_grade_qset.for_course_run_keys(
             list(course.courserun_set.values_list('edx_course_key', flat=True))
-        ).passed().order_by('-grade')
+        ).passed().select_related('course_run').order_by('-grade')
 
     def get_all_enrolled_course_runs(self):
         """


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #3233

#### What's this PR do?
Show certificate link for edx certificates for non FA courses.

#### How should this be manually tested?
Can test this only if there is a verified certificate on edx.
Can create a `CachedCertificate`:
```
cert_json = {
            "username": username,
            "course_id": course_key,
            "certificate_type": "verified",
            "is_passing": True,
            "status": "downloadable",
            "download_url": some_url,
            "grade": "0.98"
        }
CachedCertificate.deserialize_edx_data([cert_json])
```