### PR TITLE
Raised an exception to sentry when course team e-mails fail

### DIFF
--- a/mail/api.py
+++ b/mail/api.py
@@ -90,7 +90,7 @@ class MailgunClient:
     @classmethod
     def send_batch(cls, subject, body, recipients,  # pylint: disable=too-many-arguments, too-many-locals
                    sender_address=None, sender_name=None, chunk_size=settings.MAILGUN_BATCH_CHUNK_SIZE,
-                   raise_for_status=True):
+                   raise_for_status=True, log_error_on_bounce=False):
         """
         Sends a text email to a list of recipients (one email per recipient) via batch.
 
@@ -105,6 +105,7 @@ class MailgunClient:
             sender_name (str): Sender name
             chunk_size (int): The maximum amount of emails to be sent at the same time
             raise_for_status (bool): If true, raise for non 2xx statuses
+            log_error_on_bounce (bool): App will log bounce email event when True
 
         Returns:
             list:
@@ -151,6 +152,9 @@ class MailgunClient:
                 'html': filter_recipient_variables(body),
                 'text': filter_recipient_variables(fallback_text),
                 'recipient-variables': json.dumps(chunk_dict),
+                'v:my-custom-data': {
+                    "log_error_on_bounce": log_error_on_bounce
+                }
             }
             if sender_address:
                 params['from'] = sender_address
@@ -180,7 +184,8 @@ class MailgunClient:
     @classmethod
     def send_individual_email(cls, subject, body, recipient,  # pylint: disable=too-many-arguments
                               recipient_variables=None,
-                              sender_address=None, sender_name=None, raise_for_status=True):
+                              sender_address=None, sender_name=None, raise_for_status=True, log_error_on_bounce=False
+    ):
         """
         Sends a text email to a single recipient.
 
@@ -192,6 +197,7 @@ class MailgunClient:
             sender_address (str): Sender email address
             sender_name (str): Sender name
             raise_for_status (bool): If true and a non-zero response was received,
+            log_error_on_bounce (bool): App will log bounce email event when True
 
         Returns:
             requests.Response: response from Mailgun
@@ -204,6 +210,7 @@ class MailgunClient:
             sender_address=sender_address,
             sender_name=sender_name,
             raise_for_status=raise_for_status,
+            log_error_on_bounce=log_error_on_bounce
         )
         return responses[0]
 
@@ -240,7 +247,7 @@ class MailgunClient:
 
     @classmethod
     def send_course_team_email(  # pylint: disable=too-many-arguments
-            cls, user, course, subject, body, raise_for_status=True,
+            cls, user, course, subject, body, raise_for_status=True, log_error_on_bounce=False
     ):
         """
        Sends a text email from a user to a course team.
@@ -251,7 +258,9 @@ class MailgunClient:
             subject (str): Email subject
             body (str): Email body
             raise_for_status (bool): If true and we received a non 2xx status code from Mailgun, raise an exception
-        Returns:
+            log_error_on_bounce (bool): App will log bounce email event when True
+
+       Returns:
             requests.Response: HTTP Response from Mailgun
        """
         if not course.contact_email:
@@ -266,6 +275,7 @@ class MailgunClient:
             sender_address=user.email,
             sender_name=user.profile.display_name,
             raise_for_status=raise_for_status,
+            log_error_on_bounce=log_error_on_bounce
         )
         return response
 

--- a/mail/api.py
+++ b/mail/api.py
@@ -183,9 +183,8 @@ class MailgunClient:
 
     @classmethod
     def send_individual_email(cls, subject, body, recipient,  # pylint: disable=too-many-arguments
-                              recipient_variables=None,
-                              sender_address=None, sender_name=None, raise_for_status=True, log_error_on_bounce=False
-    ):
+                              recipient_variables=None, sender_address=None, sender_name=None,
+                              raise_for_status=True, log_error_on_bounce=False):
         """
         Sends a text email to a single recipient.
 

--- a/mail/api.py
+++ b/mail/api.py
@@ -152,7 +152,7 @@ class MailgunClient:
                 'html': filter_recipient_variables(body),
                 'text': filter_recipient_variables(fallback_text),
                 'recipient-variables': json.dumps(chunk_dict),
-                'X-Mailgun-Variables': {
+                'v:my-custom-data': {
                     "log_error_on_bounce": log_error_on_bounce
                 }
             }

--- a/mail/api.py
+++ b/mail/api.py
@@ -152,7 +152,7 @@ class MailgunClient:
                 'html': filter_recipient_variables(body),
                 'text': filter_recipient_variables(fallback_text),
                 'recipient-variables': json.dumps(chunk_dict),
-                'v:my-custom-data': {
+                'X-Mailgun-Variables': {
                     "log_error_on_bounce": log_error_on_bounce
                 }
             }

--- a/mail/api.py
+++ b/mail/api.py
@@ -90,7 +90,7 @@ class MailgunClient:
     @classmethod
     def send_batch(cls, subject, body, recipients,  # pylint: disable=too-many-arguments, too-many-locals
                    sender_address=None, sender_name=None, chunk_size=settings.MAILGUN_BATCH_CHUNK_SIZE,
-                   raise_for_status=True, log_error_on_bounce=False):
+                   raise_for_status=True, log_error_on_bounce=True):
         """
         Sends a text email to a list of recipients (one email per recipient) via batch.
 
