### PR TITLE
Fixed discussions redirect to show user error page

### DIFF
--- a/discussions/exceptions.py
+++ b/discussions/exceptions.py
@@ -19,3 +19,7 @@ class SubscriberSyncException(Exception):
 
 class ModeratorSyncException(Exception):
     """Exception indicating a failure to add or remove a moderator"""
+
+
+class UnableToAuthenticateDiscussionUserException(Exception):
+    """Exception indicating we were unable to generate a valid JWT for a DiscussionUser"""

--- a/discussions/views.py
+++ b/discussions/views.py
@@ -1,7 +1,6 @@
 """APIs for discussions"""
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponse
 from django.shortcuts import redirect
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
@@ -10,6 +9,7 @@ from rest_framework.generics import CreateAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from discussions.exceptions import UnableToAuthenticateDiscussionUserException
 from discussions.permissions import CanCreateChannel
 from discussions.serializers import ChannelSerializer
 from discussions.utils import get_token_for_request
@@ -59,7 +59,7 @@ def discussions_redirect(request):
         response = redirect(settings.OPEN_DISCUSSIONS_REDIRECT_URL)
         _set_jwt_cookie(response, token)
     else:
-        response = HttpResponse('', status=status.HTTP_409_CONFLICT)
+        raise UnableToAuthenticateDiscussionUserException("Unable to generate a JWT token for user")
 
     return response
 

--- a/discussions/views_test.py
+++ b/discussions/views_test.py
@@ -8,6 +8,7 @@ from rest_framework.test import (
     APIClient,
 )
 
+from discussions.exceptions import UnableToAuthenticateDiscussionUserException
 from discussions.factories import ChannelFactory
 from micromasters.factories import UserFactory
 from roles.factories import RoleFactory
@@ -76,9 +77,8 @@ def test_logged_in_user_redirect_no_username(client, patched_users_api):
     user.discussion_user.save()
 
     client.force_login(user)
-    response = client.get(reverse('discussions'), follow=True)
-    assert response.status_code == 409
-    assert 'jwt_cookie' not in response.client.cookies
+    with pytest.raises(UnableToAuthenticateDiscussionUserException):
+        client.get(reverse('discussions'))
 
 
 CREATE_CHANNEL_INPUT = {


### PR DESCRIPTION
Fixes #3550 

#### What's this PR do?
Updates /discussions/ view to fail hard when a JWT couldn't be generated.

#### How should this be manually tested?
Ensure your user has to `DiscussionUser` record and go to `/discussions/`. You should see an error page instead of a blank page.
