### PR TITLE
Add contributors when new channel is created

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -49,3 +49,15 @@ def mocked_elasticsearch(mocked_elasticsearch_module_patcher):
     for mock in mocked_elasticsearch_module_patcher.patcher_mocks:
         mock.reset_mock()
     return mocked_elasticsearch_module_patcher
+
+
+@pytest.fixture()
+def discussion_settings(settings):
+    """Set discussion-specific settings"""
+    settings.OPEN_DISCUSSIONS_JWT_SECRET = 'secret'
+    settings.OPEN_DISCUSSIONS_COOKIE_NAME = 'jwt_cookie'
+    settings.OPEN_DISCUSSIONS_COOKIE_DOMAIN = 'localhost'
+    settings.OPEN_DISCUSSIONS_REDIRECT_URL = 'http://localhost/'
+    settings.OPEN_DISCUSSIONS_BASE_URL = 'http://localhost/'
+    settings.OPEN_DISCUSSIONS_API_USERNAME = 'mitodl'
+    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = True

--- a/discussions/api.py
+++ b/discussions/api.py
@@ -92,22 +92,23 @@ def create_discussion_user(discussion_user):
     profile = discussion_user.user.profile
 
     api = get_staff_client()
-    try:
-        result = api.users.create(
-            name=profile.full_name,
-            image=profile.image.url if profile.image else None,
-            image_small=profile.image_small.url if profile.image_small else None,
-            image_medium=profile.image_medium.url if profile.image_medium else None,
-        )
-        result.raise_for_status()
+    result = api.users.create(
+        name=profile.full_name,
+        image=profile.image.url if profile.image else None,
+        image_small=profile.image_small.url if profile.image_small else None,
+        image_medium=profile.image_medium.url if profile.image_medium else None,
+    )
 
-        discussion_user.username = result.json()['username']
-        discussion_user.last_sync = profile.updated_on
-        discussion_user.save()
+    try:
+        result.raise_for_status()
     except HTTPError as ex:
         raise DiscussionUserSyncException(
             "Error creating discussion user for {}".format(profile.user.username)
         ) from ex
+
+    discussion_user.username = result.json()['username']
+    discussion_user.last_sync = profile.updated_on
+    discussion_user.save()
 
 
 def update_discussion_user(discussion_user):
@@ -126,22 +127,23 @@ def update_discussion_user(discussion_user):
         return
 
     api = get_staff_client()
-    try:
-        result = api.users.update(
-            discussion_user.username,
-            name=profile.full_name,
-            image=profile.image.url if profile.image else None,
-            image_small=profile.image_small.url if profile.image_small else None,
-            image_medium=profile.image_medium.url if profile.image_medium else None,
-        )
-        result.raise_for_status()
+    result = api.users.update(
+        discussion_user.username,
+        name=profile.full_name,
+        image=profile.image.url if profile.image else None,
+        image_small=profile.image_small.url if profile.image_small else None,
+        image_medium=profile.image_medium.url if profile.image_medium else None,
+    )
 
-        discussion_user.last_sync = profile.updated_on
-        discussion_user.save()
+    try:
+        result.raise_for_status()
     except HTTPError as ex:
         raise DiscussionUserSyncException(
             "Error updating discussion user for {}".format(profile.user.username)
         ) from ex
+
+    discussion_user.last_sync = profile.updated_on
+    discussion_user.save()
 
 
 def add_to_channel(channel_name, discussion_username):

--- a/discussions/api.py
+++ b/discussions/api.py
@@ -292,11 +292,11 @@ def add_channel(
     # Do a one time sync of all matching profiles
     user_ids = list(search_for_field(updated_search, 'user_id'))
     from discussions import tasks
-    tasks.add_contributors.delay(channel.name, user_ids)
+    tasks.add_users_to_channel.delay(channel.name, user_ids)
     return channel
 
 
-def add_contributors(channel_name, user_ids, retries=3):
+def add_users_to_channel(channel_name, user_ids, retries=3):
     """
     Add users to a open-discussions channel as contributors and subscribers
 
@@ -326,6 +326,6 @@ def add_contributors(channel_name, user_ids, retries=3):
 
     if len(failed_user_ids) > 0:
         if retries > 1:
-            add_contributors(channel_name, failed_user_ids, retries - 1)
+            add_users_to_channel(channel_name, failed_user_ids, retries - 1)
         else:
             raise DiscussionUserSyncException("Unable to sync these users: {}".format(failed_user_ids))

--- a/discussions/api.py
+++ b/discussions/api.py
@@ -214,9 +214,6 @@ def sync_user_to_channels(user_id):
     Args:
         user_id (int): A user id
     """
-    if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
-        return
-
     # This guards against a race condition where the user's profile is in a celery task
     # and hasn't yet actually been created
     user = User.objects.get(id=user_id)

--- a/discussions/api.py
+++ b/discussions/api.py
@@ -1,20 +1,35 @@
 """API for open discussions integration"""
+import logging
+
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 from open_discussions_api.client import OpenDiscussionsApi
 from open_discussions_api.constants import ROLE_STAFF
+from requests.exceptions import HTTPError
+from rest_framework import status as statuses
 
 from discussions.models import (
-    DiscussionUser,
     Channel,
+    DiscussionUser,
 )
 from discussions.exceptions import (
     ChannelCreationException,
+    ContributorSyncException,
     DiscussionUserSyncException,
+    ModeratorSyncException,
+    SubscriberSyncException,
 )
-from search.api import adjust_search_for_percolator
+from search.api import (
+    adjust_search_for_percolator,
+    search_for_field,
+    search_percolate_queries,
+)
 from search.models import PercolateQuery
+
+
+log = logging.getLogger(__name__)
 
 
 def get_staff_client():
@@ -41,7 +56,10 @@ def create_or_update_discussion_user(user_id):
     Create or update a DiscussionUser record and sync it
 
     Args:
-        user_id (str): user id of the user to sync
+        user_id (int): user id of the user to sync
+
+    Returns:
+        DiscussionUser: The DiscussionUser connected to the user
     """
     discussion_user, _ = DiscussionUser.objects.get_or_create(user_id=user_id)
 
@@ -58,6 +76,8 @@ def create_or_update_discussion_user(user_id):
         else:
             update_discussion_user(discussion_user)
 
+        return discussion_user
+
 
 def create_discussion_user(discussion_user):
     """
@@ -72,21 +92,22 @@ def create_discussion_user(discussion_user):
     profile = discussion_user.user.profile
 
     api = get_staff_client()
-    result = api.users.create(
-        name=profile.full_name,
-        image=profile.image.url if profile.image else None,
-        image_small=profile.image_small.url if profile.image_small else None,
-        image_medium=profile.image_medium.url if profile.image_medium else None,
-    )
+    try:
+        result = api.users.create(
+            name=profile.full_name,
+            image=profile.image.url if profile.image else None,
+            image_small=profile.image_small.url if profile.image_small else None,
+            image_medium=profile.image_medium.url if profile.image_medium else None,
+        )
+        result.raise_for_status()
 
-    if result.status_code == 201:
         discussion_user.username = result.json()['username']
         discussion_user.last_sync = profile.updated_on
         discussion_user.save()
-    else:
+    except HTTPError as ex:
         raise DiscussionUserSyncException(
-            "Error creating discussion user, got status_code {}".format(result.status_code)
-        )
+            "Error creating discussion user for {}".format(profile.user.username)
+        ) from ex
 
 
 def update_discussion_user(discussion_user):
@@ -105,24 +126,119 @@ def update_discussion_user(discussion_user):
         return
 
     api = get_staff_client()
-    result = api.users.update(
-        discussion_user.username,
-        name=profile.full_name,
-        image=profile.image.url if profile.image else None,
-        image_small=profile.image_small.url if profile.image_small else None,
-        image_medium=profile.image_medium.url if profile.image_medium else None,
-    )
+    try:
+        result = api.users.update(
+            discussion_user.username,
+            name=profile.full_name,
+            image=profile.image.url if profile.image else None,
+            image_small=profile.image_small.url if profile.image_small else None,
+            image_medium=profile.image_medium.url if profile.image_medium else None,
+        )
+        result.raise_for_status()
 
-    if result.status_code == 200:
         discussion_user.last_sync = profile.updated_on
         discussion_user.save()
