### PR TITLE
add package.json script for running JS tests in watch mode

### DIFF
--- a/js_test.sh
+++ b/js_test.sh
@@ -7,6 +7,9 @@ then
 elif [[ ! -z "$CODECOV" ]]
 then
     export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=lcovonly -R spec mocha"
+elif [[ ! -z "$WATCH" ]]
+then
+    export CMD="node ./node_modules/mocha/bin/_mocha --watch"
 else
     export CMD="node ./node_modules/mocha/bin/_mocha"
 fi

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "test": "./js_test.sh",
     "coverage": "COVERAGE=1 ./js_test.sh",
     "codecov": "CODECOV=1 ./js_test.sh",
+    "watch": "WATCH=1 ./js_test.sh",
     "flow": "flow check"
   }
 }

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -79,7 +79,15 @@ process.on('unhandledRejection', reason => { // eslint-disable-line no-unused-va
 
 // fix 'unknown prop' error
 import injectTapEventPlugin from 'react-tap-event-plugin';
-injectTapEventPlugin();
+
+// injectTapEventPlugin should only be called once, and it throws an
+// error if it is called twice. we wrap our call to it in a try / catch
+// so that it doesn't throw an error when running tests in watch mode
+// (which would otherwise cause it to be called twice)
+try {
+  injectTapEventPlugin();
+} catch (_) { // eslint-disable-line no-empty
+}
 
 // enable chai-as-promised
 import chai from 'chai';


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

what it says on the can

#### How should this be manually tested?

you should be able to do `npm run watch` in your docker container. the tests should run in watch mode, and should all be passing. everything else should be unchanged.