### PR TITLE
Add queryset for create channel API

### DIFF
--- a/discussions/views.py
+++ b/discussions/views.py
@@ -77,3 +77,6 @@ class ChannelsView(CreateAPIView):
         CanCreateChannel,
     )
     serializer_class = ChannelSerializer
+
+    # Make django-rest-framework happy
+    queryset = []


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3533 

#### What's this PR do?
Adds a queryset to the create channel view since it's required by django-rest-framework. The queryset is not used for anything so it is an empty list.

#### How should this be manually tested?
Create a channel via the `/api/v0/channels/` rest API. You should get an error. Look in the heroku logs and verify that the error is not due to the lack of queryset.