### PR TITLE
Overall final grade for course

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -519,7 +519,7 @@ def get_overall_final_grade_for_course(mmtrack, course):
     if not course.has_exam:
         return str(round(best_grade.grade_percent))
 
-    best_exam = mmtrack.get_best_proctorate_exam_grade(course)
+    best_exam = mmtrack.get_best_proctored_exam_grade(course)
     if best_exam is None:
         return ""
 

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -24,6 +24,9 @@ from exams.models import ExamAuthorization, ExamRun
 # maximum number of exam attempts per payment
 ATTEMPTS_PER_PAID_RUN = 2
 
+COURSE_GRADE_WEIGHT = 0.4
+EXAM_GRADE_WEIGHT = 0.6
+
 log = logging.getLogger(__name__)
 
 # pylint: disable=too-many-branches
@@ -223,6 +226,7 @@ def get_info_for_course(course, mmtrack):
         ).data,
         "has_exam": course.has_exam,
         "certificate_url": get_certificate_url(mmtrack, course),
+        "overall_grade": get_overall_final_grade_for_course(mmtrack, course)
     }
 
     def _add_run(run, mmtrack_, status):
@@ -496,3 +500,27 @@ def get_certificate_url(mmtrack, course):
             if download_url:
                 url = urljoin(settings.EDXORG_BASE_URL, download_url)
     return url
+
+
+def get_overall_final_grade_for_course(mmtrack, course):
+    """
+    Calculate overall grade for course
+
+    Args:
+        mmtrack (dashboard.utils.MMTrack): an instance of all user information about a program
+        course (courses.models.Course): A course
+    Returns:
+        str: the overall final grade
+    """
+    final_grades = mmtrack.get_passing_final_grades_for_course(course)
+    best_grade = final_grades.first()
+    if best_grade is None:
+        return ""
+    if not course.has_exam:
+        return str(round(best_grade.grade_percent))
+
+    best_exam = mmtrack.get_best_proctorate_exam_grade(course)
+    if best_exam is None:
+        return ""
+
+    return str(round(best_grade.grade_percent * COURSE_GRADE_WEIGHT + best_exam.score * EXAM_GRADE_WEIGHT))

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -755,6 +755,7 @@ class CourseRunTest(CourseTests):
 
 
 @ddt.ddt
+@patch('dashboard.api.get_overall_final_grade_for_course', return_value="")
 @patch('dashboard.api.get_certificate_url', return_value="")
 @patch('dashboard.api.get_future_exam_runs', return_value=[])
 @patch('dashboard.api.has_to_pay_for_exam', return_value=False)
