### PR TITLE
Use transaction.on_commit to fix a race condition

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -61,3 +61,19 @@ def discussion_settings(settings):
     settings.OPEN_DISCUSSIONS_BASE_URL = 'http://localhost/'
     settings.OPEN_DISCUSSIONS_API_USERNAME = 'mitodl'
     settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = True
+
+
+@pytest.fixture()
+def mocked_on_commit(mocker):
+    """
+    Patch on_commit to execute immediately instead of waiting for transaction to commit.
+    Since tests run inside transactions this will delay execution until after the test.
+    Since uses of on_commit are usually meant to delay executing tasks, and since
+    tasks are executed immediately in unit tests, executing immediately shouldn't
+    cause problems here.
+    """
+    return mocker.patch(
+        'django.db.transaction.on_commit',
+        autospec=True,
+        side_effect=lambda callback: callback(),
+    )

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -30,7 +30,11 @@ from profiles.factories import (
 )
 from search.models import PercolateQuery
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.usefixtures('mocked_elasticsearch'),
+    pytest.mark.usefixtures('mocked_on_commit'),
+    pytest.mark.django_db,
+]
 
 
 # pylint: disable=too-many-locals, unused-argument

--- a/discussions/signals.py
+++ b/discussions/signals.py
@@ -2,6 +2,7 @@
 Signals for user profiles
 """
 from django.conf import settings
+from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -16,4 +17,4 @@ def sync_user_profile(sender, instance, created, **kwargs):  # pylint: disable=u
     """
     if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
         return
-    tasks.sync_discussion_user.delay(instance.user_id)
+    transaction.on_commit(lambda: tasks.sync_discussion_user.delay(instance.user_id))

--- a/discussions/signals_test.py
+++ b/discussions/signals_test.py
@@ -7,7 +7,11 @@ from factory.django import mute_signals
 from profiles.factories import ProfileFactory
 from micromasters.factories import UserFactory
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.usefixtures('mocked_elasticsearch'),
+    pytest.mark.usefixtures('mocked_on_commit'),
+    pytest.mark.django_db,
+]
 
 
 # pylint: disable=unused-argument

--- a/discussions/tasks_test.py
+++ b/discussions/tasks_test.py
@@ -6,7 +6,11 @@ from discussions import tasks
 from discussions.exceptions import DiscussionUserSyncException
 from profiles.factories import UserFactory
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.usefixtures('mocked_elasticsearch'),
+    pytest.mark.usefixtures('mocked_on_commit'),
+    pytest.mark.django_db,
+]
 
 
 # pylint: disable=unused-argument

--- a/discussions/views_test.py
+++ b/discussions/views_test.py
@@ -13,7 +13,11 @@ from micromasters.factories import UserFactory
 from roles.factories import RoleFactory
 from roles.models import Staff
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.usefixtures('mocked_elasticsearch'),
+    pytest.mark.usefixtures('mocked_on_commit'),
+    pytest.mark.django_db,
+]
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3557 

#### What's this PR do?
Adds a `transaction.on_commit` to fix a race condition

#### How should this be manually tested?
I'm not sure how difficult this would be. I think the only way to know for sure is to keep an eye out for future exceptions like this