### PR TITLE
simple discussions link

### DIFF
--- a/static/js/components/DiscussionCard.js
+++ b/static/js/components/DiscussionCard.js
@@ -1,0 +1,24 @@
+// @flow
+import React from "react"
+import { Card } from "react-mdl/lib/Card"
+import Icon from "react-mdl/lib/Icon"
+
+import type { Program } from "../flow/programTypes"
+
+type DiscussionCardProps = {
+  program: Program
+}
+
+const DiscussionCard = ({ program }: DiscussionCardProps) => (
+  <Card className="discussion-card" shadow={0}>
+    <div className="discussions-link">
+      <Icon name="forum" />
+      <a href="/discussions" target="_blank" rel="noopener noreferrer">
+        MicroMasters Discussion
+      </a>
+    </div>
+    <p>Discuss the {program.title} MicroMasters with other learners.</p>
+  </Card>
+)
+
+export default DiscussionCard

--- a/static/js/components/DiscussionCard_test.js
+++ b/static/js/components/DiscussionCard_test.js
@@ -1,0 +1,25 @@
+// @flow
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+
+import DiscussionCard from "./DiscussionCard"
+
+import { DASHBOARD_RESPONSE } from "../test_constants"
+
+describe("DiscussionCard", () => {
+  const program = DASHBOARD_RESPONSE.programs[0]
+
+  it("should render what we expect", () => {
+    const wrapper = shallow(<DiscussionCard program={program} />)
+    const linkProps = wrapper.find("a").props()
+    assert.equal(linkProps.href, "/discussions")
+    assert.equal(linkProps.children, "MicroMasters Discussion")
+    assert.equal(linkProps.target, "_blank")
+    const paraProps = wrapper.find("p").props()
+    assert.equal(
+      paraProps.children.join(""),
+      `Discuss the ${program.title} MicroMasters with other learners.`
+    )
+  })
+})

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -60,6 +60,7 @@ import FinalExamCard from "../components/dashboard/FinalExamCard"
 import ErrorMessage from "../components/ErrorMessage"
 import LearnersInProgramCard from "../components/LearnersInProgramCard"
 import ProgressWidget from "../components/ProgressWidget"
+import DiscussionCard from "../components/DiscussionCard"
 import { clearCoupons, fetchCoupons } from "../actions/coupons"
 import {
   setDocumentSentDate,
@@ -823,6 +824,9 @@ class DashboardPage extends React.Component {
           </div>
           <div className="second-column">
             <ProgressWidget program={program} />
+            {SETTINGS.FEATURES.DISCUSSIONS_POST_UI ? (
+              <DiscussionCard program={program} />
+            ) : null}
             {this.renderLearnersInProgramCard(program.id)}
           </div>
         </div>

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -92,6 +92,7 @@ import Grades, {
   gradeDetailPopupKey
 } from "../components/dashboard/courses/Grades"
 import { EDX_GRADE } from "./DashboardPage"
+import DiscussionCard from "../components/DiscussionCard"
 
 describe("DashboardPage", () => {
   let renderComponent, helper, listenForActions
@@ -134,6 +135,23 @@ describe("DashboardPage", () => {
       assert.lengthOf(wrapper.find(".course-list"), 1)
       assert.lengthOf(wrapper.find(".progress-widget"), 1)
       assert.lengthOf(wrapper.find(".learners-card"), 1)
+    })
+  })
+  ;[true, false].forEach(showCard => {
+    it(`should ${showCard
+      ? "show"
+      : "not show"} discussions card when feature flag is ${showCard}`, () => {
+      SETTINGS.FEATURES.DISCUSSIONS_POST_UI = showCard
+      return renderComponent(
+        "/dashboard",
+        DASHBOARD_SUCCESS_ACTIONS
+      ).then(([wrapper]) => {
+        if (showCard) {
+          assert.lengthOf(wrapper.find(DiscussionCard), 1)
+        } else {
+          assert.lengthOf(wrapper.find(DiscussionCard), 0)
+        }
+      })
     })
   })
 

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -17,7 +17,8 @@ const _createSettings = () => ({
   EXAMS_SSO_CLIENT_CODE: "foobarcode",
   EXAMS_SSO_URL:         "http://foo.bar/baz",
   FEATURES:              {
-    PROGRAM_LEARNERS: true
+    PROGRAM_LEARNERS:    true,
+    DISCUSSIONS_POST_UI: true
   },
   get username() {
     throw new Error("username was removed")

--- a/static/scss/discussion-card.scss
+++ b/static/scss/discussion-card.scss
@@ -1,0 +1,21 @@
+.discussion-card {
+  min-height: 0;
+
+  p {
+    margin-bottom: 0;
+  }
+
+  a {
+    margin: 6px 0;
+  }
+
+  .discussions-link {
+    display: flex;
+    align-items: center;
+
+    i {
+      margin-right: 5px;
+      color: $link-text;
+    }
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -38,6 +38,7 @@
 @import "staff-learner-info-card";
 @import "automatic-emails";
 @import "certificate";
+@import "discussion-card";
 
 .selected {
   font-weight: bold;

--- a/ui/views.py
+++ b/ui/views.py
@@ -62,7 +62,8 @@ class ReactView(View):  # pylint: disable=unused-argument
             "EXAMS_SSO_CLIENT_CODE": settings.EXAMS_SSO_CLIENT_CODE,
             "EXAMS_SSO_URL": settings.EXAMS_SSO_URL,
             "FEATURES": {
-                "PROGRAM_LEARNERS": settings.FEATURES.get('PROGRAM_LEARNERS_ENABLED', False)
+                "PROGRAM_LEARNERS": settings.FEATURES.get('PROGRAM_LEARNERS_ENABLED', False),
+                "DISCUSSIONS_POST_UI": settings.FEATURES.get('OPEN_DISCUSSIONS_POST_UI', False)
             },
         }
 

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -332,6 +332,7 @@ class DashboardTests(ViewsTests):
                 'EXAMS_SSO_URL': 'url',
                 'FEATURES': {
                     'PROGRAM_LEARNERS': False,
+                    'DISCUSSIONS_POST_UI': False,
                 },
             }
             assert resp.context['is_public'] is False
@@ -768,6 +769,7 @@ class TestUsersPage(ViewsTests):
                     'EXAMS_SSO_URL': 'url',
                     'FEATURES': {
                         'PROGRAM_LEARNERS': False,
+                        'DISCUSSIONS_POST_UI': False,
                     },
                 }
                 assert has_permission.called
@@ -837,6 +839,7 @@ class TestUsersPage(ViewsTests):
                     'EXAMS_SSO_URL': 'url',
                     'FEATURES': {
                         'PROGRAM_LEARNERS': False,
+                        'DISCUSSIONS_POST_UI': False,
                     },
                 }
                 assert has_permission.called


### PR DESCRIPTION
#### What are the relevant tickets?

first draft of #3476 

#### What's this PR do?

this adds a very simple card to the dashboard page that links the user over to discussions

#### How should this be manually tested?

if you open up the dashboard you should see something like this:

![fjfjfjfffffawefawefd](https://user-images.githubusercontent.com/6207644/30553029-eaa20c6e-9c6d-11e7-9e24-6cd308e0c51e.png)

clicking on the link should open the discussions app in a new tab, and you should be signed in, able to post, comment, etc.