### PR TITLE
Make MAILGUN_URL and MAILGUN_KEY required values

### DIFF
--- a/app.json
+++ b/app.json
@@ -107,6 +107,9 @@
     "MAILGUN_KEY": {
       "description": "The token for authenticating against the Mailgun API"
     },
+    "MAILGUN_URL": {
+      "description": "The URL used to connect with Mailgun"
+    },
     "MICROMASTERS_ADMIN_EMAIL": {
       "description": "E-mail to send 500 reports to.",
       "required": false

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -284,8 +284,12 @@ EMAIL_USE_TLS = get_bool('MICROMASTERS_EMAIL_TLS', False)
 EMAIL_SUPPORT = get_string('MICROMASTERS_SUPPORT_EMAIL', 'support@example.com')
 DEFAULT_FROM_EMAIL = get_string('MICROMASTERS_FROM_EMAIL', 'webmaster@localhost')
 ECOMMERCE_EMAIL = get_string('MICROMASTERS_ECOMMERCE_EMAIL', 'support@example.com')
-MAILGUN_URL = get_string('MAILGUN_URL', 'https://api.mailgun.net/v3/micromasters.mit.edu')
+MAILGUN_URL = get_string('MAILGUN_URL', None)
+if not MAILGUN_URL:
+    raise ImproperlyConfigured("MAILGUN_URL not set")
 MAILGUN_KEY = get_string('MAILGUN_KEY', None)
+if not MAILGUN_URL:
+    raise ImproperlyConfigured("MAILGUN_KEY not set")
 MAILGUN_BATCH_CHUNK_SIZE = get_int('MAILGUN_BATCH_CHUNK_SIZE', 1000)
 MAILGUN_RECIPIENT_OVERRIDE = get_string('MAILGUN_RECIPIENT_OVERRIDE', None)
 MAILGUN_FROM_EMAIL = get_string('MAILGUN_FROM_EMAIL', 'no-reply@micromasters.mit.edu')

--- a/micromasters/tests/test_settings.py
+++ b/micromasters/tests/test_settings.py
@@ -14,6 +14,12 @@ import semantic_version
 from search.base import MockedESTestCase
 
 
+REQUIRED_SETTINGS = {
+    'MAILGUN_URL': 'http://fake.mailgun.url',
+    'MAILGUN_KEY': 'fake_mailgun_key'
+}
+
+
 class TestSettings(MockedESTestCase):
     """Validate that settings work as expected."""
 
@@ -33,6 +39,7 @@ class TestSettings(MockedESTestCase):
         """Verify that we enable and configure S3 with a variable"""
         # Unset, we don't do S3
         with mock.patch.dict('os.environ', {
+            **REQUIRED_SETTINGS,
             'MICROMASTERS_USE_S3': 'False'
         }, clear=True):
             settings_vars = self.reload_settings()
@@ -43,12 +50,14 @@ class TestSettings(MockedESTestCase):
 
         with self.assertRaises(ImproperlyConfigured):
             with mock.patch.dict('os.environ', {
+                **REQUIRED_SETTINGS,
                 'MICROMASTERS_USE_S3': 'True',
             }, clear=True):
                 self.reload_settings()
 
         # Verify it all works with it enabled and configured 'properly'
         with mock.patch.dict('os.environ', {
+            **REQUIRED_SETTINGS,
             'MICROMASTERS_USE_S3': 'True',
             'AWS_ACCESS_KEY_ID': '1',
             'AWS_SECRET_ACCESS_KEY': '2',
@@ -64,6 +73,7 @@ class TestSettings(MockedESTestCase):
         """Verify that we configure email with environment variable"""
 
         with mock.patch.dict('os.environ', {
+            **REQUIRED_SETTINGS,
             'MICROMASTERS_ADMIN_EMAIL': ''
         }, clear=True):
             settings_vars = self.reload_settings()
@@ -71,6 +81,7 @@ class TestSettings(MockedESTestCase):
 
         test_admin_email = 'cuddle_bunnies@example.com'
         with mock.patch.dict('os.environ', {
+            **REQUIRED_SETTINGS,
             'MICROMASTERS_ADMIN_EMAIL': test_admin_email,
         }, clear=True):
             settings_vars = self.reload_settings()
@@ -88,7 +99,7 @@ class TestSettings(MockedESTestCase):
         """Verify that we can enable/disable database SSL with a var"""
 
         # Check default state is SSL on
-        with mock.patch.dict('os.environ', {}, clear=True):
+        with mock.patch.dict('os.environ', REQUIRED_SETTINGS, clear=True):
             settings_vars = self.reload_settings()
             self.assertEqual(
                 settings_vars['DATABASES']['default']['OPTIONS'],
@@ -97,6 +108,7 @@ class TestSettings(MockedESTestCase):
 
         # Check enabling the setting explicitly
         with mock.patch.dict('os.environ', {
+            **REQUIRED_SETTINGS,
             'MICROMASTERS_DB_DISABLE_SSL': 'True'
         }, clear=True):
             settings_vars = self.reload_settings()
@@ -107,6 +119,7 @@ class TestSettings(MockedESTestCase):
 
         # Disable it
         with mock.patch.dict('os.environ', {
+            **REQUIRED_SETTINGS,
             'MICROMASTERS_DB_DISABLE_SSL': 'False'
         }, clear=True):
             settings_vars = self.reload_settings()

--- a/scripts/test/run_selenium_tests_dev.sh
+++ b/scripts/test/run_selenium_tests_dev.sh
@@ -22,4 +22,6 @@ docker-compose run \
    -e USE_WEBPACK_DEV_SERVER=True \
    -e WEBPACK_DEV_SERVER_HOST="$WEBPACK_SELENIUM_DEV_SERVER_HOST" \
    -e ELASTICSEARCH_DEFAULT_PAGE_SIZE=5 \
+   -e MAILGUN_URL=http://fake.mailgun.url \
+   -e MAILGUN_KEY=fake_mailgun_key \
    selenium py.test ${@-./selenium_tests}

--- a/scripts/test/run_selenium_tests_travis.sh
+++ b/scripts/test/run_selenium_tests_travis.sh
@@ -13,4 +13,6 @@ docker-compose -f travis-docker-compose.yml run \
    -e DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:7000-8000 \
    -e ELASTICSEARCH_INDEX=testindex \
    -e ELASTICSEARCH_DEFAULT_PAGE_SIZE=5 \
+   -e MAILGUN_URL=http://fake.mailgun.url \
+   -e MAILGUN_KEY=fake_mailgun_key \
    selenium py.test ./selenium_tests

--- a/tox.ini
+++ b/tox.ini
@@ -31,4 +31,6 @@ setenv =
     DISABLE_WEBPACK_LOADER_STATS=True
     MICROMASTERS_DB_DISABLE_SSL=True
     MICROMASTERS_SECURE_SSL_REDIRECT=False
+    MAILGUN_URL=http://fake.mailgun.url
+    MAILGUN_KEY=fake_mailgun_key
     USE_WEBPACK_DEV_SERVER=False


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3599 

#### What's this PR do?
Removes the invalid default value for `MAILGUN_URL` and checks that these variables are present in settings.py

#### How should this be manually tested?
Set the correct URL in your environment variable and send an email from the learner search page
