### PR TITLE
Added endpoint urls to JWT payload

### DIFF
--- a/app.json
+++ b/app.json
@@ -111,6 +111,10 @@
       "description": "E-mail to send 500 reports to.",
       "required": false
     },
+    "MICROMASTERS_CORS_ORIGIN_WHITELIST": {
+      "description": "List of origins to allow CORS requests from (e.g. ['otherhost.com', 'myhost.edu'])",
+      "required": false
+    },
     "MICROMASTERS_DB_CONN_MAX_AGE": {
       "required": true,
       "value": "0"
@@ -180,7 +184,7 @@
       "description": "The domain to set the JWT token cookie on",
       "required": false
     },
-    "OPEN_DISCUSSIONS_COOKIE_EXPIRES_DELTA": {
+    "OPEN_DISCUSSIONS_JWT_EXPIRES_DELTA": {
       "description": "How long the JWT cookie should live before expiration",
       "required": false
     },

--- a/discussions/utils.py
+++ b/discussions/utils.py
@@ -1,16 +1,19 @@
 """Discussions utils"""
 from django.conf import settings
+from django.core.urlresolvers import reverse
 from open_discussions_api import utils
 
 from discussions.models import DiscussionUser
 
 
-def get_token_for_user(user):
+def get_token_for_user(user, auth_url=None, session_url=None):
     """
     Generates a token for the given user
 
     Args:
         user (django.contrib.auth.models.User): the user to generate a token for
+        auth_url (str): urls to reauthenticate the user
+        session_url (str): url to renew the user session at
 
     Returns:
         str: the token or None
@@ -28,7 +31,25 @@ def get_token_for_user(user):
             settings.OPEN_DISCUSSIONS_JWT_SECRET,
             discussion_user.username,
             [],  # no roles for learners,
-            expires_delta=settings.OPEN_DISCUSSIONS_COOKIE_EXPIRES_DELTA
+            expires_delta=settings.OPEN_DISCUSSIONS_JWT_EXPIRES_DELTA,
+            extra_payload=dict(auth_url=auth_url, session_url=session_url)
         )
 
     return None
+
+
+def get_token_for_request(request):
+    """
+    Gets a token for a given request
+
+    Args:
+        request (django.http.HttpRequest): the django request
+
+    Returns:
+        str: the token or None
+    """
+    return get_token_for_user(
+        request.user,
+        auth_url=request.build_absolute_uri(reverse('discussions')),  # this will redirect to login
+        session_url=request.build_absolute_uri(reverse('discussions_token')),
+    )

--- a/discussions/utils_test.py
+++ b/discussions/utils_test.py
@@ -51,10 +51,19 @@ def test_get_token_for_user(settings, mocker):
         user = UserFactory.create()
 
     settings.OPEN_DISCUSSIONS_JWT_SECRET = 'secret'
-    settings.OPEN_DISCUSSIONS_COOKIE_EXPIRES_DELTA = 3600
+    settings.OPEN_DISCUSSIONS_JWT_EXPIRES_DELTA = 3600
 
     mock_get_token = mocker.patch('open_discussions_api.utils.get_token')
 
     DiscussionUser.objects.create(user=user, username='username')
     assert get_token_for_user(user) is not None
-    mock_get_token.assert_called_once_with('secret', 'username', [], expires_delta=3600)
+    mock_get_token.assert_called_once_with(
+        'secret',
+        'username',
+        [],
+        expires_delta=3600,
+        extra_payload={
+            'auth_url': None,
+            'session_url': None
+        }
+    )

--- a/discussions/views.py
+++ b/discussions/views.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 
 from discussions.permissions import CanCreateChannel
 from discussions.serializers import ChannelSerializer
-from discussions.utils import get_token_for_user
+from discussions.utils import get_token_for_request
 
 
 def _set_jwt_cookie(response, token):
@@ -27,8 +27,7 @@ def _set_jwt_cookie(response, token):
         settings.OPEN_DISCUSSIONS_COOKIE_NAME,
         token,
         domain=settings.OPEN_DISCUSSIONS_COOKIE_DOMAIN,
-        httponly=True,
-        max_age=settings.OPEN_DISCUSSIONS_COOKIE_EXPIRES_DELTA
+        httponly=True
     )
 
 
@@ -37,7 +36,7 @@ def discussions_token(request):
     """
     API view for setting discussions JWT token
     """
-    token = get_token_for_user(request.user)
+    token = get_token_for_request(request)
     if token is not None:
         response = Response({
             'has_token': True
@@ -55,7 +54,7 @@ def discussions_redirect(request):
     """
     View for setting discussions JWT token and redirecting to discussions
     """
-    token = get_token_for_user(request.user)
+    token = get_token_for_request(request)
     if token is not None:
         response = redirect(settings.OPEN_DISCUSSIONS_REDIRECT_URL)
         _set_jwt_cookie(response, token)

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -94,6 +94,7 @@ INSTALLED_APPS = (
     # other third party APPS
     'rolepermissions',
     'raven.contrib.django.raven_compat',
+    'corsheaders',
 
     # Our INSTALLED_APPS
     'backends',
@@ -122,6 +123,7 @@ if not DISABLE_WEBPACK_LOADER_STATS:
 MIDDLEWARE = (
     'raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -399,6 +401,10 @@ RAVEN_CONFIG = {
     'release': VERSION
 }
 
+# CORS
+CORS_ORIGIN_WHITELIST = get_list_of_str("MICROMASTERS_CORS_ORIGIN_WHITELIST", [])
+CORS_ALLOW_CREDENTIALS = True
+
 # to run the app locally on mac you need to bypass syslog
 if get_bool('MICROMASTERS_BYPASS_SYSLOG', False):
     LOGGING['handlers'].pop('syslog')
@@ -558,7 +564,7 @@ EXAMS_AUDIT_AWS_SECRET_ACCESS_KEY = get_string('EXAMS_AUDIT_AWS_SECRET_ACCESS_KE
 OPEN_DISCUSSIONS_API_USERNAME = get_string('OPEN_DISCUSSIONS_API_USERNAME', None)
 OPEN_DISCUSSIONS_BASE_URL = get_string('OPEN_DISCUSSIONS_BASE_URL', None)
 OPEN_DISCUSSIONS_COOKIE_DOMAIN = get_string('OPEN_DISCUSSIONS_COOKIE_DOMAIN', None)
-OPEN_DISCUSSIONS_COOKIE_EXPIRES_DELTA = get_int('OPEN_DISCUSSIONS_COOKIE_EXPIRES_DELTA', 60*60)
+OPEN_DISCUSSIONS_JWT_EXPIRES_DELTA = get_int('OPEN_DISCUSSIONS_JWT_EXPIRES_DELTA', 60*60)
 OPEN_DISCUSSIONS_COOKIE_NAME = get_string('OPEN_DISCUSSIONS_COOKIE_NAME', 'open_discussions_jwt')
 OPEN_DISCUSSIONS_JWT_SECRET = get_string('OPEN_DISCUSSIONS_JWT_SECRET', None)
 OPEN_DISCUSSIONS_REDIRECT_URL = get_string('OPEN_DISCUSSIONS_REDIRECT_URL', None)

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ boto==2.39.0
 celery==4.0.2
 dj-database-url==0.3.0
 dj-static==0.0.6
+django-cors-headers==2.1.0
 django-redis==4.7.0
 django-role-permissions==1.2
 django-server-status==0.4.0
@@ -21,7 +22,7 @@ html5lib==0.999999999
 ipython
 jsonfield==1.0.3
 newrelic
-open-discussions-client==0.2.0
+open-discussions-client==0.2.1
 phonenumbers==8.3.2
 psycopg2==2.6
 pycountry==16.11.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ decorator==4.1.2          # via ipython, traitlets
 defusedxml==0.5.0         # via python3-openid, social-auth-core
 dj-database-url==0.3.0
 dj-static==0.0.6
+django-cors-headers==2.1.0
 django-discover-runner==1.0  # via django-role-permissions
 django-modelcluster==3.1  # via wagtail
 django-redis==4.7.0
@@ -45,7 +46,7 @@ jsonfield==1.0.3
 kombu==4.1.0              # via celery, django-server-status
 newrelic==2.88.1.73
 oauthlib==2.0.2           # via requests-oauthlib, social-auth-core
-open-discussions-client==0.2.0
+open-discussions-client==0.2.1
 paramiko==2.2.1           # via pysftp
 pbr==3.1.1                # via stevedore
 pexpect==4.2.1            # via ipython


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #3479 

#### What's this PR do?
Adds `session_url` and `auth_url` to the JWT payload.

#### How should this be manually tested?

Add these settings to `.env` (in addition to the ones in #3504) and verify that `/discussions/` still redirects you to the discussions app:

```
MICROMASTERS_CORS_ORIGIN_WHITELIST=['localhost:8063']
```
