### PR TITLE
Fixed course upgrade deadline on learners page

### DIFF
--- a/static/js/components/dashboard/courses/ProgressMessage.js
+++ b/static/js/components/dashboard/courses/ProgressMessage.js
@@ -57,7 +57,7 @@ export const staffCourseInfo = (courseRun: CourseRun, course: Course) => {
     }
     if (courseRun.status === STATUS_CAN_UPGRADE) {
       if (courseCurrentlyInProgress(courseRun)) {
-        return `Auditing (Upgrade deadline ${moment(courseRun.course_end_date).format(COURSE_CARD_FORMAT)})`;
+        return `Auditing (Upgrade deadline ${moment(courseRun.course_upgrade_deadline).format(COURSE_CARD_FORMAT)})`;
       }
       return "Auditing";
     }

--- a/static/js/components/dashboard/courses/ProgressMessage_test.js
+++ b/static/js/components/dashboard/courses/ProgressMessage_test.js
@@ -121,7 +121,7 @@ describe('Course ProgressMessage', () => {
       course.runs[0].status = STATUS_CAN_UPGRADE;
       assert.equal(
         staffCourseInfo(course.runs[0], course),
-        `Auditing (Upgrade deadline ${moment(course.runs[0].course_end_date).format(COURSE_CARD_FORMAT)})`
+        `Auditing (Upgrade deadline ${moment(course.runs[0].course_upgrade_deadline).format(COURSE_CARD_FORMAT)})`
       );
     });
 


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3496

#### What's this PR do?
Fixed upgrade deadline on leaners page, it was showing course end date which is wrong.

#### How should this be manually tested?
As staff user go to leaners page, you must be enroll in course

@pdpinch

#### Screenshots (if appropriate)
<img width="640" alt="screen shot 2017-08-30 at 3 13 57 pm" src="https://user-images.githubusercontent.com/10431250/29867715-df67a804-8d95-11e7-9ff0-8bc511d663fe.png">