-    else:
+    except HTTPError as ex:
         raise DiscussionUserSyncException(
-            "Error updating discussion user, got status_code {}".format(result.status_code)
-        )
+            "Error updating discussion user for {}".format(profile.user.username)
+        ) from ex
 
 
-def add_channel(original_search, title, name, public_description, channel_type):
+def add_to_channel(channel_name, discussion_username):
+    """
+    Add a user to channel as contributor and subscriber
+
+    Args:
+        channel_name (str): An open-discussions channel
+        discussion_username (str): The username used by open-discussions
+    """
+    admin_client = get_staff_client()
+    try:
+        admin_client.channels.add_contributor(channel_name, discussion_username).raise_for_status()
+    except HTTPError as ex:
+        raise ContributorSyncException("Error adding contributor {user} to channel {channel}".format(
+            user=discussion_username,
+            channel=channel_name,
+        )) from ex
+
+    try:
+        admin_client.channels.add_subscriber(channel_name, discussion_username).raise_for_status()
+    except HTTPError as ex:
+        raise SubscriberSyncException("Error adding subscriber {user} to channel {channel}".format(
+            user=discussion_username,
+            channel=channel_name,
+        )) from ex
+
+
+def remove_from_channel(channel_name, discussion_username):
+    """
+    Remove a user from a channel as contributor and subscriber
+
+    Args:
+        channel_name (str): An open-discussions channel
+        discussion_username (str): The username used by open-discussions
+    """
+    admin_client = get_staff_client()
+    try:
+        response = admin_client.channels.remove_contributor(channel_name, discussion_username)
+        if not response.ok and response.status_code not in (statuses.HTTP_404_NOT_FOUND, statuses.HTTP_409_CONFLICT):
+            # 404 means user was not a contributor, so everything is fine
+            # 409 means user is a moderator and so can't be removed as a contributor, which is also fine
+            response.raise_for_status()
+    except HTTPError as ex:
+        raise ContributorSyncException("Unable to remove a contributor {user} from channel {channel}".format(
+            user=discussion_username,
+            channel=channel_name
+        )) from ex
+
+    try:
+        response = admin_client.channels.remove_subscriber(channel_name, discussion_username)
+        if not response.ok and response.status_code != statuses.HTTP_404_NOT_FOUND:
+            # 404 means the subscriber was already removed, which is fine
+            response.raise_for_status()
+    except HTTPError as ex:
+        raise SubscriberSyncException("Unable to remove a subscriber {user} from channel {channel}".format(
+            user=discussion_username,
+            channel=channel_name,
+        )) from ex
+
+
+def sync_user_to_channels(user_id):
+    """
+    Make sure the user's profile exists on open-discussions,
+    then update user's subscription and contributor status.
+
+    Args:
+        user_id (int): A user id
+    """
+    if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
+        return
+
+    # This guards against a race condition where the user's profile is in a celery task
+    # and hasn't yet actually been created
+    user = User.objects.get(id=user_id)
+    discussion_user = create_or_update_discussion_user(user_id)
+
+    membership_channel_ids = []
+    for enrollment_id in user.programenrollment_set.values_list("id", flat=True):
+        queries = search_percolate_queries(enrollment_id, PercolateQuery.DISCUSSION_CHANNEL_TYPE)
+        membership_channel_ids.extend(queries.values_list("channel__id", flat=True))
+
+    all_channel_ids = set(Channel.objects.values_list("id", flat=True))
+    membership_channels = Channel.objects.filter(id__in=membership_channel_ids)
+    for channel in membership_channels:
+        add_to_channel(channel.name, discussion_user.username)
+
+    nonmembership_channels = Channel.objects.filter(
+        id__in=all_channel_ids.difference(membership_channel_ids)
+    )
+    for channel in nonmembership_channels:
+        remove_from_channel(channel.name, discussion_user.username)
+
+
+def add_channel(
+        original_search, title, name, public_description, channel_type, moderator_username,
+):  # pylint: disable=too-many-arguments
     """
     Add the channel and associated query
 
@@ -134,19 +250,29 @@ def add_channel(original_search, title, name, public_description, channel_type):
         name (str): Name of the channel
         public_description (str): Description for the channel
         channel_type (str): Whether the channel is public or private
+        moderator_username (str): The moderator of the new channel
 
     Returns:
         Channel: A new channel object
     """
     client = get_staff_client()
-    response = client.channels.create(
-        title=title,
-        name=name,
-        public_description=public_description,
-        channel_type=channel_type,
-    )
-    if not response.ok:
-        raise ChannelCreationException("Error creating channel: {}".format(response.content))
+    try:
+        client.channels.create(
+            title=title,
+            name=name,
+            public_description=public_description,
+            channel_type=channel_type,
+        ).raise_for_status()
+    except HTTPError as ex:
+        raise ChannelCreationException("Error creating channel {}".format(name)) from ex
+
+    try:
+        client.channels.add_moderator(name, moderator_username).raise_for_status()
+    except HTTPError as ex:
+        raise ModeratorSyncException("Error adding {moderator} as moderator to channel {channel_name}".format(
+            moderator=moderator_username,
+            channel_name=name,
+        )) from ex
 
     updated_search = adjust_search_for_percolator(original_search)
     with transaction.atomic():
@@ -155,7 +281,48 @@ def add_channel(original_search, title, name, public_description, channel_type):
             query=updated_search.to_dict(),
             source_type=PercolateQuery.DISCUSSION_CHANNEL_TYPE,
         )
