### PR TITLE
Added message for future scheduled exams for learners who haven't taken an exam yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ Tests should be run in the Docker container, not the host machine. They can be r
     docker-compose run watch npm run flow
     # Run SCSS linter
     docker-compose run watch npm run scss_lint
+    # RUN prettier-eslint, fixes style issues
+    docker-compose run watch npm run fmt
 
 Note that running [`flow`](https://flowtype.org) may not work properly if your
 host machine isn't running Linux. If you are using a Mac, you'll need to run

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -118,7 +118,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     ])
   }
 
-  // Course is running, user has already paid, we show no messages
+  // Course is running, user has already paid,
   if (courseUpcomingOrCurrent(firstRun) && paid) {
     return S.Just([
       {

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -60,6 +60,18 @@ type CalculateMessagesProps = {
   coupon?: Coupon
 }
 
+const messageForNotAttemptedExam = (course: Course) => {
+  let message = "There are currently no exams available for scheduling. Please check back later."
+
+  if (course.can_schedule_exam) {
+    message = "Click above to schedule an exam with Pearson."
+  } else if (!R.isEmpty(course.exams_schedulable_in_future)) {
+    message = "You can sign up to take the exam starting on " +
+              `on ${formatDate(course.exams_schedulable_in_future[0])}.`
+  }
+  return message
+}
+
 // this calculates any status messages we'll need to show the user
 // we wrap the array of messages in a Maybe, so that we can indicate
 // the case where there are no messages cleanly
@@ -108,7 +120,11 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
 
   // Course is running, user has already paid, we show no messages
   if (courseUpcomingOrCurrent(firstRun) && paid) {
-    return S.Nothing
+    return S.Just([
+      {
+        message: messageForNotAttemptedExam(course)
+      }
+    ])
   }
 
   const messages = []

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -61,13 +61,15 @@ type CalculateMessagesProps = {
 }
 
 const messageForNotAttemptedExam = (course: Course) => {
-  let message = "There are currently no exams available for scheduling. Please check back later."
+  let message =
+    "There are currently no exams available for scheduling. Please check back later."
 
   if (course.can_schedule_exam) {
     message = "Click above to schedule an exam with Pearson."
   } else if (!R.isEmpty(course.exams_schedulable_in_future)) {
-    message = "You can sign up to take the exam starting on " +
-              `on ${formatDate(course.exams_schedulable_in_future[0])}.`
+    message =
+      "You can sign up to take the exam starting on " +
+      `on ${formatDate(course.exams_schedulable_in_future[0])}.`
   }
   return message
 }

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -29,7 +29,7 @@ import {
   makeRunDueSoon,
   makeRunFailed
 } from "./test_util"
-import { assertIsJust, assertIsNothing } from "../../../lib/test_utils"
+import { assertIsJust } from "../../../lib/test_utils"
 import {
   COURSE_ACTION_PAY,
   COURSE_ACTION_REENROLL,
@@ -197,7 +197,6 @@ describe("Course Status Messages", () => {
           }
         ])
       })
-
     })
 
     describe("should prompt users who pass the class to take the exam, if applicable", () => {

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -136,13 +136,6 @@ describe("Course Status Messages", () => {
       assert.isTrue(makeCouponTargetMessageStub.calledWith(coupon))
     })
 
-    it("should return Nothing if the user paid and the course is running", () => {
-      makeRunCurrent(course.runs[0])
-      makeRunPaid(course.runs[0])
-      makeRunEnrolled(course.runs[0])
-      assertIsNothing(calculateMessages(calculateMessagesProps))
-    })
-
     it("should nag unpaid auditors to pay", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
@@ -159,6 +152,52 @@ describe("Course Status Messages", () => {
           COURSE_ACTION_PAY
         )
       )
+    })
+
+    describe("should prompt users who are paid and enrolled in the class, if applicable", () => {
+      beforeEach(() => {
+        makeRunCurrent(course.runs[0])
+        makeRunPaid(course.runs[0])
+        makeRunEnrolled(course.runs[0])
+      })
+
+      it("should prompt to schedule exam", () => {
+        course.can_schedule_exam = true
+
+        assertIsJust(calculateMessages(calculateMessagesProps), [
+          {
+            message: "Click above to schedule an exam with Pearson."
+          }
+        ])
+      })
+
+      it("should prompt to sign up for future", () => {
+        course.can_schedule_exam = false
+        course.exams_schedulable_in_future = [
+          moment()
+            .add(2, "day")
+            .format()
+        ]
+
+        assertIsJust(calculateMessages(calculateMessagesProps), [
+          {
+            message: "You can sign up to take the exam starting on " +
+              `on ${formatDate(course.exams_schedulable_in_future[0])}.`
+          }
+        ])
+      })
+
+      it("should inform that no exam is avaiable", () => {
+        course.can_schedule_exam = false
+        course.exams_schedulable_in_future = []
+
+        assertIsJust(calculateMessages(calculateMessagesProps), [
+          {
+            message: "There are currently no exams available for scheduling. Please check back later."
+          }
+        ])
+      })
+
     })
 
     describe("should prompt users who pass the class to take the exam, if applicable", () => {

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -181,7 +181,8 @@ describe("Course Status Messages", () => {
 
         assertIsJust(calculateMessages(calculateMessagesProps), [
           {
-            message: "You can sign up to take the exam starting on " +
+            message:
+              "You can sign up to take the exam starting on " +
               `on ${formatDate(course.exams_schedulable_in_future[0])}.`
           }
         ])
@@ -193,7 +194,8 @@ describe("Course Status Messages", () => {
 
         assertIsJust(calculateMessages(calculateMessagesProps), [
           {
-            message: "There are currently no exams available for scheduling. Please check back later."
+            message:
+              "There are currently no exams available for scheduling. Please check back later."
           }
         ])
       })


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3461

#### What's this PR do?
In this PR i am showing messages to learner who is enroll and paid the course. So that he can get an idea, what going on with exam

@pdpinch 
#### How should this be manually tested?
```python
from dashboard.models import CachedEnrollment
from courses.models import *
from django.contrib.auth.models import User
from exams.factories import ExamRunFactory
from exams.models import *
from dashboard.factories import CachedEnrollmentFactory
from ecommerce.factories import (OrderFactory, LineFactory)
from exams.factories import ExamAuthorizationFactory
from exams.factories import ExamProfileFactory

user = User.objects.filter(username='username')[0]
course = Course.objects.filter(title='Digital Learning 100')[0]
course_run = CourseRun.objects.get(edx_course_key='course-v1:MITx+Digital+Learning+100+Aug_2016')

# pay for run
order = OrderFactory.create(user=user, status='fulfilled', total_price_paid=1200)
LineFactory.create(order=order, course_key=course_run.edx_course_key)

# enroll for run
CachedEnrollmentFactory.create(user=user, course_run=course_run)

# create an exam
exam_run=ExamRunFactory.create(course=course, authorized=True)
au=ExamAuthorizationFactory.create(user=user, course=course, exam_run=exam_run, status= 'success', exam_taken=False)
exam_profile= ExamProfileFactory.create(status='success', profile=user.profile)
```

#### Where should the reviewer start?
see the tests

#### Screenshots (if appropriate)
<img width="821" alt="screen shot 2017-09-28 at 4 32 32 pm" src="https://user-images.githubusercontent.com/10431250/30964417-abd4ec18-a46a-11e7-9b64-d240e36d3ff5.png">

