### PR TITLE
Add payment deadline to course status

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "minimist": "^1.2.0",
     "mocha": "^3.4.2",
     "moment": "^2.18.1",
+    "moment-timezone": "^0.5.13",
     "node-sass": "^4.5.3",
     "nyc": "^10.1.2",
     "object.entries": "^1.0.4",

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -95,6 +95,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   const passedExam = hasPassingExamGrade(course)
   const failedExam = hasFailingExamGrade(course)
   const paymentDueDate = moment(firstRun.course_upgrade_deadline)
+  const dueDate = paymentDueDate.format(COURSE_CARD_FORMAT)
   if (firstRun.status === STATUS_PAID_BUT_NOT_ENROLLED) {
     const contactHref = `mailto:${SETTINGS.support_email}`
     return S.Just([
@@ -146,7 +147,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   ) {
     messages.push({
       message:
-        "You are auditing. To get credit, you need to pay for the course.",
+        `You are auditing. To get credit, you need to pay for the course. (Payment due on ${dueDate})`,
       action: courseAction(firstRun, COURSE_ACTION_PAY)
     })
     return S.Just(messages)
@@ -282,7 +283,6 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
           )
         )
       } else {
-        const dueDate = paymentDueDate.format(COURSE_CARD_FORMAT)
         if (exams) {
           messages.push({
             message: `The edX course is complete, but you need to pass the exam. (Payment due on ${dueDate})`,

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -146,9 +146,8 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     firstRun.status === STATUS_CAN_UPGRADE
   ) {
     messages.push({
-      message:
-        `You are auditing. To get credit, you need to pay for the course. (Payment due on ${dueDate})`,
-      action: courseAction(firstRun, COURSE_ACTION_PAY)
+      message: `You are auditing. To get credit, you need to pay for the course. (Payment due on ${dueDate})`,
+      action:  courseAction(firstRun, COURSE_ACTION_PAY)
     })
     return S.Just(messages)
   }

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -2,7 +2,7 @@
 /* global SETTINGS: false */
 import React from "react"
 import R from "ramda"
-import moment from "moment"
+import moment from "moment-timezone"
 
 import type { Coupon } from "../../../flow/couponTypes"
 import type { Course, CourseRun } from "../../../flow/programTypes"
@@ -144,10 +144,10 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     courseUpcomingOrCurrent(firstRun) ||
     firstRun.status === STATUS_CAN_UPGRADE
   ) {
-
+    const date_with_zone = moment(firstRun.course_upgrade_deadline).tz(moment.tz.guess())
     messages.push({
       message: `You are auditing. To get credit, you need to pay for the course.
-       (Payment due on ${paymentDueDate.format(COURSE_DEADLINE_FORMAT)})`,
+       (Payment due on ${date_with_zone.format(COURSE_DEADLINE_FORMAT)})`,
       action:  courseAction(firstRun, COURSE_ACTION_PAY)
     })
     return S.Just(messages)

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -144,10 +144,11 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     courseUpcomingOrCurrent(firstRun) ||
     firstRun.status === STATUS_CAN_UPGRADE
   ) {
-    const date_with_zone = moment(firstRun.course_upgrade_deadline).tz(moment.tz.guess())
+    const dateWithZone = moment(firstRun.course_upgrade_deadline)
+      .tz(moment.tz.guess())
+      .format(COURSE_DEADLINE_FORMAT)
     messages.push({
-      message: `You are auditing. To get credit, you need to pay for the course.
-       (Payment due on ${date_with_zone.format(COURSE_DEADLINE_FORMAT)})`,
+      message: `You are auditing. To get credit, you need to pay for the course. (Payment due on ${dateWithZone})`,
       action:  courseAction(firstRun, COURSE_ACTION_PAY)
     })
     return S.Just(messages)

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -30,7 +30,7 @@ import {
   hasFailingExamGrade,
   hasPassedCourseRun
 } from "../../../lib/grades"
-import { COURSE_CARD_FORMAT } from "../../../constants"
+import { COURSE_CARD_FORMAT, COURSE_DEADLINE_FORMAT } from "../../../constants"
 
 type Message = {
   message: string | React$Element<*>,
@@ -95,7 +95,6 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   const passedExam = hasPassingExamGrade(course)
   const failedExam = hasFailingExamGrade(course)
   const paymentDueDate = moment(firstRun.course_upgrade_deadline)
-  const dueDate = paymentDueDate.format(COURSE_CARD_FORMAT)
   if (firstRun.status === STATUS_PAID_BUT_NOT_ENROLLED) {
     const contactHref = `mailto:${SETTINGS.support_email}`
     return S.Just([
@@ -145,8 +144,10 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     courseUpcomingOrCurrent(firstRun) ||
     firstRun.status === STATUS_CAN_UPGRADE
   ) {
+
     messages.push({
-      message: `You are auditing. To get credit, you need to pay for the course. (Payment due on ${dueDate})`,
+      message: `You are auditing. To get credit, you need to pay for the course.
+       (Payment due on ${paymentDueDate.format(COURSE_DEADLINE_FORMAT)})`,
       action:  courseAction(firstRun, COURSE_ACTION_PAY)
     })
     return S.Just(messages)
@@ -282,6 +283,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
           )
         )
       } else {
+        const dueDate = paymentDueDate.format(COURSE_CARD_FORMAT)
         if (exams) {
           messages.push({
             message: `The edX course is complete, but you need to pass the exam. (Payment due on ${dueDate})`,

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -144,11 +144,16 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     courseUpcomingOrCurrent(firstRun) ||
     firstRun.status === STATUS_CAN_UPGRADE
   ) {
-    const dateWithZone = moment(firstRun.course_upgrade_deadline)
+    const message =
+      "You are auditing. To get credit, you need to pay for the course."
+    const dateWithZone = paymentDueDate
       .tz(moment.tz.guess())
       .format(COURSE_DEADLINE_FORMAT)
+    const paymentDueMessage = paymentDueDate.isValid()
+      ? ` (Payment due on ${dateWithZone})`
+      : ""
     messages.push({
-      message: `You are auditing. To get credit, you need to pay for the course. (Payment due on ${dateWithZone})`,
+      message: message + paymentDueMessage,
       action:  courseAction(firstRun, COURSE_ACTION_PAY)
     })
     return S.Just(messages)

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -35,6 +35,7 @@ import {
   COURSE_ACTION_REENROLL,
   COUPON_CONTENT_TYPE_COURSE,
   COURSE_CARD_FORMAT,
+  COURSE_DEADLINE_FORMAT,
   STATUS_PAID_BUT_NOT_ENROLLED
 } from "../../../constants"
 import * as libCoupon from "../../../lib/coupon"
@@ -140,7 +141,7 @@ describe("Course Status Messages", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
       const dueDate = moment(course.runs[0].course_upgrade_deadline).format(
-        COURSE_CARD_FORMAT
+        COURSE_DEADLINE_FORMAT
       )
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -140,7 +140,7 @@ describe("Course Status Messages", () => {
     it("should nag unpaid auditors to pay", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
-      const dueDate = moment(course.runs[0].course_upgrade_deadline).format(
+      const dueDate = moment(course.runs[0].course_upgrade_deadline).tz(moment.tz.guess()moment().format(
         COURSE_DEADLINE_FORMAT
       )
       assertIsJust(calculateMessages(calculateMessagesProps), [

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -164,7 +164,8 @@ describe("Course Status Messages", () => {
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
           action:  "course action was called",
-          message: "You are auditing. To get credit, you need to pay for the course."
+          message:
+            "You are auditing. To get credit, you need to pay for the course."
         }
       ])
       assert(

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -139,12 +139,13 @@ describe("Course Status Messages", () => {
     it("should nag unpaid auditors to pay", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
-      const dueDate = moment(course.runs[0].course_upgrade_deadline).format(COURSE_CARD_FORMAT)
+      const dueDate = moment(course.runs[0].course_upgrade_deadline).format(
+        COURSE_CARD_FORMAT
+      )
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
           action:  "course action was called",
-          message:
-            `You are auditing. To get credit, you need to pay for the course. (Payment due on ${dueDate})`
+          message: `You are auditing. To get credit, you need to pay for the course. (Payment due on ${dueDate})`
         }
       ])
       assert(

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -140,9 +140,9 @@ describe("Course Status Messages", () => {
     it("should nag unpaid auditors to pay", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
-      const dueDate = moment(course.runs[0].course_upgrade_deadline).tz(moment.tz.guess()moment().format(
-        COURSE_DEADLINE_FORMAT
-      )
+      const dueDate = moment(course.runs[0].course_upgrade_deadline)
+        .tz(moment.tz.guess())
+        .format(COURSE_DEADLINE_FORMAT)
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
           action:  "course action was called",

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -139,11 +139,12 @@ describe("Course Status Messages", () => {
     it("should nag unpaid auditors to pay", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
+      const dueDate = moment(course.runs[0].course_upgrade_deadline).format(COURSE_CARD_FORMAT)
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
           action:  "course action was called",
           message:
-            "You are auditing. To get credit, you need to pay for the course."
+            `You are auditing. To get credit, you need to pay for the course. (Payment due on ${dueDate})`
         }
       ])
       assert(

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -4,7 +4,7 @@ import React from "react"
 import { shallow } from "enzyme"
 import { assert } from "chai"
 import sinon from "sinon"
-import moment from "moment"
+import moment from "moment-timezone"
 
 import {
   formatAction,

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -11,6 +11,7 @@ export const ISO_8601_FORMAT = "YYYY-MM-DD"
 export const DASHBOARD_FORMAT = "MMM D, Y"
 export const DASHBOARD_MONTH_FORMAT = "MM[/]YYYY"
 export const COURSE_CARD_FORMAT = "MM/DD/YYYY"
+export const COURSE_DEADLINE_FORMAT = "MM/DD/YYYY [at] hA"
 
 export const CP1252_REGEX = /^[\u0020-\u00FF]*$/
 // greater-than, comma, quotation-mark

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -11,7 +11,7 @@ export const ISO_8601_FORMAT = "YYYY-MM-DD"
 export const DASHBOARD_FORMAT = "MMM D, Y"
 export const DASHBOARD_MONTH_FORMAT = "MM[/]YYYY"
 export const COURSE_CARD_FORMAT = "MM/DD/YYYY"
-export const COURSE_DEADLINE_FORMAT = "MM/DD/YYYY [at] hA"
+export const COURSE_DEADLINE_FORMAT = "MM/DD/YYYY [at] hA z"
 
 export const CP1252_REGEX = /^[\u0020-\u00FF]*$/
 // greater-than, comma, quotation-mark


### PR DESCRIPTION
#### What are the relevant tickets?
Fix  #3516

#### What's this PR do?
Display payment deadline for course 

#### How should this be manually tested?
Use this command ```./manage.py alter_data set_past_run_to_passed --username staff --course-title 'Analog Learning 200' --audit```

You should be able to see the payment deadline

![screen shot 2017-10-05 at 3 01 16 pm](https://user-images.githubusercontent.com/7574259/31247308-21700728-a9de-11e7-8c0c-8247d3b30e12.png)