-        return Channel.objects.create(
+        channel = Channel.objects.create(
             query=percolate_query,
             name=name,
         )
+
+    # Do a one time sync of all matching profiles
+    user_ids = search_for_field(updated_search, 'user_id')
+    from discussions import tasks
+    tasks.add_contributors(channel.name, user_ids)
+    return channel
+
+
+def add_contributors(channel_name, user_ids, retries=3):
+    """
+    Add users to a open-discussions channel as contributors and subscribers
+
+    Args:
+        channel_name (str): The name of the channel
+        user_ids (set of int): profile ids to sync
+        retries (int):
+            Number of times to resync failed profiles. This is independent of Celery's retry mechanism
+            because we want to only retry the failed profiles.
+    """
+
+    failed_user_ids = set()
+    for user_id in user_ids:
+        try:
+            # This guards against a race condition where the user's profile is in a celery task
+            # and hasn't yet actually been created
+            discussion_user = create_or_update_discussion_user(user_id)
+
+            add_to_channel(channel_name, discussion_user.username)
+        except:  # pylint: disable=bare-except
+            log.exception(
+                "Error syncing user channel membership for user id #%s, channel %s",
+                user_id,
+                channel_name,
+            )
+            failed_user_ids.add(user_id)
+
+    if len(failed_user_ids) > 0:
+        if retries > 1:
+            add_contributors(channel_name, failed_user_ids, retries - 1)
+        else:
+            raise DiscussionUserSyncException("Unable to sync these users: {}".format(failed_user_ids))

--- a/discussions/api.py
+++ b/discussions/api.py
@@ -289,7 +289,7 @@ def add_channel(
     # Do a one time sync of all matching profiles
     user_ids = search_for_field(updated_search, 'user_id')
     from discussions import tasks
-    tasks.add_contributors(channel.name, user_ids)
+    tasks.add_contributors.delay(channel.name, user_ids)
     return channel
 
 

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -27,6 +27,7 @@ from profiles.factories import (
     ProfileFactory,
     UserFactory,
 )
+from search.api import create_search_obj
 from search.models import PercolateQuery
 
 pytestmark = pytest.mark.django_db

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -7,20 +7,32 @@ from elasticsearch_dsl import Search
 from factory.django import mute_signals
 from open_discussions_api.constants import ROLE_STAFF
 import pytest
+from requests.exceptions import HTTPError
 
+from dashboard.factories import ProgramEnrollmentFactory
 from discussions import api
-from discussions.exceptions import DiscussionUserSyncException, ChannelCreationException
+from discussions.exceptions import (
+    ChannelCreationException,
+    ContributorSyncException,
+    DiscussionUserSyncException,
+    ModeratorSyncException,
+    SubscriberSyncException,
+)
 from discussions.factories import ChannelFactory
 from discussions.models import (
     Channel,
     DiscussionUser,
 )
-from profiles.factories import ProfileFactory
+from profiles.factories import (
+    ProfileFactory,
+    UserFactory,
+)
 from search.models import PercolateQuery
 
 pytestmark = pytest.mark.django_db
 
 
+# pylint: disable=too-many-locals, unused-argument
 @pytest.fixture
 def mock_staff_client(mocker):
     """Mocks the staff client"""
@@ -96,17 +108,16 @@ def test_create_discussion_user(mock_staff_client):
     )
 
 
-@pytest.mark.parametrize('status_code', [200, 300, 301, 400, 401, 403, 500])
-def test_create_discussion_user_error(mock_staff_client, status_code):
-    """Verify create_discussion_user handles non 201 status codes"""
-    mock_staff_client.users.create.return_value.status_code = status_code
+def test_create_discussion_user_error(mock_staff_client):
+    """Verify create_discussion_user handles non 2xx status codes"""
+    mock_staff_client.users.create.return_value.raise_for_status.side_effect = HTTPError
     with mute_signals(post_save):
         profile = ProfileFactory.create()
     discussion_user = DiscussionUser.objects.create(user=profile.user)
     with pytest.raises(DiscussionUserSyncException) as exc:
         api.create_discussion_user(discussion_user)
 
-    assert str(exc.value) == "Error creating discussion user, got status_code {}".format(status_code)
+    assert str(exc.value) == "Error creating discussion user for {}".format(profile.user.username)
 
 
 def test_update_discussion_user(mock_staff_client):
@@ -138,20 +149,155 @@ def test_update_discussion_user_no_update(mock_staff_client):
     assert mock_staff_client.users.update.call_count == 0
 
 
-@pytest.mark.parametrize('status_code', [201, 300, 301, 400, 401, 403, 500])
-def test_update_discussion_user_error(mock_staff_client, status_code):
-    """Verify update_discussion_user handles non-200 status codes"""
-    mock_staff_client.users.update.return_value.status_code = status_code
+def test_update_discussion_user_error(mock_staff_client):
+    """Verify update_discussion_user handles non-2xx status codes"""
+    mock_staff_client.users.update.return_value.raise_for_status.side_effect = HTTPError
     with mute_signals(post_save):
         profile = ProfileFactory.create()
     discussion_user = DiscussionUser.objects.create(user=profile.user, username='username')
     with pytest.raises(DiscussionUserSyncException) as exc:
         api.update_discussion_user(discussion_user)
 
-    assert str(exc.value) == "Error updating discussion user, got status_code {}".format(status_code)
+    assert str(exc.value) == "Error updating discussion user for {}".format(profile.user.username)
 
 
-def test_add_channel(mock_staff_client, mocker):
+def test_add_to_channel(mock_staff_client):
+    """add_to_channel should add user as contributor and subscriber"""
+    channel_name = 'channel'
+    discussion_username = 'username'
+    api.add_to_channel(channel_name, discussion_username)
+    mock_staff_client.channels.add_contributor.assert_called_once_with(channel_name, discussion_username)
+    mock_staff_client.channels.add_subscriber.assert_called_once_with(channel_name, discussion_username)
+
+
+def test_add_to_channel_failed_contributor(mock_staff_client):
+    """add_to_channel should raise an exception if it fails to add a contributor"""
+    mock_staff_client.channels.add_contributor.return_value.raise_for_status.side_effect = HTTPError
+    with pytest.raises(ContributorSyncException) as ex:
+        api.add_to_channel('channel', 'user')
+    assert ex.value.args[0] == 'Error adding contributor user to channel channel'
+    assert mock_staff_client.channel.add_subscriber.called is False
+
+
+def test_add_to_channel_failed_subscriber(mock_staff_client):
+    """add_to_channel should raise an exception if it fails to add a subscriber"""
+    channel_name = 'channel'
+    discussion_username = 'username'
+    mock_staff_client.channels.add_subscriber.return_value.raise_for_status.side_effect = HTTPError
+    with pytest.raises(SubscriberSyncException) as ex:
+        api.add_to_channel(channel_name, discussion_username)
+    assert ex.value.args[0] == 'Error adding subscriber {user} to channel {channel}'.format(
+        user=discussion_username,
+        channel=channel_name,
+    )
+
+    mock_staff_client.channels.add_contributor.assert_called_once_with(channel_name, discussion_username)
+    mock_staff_client.channels.add_subscriber.assert_called_once_with(channel_name, discussion_username)
+
+
+@pytest.mark.parametrize("contributor_status_code,subscriber_status_code", [
+    (200, 200),
+    (404, 404),
+    (409, 404),
+])
+def test_remove_from_channel(mock_staff_client, contributor_status_code, subscriber_status_code):
+    """remove_from_channel should remove a user's contributor and subscriber status"""
+    channel_name = 'channel'
+    discussion_username = 'username'
+    api.remove_from_channel(channel_name, discussion_username)
+    mock_staff_client.channels.remove_contributor.assert_called_once_with(channel_name, discussion_username)
+    mock_staff_client.channels.remove_subscriber.assert_called_once_with(channel_name, discussion_username)
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403, 500, 505])
+def test_remove_from_channel_failed_contributor(mock_staff_client, status_code):
+    """
+    remove_from_channel should raise an exception if it fails to remove a user's contributor status,
+    depending on the status code
+    """
+    response = mock_staff_client.channels.remove_contributor.return_value
+    response.ok = False
+    response.status_code = status_code
+    response.raise_for_status.side_effect = HTTPError
+
+    with pytest.raises(ContributorSyncException) as ex:
+        api.remove_from_channel('channel', 'user')
+    assert ex.value.args[0] == 'Unable to remove a contributor user from channel channel'
+    assert mock_staff_client.channel.remove_subscriber.called is False
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403, 409, 500, 505])
+def test_remove_from_channel_failed_subscriber(mock_staff_client, status_code):
+    """
+    remove_from_channel should raise an exception if it fails to remove a user's subscriber status,
+    depending on the status code
+    """
+    mock_staff_client.channels.remove_contributor.return_value.ok = True
+    response = mock_staff_client.channels.remove_subscriber.return_value
+    response.ok = False
+    response.status_code = status_code
+    response.raise_for_status.side_effect = HTTPError
+    channel_name = 'channel'
+    discussion_username = 'username'
+
+    with pytest.raises(SubscriberSyncException) as ex:
+        api.remove_from_channel(channel_name, discussion_username)
+    assert ex.value.args[0] == 'Unable to remove a subscriber username from channel channel'
+    mock_staff_client.channels.remove_contributor.assert_called_once_with(channel_name, discussion_username)
+    assert mock_staff_client.channel.remove_subscriber.called is False
+
+
+def test_sync_user_to_channels_no_feature(settings, mocker):
+    """If the feature flag is off nothing should happen"""
+    patched = mocker.patch('discussions.api.create_or_update_discussion_user')
+    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = False
+    user = UserFactory.create()
+    api.sync_user_to_channels(user.id)
+    assert patched.called is False
+
+
+def test_sync_user_to_channels(mocker, patched_users_api):
+    """sync_user_to_channels should add or remove the user's membership from channels"""
+    member_channels = [ChannelFactory.create() for _ in range(4)]
+    nonmember_channels = [ChannelFactory.create() for _ in range(3)]
+
+    user = ProgramEnrollmentFactory.create().user
+    enrollment = ProgramEnrollmentFactory.create(user=user)
+
+    assert PercolateQuery.objects.count() == len(member_channels) + len(nonmember_channels)
+
+    def _search_percolate_queries(enrollment_id, discussion_type):
+        """Helper function to return a percolate queryset for enrollment"""
+        if enrollment_id == enrollment.id:
+            return PercolateQuery.objects.filter(channel__in=member_channels)
+        else:
+            return PercolateQuery.objects.none()
+
+    search_percolate_queries_stub = mocker.patch(
+        'discussions.api.search_percolate_queries',
+        autospec=True,
+        side_effect=_search_percolate_queries
+    )
+    add_to_channel_stub = mocker.patch('discussions.api.add_to_channel', autospec=True)
+    remove_from_channel_stub = mocker.patch('discussions.api.remove_from_channel', autospec=True)
+
+    api.sync_user_to_channels(user.id)
+
+    assert search_percolate_queries_stub.call_count == user.programenrollment_set.count()
+    for enrollment in user.programenrollment_set.all():
+        search_percolate_queries_stub.assert_any_call(
+            enrollment.id,
+            PercolateQuery.DISCUSSION_CHANNEL_TYPE,
+        )
+    assert add_to_channel_stub.call_count == len(member_channels)
+    assert remove_from_channel_stub.call_count == len(nonmember_channels)
+    for channel in member_channels:
+        add_to_channel_stub.assert_any_call(channel.name, user.discussion_user.username)
+    for channel in nonmember_channels:
+        remove_from_channel_stub.assert_any_call(channel.name, user.discussion_user.username)
+
+
+def test_add_channel(mock_staff_client, mocker, patched_users_api):
     """add_channel should tell open-discussions to create a channel"""
     mock_staff_client.channels.create.return_value.ok = True
 
