### PR TITLE
Update logging configuration to show celery exceptions

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -308,10 +308,6 @@ LOG_HOST = get_string('MICROMASTERS_LOG_HOST', 'localhost')
 LOG_HOST_PORT = get_int('MICROMASTERS_LOG_HOST_PORT', 514)
 
 HOSTNAME = platform.node().split('.')[0]
-DEFAULT_LOG_STANZA = {
-    'handlers': ['console', 'syslog'],
-    'level': LOG_LEVEL,
-}
 
 # nplusone profiler logger configuration
 NPLUSONE_LOGGER = logging.getLogger('nplusone')
@@ -319,7 +315,7 @@ NPLUSONE_LOG_LEVEL = logging.ERROR
 
 LOGGING = {
     'version': 1,
-    'disable_existing_loggers': True,
+    'disable_existing_loggers': False,
     'filters': {
         'require_debug_false': {
             '()': 'django.utils.log.RequireDebugFalse',
@@ -360,11 +356,10 @@ LOGGING = {
         }
     },
     'loggers': {
-        'root': DEFAULT_LOG_STANZA,
-        'ui': DEFAULT_LOG_STANZA,
-        'backends': DEFAULT_LOG_STANZA,
-        'profiles': DEFAULT_LOG_STANZA,
-        'courses': DEFAULT_LOG_STANZA,
+        'root': {
+            'handlers': ['console', 'syslog'],
+            'level': LOG_LEVEL,
+        },
         'django': {
             'propagate': True,
             'level': DJANGO_LOG_LEVEL,

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -371,7 +371,7 @@ LOGGING = {
             'propagate': True,
         },
         'urllib3': {
-            'level': 'INFO',
+            'level': ES_LOG_LEVEL,
         },
         'elasticsearch': {
             'level': ES_LOG_LEVEL,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3590 

#### What's this PR do?
Turns off `disable_existing_loggers` which allows celery logging to show up in the console. According to [this](https://docs.djangoproject.com/en/1.11/topics/logging/#configuring-logging) this having it set to true is usually not desirable. I feel like this was set to true originally just because it was the default value.

#### How should this be manually tested?
 - Add a `raise Exception("test")` in `discussions/tasks.py` `sync_discussion_user`.
 - Check out master, restart micromasters and run `profile.save()` on some profile of your choosing. You should see no message in the console.
 - Check out this PR, restart micromasters and run `profile.save()`. You should now see the exception in the output.

#### Any background context you want to provide?
This is the original PR which added this configuration, though there isn't much explanation here: https://github.com/mitodl/lore/pull/58
