### PR TITLE
Filter on coupon id for automatic emails

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -317,7 +317,7 @@ class Coupon(TimestampedModel, AuditableModel):
                 True if the coupon is not automatic and it has already been redeemed by someone else
         """
         return (
-            not Coupon.is_automatic_qset().filter(id=user.id).exists() and
+            not Coupon.is_automatic_qset().filter(id=self.id).exists() and
             RedeemedCoupon.objects.filter(
                 coupon=self,
                 order__status=Order.FULFILLED,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3508 

#### What's this PR do?
Fixes a filter bug where the user id was compared with the coupon id. This caused some coupons to incorrectly be marked as already redeemed, preventing users from using them.

#### How should this be manually tested?
Talk to me