@@ -161,16 +307,35 @@ def test_add_channel(mock_staff_client, mocker):
     channel_type = "private"
     input_search = Search.from_dict({"unmodified": "search"})
     modified_search = Search.from_dict({"result": "modified"})
+
     adjust_search_for_percolator_stub = mocker.patch(
         'discussions.api.adjust_search_for_percolator',
+        autospec=True,
         return_value=modified_search,
     )
+
+    contributors = [UserFactory.create() for _ in range(5)]
+    contributor_ids = [user.id for user in contributors]
+    search_for_field_stub = mocker.patch(
+        'discussions.api.search_for_field',
+        autospec=True,
+        return_value=contributor_ids,
+    )
+    add_contributors_task_stub = mocker.patch(
+        'discussions.api.add_contributors',
+        autospec=True,
+    )
+
+    moderator = UserFactory.create()
+    moderator_name = moderator.discussion_user.username
+
     channel = api.add_channel(
         original_search=input_search,
         title=title,
         name=name,
         public_description=public_description,
         channel_type=channel_type,
+        moderator_username=moderator_name,
     )
 
     mock_staff_client.channels.create.assert_called_once_with(
@@ -180,6 +345,9 @@ def test_add_channel(mock_staff_client, mocker):
         channel_type=channel_type,
     )
     adjust_search_for_percolator_stub.assert_called_once_with(input_search)
+    mock_staff_client.channels.add_moderator.assert_called_once_with(
+        name, moderator_name
+    )
 
     assert channel.name == name
     query = channel.query
@@ -187,18 +355,53 @@ def test_add_channel(mock_staff_client, mocker):
     assert query.original_query == input_search.to_dict()
     assert query.query == modified_search.to_dict()
 
+    assert search_for_field_stub.call_count == 1
+    assert search_for_field_stub.call_args[0][0].to_dict() == modified_search.to_dict()
+    assert search_for_field_stub.call_args[0][1] == 'user_id'
 
-def test_add_channel_failed_create_channel(mock_staff_client):
+    add_contributors_task_stub.assert_called_once_with(channel.name, contributor_ids)
+
+
+def test_add_channel_failed_create_channel(mock_staff_client, mocker):
     """If client.channels.create fails an exception should be raised"""
-    mock_staff_client.channels.create.return_value.ok = False
-    mock_staff_client.channels.create.return_value.content = "error message"
+    mock_staff_client.channels.create.return_value.raise_for_status.side_effect = HTTPError
 
     with pytest.raises(ChannelCreationException) as ex:
-        api.add_channel(Search.from_dict({}), "title", "name", "public_description", "channel_type")
-    assert ex.value.args[0] == "Error creating channel: error message"
-    assert mock_staff_client.channels.create.called is True
+        api.add_channel(
+            Search.from_dict({}),
+            "title",
+            "name",
+            "public_description",
+            "channel_type",
+            "mod",
+        )
+    assert ex.value.args[0] == "Error creating channel name"
+    mock_staff_client.channels.create.return_value.raise_for_status.assert_called_with()
+    assert mock_staff_client.channels.create.call_count == 1
     assert PercolateQuery.objects.count() == 0
     assert Channel.objects.count() == 0
+
+
+def test_add_channel_failed_add_moderator(mock_staff_client, mocker):
+    """If add_moderator fails an exception should be raised"""
+    mock_staff_client.channels.add_moderator.return_value.raise_for_status.side_effect = HTTPError
+
+    with pytest.raises(ModeratorSyncException) as ex:
+        api.add_channel(
+            Search.from_dict({}),
+            "title",
+            "name",
+            "public_description",
+            "channel_type",
+            "mod",
+        )
+    assert ex.value.args[0] == "Error adding {moderator} as moderator to channel {channel}".format(
+        moderator='mod',
+        channel='name',
+    )
+
+    assert mock_staff_client.channels.create.called is True
+    mock_staff_client.channels.add_moderator.return_value.raise_for_status.assert_called_with()
 
 
 def test_add_channel_channel_already_exists(mock_staff_client):
@@ -219,6 +422,7 @@ def test_add_channel_channel_already_exists(mock_staff_client):
             name=name,
             public_description=public_description,
             channel_type=channel_type,
+            moderator_username='mod',
         )
 
     mock_staff_client.channels.create.assert_called_once_with(
@@ -227,3 +431,80 @@ def test_add_channel_channel_already_exists(mock_staff_client):
         public_description=public_description,
         channel_type=channel_type,
     )
+
+
+def test_add_contributors(mocker):
+    """
+    add_contributors should add a number of users as contributors and subscribers, retrying if necessary
+    """
+    def _make_fake_discussionuser(user_id):
+        """Helper function to make a mock DiscussionUser"""
+        return mocker.Mock(username='discussion_user_{}'.format(user_id))
+
+    stub = mocker.patch(
+        'discussions.api.create_or_update_discussion_user',
+        autospec=True,
+        side_effect=_make_fake_discussionuser
+    )
+    add_to_channel_stub = mocker.patch('discussions.api.add_to_channel', autospec=True)
+
+    users = [UserFactory.create() for _ in range(5)]
+    channel_name = 'channel_name'
+    api.add_contributors(channel_name, set([user.id for user in users]))
+    for user in users:
+        stub.assert_any_call(user.id)
+        add_to_channel_stub.assert_any_call(channel_name, "discussion_user_{}".format(user.id))
+
+
+def test_add_contributors_retry(patched_users_api, mocker):
+    """
+    add_contributors should retry up to three times
+    """
+
+    failed_username = None
+
+    def _raise_once(_, username):
+        """Helper function to store the failed user id and raise an exception"""
+        nonlocal failed_username
+        if failed_username is None:
+            failed_username = username
+            raise TypeError
+
+    add_to_channel_stub = mocker.patch('discussions.api.add_to_channel', autospec=True, side_effect=_raise_once)
+
+    users = [UserFactory.create() for _ in range(5)]
+    channel_name = 'channel_name'
+    api.add_contributors(channel_name, set([user.id for user in users]))
+    for user in users:
+        add_to_channel_stub.assert_any_call(channel_name, user.discussion_user.username)
+
+    # There should be one extra call, for the retry after failure
+    assert add_to_channel_stub.call_count == len(users) + 1
+
+
+def test_add_contributors_failed(patched_users_api, mocker):
+    """
+    If the retry count is exceeded an exception should be raised
+    """
+    failed_username = None
+
+    def _raise_once(_, username):
+        """Helper function to store the failed user id and raise an exception"""
+        nonlocal failed_username
+        if failed_username is None:
+            failed_username = username
+            raise TypeError
+        elif username == failed_username:
+            raise TypeError
+
+    add_to_channel_stub = mocker.patch('discussions.api.add_to_channel', autospec=True, side_effect=_raise_once)
+
+    users = [UserFactory.create() for _ in range(5)]
+    with pytest.raises(DiscussionUserSyncException) as ex:
+        api.add_contributors('channel', set([user.id for user in users]))
+    assert ex.value.args[0] == "Unable to sync these users: {}".format(
+        set([DiscussionUser.objects.get(username=failed_username).user.id])
+    )
+
+    # there are 3 retries
+    assert add_to_channel_stub.call_count == 2 + len(users)

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -264,15 +264,6 @@ def test_remove_from_channel_failed_subscriber(mock_staff_client, status_code):
     assert mock_staff_client.channels.remove_contributor.called is False
 
 
-def test_sync_user_to_channels_no_feature(settings, mocker):
-    """If the feature flag is off nothing should happen"""
-    patched = mocker.patch('discussions.api.create_or_update_discussion_user')
-    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = False
-    user = UserFactory.create()
-    api.sync_user_to_channels(user.id)
-    assert patched.called is False
-
-
 def test_sync_user_to_channels(mocker, patched_users_api):
     """sync_user_to_channels should add or remove the user's membership from channels"""
     member_channels = [ChannelFactory.create() for _ in range(4)]

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -450,7 +450,7 @@ def test_add_contributors(mocker):
 
     users = [UserFactory.create() for _ in range(5)]
     channel_name = 'channel_name'
