### PR TITLE
Allow empty public_description

### DIFF
--- a/discussions/serializers.py
+++ b/discussions/serializers.py
@@ -14,7 +14,7 @@ class ChannelSerializer(serializers.Serializer):
     """
     title = serializers.CharField()
     name = serializers.CharField()
-    public_description = serializers.CharField()
+    public_description = serializers.CharField(required=False, allow_blank=True)
     channel_type = serializers.ChoiceField(choices=[
         (choice, choice) for choice in VALID_CHANNEL_TYPES
     ])

--- a/discussions/views_test.py
+++ b/discussions/views_test.py
@@ -169,7 +169,7 @@ def test_create_channel_user_without_permission(patched_users_api):
     assert resp.status_code == 403
 
 
-@pytest.mark.parametrize("missing_param", ["title", "name", "public_description", "channel_type", "query"])
+@pytest.mark.parametrize("missing_param", ["title", "name", "channel_type", "query"])
 def test_create_channel_missing_param(missing_param, patched_users_api):
     """A missing param should cause a validation error"""
     client = APIClient()

--- a/discussions/views_test.py
+++ b/discussions/views_test.py
@@ -85,19 +85,20 @@ def test_logged_in_user_redirect_no_username(client, patched_users_api):
         client.get(reverse('discussions'))
 
 
-def _make_create_channel_input(program_id):
+def _make_create_channel_input(program_id, description="default description"):
     """Generate parameters for create API"""
     return {
         "title": "title",
         "name": "name",
-        "public_description": "public description",
+        "public_description": description,
         "channel_type": "public",
         "query": {},
         "program_id": program_id,
     }
 
 
-def test_create_channel(mocker, patched_users_api):
+@pytest.mark.parametrize("description", ["public description", ""])
+def test_create_channel(description, mocker, patched_users_api):
     """Staff can create a channel using the REST API"""
     client = APIClient()
     role = RoleFactory.create(role=Staff.ROLE_ID)
@@ -107,7 +108,7 @@ def test_create_channel(mocker, patched_users_api):
     channel = ChannelFactory.create()
     add_channel_mock = mocker.patch('discussions.serializers.add_channel', return_value=channel, autospec=True)
 
-    create_channel_input = _make_create_channel_input(role.program.id)
+    create_channel_input = _make_create_channel_input(role.program.id, description)
     resp = client.post(reverse('channel-list'), data={
         **create_channel_input,
         "name": channel.name,

--- a/static/js/lib/validation/discussions.js
+++ b/static/js/lib/validation/discussions.js
@@ -17,7 +17,7 @@ const checkName = checkProp(
 )
 
 const requiredMessages = {
-  name: "Channel name is required",
+  name:  "Channel name is required",
   title: "Channel title is required"
 }
 

--- a/static/js/lib/validation/discussions.js
+++ b/static/js/lib/validation/discussions.js
@@ -17,8 +17,8 @@ const checkName = checkProp(
 )
 
 const requiredMessages = {
-  name:               "Channel name is required",
-  title:              "Channel title is required"
+  name: "Channel name is required",
+  title: "Channel title is required"
 }
 
 const checkRequiredFields = R.compose(

--- a/static/js/lib/validation/discussions.js
+++ b/static/js/lib/validation/discussions.js
@@ -18,8 +18,7 @@ const checkName = checkProp(
 
 const requiredMessages = {
   name:               "Channel name is required",
-  title:              "Channel title is required",
-  public_description: "Channel description is required"
+  title:              "Channel title is required"
 }
 
 const checkRequiredFields = R.compose(

--- a/static/js/lib/validation/discussions_test.js
+++ b/static/js/lib/validation/discussions_test.js
@@ -5,8 +5,8 @@ import { discussionErrors, CHANNEL_NAME_ERROR } from "./discussions"
 describe("Discussion validation functions", () => {
   it("should return that two fields are required", () => {
     assert.deepEqual(discussionErrors({}), {
-      name:               "Channel name is required",
-      title:              "Channel title is required"
+      name: "Channel name is required",
+      title: "Channel title is required"
     })
   })
 
@@ -14,8 +14,8 @@ describe("Discussion validation functions", () => {
     it(`should return an error for invalid channel name: ${invalidName}`, () => {
       assert.deepEqual(
         discussionErrors({
-          name:               invalidName,
-          title:              "valid",
+          name: invalidName,
+          title: "valid",
           public_description: "valid"
         }),
         {
@@ -40,8 +40,8 @@ describe("Discussion validation functions", () => {
     it(`should not return an error for valid channel name: ${validName}`, () => {
       assert.deepEqual(
         discussionErrors({
-          name:               validName,
-          title:              "valid",
+          name: validName,
+          title: "valid",
           public_description: "valid"
         }),
         {}

--- a/static/js/lib/validation/discussions_test.js
+++ b/static/js/lib/validation/discussions_test.js
@@ -3,11 +3,10 @@ import { assert } from "chai"
 import { discussionErrors, CHANNEL_NAME_ERROR } from "./discussions"
 
 describe("Discussion validation functions", () => {
-  it("should return that all fields are required", () => {
+  it("should return that two fields are required", () => {
     assert.deepEqual(discussionErrors({}), {
       name:               "Channel name is required",
-      title:              "Channel title is required",
-      public_description: "Channel description is required"
+      title:              "Channel title is required"
     })
   })
 

--- a/static/js/lib/validation/discussions_test.js
+++ b/static/js/lib/validation/discussions_test.js
@@ -5,7 +5,7 @@ import { discussionErrors, CHANNEL_NAME_ERROR } from "./discussions"
 describe("Discussion validation functions", () => {
   it("should return that two fields are required", () => {
     assert.deepEqual(discussionErrors({}), {
-      name: "Channel name is required",
+      name:  "Channel name is required",
       title: "Channel title is required"
     })
   })
@@ -14,8 +14,8 @@ describe("Discussion validation functions", () => {
     it(`should return an error for invalid channel name: ${invalidName}`, () => {
       assert.deepEqual(
         discussionErrors({
-          name: invalidName,
-          title: "valid",
+          name:               invalidName,
+          title:              "valid",
           public_description: "valid"
         }),
         {
@@ -40,8 +40,8 @@ describe("Discussion validation functions", () => {
     it(`should not return an error for valid channel name: ${validName}`, () => {
       assert.deepEqual(
         discussionErrors({
-          name: validName,
-          title: "valid",
+          name:               validName,
+          title:              "valid",
           public_description: "valid"
         }),
         {}

--- a/static/js/reducers/channel_dialog_test.js
+++ b/static/js/reducers/channel_dialog_test.js
@@ -33,8 +33,7 @@ describe("channel_dialog reducers", () => {
 
   const VALIDATION_ERRORS = {
     title:              "Channel title is required",
-    name:               "Channel name is required",
-    public_description: "Channel description is required"
+    name:               "Channel name is required"
   }
 
   it("should let you start editing an channel", async () => {

--- a/static/js/reducers/channel_dialog_test.js
+++ b/static/js/reducers/channel_dialog_test.js
@@ -33,7 +33,7 @@ describe("channel_dialog reducers", () => {
 
   const VALIDATION_ERRORS = {
     title: "Channel title is required",
-    name: "Channel name is required"
+    name:  "Channel name is required"
   }
 
   it("should let you start editing an channel", async () => {
@@ -54,7 +54,7 @@ describe("channel_dialog reducers", () => {
     )
     assert.deepEqual(state, {
       ...INITIAL_CHANNEL_STATE,
-      inputs: updatedInputs,
+      inputs:           updatedInputs,
       validationErrors: R.dissoc("title", VALIDATION_ERRORS)
     })
   })
@@ -69,10 +69,10 @@ describe("channel_dialog reducers for the createChannel action", () => {
   let helper, createFuncStub, dispatchThen
   const createArgs = [
     {
-      name: "name",
-      title: "title",
+      name:               "name",
+      title:              "title",
       public_description: "public_description",
-      channel_type: "private"
+      channel_type:       "private"
     }
   ]
 

--- a/static/js/reducers/channel_dialog_test.js
+++ b/static/js/reducers/channel_dialog_test.js
@@ -32,8 +32,8 @@ describe("channel_dialog reducers", () => {
   })
 
   const VALIDATION_ERRORS = {
-    title:              "Channel title is required",
-    name:               "Channel name is required"
+    title: "Channel title is required",
+    name: "Channel name is required"
   }
 
   it("should let you start editing an channel", async () => {
@@ -54,7 +54,7 @@ describe("channel_dialog reducers", () => {
     )
     assert.deepEqual(state, {
       ...INITIAL_CHANNEL_STATE,
-      inputs:           updatedInputs,
+      inputs: updatedInputs,
       validationErrors: R.dissoc("title", VALIDATION_ERRORS)
     })
   })
@@ -69,10 +69,10 @@ describe("channel_dialog reducers for the createChannel action", () => {
   let helper, createFuncStub, dispatchThen
   const createArgs = [
     {
-      name:               "name",
-      title:              "title",
+      name: "name",
+      title: "title",
       public_description: "public_description",
-      channel_type:       "private"
+      channel_type: "private"
     }
   ]
 


### PR DESCRIPTION
#### What are the relevant tickets?
Depends on https://github.com/mitodl/open-discussions/pull/254

#### What's this PR do?
Make public_description not required

#### How should this be manually tested?
Should be able to create a channel with empty description.
