### PR TITLE
Remove afterImageUpload callback which was erroring and is unnecessary

### DIFF
--- a/static/js/components/PersonalTab.js
+++ b/static/js/components/PersonalTab.js
@@ -18,7 +18,6 @@ import {
 } from "../lib/validation/profile"
 import type {
   Profile,
-  ProfileFetchResponse,
   SaveProfileFunc,
   ValidationErrors,
   UpdateProfileFunc
@@ -111,14 +110,6 @@ export default class PersonalTab extends React.Component {
     )
   }
 
-  afterImageUpload = (fetchResponse: ProfileFetchResponse): void => {
-    const { profile, updateProfile } = this.props
-    let editState = _.cloneDeep(profile)
-    let { payload: { profile: { image } } } = fetchResponse
-    let newEditState = { ...editState, image }
-    updateProfile(newEditState, personalTabValidator)
-  }
-
   render() {
     const { ui: { selectedProgram }, errors, uneditedProfile } = this.props
 
@@ -146,7 +137,6 @@ export default class PersonalTab extends React.Component {
               editable={true}
               showLink={true}
               linkText="Click here to add a profile photo"
-              afterImageUpload={this.afterImageUpload}
             />
             <span className="validation-error-text">
               {_.get(errors, ["image"])}

--- a/static/js/containers/ProfileImage.js
+++ b/static/js/containers/ProfileImage.js
@@ -10,7 +10,7 @@ import {
   getPreferredName,
   userPrivilegeCheck
 } from "../util/util"
-import type { Profile, ProfileFetchResponse } from "../flow/profileTypes"
+import type { Profile } from "../flow/profileTypes"
 import ProfileImageUploader from "../components/ProfileImageUploader"
 import { createActionHelper } from "../lib/redux"
 import {
@@ -29,7 +29,6 @@ const formatPhotoName = photo => `${photo.name.replace(/\.\w*$/, "")}.jpg`
 
 class ProfileImage extends React.Component {
   props: {
-    afterImageUpload: ?(o: ProfileFetchResponse) => void,
     clearPhotoEdit: () => void,
     dispatch: Dispatch,
     editable: boolean,
@@ -53,8 +52,7 @@ class ProfileImage extends React.Component {
       profile: { username },
       imageUpload: { edit, photo },
       dispatch,
-      clearPhotoEdit,
-      afterImageUpload
+      clearPhotoEdit
     } = this.props
 
     return dispatch(
@@ -62,11 +60,7 @@ class ProfileImage extends React.Component {
     ).then(() => {
       clearPhotoEdit()
       this.setDialogVisibility(false)
-      return this.fetchUserProfile().then(resp => {
-        if (afterImageUpload) {
-          afterImageUpload(resp)
-        }
-      })
+      return this.fetchUserProfile()
     })
   }
 

--- a/static/js/containers/ProfileImage_test.js
+++ b/static/js/containers/ProfileImage_test.js
@@ -9,14 +9,9 @@ import { Provider } from "react-redux"
 
 import ProfileImage, { PROFILE_IMAGE_DIALOG } from "./ProfileImage"
 import IntegrationTestHelper from "../util/integration_test_helper"
-import ProfileImageUploader from "../components/ProfileImageUploader"
 import { showDialog } from "../actions/ui"
 import * as api from "../lib/api"
-import {
-  startPhotoEdit,
-  updatePhotoEdit,
-  requestPatchUserPhoto
-} from "../actions/image_upload"
+import { startPhotoEdit, requestPatchUserPhoto } from "../actions/image_upload"
 
 describe("ProfileImage", () => {
   let helper, sandbox, updateProfileImageStub, div
@@ -113,26 +108,6 @@ describe("ProfileImage", () => {
         helper.store.getState().ui.dialogVisibility[PROFILE_IMAGE_DIALOG],
         "should be open now"
       )
-    })
-
-    it("should call an afterImageUpload prop after success, if it is present", () => {
-      let afterImageUpload = sandbox.stub().returns(Promise.resolve())
-      let image = renderProfileImage({
-        editable:         true,
-        afterImageUpload: afterImageUpload
-      })
-      helper.store.dispatch(startPhotoEdit({ name: "a name" }))
-      helper.store.dispatch(updatePhotoEdit({ name: "a name" }))
-      let uploader = image.find(ProfileImageUploader)
-      return uploader
-        .props()
-        .updateUserPhoto()
-        .then(() => {
-          assert.ok(
-            afterImageUpload.called,
-            "afterImageUpload callback should have been called"
-          )
-        })
     })
 
     it("should have a ProfileImageUploader only for the logged in user", () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3544 

#### What's this PR do?
Fixes a console error when uploading the profile image

#### How should this be manually tested?
Go to `/profile` and upload an image. You should see a console error when on master but not on this branch