-    api.add_contributors(channel_name, set([user.id for user in users]))
+    api.add_contributors(channel_name, [user.id for user in users])
     for user in users:
         stub.assert_any_call(user.id)
         add_to_channel_stub.assert_any_call(channel_name, "discussion_user_{}".format(user.id))
@@ -474,7 +474,7 @@ def test_add_contributors_retry(patched_users_api, mocker):
 
     users = [UserFactory.create() for _ in range(5)]
     channel_name = 'channel_name'
-    api.add_contributors(channel_name, set([user.id for user in users]))
+    api.add_contributors(channel_name, [user.id for user in users])
     for user in users:
         add_to_channel_stub.assert_any_call(channel_name, user.discussion_user.username)
 
@@ -501,9 +501,9 @@ def test_add_contributors_failed(patched_users_api, mocker):
 
     users = [UserFactory.create() for _ in range(5)]
     with pytest.raises(DiscussionUserSyncException) as ex:
-        api.add_contributors('channel', set([user.id for user in users]))
+        api.add_contributors('channel', [user.id for user in users])
     assert ex.value.args[0] == "Unable to sync these users: {}".format(
-        set([DiscussionUser.objects.get(username=failed_username).user.id])
+        [DiscussionUser.objects.get(username=failed_username).user.id]
     )
 
     # there are 3 retries

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -360,7 +360,7 @@ def test_add_channel(mock_staff_client, mocker, patched_users_api):
     assert search_for_field_stub.call_args[0][0].to_dict() == modified_search.to_dict()
     assert search_for_field_stub.call_args[0][1] == 'user_id'
 
-    add_contributors_task_stub.assert_called_once_with(channel.name, contributor_ids)
+    add_contributors_task_stub.delay.assert_called_once_with(channel.name, contributor_ids)
 
 
 def test_add_channel_failed_create_channel(mock_staff_client, mocker):

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -8,6 +8,7 @@ from factory.django import mute_signals
 from open_discussions_api.constants import ROLE_STAFF
 import pytest
 from requests.exceptions import HTTPError
+from rest_framework import status as statuses
 
 from dashboard.factories import ProgramEnrollmentFactory
 from discussions import api
@@ -196,9 +197,9 @@ def test_add_to_channel_failed_subscriber(mock_staff_client):
 
 
 @pytest.mark.parametrize("contributor_status_code,subscriber_status_code", [
-    (200, 200),
-    (404, 404),
-    (409, 404),
+    (statuses.HTTP_200_OK, statuses.HTTP_200_OK),
+    (statuses.HTTP_404_NOT_FOUND, statuses.HTTP_404_NOT_FOUND),
+    (statuses.HTTP_409_CONFLICT, statuses.HTTP_404_NOT_FOUND),
 ])
 def test_remove_from_channel(mock_staff_client, contributor_status_code, subscriber_status_code):
     """remove_from_channel should remove a user's contributor and subscriber status"""