@@ -867,7 +868,9 @@ class InfoCourseTest(CourseTests):
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_no_runs(self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+    def test_info_no_runs(
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay
+    ):
         """test for get_info_for_course for course with no runs"""
         self.assert_course_equal(
             self.course_noruns,
@@ -878,11 +881,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_with_contact_email(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay
     ):  # pylint: disable=no-self-use
         """test that get_info_for_course indicates that a course has a contact_email """
         course = CourseFactory.create(contact_email="abc@example.com")
@@ -893,11 +897,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.is_exam_schedulable')
     @ddt.data((True), (False))
     def test_info_returns_exam_schedulable(
-            self, boolean, mock_schedulable, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, boolean, mock_schedulable, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test that get_info_for_course returns whether the exam is schedulable"""
         course = CourseFactory.create(contact_email=None)
         mock_schedulable.return_value = boolean
@@ -906,9 +911,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_returns_has_exam(self, mock_schedulable, mock_get_cert, mock_future_exams, mock_has_to_pay):
+    def test_info_returns_has_exam(
+            self, mock_schedulable, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay
+    ):
         """test that get_info_for_course returns whether the course has an exam module or not"""
         course = CourseFactory.create(contact_email=None)
         self.assert_course_equal(
@@ -925,11 +933,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 2
         assert mock_future_exams.call_count == 2
         assert mock_get_cert.call_count == 2
+        assert mock_grade.call_count == 2
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_without_contact_email(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay
     ):  # pylint: disable=no-self-use
         """test that get_info_for_course indicates that a course has no contact_email """
         course = CourseFactory.create(contact_email=None)
@@ -940,11 +949,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_not_enrolled_offered(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with with an offered run"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -963,11 +973,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_not_enrolled_but_paid(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with with a paid but not enrolled run"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -991,11 +1002,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_not_passed_offered(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with a run not passed and another offered"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1016,11 +1028,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_not_enrolled_not_passed_not_offered(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with run not passed and nothing offered"""
         self.mmtrack.configure_mock(**{'has_passed_course.return_value': False})
         with patch(
@@ -1039,10 +1052,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_grade(self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+    def test_info_grade(
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with a course current and another not passed"""
         self.mmtrack.configure_mock(**{'has_passed_course.return_value': False})
         with patch(
@@ -1061,11 +1076,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_check_but_not_passed(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay,):
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay,):
         """
         test for get_info_for_course in case a check if the course has been passed is required
         """
@@ -1086,11 +1102,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_missed_deadline(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course with a missed upgrade deadline
         """
@@ -1110,11 +1127,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_check_but_not_passed_no_next(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course in case a check if the course has been passed
         is required for the course, the course has not been passed and there is no next run
@@ -1136,10 +1154,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_check_passed(self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+    def test_info_check_passed(
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course in case a check if the course has been passed
         is required for the course and the course has been passed
@@ -1165,10 +1185,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_will_attend(self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+    def test_info_will_attend(
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with enrolled run that will happen in the future"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1185,10 +1207,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
-    def test_info_upgrade(self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+    def test_info_upgrade(
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with a run that needs to be upgraded"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1205,11 +1229,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_upgrade_in_past(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course for course with a run
         that needs to be upgraded but before a current enrolled one
@@ -1230,11 +1255,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_default_should_not_happen(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course for course with a run with an
         unexpected state but that can be offered
@@ -1254,11 +1280,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_default_should_not_happen_no_next(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course with no next and weird status"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1275,11 +1302,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_read_cert_for_all_no_next(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course in case the less recent course is flagged to be checked if passed
         """
@@ -1305,11 +1333,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_course_run_end_date_mixed(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         Test with a mix of end_date being None and also a valid date
         """
@@ -1349,11 +1378,12 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_course_with_proctorate_exam(
-            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         Test with proctorate exam results
         """
@@ -1372,6 +1402,7 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
+        assert mock_grade.call_count == 1
         self.mmtrack.get_course_proctorate_exam_results.assert_called_once_with(self.course_noruns)
 
 

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1709,7 +1709,7 @@ class ExamAttemptsTests(CourseTests):
 
 
 @ddt.ddt
-class GetCertificateForCourse(CourseTests):
+class GetCertificateForCourseTests(CourseTests):
     """Tests get_certificate_url for a course"""
 
     def setUp(self):
@@ -1775,7 +1775,7 @@ class GetCertificateForCourse(CourseTests):
         assert api.get_certificate_url(self.mmtrack, self.course) == certificate_url
 
 
-class GetOverallGradeForCourse(CourseTests):
+class GetOverallGradeForCourseTests(CourseTests):
     """Tests get_overall_final_grade_for_course for a course"""
 
     def setUp(self):
@@ -1794,7 +1794,7 @@ class GetOverallGradeForCourse(CourseTests):
         best_exam = ProctoredExamGradeFactory(
             user=self.user, course=self.course, percentage_grade=0.7
         )
-        self.mmtrack.get_best_proctorate_exam_grade.return_value = best_exam
+        self.mmtrack.get_best_proctored_exam_grade.return_value = best_exam
         assert api.get_overall_final_grade_for_course(self.mmtrack, self.course) == '74'
 
     def test_no_final_grade(self):
@@ -1808,7 +1808,7 @@ class GetOverallGradeForCourse(CourseTests):
 
         FinalGradeFactory.create(user=self.user, course_run=self.course_run, grade=0.8, passed=True)
         self.mmtrack.get_passing_final_grades_for_course.return_value = FinalGrade.objects.filter(user=self.user)
-        self.mmtrack.get_best_proctorate_exam_grade.return_value = None
+        self.mmtrack.get_best_proctored_exam_grade.return_value = None
         assert api.get_overall_final_grade_for_course(self.mmtrack, self.course) == '80'
 
     def test_no_passing_exam(self):
@@ -1817,5 +1817,5 @@ class GetOverallGradeForCourse(CourseTests):
         FinalGradeFactory.create(user=self.user, course_run=self.course_run, grade=0.8, passed=True)
         ExamRunFactory.create(course=self.course)
         self.mmtrack.get_passing_final_grades_for_course.return_value = FinalGrade.objects.filter(user=self.user)
-        self.mmtrack.get_best_proctorate_exam_grade.return_value = None
+        self.mmtrack.get_best_proctored_exam_grade.return_value = None
         assert api.get_overall_final_grade_for_course(self.mmtrack, self.course) == ''

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -418,7 +418,7 @@ class MMTrack:
             )
             return ExamProfile.PROFILE_INVALID
 
-    def get_best_proctorate_exam_grade(self, course):
+    def get_best_proctored_exam_grade(self, course):
 
         """
         Returns the best exam grade
@@ -429,7 +429,9 @@ class MMTrack:
         Returns:
             grades.models.ProctoredExamGrade: the best exam grade
         """
-        return self.get_course_proctorate_exam_results(course).filter(passed=True).order_by('percentage_grade').last()
+        return self.get_course_proctorate_exam_results(course).filter(
+            passed=True
+        ).order_by('-percentage_grade').first()
 
     def get_course_proctorate_exam_results(self, course):
         """

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -418,6 +418,19 @@ class MMTrack:
             )
             return ExamProfile.PROFILE_INVALID
 
+    def get_best_proctorate_exam_grade(self, course):
+
+        """
+        Returns the best exam grade
+
+        Args:
+            course (courses.models.Course): a course
+
+        Returns:
+            grades.models.ProctoredExamGrade: the best exam grade
+        """
+        return self.get_course_proctorate_exam_results(course).filter(passed=True).order_by('percentage_grade').last()
+
     def get_course_proctorate_exam_results(self, course):
         """
         Returns the queryset of the proctorate exams results for the user in a course

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -669,7 +669,7 @@ class MMTrackTest(MockedESTestCase):
         low_grade.save()
         assert mmtrack.get_passing_final_grades_for_course(finaid_course).count() == 3
 
-    def test_get_best_proctorate_exam_grade(self):
+    def test_get_best_proctored_exam_grade(self):
         """
         Test get_best_proctorate_exam_grade to return a passed exam with the highest score
         """
@@ -682,18 +682,18 @@ class MMTrackTest(MockedESTestCase):
         last_week = now_in_utc() - timedelta(weeks=1)
 
         ProctoredExamGradeFactory.create(user=self.user, course=finaid_course, passed=False, percentage_grade=0.6)
-        assert mmtrack.get_best_proctorate_exam_grade(finaid_course) is None
+        assert mmtrack.get_best_proctored_exam_grade(finaid_course) is None
         best_exam = ProctoredExamGradeFactory.create(
             user=self.user, course=finaid_course, passed=True, percentage_grade=0.9,
             exam_run__date_grades_available=last_week
         )
-        assert mmtrack.get_best_proctorate_exam_grade(finaid_course) == best_exam
+        assert mmtrack.get_best_proctored_exam_grade(finaid_course) == best_exam
 
         ProctoredExamGradeFactory.create(
             user=self.user, course=finaid_course, passed=True, percentage_grade=0.8,
             exam_run__date_grades_available=last_week
         )
-        assert mmtrack.get_best_proctorate_exam_grade(finaid_course) == best_exam
+        assert mmtrack.get_best_proctored_exam_grade(finaid_course) == best_exam
 
     def test_get_mmtrack(self):
         """

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -20,7 +20,7 @@ from ecommerce.factories import LineFactory, OrderFactory
 from ecommerce.models import Order
 from exams.factories import ExamProfileFactory, ExamAuthorizationFactory, ExamRunFactory
 from exams.models import ExamProfile, ExamAuthorization
-from grades.factories import FinalGradeFactory
+from grades.factories import FinalGradeFactory, ProctoredExamGradeFactory
 from grades.models import FinalGrade, MicromastersProgramCertificate
 from micromasters.factories import UserFactory
 from micromasters.utils import (
@@ -668,6 +668,32 @@ class MMTrackTest(MockedESTestCase):
         low_grade.passed = False
         low_grade.save()
         assert mmtrack.get_passing_final_grades_for_course(finaid_course).count() == 3
+
+    def test_get_best_proctorate_exam_grade(self):
+        """
+        Test get_best_proctorate_exam_grade to return a passed exam with the highest score
+        """
+        mmtrack = MMTrack(
+            user=self.user,
+            program=self.program_financial_aid,
+            edx_user_data=self.cached_edx_user_data
+        )
+        finaid_course = self.crun_fa.course
+        last_week = now_in_utc() - timedelta(weeks=1)
+
+        ProctoredExamGradeFactory.create(user=self.user, course=finaid_course, passed=False, percentage_grade=0.6)
+        assert mmtrack.get_best_proctorate_exam_grade(finaid_course) is None
+        best_exam = ProctoredExamGradeFactory.create(
+            user=self.user, course=finaid_course, passed=True, percentage_grade=0.9,
+            exam_run__date_grades_available=last_week
+        )
+        assert mmtrack.get_best_proctorate_exam_grade(finaid_course) == best_exam
+
+        ProctoredExamGradeFactory.create(
+            user=self.user, course=finaid_course, passed=True, percentage_grade=0.8,
+            exam_run__date_grades_available=last_week
+        )
+        assert mmtrack.get_best_proctorate_exam_grade(finaid_course) == best_exam
 
     def test_get_mmtrack(self):
         """

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -73,7 +73,8 @@ const COURSE: Course = {
   has_to_pay:                  false,
   has_exam:                    false,
   proctorate_exams_grades:     [],
-  certificate_url:             ""
+  certificate_url:             "",
+  overall_grade:               ""
 }
 
 const PROGRAM: AvailableProgram = {

--- a/static/js/components/dashboard/courses/Grades.js
+++ b/static/js/components/dashboard/courses/Grades.js
@@ -5,7 +5,7 @@ import Icon from "react-mdl/lib/Icon"
 
 import type { Course } from "../../../flow/programTypes"
 import { formatGrade } from "../util"
-import { S, reduceM } from "../../../lib/sanctuary"
+import { S, reduceM, getm } from "../../../lib/sanctuary"
 import { classify } from "../../../util/util"
 import {
   getLargestExamGrade,
@@ -57,7 +57,8 @@ const renderFinalGrade = R.ifElse(
   R.compose(
     reduceM("--", renderGrade("Final Grade")),
     S.map(formatGrade),
-    calculateFinalGrade
+    S.filter(R.complement(R.isEmpty)),
+    getm("overall_grade")
   ),
   R.always(null)
 )

--- a/static/js/components/dashboard/courses/Grades.js
+++ b/static/js/components/dashboard/courses/Grades.js
@@ -10,7 +10,6 @@ import { classify } from "../../../util/util"
 import {
   getLargestExamGrade,
   getLargestEdXGrade,
-  calculateFinalGrade,
   passedCourse
 } from "../../../lib/grades"
 import { hasPearsonExam } from "./util"
@@ -57,7 +56,7 @@ const renderFinalGrade = R.ifElse(
   R.compose(
     reduceM("--", renderGrade("Final Grade")),
     S.map(formatGrade),
-    S.filter(R.complement(R.isEmpty)),
+    S.filter(R.complement(R.equals(""))),
     getm("overall_grade")
   ),
   R.always(null)

--- a/static/js/components/dashboard/courses/Grades_test.js
+++ b/static/js/components/dashboard/courses/Grades_test.js
@@ -10,7 +10,6 @@ import {
   makeCourse,
   makeProctoredExamResult
 } from "../../../factories/dashboard"
-import { COURSE_GRADE_WEIGHT, EXAM_GRADE_WEIGHT } from "../../../lib/grades"
 import { STATUS_PASSED, STATUS_OFFERED } from "../../../constants"
 import { EXAM_GRADE, EDX_GRADE } from "../../../containers/DashboardPage"
 

--- a/static/js/components/dashboard/courses/Grades_test.js
+++ b/static/js/components/dashboard/courses/Grades_test.js
@@ -61,16 +61,9 @@ describe("Course Grades", () => {
   })
 
   it("should display a calculated final grade", () => {
-    course.runs[0].final_grade = 82
-    course.proctorate_exams_grades = [makeProctoredExamResult()]
+    course.overall_grade = "40"
     const grades = renderGrades()
-    const expectation = _.round(
-      // $FlowFixMe: flow doesnt like this
-      COURSE_GRADE_WEIGHT * course.runs[0].final_grade +
-        EXAM_GRADE_WEIGHT *
-          (course.proctorate_exams_grades[0].percentage_grade * 100)
-    )
-    assert.equal(grades.find(".final-grade .number").text(), `${expectation}%`)
+    assert.equal(grades.find(".final-grade .number").text(), `${course.overall_grade}%`)
   })
 
   it("should only display the edX grade if has_exam == false", () => {

--- a/static/js/components/dashboard/courses/Grades_test.js
+++ b/static/js/components/dashboard/courses/Grades_test.js
@@ -60,10 +60,13 @@ describe("Course Grades", () => {
     )
   })
 
-  it("should display a calculated final grade", () => {
+  it("should display a final grade", () => {
     course.overall_grade = "40"
     const grades = renderGrades()
-    assert.equal(grades.find(".final-grade .number").text(), `${course.overall_grade}%`)
+    assert.equal(
+      grades.find(".final-grade .number").text(),
+      `${course.overall_grade}%`
+    )
   })
 
   it("should only display the edX grade if has_exam == false", () => {

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -94,7 +94,8 @@ export const makeCourse = (positionInProgram: number): Course => {
     has_to_pay:                  false,
     has_exam:                    false,
     proctorate_exams_grades:     [],
-    certificate_url:             ""
+    certificate_url:             "",
+    overall_grade:               ""
   }
 }
 

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -61,6 +61,7 @@ export type Course = {
   proctorate_exams_grades:      Array<ProctoredExamResult>,
   has_exam:                     boolean,
   certificate_url:              string,
+  overall_grade:                string,
 }
 
 export type ProgramPageCourse = {

--- a/static/js/lib/grades.js
+++ b/static/js/lib/grades.js
@@ -29,16 +29,6 @@ export const getLargestEdXGrade = R.compose(
   getm("runs")
 )
 
-export const COURSE_GRADE_WEIGHT = 0.4
-
-export const EXAM_GRADE_WEIGHT = 0.6
-
-// calculateFinalGrade :: Course -> Maybe Number
-export const calculateFinalGrade = R.converge(S.lift2(R.add), [
-  R.compose(S.map(R.multiply(COURSE_GRADE_WEIGHT)), getLargestEdXGrade),
-  R.compose(S.map(R.multiply(EXAM_GRADE_WEIGHT)), getLargestExamGrade)
-])
-
 export const hasPassingExamGrade = R.compose(
   R.any(R.propEq("passed", true)),
   R.propOr([], "proctorate_exams_grades")

--- a/static/js/lib/grades_test.js
+++ b/static/js/lib/grades_test.js
@@ -8,7 +8,7 @@ import {
   hasPassingExamGrade,
   hasFailingExamGrade,
   hasPassedCourseRun,
-  passedCourse,
+  passedCourse
 } from "./grades"
 import {
   STATUS_PASSED,
@@ -115,7 +115,7 @@ describe("Grades library", () => {
     })
 
     it("should return false otherwise", () => {
-      [
+      ;[
         STATUS_NOT_PASSED,
         STATUS_OFFERED,
         STATUS_CAN_UPGRADE,

--- a/static/js/lib/grades_test.js
+++ b/static/js/lib/grades_test.js
@@ -5,13 +5,10 @@ import { makeCourse, makeProctoredExamResult } from "../factories/dashboard"
 import {
   getLargestExamGrade,
   getLargestEdXGrade,
-  calculateFinalGrade,
   hasPassingExamGrade,
   hasFailingExamGrade,
   hasPassedCourseRun,
   passedCourse,
-  COURSE_GRADE_WEIGHT,
-  EXAM_GRADE_WEIGHT
 } from "./grades"
 import {
   STATUS_PASSED,
@@ -56,36 +53,6 @@ describe("Grades library", () => {
       course.runs[0].final_grade = 39
       course.runs[1].final_grade = 92
       assertIsJust(getLargestEdXGrade(course), 92)
-    })
-  })
-
-  describe("calculateFinalGrade", () => {
-    it("returns Nothing if there are no grades", () => {
-      assertIsNothing(calculateFinalGrade(course))
-    })
-
-    it("returns Nothing if just exam grades are missing", () => {
-      course.runs.forEach(run => {
-        run.final_grade = Math.floor(Math.random() * 100)
-      })
-      assertIsNothing(calculateFinalGrade(course))
-    })
-
-    it("returns Nothing if just course grades are missing", () => {
-      course.proctorate_exams_grades = [makeProctoredExamResult()]
-      assertIsNothing(calculateFinalGrade(course))
-    })
-
-    it("returns Just if both grade types are present", () => {
-      course.runs[0].final_grade = Math.floor(Math.random() * 100)
-      course.proctorate_exams_grades = [makeProctoredExamResult()]
-
-      assertIsJust(
-        calculateFinalGrade(course),
-        COURSE_GRADE_WEIGHT * (course.runs[0].final_grade: any) +
-          EXAM_GRADE_WEIGHT *
-            (course.proctorate_exams_grades[0].percentage_grade * 100)
-      )
     })
   })
 

--- a/static/js/lib/grades_test.js
+++ b/static/js/lib/grades_test.js
@@ -115,7 +115,7 @@ describe("Grades library", () => {
     })
 
     it("should return false otherwise", () => {
-      ;[
+      [
         STATUS_NOT_PASSED,
         STATUS_OFFERED,
         STATUS_CAN_UPGRADE,


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3492

#### What's this PR do?
Added overall final grade data to the dashboard API.

#### How should this be manually tested?
Set a past course run to passed and create an exam run with a passing exam grade. you should be able to see the final grade for course just as before.