### PR TITLE
Redirect to new channel after creating it

### DIFF
--- a/static/js/components/channels/withChannelCreateDialog.js
+++ b/static/js/components/channels/withChannelCreateDialog.js
@@ -4,14 +4,13 @@ import React from "react"
 import R from "ramda"
 import type { Dispatch } from "redux"
 
-import { showDialog, hideDialog, setToastMessage } from "../../actions/ui"
+import { showDialog, hideDialog } from "../../actions/ui"
 import {
   startChannelEdit,
   clearChannelEdit,
   updateChannelEdit,
   createChannel
 } from "../../actions/channels"
-import { TOAST_SUCCESS } from "../../constants"
 import { actions } from "../../lib/redux_rest"
 import { discussionErrors } from "../../lib/validation/discussions"
 import { getDisplayName } from "../../util/util"

--- a/static/js/components/channels/withChannelCreateDialog.js
+++ b/static/js/components/channels/withChannelCreateDialog.js
@@ -81,13 +81,6 @@ export const withChannelCreateDialog = (WrappedComponent: ReactClass<*>) => {
             const channelUrl = `${SETTINGS.open_discussions_redirect_url}channel/${channel.name}`
             window.open(channelUrl, "_self")
           }
-
-          return dispatch(
-            setToastMessage({
-              message: `Your channel "${channel.title}" has been created.`,
-              icon:    TOAST_SUCCESS
-            })
-          )
         })
       }
     }

--- a/static/js/components/channels/withChannelCreateDialog.js
+++ b/static/js/components/channels/withChannelCreateDialog.js
@@ -79,7 +79,7 @@ export const withChannelCreateDialog = (WrappedComponent: ReactClass<*>) => {
 
           if (SETTINGS.open_discussions_redirect_url) {
             const channelUrl = `${SETTINGS.open_discussions_redirect_url}channel/${channel.name}`
-            window.open(channelUrl, "_blank")
+            window.open(channelUrl, "_self")
           }
 
           return dispatch(

--- a/static/js/components/channels/withChannelCreateDialog_test.js
+++ b/static/js/components/channels/withChannelCreateDialog_test.js
@@ -10,14 +10,14 @@ import fetchMock from "fetch-mock"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import { withChannelCreateDialog } from "./withChannelCreateDialog"
 import { actions } from "../../lib/redux_rest"
-import { CHANNEL_CREATE_DIALOG, TOAST_SUCCESS } from "../../constants"
+import { CHANNEL_CREATE_DIALOG } from "../../constants"
 import {
   START_CHANNEL_EDIT,
   CLEAR_CHANNEL_EDIT,
   INITIATE_CREATE_CHANNEL,
   CREATE_CHANNEL_SUCCESS
 } from "../../actions/channels"
-import { SHOW_DIALOG, HIDE_DIALOG, SET_TOAST_MESSAGE } from "../../actions/ui"
+import { SHOW_DIALOG, HIDE_DIALOG } from "../../actions/ui"
 import { INITIAL_CHANNEL_STATE } from "../../reducers/channel_dialog"
 
 describe("withChannelCreateDialog higher-order component", () => {

--- a/static/js/components/channels/withChannelCreateDialog_test.js
+++ b/static/js/components/channels/withChannelCreateDialog_test.js
@@ -139,7 +139,6 @@ describe("withChannelCreateDialog higher-order component", () => {
         actions.channels.post.requestType,
         actions.channels.post.successType,
         CREATE_CHANNEL_SUCCESS,
-        SET_TOAST_MESSAGE,
         CLEAR_CHANNEL_EDIT,
         HIDE_DIALOG
       ],
@@ -150,9 +149,5 @@ describe("withChannelCreateDialog higher-order component", () => {
     assert.isTrue(buildQuerySpy.called)
     assert.isTrue(openSpy.called)
     assert.isFalse(state.ui.dialogVisibility[CHANNEL_CREATE_DIALOG])
-    assert.deepEqual(state.ui.toastMessage, {
-      message: 'Your channel "title" has been created.',
-      icon:    TOAST_SUCCESS
-    })
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3582

#### What's this PR do?
Redirect to new channel after creating it

#### How should this be manually tested?
Create a new channel, when you click CREATE button the window should redirect to the new channel.

