### PR TITLE
Change course status in GradeDetailPopup to Auditing

### DIFF
--- a/static/js/components/dashboard/courses/GradeDetailPopup.js
+++ b/static/js/components/dashboard/courses/GradeDetailPopup.js
@@ -15,7 +15,7 @@ import {
   STATUS_NOT_PASSED,
   STATUS_PASSED,
   STATUS_CURRENTLY_ENROLLED,
-  DASHBOARD_FORMAT,
+  DASHBOARD_FORMAT
 } from "../../../constants"
 import type { GradeType } from "../../../containers/DashboardPage"
 import { EDX_GRADE } from "../../../containers/DashboardPage"

--- a/static/js/components/dashboard/courses/GradeDetailPopup.js
+++ b/static/js/components/dashboard/courses/GradeDetailPopup.js
@@ -14,7 +14,8 @@ import { formatGrade } from "../util"
 import {
   STATUS_NOT_PASSED,
   STATUS_PASSED,
-  DASHBOARD_FORMAT
+  STATUS_CURRENTLY_ENROLLED,
+  DASHBOARD_FORMAT,
 } from "../../../constants"
 import type { GradeType } from "../../../containers/DashboardPage"
 import { EDX_GRADE } from "../../../containers/DashboardPage"
@@ -49,6 +50,9 @@ const runStatus = (courseRun: CourseRun): React$Element<*> => {
   }
   if (courseRun.status === STATUS_PASSED) {
     return passed()
+  }
+  if (courseRun.status === STATUS_CURRENTLY_ENROLLED) {
+    return <div className="status audited">Auditing</div>
   }
   return <div className="status audited">Audited</div>
 }

--- a/static/js/components/dashboard/courses/GradeDetailPopup_test.js
+++ b/static/js/components/dashboard/courses/GradeDetailPopup_test.js
@@ -11,7 +11,7 @@ import {
   makeCourse,
   makeProctoredExamResult
 } from "../../../factories/dashboard"
-import { makeRunPassed, makeRunFailed } from "./test_util"
+import { makeRunPassed, makeRunFailed, makeRunEnrolled } from "./test_util"
 import { EXAM_GRADE, EDX_GRADE } from "../../../containers/DashboardPage"
 import { formatGrade } from "../util"
 
@@ -46,6 +46,18 @@ describe("GradeDetailPopup", () => {
       .forEach((node, idx) =>
         assert.equal(node.text(), `${course.runs[idx].title}Audited`)
       )
+  })
+
+  it("shows info for a currently enrolled course", () => {
+    makeRunEnrolled(course.runs[0])
+    const wrapper = renderDetailPopup()
+    assert.equal(
+      wrapper
+        .find(".course-run-row")
+        .first()
+        .text(),
+      `${course.runs[0].title}Auditing`
+    )
   })
 
   it("shows info for a passed course", () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3575

#### What's this PR do?
Change course status in GradeDetailPopup for `currently-enrolled` status to as Auditing

#### How should this be manually tested?
Use a management command to enroll your user in a course run.
```alter_data set_to_enrolled --username staff --course-title 'Analog Learning 100'```