@@ -184,7 +184,7 @@ class MailgunClient:
     @classmethod
     def send_individual_email(cls, subject, body, recipient,  # pylint: disable=too-many-arguments
                               recipient_variables=None, sender_address=None, sender_name=None,
-                              raise_for_status=True, log_error_on_bounce=False):
+                              raise_for_status=True, log_error_on_bounce=True):
         """
         Sends a text email to a single recipient.
 
@@ -215,7 +215,7 @@ class MailgunClient:
 
     @classmethod
     def send_financial_aid_email(  # pylint: disable=too-many-arguments
-            cls, acting_user, financial_aid, subject, body, raise_for_status=True,
+            cls, acting_user, financial_aid, subject, body, raise_for_status=True, log_error_on_bounce=True
     ):
         """
         Sends a text email to a single recipient, specifically as part of the financial aid workflow. This bundles
@@ -227,12 +227,19 @@ class MailgunClient:
             subject (str): email subject
             body (str): email body
             raise_for_status (bool): If true and we received a non 2xx status code from Mailgun, raise an exception
+            log_error_on_bounce (bool): App will log bounce email event when True
         Returns:
             requests.Response: response from Mailgun
         """
         from_address = cls.default_params()['from']
         to_address = financial_aid.user.email
-        response = cls.send_individual_email(subject, body, to_address, raise_for_status=raise_for_status)
+        response = cls.send_individual_email(
+            subject,
+            body,
+            to_address,
+            raise_for_status=raise_for_status,
+            log_error_on_bounce=log_error_on_bounce
+        )
         if response.ok:
             FinancialAidEmailAudit.objects.create(
                 acting_user=acting_user,
@@ -246,7 +253,7 @@ class MailgunClient:
 
     @classmethod
     def send_course_team_email(  # pylint: disable=too-many-arguments
-            cls, user, course, subject, body, raise_for_status=True, log_error_on_bounce=False
+            cls, user, course, subject, body, raise_for_status=True, log_error_on_bounce=True
     ):
         """
        Sends a text email from a user to a course team.

--- a/mail/api.py
+++ b/mail/api.py
@@ -152,9 +152,9 @@ class MailgunClient:
                 'html': filter_recipient_variables(body),
                 'text': filter_recipient_variables(fallback_text),
                 'recipient-variables': json.dumps(chunk_dict),
-                'v:my-custom-data': {
+                'v:my-custom-data': json.dumps({
                     "log_error_on_bounce": log_error_on_bounce
-                }
+                })
             }
             if sender_address:
                 params['from'] = sender_address

--- a/mail/permissions.py
+++ b/mail/permissions.py
@@ -1,6 +1,10 @@
 """
 Permission classes for mail views
 """
+import hashlib
+import hmac
+
+from django.conf import settings
 
 from rolepermissions.verifications import has_permission
 from rest_framework.permissions import BasePermission
@@ -101,3 +105,34 @@ class UserCanMessageCourseTeamPermission(BasePermission):
         )
         course_run_keys = obj.courserun_set.values_list('edx_course_key', flat=True)
         return any([mmtrack.has_paid(course_run_key) for course_run_key in course_run_keys])
