### PR TITLE
Generate CourseCertificates only when exam grades are available

### DIFF
--- a/grades/tasks.py
+++ b/grades/tasks.py
@@ -46,9 +46,9 @@ def generate_course_certificates_for_fa_students():
         .annotate(exam_run_count=Count('course_run__course__exam_runs'))
         .values(
             'id',
-            'user__id',
+            'user',
             'user__username',
-            'course_run__course__id',
+            'course_run__course',
             'course_run__edx_course_key',
             'exam_run_count',
         )
@@ -60,9 +60,10 @@ def generate_course_certificates_for_fa_students():
     final_grades_to_certify = filter(
         lambda final_grade_dict: (
             final_grade_dict['exam_run_count'] == 0 or
-            ProctoredExamGrade.objects.filter(
-                user_id=final_grade_dict['user__id'],
-                course_id=final_grade_dict['course_run__course__id'],
+            ProctoredExamGrade.for_user_course(
+                final_grade_dict['user'],
+                final_grade_dict['course_run__course'])
+            .filter(
                 passed=True
             ).exists()
         ),

--- a/grades/tasks_pytest_test.py
+++ b/grades/tasks_pytest_test.py
@@ -1,6 +1,7 @@
 """
 Tests for grades tasks
 """
+from datetime import timedelta
 import pytest
 import factory
 from courses.factories import CourseFactory
@@ -11,7 +12,7 @@ from grades.factories import (
     ProctoredExamGradeFactory,
 )
 from grades.models import MicromastersCourseCertificate
-
+from micromasters.utils import now_in_utc
 
 pytestmark = [
     pytest.mark.usefixtures('mocked_elasticsearch'),
@@ -24,24 +25,41 @@ def test_generate_course_certificates():
     Test that generate_course_certificates_for_fa_students creates certificates for appropriate FinalGrades
     """
     course = CourseFactory.create(program__financial_aid_availability=True)
-    course_with_exams = ExamRunFactory.create(course__program__financial_aid_availability=True).course
+    # Create two exam runs for course with different date_grades_available
+    exam_run_grades_available = ExamRunFactory.create(
+        course__program__financial_aid_availability=True,
+        date_grades_available=now_in_utc() - timedelta(weeks=1))
+    course_with_exams = exam_run_grades_available.course
+    exam_run_no_grades = ExamRunFactory.create(
+        course=course_with_exams,
+        date_grades_available=now_in_utc() + timedelta(weeks=1))
+    # Another non-fa course
     non_fa_course = CourseFactory.create(program__financial_aid_availability=False)
     # Create FinalGrade records with different courses and a mix of passed and failed outcomes
     passed_final_grades = FinalGradeFactory.create_batch(4, course_run__course=course, passed=True)
     passed_final_grades_with_exam = FinalGradeFactory.create_batch(
-        4,
+        6,
         course_run__course=course_with_exams,
         passed=True
     )
     FinalGradeFactory.create(course_run__course=non_fa_course, passed=True)
     FinalGradeFactory.create(course_run__course=course, passed=False)
-    # Create ProctoredExamGrade records with a mix of passed and failed outcomes
+    # Create ProctoredExamGrade records with a mix of passed and failed outcomes, and exam grade availability
     final_grades_with_passed_exam = passed_final_grades_with_exam[:2]
-    final_grades_with_failed_exam = passed_final_grades_with_exam[2:]
+    final_grades_with_passed_exam_no_grades = passed_final_grades_with_exam[2:4]
+    final_grades_with_failed_exam = passed_final_grades_with_exam[4:]
     ProctoredExamGradeFactory.create_batch(
         2,
         user=factory.Iterator([final_grade.user for final_grade in final_grades_with_passed_exam]),
         course=course_with_exams,
+        exam_run=exam_run_grades_available,
+        passed=True,
+    )
+    ProctoredExamGradeFactory.create_batch(
+        2,
+        user=factory.Iterator([final_grade.user for final_grade in final_grades_with_passed_exam_no_grades]),
+        course=course_with_exams,
+        exam_run=exam_run_no_grades,
         passed=True,
     )
     ProctoredExamGradeFactory.create_batch(


### PR DESCRIPTION

#### What are the relevant tickets?
Fix #3579

#### What's this PR do?
Modifies `generate_course_certificates_for_fa_students` to generate MicromastersCourseCertificates only when exam grades are available.

#### How should this be manually tested?
Take a look at the test
