### PR TITLE
add the open discussions redirect URL to the SETTINGS object

### DIFF
--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -20,6 +20,7 @@ declare var SETTINGS: {
   es_page_size: number,
   search_url: string,
   roles: Array<{ role: string }>,
+  open_discussions_redirect_url: string,
 };
 
 // mocha

--- a/ui/views.py
+++ b/ui/views.py
@@ -65,6 +65,7 @@ class ReactView(View):  # pylint: disable=unused-argument
                 "PROGRAM_LEARNERS": settings.FEATURES.get('PROGRAM_LEARNERS_ENABLED', False),
                 "DISCUSSIONS_POST_UI": settings.FEATURES.get('OPEN_DISCUSSIONS_POST_UI', False)
             },
+            "open_discussions_redirect_url": settings.OPEN_DISCUSSIONS_REDIRECT_URL,
         }
 
         return render(

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -284,6 +284,7 @@ class DashboardTests(ViewsTests):
         edx_base_url = FuzzyText().fuzz()
         host = FuzzyText().fuzz()
         email_support = FuzzyText().fuzz()
+        open_discussions_redirect_url = FuzzyText().fuzz()
         with self.settings(
             GA_TRACKING_ID=ga_tracking_id,
             REACT_GA_DEBUG=react_ga_debug,
@@ -295,6 +296,7 @@ class DashboardTests(ViewsTests):
             ELASTICSEARCH_DEFAULT_PAGE_SIZE=10,
             EXAMS_SSO_CLIENT_CODE='itsacode',
             EXAMS_SSO_URL='url',
+            OPEN_DISCUSSIONS_REDIRECT_URL=open_discussions_redirect_url,
         ), patch('ui.templatetags.render_bundle._get_bundle') as get_bundle:
             resp = self.client.get(DASHBOARD_URL)
 
@@ -334,6 +336,7 @@ class DashboardTests(ViewsTests):
                     'PROGRAM_LEARNERS': False,
                     'DISCUSSIONS_POST_UI': False,
                 },
+                'open_discussions_redirect_url': open_discussions_redirect_url
             }
             assert resp.context['is_public'] is False
             assert resp.context['has_zendesk_widget'] is True
@@ -721,6 +724,7 @@ class TestUsersPage(ViewsTests):
         edx_base_url = FuzzyText().fuzz()
         host = FuzzyText().fuzz()
         email_support = FuzzyText().fuzz()
+        open_discussions_redirect_url = FuzzyText().fuzz()
         with self.settings(
             GA_TRACKING_ID=ga_tracking_id,
             REACT_GA_DEBUG=react_ga_debug,
@@ -732,6 +736,7 @@ class TestUsersPage(ViewsTests):
             ELASTICSEARCH_DEFAULT_PAGE_SIZE=10,
             EXAMS_SSO_CLIENT_CODE='itsacode',
             EXAMS_SSO_URL='url',
+            OPEN_DISCUSSIONS_REDIRECT_URL=open_discussions_redirect_url
         ):
             # Mock has_permission so we don't worry about testing permissions here
             has_permission = Mock(return_value=True)
@@ -771,6 +776,7 @@ class TestUsersPage(ViewsTests):
                         'PROGRAM_LEARNERS': False,
                         'DISCUSSIONS_POST_UI': False,
                     },
+                    'open_discussions_redirect_url': open_discussions_redirect_url
                 }
                 assert has_permission.called
 
@@ -797,6 +803,7 @@ class TestUsersPage(ViewsTests):
         edx_base_url = FuzzyText().fuzz()
         host = FuzzyText().fuzz()
         email_support = FuzzyText().fuzz()
+        open_discussions_redirect_url = FuzzyText().fuzz()
         with self.settings(
             GA_TRACKING_ID=ga_tracking_id,
             REACT_GA_DEBUG=react_ga_debug,
@@ -808,6 +815,7 @@ class TestUsersPage(ViewsTests):
             ELASTICSEARCH_DEFAULT_PAGE_SIZE=10,
             EXAMS_SSO_CLIENT_CODE='itsacode',
             EXAMS_SSO_URL='url',
+            OPEN_DISCUSSIONS_REDIRECT_URL=open_discussions_redirect_url
         ):
             # Mock has_permission so we don't worry about testing permissions here
             has_permission = Mock(return_value=True)
@@ -841,6 +849,7 @@ class TestUsersPage(ViewsTests):
                         'PROGRAM_LEARNERS': False,
                         'DISCUSSIONS_POST_UI': False,
                     },
+                    'open_discussions_redirect_url': open_discussions_redirect_url
                 }
                 assert has_permission.called
 


### PR DESCRIPTION
#### What are the relevant tickets?

part of the work for #3476 

#### What's this PR do?

adds the open discussions redirect environment variable value to the SETTINGS object, so we can use that value on the frontend. For the recent posts component we need it so we know where to make the request.

#### How should this be manually tested?

Make sure that you have the env var set (`OPEN_DISCUSSIONS_REDIRECT_URL`) and open up `/dashboard`. Check that `SETTINGS.open_discussions_redirect_url` is the same string.