+
+
+class MailGunWebHookPermission(BasePermission):
+    """
+    Permission class indicating permission to log bounced emails
+    """
+    @classmethod
+    def verify(cls, token, timestamp, signature, api_key=None):
+        """Verify signature of event for security"""
+        api_key = api_key or settings.MAILGUN_KEY
+        if timestamp is not None and signature is not None and token is not None and api_key is not None:
+            key_bytes = bytes(api_key, 'latin-1')
+            data_bytes = bytes('{}{}'.format(timestamp, token), 'latin-1')
+
+            hmac_digest = hmac.new(
+                key=key_bytes,
+                msg=data_bytes,
+                digestmod=hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(signature, hmac_digest)
+
+        return False
+
+    def has_permission(self, request, view):
+        """
+        Returns True if signature matches
+        """
+        timestamp = request.POST.get("timestamp", None)
+        signature = request.POST.get("signature", None)
+        token = request.POST.get("token", None)
+        return MailGunWebHookPermission.verify(token, timestamp, signature)

--- a/mail/permissions.py
+++ b/mail/permissions.py
@@ -109,10 +109,10 @@ class UserCanMessageCourseTeamPermission(BasePermission):
 
 class MailGunWebHookPermission(BasePermission):
     """
-    Permission class indicating permission to log bounced emails
+    Verifies HMAC signature for Mailgun webhook
     """
     @classmethod
-    def verify(cls, token, timestamp, signature, api_key=None):
+    def verify(cls, token, timestamp, signature):
         """
         Verify signature of event for security
 
@@ -124,9 +124,8 @@ class MailGunWebHookPermission(BasePermission):
         Returns:
             boolean: True if signature is valid
         """
-        api_key = api_key or settings.MAILGUN_KEY
-        if timestamp is not None and signature is not None and token is not None and api_key is not None:
-            key_bytes = bytes(api_key, 'latin-1')
+        if timestamp is not None and signature is not None and token is not None:
+            key_bytes = bytes(settings.MAILGUN_KEY, 'latin-1')
             data_bytes = bytes('{}{}'.format(timestamp, token), 'latin-1')
 
             hmac_digest = hmac.new(

--- a/mail/permissions.py
+++ b/mail/permissions.py
@@ -113,7 +113,17 @@ class MailGunWebHookPermission(BasePermission):
     """
     @classmethod
     def verify(cls, token, timestamp, signature, api_key=None):
-        """Verify signature of event for security"""
+        """
+        Verify signature of event for security
+
+        Args:
+            token (str): Randomly generated alpha numeric string with length 50.
+            timestamp (int): Number of seconds passed since January 1, 1970
+            signature (str): String with hexadecimal digits generate by HMAC algorithm.
+
+        Returns:
+            boolean: True if signature is valid
+        """
         api_key = api_key or settings.MAILGUN_KEY
         if timestamp is not None and signature is not None and token is not None and api_key is not None:
             key_bytes = bytes(api_key, 'latin-1')

--- a/mail/urls.py
+++ b/mail/urls.py
@@ -20,6 +20,6 @@ urlpatterns = [
     url(r'^api/v0/mail/search/$', SearchResultMailView.as_view(), name='search_result_mail_api'),
     url(r'^api/v0/mail/course/(?P<course_id>[\d]+)/$', CourseTeamMailView.as_view(), name='course_team_mail_api'),
     url(r'^api/v0/mail/learner/(?P<student_id>[\d]+)/$', LearnerMailView.as_view(), name='learner_mail_api'),
-    url(r'^api/v0/mail/webhook/$', MailWebhookView.as_view(), name='email_bounced_view'),
+    url(r'^api/v0/mail/webhook/$', MailWebhookView.as_view(), name='mailgun_webhook'),
     url(r'^api/v0/mail/', include(router.urls)),
 ]

--- a/mail/urls.py
+++ b/mail/urls.py
@@ -8,6 +8,7 @@ from mail.views import (
     SearchResultMailView,
     CourseTeamMailView,
     AutomaticEmailView,
+    EmailBouncedView,
 )
 
 router = routers.DefaultRouter()
@@ -19,5 +20,6 @@ urlpatterns = [
     url(r'^api/v0/mail/search/$', SearchResultMailView.as_view(), name='search_result_mail_api'),
     url(r'^api/v0/mail/course/(?P<course_id>[\d]+)/$', CourseTeamMailView.as_view(), name='course_team_mail_api'),
     url(r'^api/v0/mail/learner/(?P<student_id>[\d]+)/$', LearnerMailView.as_view(), name='learner_mail_api'),
+    url(r'^api/v0/mail/bounce_event/$', EmailBouncedView.as_view(), name='email_bounced_view'),
     url(r'^api/v0/mail/', include(router.urls)),
 ]

--- a/mail/urls.py
+++ b/mail/urls.py
@@ -8,7 +8,7 @@ from mail.views import (
     SearchResultMailView,
     CourseTeamMailView,
     AutomaticEmailView,
-    EmailBouncedView,
+    MailWebhookView,
 )
 
 router = routers.DefaultRouter()
@@ -20,6 +20,6 @@ urlpatterns = [
     url(r'^api/v0/mail/search/$', SearchResultMailView.as_view(), name='search_result_mail_api'),
     url(r'^api/v0/mail/course/(?P<course_id>[\d]+)/$', CourseTeamMailView.as_view(), name='course_team_mail_api'),
     url(r'^api/v0/mail/learner/(?P<student_id>[\d]+)/$', LearnerMailView.as_view(), name='learner_mail_api'),
-    url(r'^api/v0/mail/bounce_event/$', EmailBouncedView.as_view(), name='email_bounced_view'),
+    url(r'^api/v0/mail/webhook/$', MailWebhookView.as_view(), name='email_bounced_view'),
     url(r'^api/v0/mail/', include(router.urls)),
 ]

--- a/mail/views.py
+++ b/mail/views.py
@@ -258,14 +258,14 @@ class MailWebhookView(APIView):
         error_msg = (
             "Webhook event {event} received by Mailgun for recipient {to}: {error}".format(
                 to=recipient,
-                error=error,
+                error="{},{}".format(error, message_headers),
                 event=event
             )
         )
 
         if log_error_on_bounce.lower() == "true" and event == "bounced":
-            log.error(error_msg, message_headers)
+            log.error(error_msg)
         else:
-            log.debug(error_msg, message_headers)
+            log.debug(error_msg)
 
         return Response(status=status.HTTP_200_OK)

--- a/mail/views.py
+++ b/mail/views.py
@@ -242,7 +242,7 @@ class FinancialAidMailView(GenericAPIView):
 
 class MailWebhookView(APIView):
     """
-    View class that handles HTTP requests to capture bounced email
+    View class that handles Mailgun webhooks
     """
     permission_classes = (MailGunWebHookPermission, )
 

--- a/mail/views.py
+++ b/mail/views.py
@@ -256,10 +256,11 @@ class MailWebhookView(APIView):
         message_headers = request.POST.get("message-headers", None)
         log_error_on_bounce = request.POST.get("log_error_on_bounce", "")
         error_msg = (
-            "Webhook event {event} received by Mailgun for recipient {to}: {error}".format(
+            "Webhook event {event} received by Mailgun for recipient {to}: {error} {header}".format(
                 to=recipient,
-                error="{},{}".format(error, message_headers),
-                event=event
+                error=error,
+                event=event,
+                header=message_headers
             )
         )
 

--- a/mail/views.py
+++ b/mail/views.py
@@ -2,6 +2,7 @@
 Views for email REST APIs
 """
 import logging
+import json
 
 from django.contrib.auth.models import User
 from rest_framework import (
@@ -246,6 +247,25 @@ class EmailBouncedView(APIView):
     """
     permission_classes = (MailGunWebHookPermission, )
 
+    @classmethod
+    def fetch_custom_var(cls, headers, keyword):
+        """
+        fetch data from message-headers
+
+        Args:
+            headers (Json): complete Json object
+            keyword (str): json key that need to fetch
+
+        Returns:
+            Json: return json object if matches
+        """
+        var_dict = None
+        for header in headers:
+            if header[0] == keyword:
+                var_dict = header[1]
+
+        return var_dict
+
     def post(self, request, *args, **kargs):  # pylint: disable=unused-argument
         """
         POST method handler
@@ -254,18 +274,29 @@ class EmailBouncedView(APIView):
         recipient = request.POST.get("recipient", None)
         error = request.POST.get("error", None)
         message_headers = request.POST.get("message-headers", None)
-        log_error_on_bounce = request.POST.get("log_error_on_bounce", False)
         error_msg = (
-            'Email to: {to} is bounced with an error message {error}, headers: {headers}'.format(
+            "Email to: {to} is bounced with an error message {error}".format(
                 to=recipient,
-                error=error,
-                headers=message_headers
+                error=error
             )
         )
 
-        if log_error_on_bounce == "True" and event == "bounced":
-            log.error(error_msg)
+        # load custom vars from headers
+        headers_obj = json.loads(message_headers)
+        custom_vars = EmailBouncedView.fetch_custom_var(headers_obj, "X-Mailgun-Variables")
+
+        if "log_error_on_bounce" not in custom_vars:
+            custom_vars = EmailBouncedView.fetch_custom_var(headers_obj, "my-custom-data")
+
+        log_error_on_bounce = False
+        if "log_error_on_bounce" in custom_vars and isinstance(custom_vars["log_error_on_bounce"], str):
+            log_error_on_bounce = True if custom_vars["log_error_on_bounce"] == "True" else False
+        elif "log_error_on_bounce" in custom_vars and isinstance(custom_vars["log_error_on_bounce"], bool):
+            log_error_on_bounce = custom_vars["log_error_on_bounce"]
+
+        if log_error_on_bounce is True and event == "bounced":
+            log.error(error_msg, message_headers)
         else:
-            log.debug(error_msg)
+            log.debug(error_msg, message_headers)
 
         return Response(status=status.HTTP_200_OK)

--- a/mail/views.py
+++ b/mail/views.py
@@ -254,7 +254,7 @@ class MailWebhookView(APIView):
         recipient = request.POST.get("recipient", None)
         error = request.POST.get("error", None)
         message_headers = request.POST.get("message-headers", None)
-        log_error_on_bounce = request.POST.get("log_error_on_bounce", False)
+        log_error_on_bounce = request.POST.get("log_error_on_bounce", "")
         error_msg = (
             "Webhook event {event} received by Mailgun for recipient {to}: {error}".format(
                 to=recipient,
@@ -263,10 +263,7 @@ class MailWebhookView(APIView):
             )
         )
 
-        if isinstance(log_error_on_bounce, str):
-            log_error_on_bounce = True if log_error_on_bounce == "True" else False
-
-        if log_error_on_bounce is True and event == "bounced":
+        if log_error_on_bounce.lower() == "true" and event == "bounced":
             log.error(error_msg, message_headers)
         else:
             log.debug(error_msg, message_headers)

--- a/mail/views.py
+++ b/mail/views.py
@@ -3,7 +3,6 @@ Views for email REST APIs
 """
 import logging
 
-from django.conf import settings
 from django.contrib.auth.models import User
 from rest_framework import (
     authentication,

--- a/mail/views.py
+++ b/mail/views.py
@@ -199,8 +199,7 @@ class CourseTeamMailView(GenericAPIView):
             user=user,
             course=course,
             subject=serializer.data['email_subject'],
-            body=serializer.data['email_body'],
-            log_error_on_bounce=True
+            body=serializer.data['email_body']
         )
         return Response(
             status=mailgun_response.status_code,
@@ -243,7 +242,7 @@ class FinancialAidMailView(GenericAPIView):
 
 class EmailBouncedView(APIView):
     """
-    View class that handles HTTP requests to course team mail API
+    View class that handles HTTP requests to capture bounced email
     """
     permission_classes = (MailGunWebHookPermission, )
 
@@ -254,19 +253,19 @@ class EmailBouncedView(APIView):
         event = request.POST.get("event", None)
         recipient = request.POST.get("recipient", None)
         error = request.POST.get("error", None)
-        message_headers = request.POST.get("message-headers", "NA")
+        message_headers = request.POST.get("message-headers", None)
         log_error_on_bounce = request.POST.get("log_error_on_bounce", False)
-
-        if event == "bounced" and log_error_on_bounce:
-            error_msg = (
-                'Email to course team: {to} is bounced with an error message {error}, headers: {headers}'.format(
-                    to=recipient,
-                    error=error,
-                    headers=message_headers
-                )
+        error_msg = (
+            'Email to: {to} is bounced with an error message {error}, headers: {headers}'.format(
+                to=recipient,
+                error=error,
+                headers=message_headers
             )
+        )
+
+        if log_error_on_bounce == "True" and event == "bounced":
             log.error(error_msg)
         else:
-            log.debug("Some event: %s from mailgun webhook", event)
+            log.debug(error_msg)
 
         return Response(status=status.HTTP_200_OK)

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -701,7 +701,7 @@ class EmailBouncedViewTests(APITestCase, MockedESTestCase):
         error_msg = (
             "Webhook event {event} received by Mailgun for recipient {to}: {error}".format(
                 to=data["recipient"],
-                error=data["error"],
+                error="{},{}".format(data["error"], None),
                 event=data["event"]
             )
         )
@@ -710,4 +710,4 @@ class EmailBouncedViewTests(APITestCase, MockedESTestCase):
         MailWebhookView().post(request)
 
         # assert that error message is logged
-        getattr(mock_logger, logger).assert_called_with(error_msg, None)
+        getattr(mock_logger, logger).assert_called_with(error_msg)

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -661,18 +661,21 @@ class EmailBouncedViewTests(APITestCase, MockedESTestCase):
         # api will always response success
         assert resp_post.status_code == status.HTTP_200_OK
 
+    @patch('mail.views.EmailBouncedView.verify')
     @patch('mail.views.log')
-    def test_email_bounced_raise_exception(self, mock_logger):
+    def test_email_bounced_raise_exception(self, mock_logger, mocked_verify):
         """Tests that api logs error when email is bounced"""
         data = {
             "event": "bounced",
             "recipient": "c@example.com",
             "error": "Unable to send email"
         }
-        error_msg = 'Email to course team: {to} is bounced with an error message {error}'.format(
+        error_msg = 'Email to course team: {to} is bounced with an error message {error}, headers: NA'.format(
             to=data["recipient"],
             error=data["error"]
         )
+        mocked_verify.return_value = True
+
         factory = RequestFactory()
         request = factory.post(self.url, data=data)
         EmailBouncedView().post(request)

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -690,8 +690,12 @@ class EmailBouncedViewTests(APITestCase, MockedESTestCase):
         assert resp_post.status_code == status_code
 
     @patch('mail.views.log')
-    @ddt.data(True, False)
-    def test_bounce(self, log_error_on_bounce, mock_logger):
+    @ddt.data(
+        (True, "error"),
+        (False, "debug")
+    )
+    @ddt.unpack
+    def test_bounce(self, log_error_on_bounce, logger, mock_logger):
         """Tests that api logs error when email is bounced"""
         header = [
             ["X-Mailgun-Variables", {"log_error_on_bounce": log_error_on_bounce}]
@@ -714,7 +718,4 @@ class EmailBouncedViewTests(APITestCase, MockedESTestCase):
         EmailBouncedView().post(request)
 
         # assert that error message is logged
-        if log_error_on_bounce:
-            mock_logger.error.assert_called_with(error_msg, header_str)
-        else:
-            mock_logger.debug.assert_called_with(error_msg, header_str)
+        getattr(mock_logger, logger).assert_called_with(error_msg, header_str)

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -647,7 +647,7 @@ class EmailBouncedViewTests(APITestCase, MockedESTestCase):
     """Test email bounce view web hook"""
     def setUp(self):
         super().setUp()
-        self.url = reverse('email_bounced_view')
+        self.url = reverse('mailgun_webhook')
 
     def test_missing_signature(self):
         """Test that webhook api returns status code 403"""

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -696,13 +696,15 @@ class EmailBouncedViewTests(APITestCase, MockedESTestCase):
             "event": "bounced",
             "recipient": "c@example.com",
             "error": "Unable to send email",
-            "log_error_on_bounce": log_error_on_bounce
+            "log_error_on_bounce": log_error_on_bounce,
+            "message-headers": "[[\"sender\": \"xyx@example.com\"]]"
         }
         error_msg = (
-            "Webhook event {event} received by Mailgun for recipient {to}: {error}".format(
+            "Webhook event {event} received by Mailgun for recipient {to}: {error} {header}".format(
                 to=data["recipient"],
-                error="{},{}".format(data["error"], None),
-                event=data["event"]
+                error=data["error"],
+                event=data["event"],
+                header=data["message-headers"]
             )
         )
         factory = RequestFactory()


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3549

#### What's this PR do?
Added a [webhook](https://documentation.mailgun.com/en/latest/user_manual.html#tracking-bounces) to raise exception when an email bounced

#### How should this be manually tested?
try to post to
http://192.168.99.100:8079/api/v0/mail/bounce_event/
**Method:** POST
**Content-Type:** application/x-www-form-urlencoded
 **POST LOAD:** `event=bounced&recipient=my-course-contact-mail@mit.edu&error=Unable to view`

It will raise exception that you can check in senetry
#### Where should the reviewer start?
see the api

@pdpinch

<img width="855" alt="screen shot 2017-10-03 at 6 34 17 pm" src="https://user-images.githubusercontent.com/10431250/31127867-849c304a-a869-11e7-84f4-7904b904bb15.png">
 