@@ -209,7 +210,13 @@ def test_remove_from_channel(mock_staff_client, contributor_status_code, subscri
     mock_staff_client.channels.remove_subscriber.assert_called_once_with(channel_name, discussion_username)
 
 
-@pytest.mark.parametrize("status_code", [400, 401, 403, 500, 505])
+@pytest.mark.parametrize("status_code", [
+    statuses.HTTP_400_BAD_REQUEST,
+    statuses.HTTP_401_UNAUTHORIZED,
+    statuses.HTTP_403_FORBIDDEN,
+    statuses.HTTP_500_INTERNAL_SERVER_ERROR,
+    statuses.HTTP_505_HTTP_VERSION_NOT_SUPPORTED
+])
 def test_remove_from_channel_failed_contributor(mock_staff_client, status_code):
     """
     remove_from_channel should raise an exception if it fails to remove a user's contributor status,
@@ -229,7 +236,14 @@ def test_remove_from_channel_failed_contributor(mock_staff_client, status_code):
     mock_staff_client.channels.remove_subscriber.assert_called_once_with(channel_name, discussion_username)
 
 
-@pytest.mark.parametrize("status_code", [400, 401, 403, 409, 500, 505])
+@pytest.mark.parametrize("status_code", [
+    statuses.HTTP_400_BAD_REQUEST,
+    statuses.HTTP_401_UNAUTHORIZED,
+    statuses.HTTP_403_FORBIDDEN,
+    statuses.HTTP_409_CONFLICT,
+    statuses.HTTP_500_INTERNAL_SERVER_ERROR,
+    statuses.HTTP_505_HTTP_VERSION_NOT_SUPPORTED
+])
 def test_remove_from_channel_failed_subscriber(mock_staff_client, status_code):
     """
     remove_from_channel should raise an exception if it fails to remove a user's subscriber status,

--- a/discussions/conftest.py
+++ b/discussions/conftest.py
@@ -7,7 +7,7 @@ import pytest
 def _update_discussion_user(discussion_user):
     """Helper function to create a DiscussionUser and update its username"""
     if discussion_user.username is None:
-        discussion_user.username = Faker('profile').generate({})['username']
+        discussion_user.username = Faker('user_name').generate({})
     discussion_user.last_sync = discussion_user.user.profile.updated_on
     discussion_user.save()
 

--- a/discussions/conftest.py
+++ b/discussions/conftest.py
@@ -1,0 +1,29 @@
+"""pytest configuration for discussions tests"""
+from factory import Faker
+import pytest
+
+
+# pylint: disable=unused-argument
+def _update_discussion_user(discussion_user):
+    """Helper function to create a DiscussionUser and update its username"""
+    if discussion_user.username is None:
+        discussion_user.username = Faker('profile').generate({})['username']
+    discussion_user.last_sync = discussion_user.user.profile.updated_on
+    discussion_user.save()
+
+
+@pytest.fixture()
+def patched_users_api(mocker):
+    """Patch functions creating the user on open-discussions"""
+    create = mocker.patch(
+        'discussions.api.create_discussion_user', autospec=True, side_effect=_update_discussion_user
+    )
+    update = mocker.patch(
+        'discussions.api.update_discussion_user', autospec=True, side_effect=_update_discussion_user
+    )
+    return create, update
+
+
+@pytest.fixture(autouse=True)
+def discussion_settings_everywhere(discussion_settings):
+    """discussion_settings with autouse=True"""

--- a/discussions/exceptions.py
+++ b/discussions/exceptions.py
@@ -7,3 +7,15 @@ class DiscussionUserSyncException(Exception):
 
 class ChannelCreationException(Exception):
     """Exception which occurs when an error happens on open-discussions when creating a channel"""
+
+
+class ContributorSyncException(Exception):
+    """Exception indicating failure to add or remove a contributor"""
+
+
+class SubscriberSyncException(Exception):
+    """Exception indicating a failure to add or remove a subscriber"""
+
+
+class ModeratorSyncException(Exception):
+    """Exception indicating a failure to add or remove a moderator"""

--- a/discussions/factories.py
+++ b/discussions/factories.py
@@ -20,7 +20,7 @@ from search.models import PercolateQuery
 
 class ChannelFactory(DjangoModelFactory):
     """Factory for Channel"""
-    name = Faker('word')
+    name = Faker('uuid4')
     query = SubFactory(PercolateQueryFactory, source_type=PercolateQuery.DISCUSSION_CHANNEL_TYPE)
 
     class Meta:

--- a/discussions/factories.py
+++ b/discussions/factories.py
@@ -1,19 +1,45 @@
 """Factories for discussions models"""
+from django.contrib.auth.models import User
+from django.db.models.signals import post_save
 from factory import (
     Faker,
     SubFactory,
 )
-from factory.django import DjangoModelFactory
+from factory.django import (
+    DjangoModelFactory,
+    mute_signals,
+)
 
-from discussions.models import Channel
+from discussions.models import (
+    Channel,
+    DiscussionUser,
+)
 from search.factories import PercolateQueryFactory
 from search.models import PercolateQuery
 
 
 class ChannelFactory(DjangoModelFactory):
     """Factory for Channel"""
-    name = Faker('numerify', text='channel_#')
+    name = Faker('numerify', text='channel_###')
     query = SubFactory(PercolateQueryFactory, source_type=PercolateQuery.DISCUSSION_CHANNEL_TYPE)
 
     class Meta:
         model = Channel
+
+
+class DiscussionUserFactory(DjangoModelFactory):
+    """Factory for DiscussionUser"""
+    user = SubFactory(User)
+    username = Faker('numerify', text='username_#')
+    last_sync = Faker('date_time_this_month')
+
+    @classmethod
+    def create(cls, *args, **kwargs):
+        """
+        Overrides the default .create() method to turn off save signals
+        """
+        with mute_signals(post_save):
+            return super().create(*args, **kwargs)
+
+    class Meta:
+        model = DiscussionUser

--- a/discussions/factories.py
+++ b/discussions/factories.py
@@ -20,7 +20,7 @@ from search.models import PercolateQuery
 
 class ChannelFactory(DjangoModelFactory):
     """Factory for Channel"""
-    name = Faker('numerify', text='channel_###')
+    name = Faker('word')
     query = SubFactory(PercolateQueryFactory, source_type=PercolateQuery.DISCUSSION_CHANNEL_TYPE)
 
     class Meta:
@@ -30,7 +30,7 @@ class ChannelFactory(DjangoModelFactory):
 class DiscussionUserFactory(DjangoModelFactory):
     """Factory for DiscussionUser"""
     user = SubFactory(User)
-    username = Faker('numerify', text='username_#')
+    username = Faker('user_name')
     last_sync = Faker('date_time_this_month')
 
     @classmethod

--- a/discussions/serializers.py
+++ b/discussions/serializers.py
@@ -5,6 +5,7 @@ from open_discussions_api.channels.constants import VALID_CHANNEL_TYPES
 from rest_framework import serializers
 
 from discussions.api import add_channel
+from discussions.models import DiscussionUser
 from search.api import create_search_obj
 
 
@@ -21,8 +22,10 @@ class ChannelSerializer(serializers.Serializer):
     query = serializers.JSONField()
 
     def create(self, validated_data):
+        user = self.context['request'].user
+        moderator_username = DiscussionUser.objects.get(user=user).username
         search_obj = create_search_obj(
-            self.context['request'].user,
+            user,
             search_param_dict=validated_data['query']
         )
         title = validated_data['title']
@@ -35,6 +38,7 @@ class ChannelSerializer(serializers.Serializer):
             name=name,
             public_description=public_description,
             channel_type=channel_type,
+            moderator_username=moderator_username,
         )
         return {
             "title": title,

--- a/discussions/serializers.py
+++ b/discussions/serializers.py
@@ -5,7 +5,6 @@ from open_discussions_api.channels.constants import VALID_CHANNEL_TYPES
 from rest_framework import serializers
 
 from discussions.api import add_channel
-from discussions.models import DiscussionUser
 from search.api import create_search_obj
 
 
@@ -23,7 +22,7 @@ class ChannelSerializer(serializers.Serializer):
 
     def create(self, validated_data):
         user = self.context['request'].user
-        moderator_username = DiscussionUser.objects.get(user=user).username
+        moderator_username = user.discussion_user.username
         search_obj = create_search_obj(
             user,
             search_param_dict=validated_data['query']

--- a/discussions/signals_test.py
+++ b/discussions/signals_test.py
@@ -10,6 +10,7 @@ from micromasters.factories import UserFactory
 pytestmark = pytest.mark.django_db
 
 
+# pylint: disable=unused-argument
 def test_sync_user_profile_disabled(settings, mocker):
     """Test that sync_user_profile doesn't call the api if disabled"""
     settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = False
@@ -20,17 +21,15 @@ def test_sync_user_profile_disabled(settings, mocker):
     assert mock_task.delay.called is False
 
 
-def test_sync_user_profile_create_enabled(settings, mocker):
+def test_sync_user_profile_create_enabled(mocker):
     """Test that sync_user_profile calls the task if enabled on create"""
-    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = True
     mock_task = mocker.patch('discussions.tasks.sync_discussion_user')
     user = UserFactory.create()
     mock_task.delay.assert_called_with(user.id)
 
 
-def test_sync_user_profile_save_enabled(settings, mocker):
+def test_sync_user_profile_save_enabled(mocker, patched_users_api):
     """Test that sync_user_profile calls the task if enabled on save"""
-    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = True
     mock_task = mocker.patch('discussions.tasks.sync_discussion_user')
     with mute_signals(post_save):
         profile = ProfileFactory.create()

--- a/discussions/tasks.py
+++ b/discussions/tasks.py
@@ -47,7 +47,7 @@ def sync_discussion_users():
 
 
 @app.task()
-def add_contributors(channel_name, user_ids):
+def add_users_to_channel(channel_name, user_ids):
     """
     Add users to a open-discussions channel as contributors and subscribers
 
@@ -59,4 +59,4 @@ def add_contributors(channel_name, user_ids):
         log.error('OPEN_DISCUSSIONS_USER_SYNC is set to False (so disabled) in the settings')
         return
 
-    api.add_contributors(channel_name, user_ids)
+    api.add_users_to_channel(channel_name, user_ids)

--- a/discussions/tasks.py
+++ b/discussions/tasks.py
@@ -53,7 +53,7 @@ def add_contributors(channel_name, user_ids):
 
     Args:
         channel_name (str): The name of the channel
-        user_ids (set of int): profile ids to sync
+        user_ids (list of int): profile ids to sync
     """
     if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
         log.error('OPEN_DISCUSSIONS_USER_SYNC is set to False (so disabled) in the settings')

--- a/discussions/tasks.py
+++ b/discussions/tasks.py
@@ -44,3 +44,19 @@ def sync_discussion_users():
             api.create_or_update_discussion_user(user_id)
         except DiscussionUserSyncException:
             log.error('Impossible to sync user_id %s to discussions', user_id)
+
+
+@app.task()
+def add_contributors(channel_name, user_ids):
+    """
+    Add users to a open-discussions channel as contributors and subscribers
+
+    Args:
+        channel_name (str): The name of the channel
+        user_ids (set of int): profile ids to sync
+    """
+    if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
+        log.error('OPEN_DISCUSSIONS_USER_SYNC is set to False (so disabled) in the settings')
+        return
+
+    api.add_contributors(channel_name, user_ids)

--- a/discussions/tasks_test.py
+++ b/discussions/tasks_test.py
@@ -1,18 +1,15 @@
 """Test for discussions tasks"""
 
 import pytest
-from django.db.models.signals import post_save
-from factory.django import mute_signals
-
 
 from discussions import tasks
 from discussions.exceptions import DiscussionUserSyncException
-from discussions.models import DiscussionUser
 from profiles.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
 
 
+# pylint: disable=unused-argument
 def test_sync_discussion_user_sync_disabled(settings, mocker):
     """Test that sync_discussion_user doesn't call the api if disabled"""
     settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = False
@@ -21,17 +18,15 @@ def test_sync_discussion_user_sync_disabled(settings, mocker):
     assert mock_api.called is False
 
 
-def test_sync_discussion_user_sync_enabled(settings, mocker):
+def test_sync_discussion_user_sync_enabled(mocker):
     """Test that sync_discussion_user call the api if enabled"""
-    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = True
     mock_api = mocker.patch('discussions.api.create_or_update_discussion_user')
     tasks.sync_discussion_user(1234)
     mock_api.assert_called_once_with(1234)
 
 
-def test_sync_discussion_user_task_api_error(settings, mocker):
+def test_sync_discussion_user_task_api_error(mocker):
     """Test that sync_discussion_user logs errors if they occur"""
-    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = True
     mock_log = mocker.patch('discussions.tasks.log')
     mock_api = mocker.patch('discussions.api.create_or_update_discussion_user')
     mock_api.side_effect = DiscussionUserSyncException()
@@ -40,7 +35,7 @@ def test_sync_discussion_user_task_api_error(settings, mocker):
     mock_log.exception.assert_called_once_with("Error syncing user profile")
 
 
-def test_sync_discussion_users_sync_disabled(settings, mocker):
+def test_sync_discussion_users_sync_disabled(settings, mocker, patched_users_api):
     """
     Test that sync_discussion_users doesn't call the api if disabled
     """
@@ -52,19 +47,20 @@ def test_sync_discussion_users_sync_disabled(settings, mocker):
     assert mock_api.called is False
 
 
-def test_sync_discussion_userw_sync_enabled(settings, mocker):
+def test_sync_discussion_users_sync_enabled(settings, mocker, patched_users_api):
     """
     Test that sync_discussion_users call the api if enabled
     and for only users with a profile and not already syncronized
     """
     users = [UserFactory.create() for _ in range(5)]
+    for user in users:
+        # Delete DiscussionUser so it will get backfilled
+        user.discussion_user.delete()
     user_already_sync = UserFactory.create()
-    DiscussionUser.objects.create(user=user_already_sync, username='foo')
-    with mute_signals(post_save):
-        user_no_profile = UserFactory.create()
+    user_no_profile = UserFactory.create()
+    user_no_profile.profile.delete()
 
-    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = True
-    mock_api = mocker.patch('discussions.api.create_or_update_discussion_user')
+    mock_api = mocker.patch('discussions.api.create_or_update_discussion_user', autospec=True)
     tasks.sync_discussion_users()
     assert mock_api.call_count == len(users)
     for user in users:
@@ -75,15 +71,32 @@ def test_sync_discussion_userw_sync_enabled(settings, mocker):
         mock_api.assert_any_call(user_already_sync.id)
 
 
-def test_sync_discussion_users_task_api_error(settings, mocker):
+def test_sync_discussion_users_task_api_error(mocker):
     """
     Test that sync_discussion_users logs errors if they occur
     """
+    mock_api = mocker.patch('discussions.api.create_or_update_discussion_user', autospec=True)
     user = UserFactory.create()
-    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = True
-    mock_log = mocker.patch('discussions.tasks.log')
-    mock_api = mocker.patch('discussions.api.create_or_update_discussion_user')
+
+    # don't count the one triggered by signals on UserFactory.create()
+    mock_api.reset_mock()
+    mock_log = mocker.patch('discussions.tasks.log', autospec=True)
     mock_api.side_effect = DiscussionUserSyncException()
     tasks.sync_discussion_users()
     mock_api.assert_called_once_with(user.id)
     mock_log.error.assert_called_once_with("Impossible to sync user_id %s to discussions", user.id)
+
+
+def test_add_contributors_no_feature_flag(settings, mocker):
+    """Don't attempt to add contributors if the feature flag is disabled"""
+    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = False
+    stub = mocker.patch('discussions.api.add_contributors')
+    tasks.add_contributors.delay('channel', [1, 2, 3])
+    assert stub.called is False
+
+
+def test_add_contributors(mocker):
+    """add_contributors should forward all arguments to the api function of the same name"""
+    stub = mocker.patch('discussions.api.add_contributors', autospec=True)
+    tasks.add_contributors.delay('channel', [1, 2, 3])
+    stub.assert_called_once_with('channel', [1, 2, 3])

--- a/discussions/tasks_test.py
+++ b/discussions/tasks_test.py
@@ -87,16 +87,16 @@ def test_sync_discussion_users_task_api_error(mocker):
     mock_log.error.assert_called_once_with("Impossible to sync user_id %s to discussions", user.id)
 
 
-def test_add_contributors_no_feature_flag(settings, mocker):
-    """Don't attempt to add contributors if the feature flag is disabled"""
+def test_add_users_to_channel_no_feature_flag(settings, mocker):
+    """Don't attempt to add users if the feature flag is disabled"""
     settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = False
-    stub = mocker.patch('discussions.api.add_contributors')
-    tasks.add_contributors.delay('channel', [1, 2, 3])
+    stub = mocker.patch('discussions.api.add_users_to_channel')
+    tasks.add_users_to_channel.delay('channel', [1, 2, 3])
     assert stub.called is False
 
 
-def test_add_contributors(mocker):
-    """add_contributors should forward all arguments to the api function of the same name"""
-    stub = mocker.patch('discussions.api.add_contributors', autospec=True)
-    tasks.add_contributors.delay('channel', [1, 2, 3])
+def test_add_users_to_channel(mocker):
+    """add_users_to_channel should forward all arguments to the api function of the same name"""
+    stub = mocker.patch('discussions.api.add_users_to_channel', autospec=True)
+    tasks.add_users_to_channel.delay('channel', [1, 2, 3])
     stub.assert_called_once_with('channel', [1, 2, 3])

--- a/profiles/signals.py
+++ b/profiles/signals.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from .models import Profile
+from profiles.models import Profile
 
 
 log = logging.getLogger(__name__)

--- a/search/api.py
+++ b/search/api.py
@@ -277,6 +277,6 @@ def adjust_search_for_percolator(search):
     search_dict = search.to_dict()
     if 'query' in search_dict:
         updated_search_dict['query'] = search_dict['query']
-    updated_search = Search(index=search._index, doc_type=search._doc_type)
+    updated_search = Search(index=search._index, doc_type=search._doc_type)  # pylint: disable=protected-access
     updated_search.update_from_dict(updated_search_dict)
     return updated_search

--- a/search/api.py
+++ b/search/api.py
@@ -277,4 +277,6 @@ def adjust_search_for_percolator(search):
     search_dict = search.to_dict()
     if 'query' in search_dict:
         updated_search_dict['query'] = search_dict['query']
-    return Search.from_dict(updated_search_dict)
+    updated_search = Search(index=search._index, doc_type=search._doc_type)
+    updated_search.update_from_dict(updated_search_dict)
+    return updated_search

--- a/search/api.py
+++ b/search/api.py
@@ -177,6 +177,37 @@ def prepare_and_execute_search(user, search_param_dict=None, search_func=execute
     return search_func(search_obj)
 
 
+def search_for_field(search_obj, field_name, page_size=DEFAULT_ES_LOOP_PAGE_SIZE):
+    """
+    Retrieves all unique instances of a field for documents that match an ES query
+
+    Args:
+        search_obj (Search): Search object
+        field_name (str): The name of the field for the value to get
+        page_size (int): Number of docs per page of results
+
+    Returns:
+        set: Set of unique values
+    """
+    results = set()
+    # Maintaining a consistent sort on '_doc' will help prevent bugs where the
+    # index is altered during the loop.
+    # This also limits the query to only return the field value.
+    search_obj = search_obj.sort('_doc').fields(field_name)
+    loop = 0
+    all_results_returned = False
+    while not all_results_returned:
+        from_index = loop * page_size
+        to_index = from_index + page_size
+        search_results = execute_search(search_obj[from_index: to_index])
+        # add the field value for every search result hit to the set
+        for hit in search_results.hits:
+            results.add(getattr(hit, field_name)[0])
+        all_results_returned = to_index >= search_results.hits.total
+        loop += 1
+    return results
+
+
 def get_all_query_matching_emails(search_obj, page_size=DEFAULT_ES_LOOP_PAGE_SIZE):
     """
     Retrieves all unique emails for documents that match an ES query
@@ -188,23 +219,7 @@ def get_all_query_matching_emails(search_obj, page_size=DEFAULT_ES_LOOP_PAGE_SIZ
     Returns:
         set: Set of unique emails
     """
-    results = set()
-    # Maintaining a consistent sort on '_doc' will help prevent bugs where the
-    # index is altered during the loop.
-    # This also limits the query to only return the 'email' field.
-    search_obj = search_obj.sort('_doc').fields('email')
-    loop = 0
-    all_results_returned = False
-    while not all_results_returned:
-        from_index = loop * page_size
-        to_index = from_index + page_size
-        search_results = execute_search(search_obj[from_index: to_index])
-        # add the email for every search result hit to the set
-        for hit in search_results.hits:
-            results.add(hit.email[0])
-        all_results_returned = to_index >= search_results.hits.total
-        loop += 1
-    return results
+    return search_for_field(search_obj, "email", page_size=page_size)
 
 
 def search_percolate_queries(program_enrollment_id, source_type):

--- a/search/api.py
+++ b/search/api.py
@@ -2,6 +2,7 @@
 Functions for executing ES searches
 """
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q as Query
 from elasticsearch_dsl import Search, Q
 
@@ -36,6 +37,11 @@ def execute_search(search_obj):
         elasticsearch_dsl.result.Response: ES response
     """
     # make sure there is a live connection
+    if search_obj._index is None:  # pylint: disable=protected-access
+        # If you're seeing this it means you're creating Search() without using
+        # create_search_obj which sets important fields like the index and doc_type.
+        raise ImproperlyConfigured("search object is missing an index")
+
     get_conn()
     return search_obj.execute()
 

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -1,7 +1,6 @@
 """
 Tests for search API functionality
 """
-import math
 from unittest.mock import Mock, patch
 import ddt
 from elasticsearch_dsl import Search, Q
@@ -220,7 +219,7 @@ class SearchAPITests(ESTestCase):
         test_es_page_size = 2
         search = create_search_obj(self.user)
         user_ids = self.program.programenrollment_set.values_list("user__email", flat=True).order_by("-user__id")
-        results = search_for_field(search, 'email', page_size=test_es_page_size)
+        results = get_all_query_matching_emails(search, page_size=test_es_page_size)
         assert results == set(user_ids[:test_es_page_size])
 
 

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -5,6 +5,7 @@ Celery tasks for search
 # The imports which are prefixed with _ are mocked to be ignored in MockedESTestCase
 
 from dashboard.models import ProgramEnrollment
+from discussions.api import sync_user_to_channels as _sync_user_to_channels
 from mail.api import send_automatic_emails as _send_automatic_emails
 from micromasters.celery import app
 from search.indexing_api import (
@@ -17,6 +18,20 @@ from search.indexing_api import (
     refresh_index as _refresh_index,
 )
 from search.models import PercolateQuery
+
+
+def post_indexing_handler(program_enrollment_ids):
+    """
+    Do the work which happens after a profile is reindexed
+
+    Args:
+        program_enrollment_ids (list of int): A list of ProgramEnrollment ids
+    """
+    _refresh_index(get_default_alias())
+    for program_enrollment in ProgramEnrollment.objects.filter(id__in=program_enrollment_ids):
+        _send_automatic_emails(program_enrollment)
+
+        _sync_user_to_channels(program_enrollment.user.id)
 
 
 @app.task
@@ -42,9 +57,7 @@ def index_program_enrolled_users(program_enrollment_ids):
     _index_program_enrolled_users(program_enrollments)
 
     # Send email for profiles that newly fit the search query for an automatic email
-    _refresh_index(get_default_alias())
-    for program_enrollment in program_enrollments:
-        _send_automatic_emails(program_enrollment)
+    post_indexing_handler(program_enrollment_ids)
 
 
 @app.task
@@ -58,9 +71,8 @@ def index_users(user_ids):
     _index_users(user_ids)
 
     # Send email for profiles that newly fit the search query for an automatic email
-    _refresh_index(get_default_alias())
-    for program_enrollment in ProgramEnrollment.objects.filter(user__in=user_ids):
-        _send_automatic_emails(program_enrollment)
+    enrollment_ids = list(ProgramEnrollment.objects.filter(user__in=user_ids).values_list("id", flat=True))
+    post_indexing_handler(enrollment_ids)
 
 
 @app.task

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -1,6 +1,11 @@
 """Tests for search tasks"""
-from dashboard.factories import ProgramEnrollmentFactory
+from ddt import (
+    data,
+    ddt,
+)
 from django.test import override_settings
+
+from dashboard.factories import ProgramEnrollmentFactory
 from search.base import MockedESTestCase
 from search.indexing_api import get_default_alias
 from search.tasks import (
@@ -12,7 +17,13 @@ from search.tasks import (
 FAKE_INDEX = 'fake'
 
 
-@override_settings(ELASTICSEARCH_INDEX=FAKE_INDEX)
+@ddt
+@override_settings(
+    ELASTICSEARCH_INDEX=FAKE_INDEX,
+    OPEN_DISCUSSIONS_JWT_SECRET='secret',
+    OPEN_DISCUSSIONS_BASE_URL='http://fake',
+    OPEN_DISCUSSIONS_API_USERNAME='mitodl',
+)
 class SearchTasksTests(MockedESTestCase):
     """
     Tests for search tasks
@@ -33,30 +44,37 @@ class SearchTasksTests(MockedESTestCase):
             elif mock.name == "_sync_user_to_channels":
                 self.sync_user_to_channels_mock = mock
 
-    def test_index_users(self):
+    @data(True, False)
+    def test_index_users(self, sync_feature_flag):
         """
         When we run the index_users task we should index user's program enrollments and send them automatic emails
         """
         enrollment1 = ProgramEnrollmentFactory.create()
         enrollment2 = ProgramEnrollmentFactory.create(user=enrollment1.user)
-        index_users([enrollment1.user.id])
-        self.index_users_mock.assert_called_with([enrollment1.user.id])
-        for enrollment in [enrollment1, enrollment2]:
-            self.send_automatic_emails_mock.assert_any_call(enrollment)
-            self.sync_user_to_channels_mock.assert_any_call(enrollment.user.id)
-        self.refresh_index_mock.assert_called_with(get_default_alias())
+        with self.settings(FEATURES={"OPEN_DISCUSSIONS_USER_SYNC": sync_feature_flag}):
+            index_users([enrollment1.user.id])
+            self.index_users_mock.assert_called_with([enrollment1.user.id])
+            for enrollment in [enrollment1, enrollment2]:
+                self.send_automatic_emails_mock.assert_any_call(enrollment)
+                if sync_feature_flag:
+                    self.sync_user_to_channels_mock.assert_any_call(enrollment.user.id)
+            self.refresh_index_mock.assert_called_with(get_default_alias())
 
-    def test_index_program_enrolled_users(self):
+    @data(True, False)
+    def test_index_program_enrolled_users(self, sync_feature_flag):
         """
         When we run the index_program_enrolled_users task we should index them and send them automatic emails
         """
         enrollments = [ProgramEnrollmentFactory.create() for _ in range(2)]
         enrollment_ids = [enrollment.id for enrollment in enrollments]
-        index_program_enrolled_users(enrollment_ids)
-        assert list(
-            self.index_program_enrolled_users_mock.call_args[0][0].values_list('id', flat=True)
-        ) == enrollment_ids
-        for enrollment in enrollments:
-            self.send_automatic_emails_mock.assert_any_call(enrollment)
-            self.sync_user_to_channels_mock.assert_any_call(enrollment.user.id)
-        self.refresh_index_mock.assert_called_with(get_default_alias())
+
+        with self.settings(FEATURES={"OPEN_DISCUSSIONS_USER_SYNC": sync_feature_flag}):
+            index_program_enrolled_users(enrollment_ids)
+            assert list(
+                self.index_program_enrolled_users_mock.call_args[0][0].values_list('id', flat=True)
+            ) == enrollment_ids
+            for enrollment in enrollments:
+                self.send_automatic_emails_mock.assert_any_call(enrollment)
+                if sync_feature_flag:
+                    self.sync_user_to_channels_mock.assert_any_call(enrollment.user.id)
+            self.refresh_index_mock.assert_called_with(get_default_alias())

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -30,6 +30,8 @@ class SearchTasksTests(MockedESTestCase):
                 self.send_automatic_emails_mock = mock
             elif mock.name == "_refresh_index":
                 self.refresh_index_mock = mock
+            elif mock.name == "_sync_user_to_channels":
+                self.sync_user_to_channels_mock = mock
 
     def test_index_users(self):
         """
@@ -41,6 +43,7 @@ class SearchTasksTests(MockedESTestCase):
         self.index_users_mock.assert_called_with([enrollment1.user.id])
         for enrollment in [enrollment1, enrollment2]:
             self.send_automatic_emails_mock.assert_any_call(enrollment)
+            self.sync_user_to_channels_mock.assert_any_call(enrollment.user.id)
         self.refresh_index_mock.assert_called_with(get_default_alias())
 
     def test_index_program_enrolled_users(self):
@@ -55,4 +58,5 @@ class SearchTasksTests(MockedESTestCase):
         ) == enrollment_ids
         for enrollment in enrollments:
             self.send_automatic_emails_mock.assert_any_call(enrollment)
+            self.sync_user_to_channels_mock.assert_any_call(enrollment.user.id)
         self.refresh_index_mock.assert_called_with(get_default_alias())


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #3475

#### What's this PR do?
Adds contributors when a new channel is created, and synchronizes new contributors when the account is created or updated

#### How should this be manually tested?
Creating a channel should populate contributors based on the provided query:
 - Seed your database using seed_db
 - Go to `/learners`, open your network tab and execute some search targeting a handful of people with some substring of their name, for example `fl`. Copy the search query from the request.
 - Go to `/api/v0/channels/` and fill out the form. Paste the query into the search query field. You should get a 201 with information about the new channel
 - On open-discussions go to `/api/v0/channels/<channel_name>/contributors/` and verify that there are the right number of users (all the users in your search plus one for the API user)

When a user updates their profile it should unenroll or enroll them via profile signal:
 - Pick a user who matched the search criteria earlier. Log in as that user on reddit. You can change the password like this:
    
        from r2.models.account import *
        a = Account._by_name("your_username_here")
        a.password = bcrypt_password("your new password")
        a._commit()

You will also need to edit the max length for the input field on the login page to allow the ULID

 - Update the profile so that their name does not fit the search criteria anymore. Verify that the user is now not a contributor and they do not see that channel in their list of subscriptions.
  - Update the profile so that their name is now in the search criteria again. Verify that the user is a member of the channel again.