### PR TITLE
Fix error navigating between profile and learner search pages

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,7 @@
 .*/node_modules/draftjs-utils/.*
 .*/node_modules/react-event-listener/src/index.js
 .*.git/.*
+.*/staticfiles/.*
 
 [include]
 ./static/js

--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -233,7 +233,7 @@ describe("ErrorMessage", () => {
           RECEIVE_GET_USER_PROFILE_FAILURE,
           RECEIVE_GET_USER_PROFILE_FAILURE,
           REQUEST_GET_PROGRAM_ENROLLMENTS,
-          RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+          RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS
         ]
         return renderComponent(
           `/learner/${SETTINGS.user.username}`,
@@ -255,7 +255,7 @@ describe("ErrorMessage", () => {
           REQUEST_GET_USER_PROFILE,
           REQUEST_GET_USER_PROFILE,
           RECEIVE_GET_USER_PROFILE_SUCCESS,
-          RECEIVE_GET_USER_PROFILE_SUCCESS,
+          RECEIVE_GET_USER_PROFILE_SUCCESS
         ]
         return renderComponent(
           `/learner/${SETTINGS.user.username}`,

--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -33,10 +33,6 @@ import {
   DASHBOARD_SUCCESS_NO_LEARNERS_ACTIONS
 } from "../containers/test_util"
 import ErrorMessage from "./ErrorMessage"
-import {
-  RECEIVE_FETCH_COUPONS_SUCCESS,
-  REQUEST_FETCH_COUPONS
-} from "../actions/coupons"
 import { actions } from "../lib/redux_rest"
 
 describe("ErrorMessage", () => {

--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -234,9 +234,6 @@ describe("ErrorMessage", () => {
           RECEIVE_GET_USER_PROFILE_FAILURE,
           REQUEST_GET_PROGRAM_ENROLLMENTS,
           RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
-          RECEIVE_FETCH_COUPONS_SUCCESS,
-          REQUEST_FETCH_COUPONS,
-          actions.prices.get.requestType
         ]
         return renderComponent(
           `/learner/${SETTINGS.user.username}`,
@@ -259,9 +256,6 @@ describe("ErrorMessage", () => {
           REQUEST_GET_USER_PROFILE,
           RECEIVE_GET_USER_PROFILE_SUCCESS,
           RECEIVE_GET_USER_PROFILE_SUCCESS,
-          RECEIVE_FETCH_COUPONS_SUCCESS,
-          REQUEST_FETCH_COUPONS,
-          actions.prices.get.requestType
         ]
         return renderComponent(
           `/learner/${SETTINGS.user.username}`,

--- a/static/js/components/Learner.js
+++ b/static/js/components/Learner.js
@@ -58,11 +58,9 @@ export default class Learner extends React.Component {
       dashboard,
       ui,
       setShowGradeDetailDialog,
-      coupons,
-      prices
     } = this.props
 
-    if (!R.isEmpty(dashboard) && coupons && !R.isEmpty(prices)) {
+    if (!R.isEmpty(dashboard)) {
       return dashboard.programs.map(program => (
         <div key={program.id}>
           <CourseListCard

--- a/static/js/components/Learner.js
+++ b/static/js/components/Learner.js
@@ -16,10 +16,7 @@ import {
 import StaffLearnerInfoCard from "./StaffLearnerInfoCard"
 import type { Profile, SaveProfileFunc } from "../flow/profileTypes"
 import type { UIState } from "../reducers/ui"
-import type { CoursePrices, DashboardState } from "../flow/dashboardTypes"
-import type { RestState } from "../flow/restTypes"
-import type { CouponsState } from "../reducers/coupons"
-import { calculatePrices } from "../lib/coupon"
+import type { DashboardState } from "../flow/dashboardTypes"
 import CourseListCard from "./dashboard/CourseListCard"
 
 export default class Learner extends React.Component {
@@ -35,8 +32,6 @@ export default class Learner extends React.Component {
     setLearnerPageAboutMeDialogVisibility: () => void,
     openLearnerEmailComposer: () => void,
     setShowGradeDetailDialog: (b: boolean, t: string) => void,
-    prices: RestState<CoursePrices>,
-    coupons: CouponsState
   }
 
   toggleShowPersonalDialog = (): void => {
@@ -68,11 +63,6 @@ export default class Learner extends React.Component {
     } = this.props
 
     if (!R.isEmpty(dashboard) && coupons && !R.isEmpty(prices)) {
-      const calculatedPrices = calculatePrices(
-        dashboard.programs,
-        prices.data || [],
-        coupons.coupons
-      )
       return dashboard.programs.map(program => (
         <div key={program.id}>
           <CourseListCard
@@ -81,10 +71,8 @@ export default class Learner extends React.Component {
             showStaffView={true}
             openCourseContactDialog={() => undefined}
             setShowGradeDetailDialog={setShowGradeDetailDialog}
-            couponPrices={calculatedPrices}
           />
           <StaffLearnerInfoCard
-            prices={calculatedPrices}
             program={program}
             setShowGradeDetailDialog={setShowGradeDetailDialog}
             dialogVisibility={ui.dialogVisibility}

--- a/static/js/components/Learner.js
+++ b/static/js/components/Learner.js
@@ -31,7 +31,7 @@ export default class Learner extends React.Component {
     startProfileEdit: () => void,
     setLearnerPageAboutMeDialogVisibility: () => void,
     openLearnerEmailComposer: () => void,
-    setShowGradeDetailDialog: (b: boolean, t: string) => void,
+    setShowGradeDetailDialog: (b: boolean, t: string) => void
   }
 
   toggleShowPersonalDialog = (): void => {
@@ -54,11 +54,7 @@ export default class Learner extends React.Component {
     startProfileEdit()
   }
   showStaffInfo = () => {
-    const {
-      dashboard,
-      ui,
-      setShowGradeDetailDialog,
-    } = this.props
+    const { dashboard, ui, setShowGradeDetailDialog } = this.props
 
     if (!R.isEmpty(dashboard)) {
       return dashboard.programs.map(program => (

--- a/static/js/components/StaffLearnerInfoCard.js
+++ b/static/js/components/StaffLearnerInfoCard.js
@@ -4,17 +4,15 @@ import { Card, CardTitle } from "react-mdl/lib/Card"
 import R from "ramda"
 
 import { circularProgressWidget } from "./ProgressWidget"
-import { programCourseInfo, classify, formatPrice } from "../util/util"
+import { programCourseInfo, classify } from "../util/util"
 import type { Program } from "../flow/programTypes"
 import { S, getm } from "../lib/sanctuary"
 import type { DialogVisibilityState } from "../reducers/ui"
-import type { CouponPrices } from "../flow/couponTypes"
 
 type StaffLearnerCardProps = {
   program: Program,
   setShowGradeDetailDialog: (b: boolean, t: string) => void,
   dialogVisibility: DialogVisibilityState,
-  prices: CouponPrices
 }
 
 const programInfoBadge = (title, text) => (
@@ -37,14 +35,8 @@ const formatCourseGrade = R.compose(
 )
 
 const StaffLearnerInfoCard = (props: StaffLearnerCardProps) => {
-  const { program, prices } = props
+  const { program } = props
   const { totalPassedCourses, totalCourses } = programCourseInfo(program)
-  const courseProgramPrice = prices.pricesInclCouponByProgram.get(program.id)
-  let priceToDisplay = "--"
-
-  if (courseProgramPrice) {
-    priceToDisplay = formatPrice(courseProgramPrice.price.toString())
-  }
 
   return (
     <Card shadow={1} className="staff-learner-info-card course-list">
@@ -58,7 +50,6 @@ const StaffLearnerInfoCard = (props: StaffLearnerCardProps) => {
             "Average program grade",
             formatCourseGrade(program)
           )}
-          {programInfoBadge("Course Price", priceToDisplay)}
         </div>
       </div>
     </Card>

--- a/static/js/components/StaffLearnerInfoCard.js
+++ b/static/js/components/StaffLearnerInfoCard.js
@@ -12,7 +12,7 @@ import type { DialogVisibilityState } from "../reducers/ui"
 type StaffLearnerCardProps = {
   program: Program,
   setShowGradeDetailDialog: (b: boolean, t: string) => void,
-  dialogVisibility: DialogVisibilityState,
+  dialogVisibility: DialogVisibilityState
 }
 
 const programInfoBadge = (title, text) => (

--- a/static/js/components/StaffLearnerInfoCard_test.js
+++ b/static/js/components/StaffLearnerInfoCard_test.js
@@ -55,25 +55,6 @@ describe("StaffLearnerInfoCard", () => {
     )
   })
 
-  const dataSet = [
-    {
-      price:   1000,
-      display: "$1000"
-    },
-    {
-      price:   0,
-      display: "$0"
-    }
-  ]
-
-  for (const data of dataSet) {
-    it(`should have the program price ${data.display}`, () => {
-      const card = renderCard(DASHBOARD_RESPONSE.programs[0], data.price)
-      const price = card.find(".course-price .program-badge").text()
-      assert.equal(price, data.display)
-    })
-  }
-
   it("should render the progress display", () => {
     const card = renderCard()
     assert.include(stringStrip(card.text()), "1 4 Courses complete")

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -23,7 +23,7 @@ const priceMessageClassName = "price-message"
 export default class CourseListCard extends React.Component {
   props: {
     program: Program,
-    couponPrices: CouponPrices,
+    couponPrices?: CouponPrices,
     openFinancialAidCalculator?: () => void,
     now?: Object,
     addCourseEnrollment?: (courseId: string) => Promise<*>,
@@ -42,6 +42,10 @@ export default class CourseListCard extends React.Component {
 
   getProgramCouponPrice = (): CouponPrice => {
     const { couponPrices, program } = this.props
+    if (!couponPrices) {
+      // shouldn't happen, we should not be here unless we already checked this
+      throw new Error('No coupon prices available')
+    }
     const couponPrice = couponPrices.pricesInclCouponByProgram.get(program.id)
     if (!couponPrice) {
       // This shouldn't happen since we should have waited for the API requests to finish before getting here

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -44,7 +44,7 @@ export default class CourseListCard extends React.Component {
     const { couponPrices, program } = this.props
     if (!couponPrices) {
       // shouldn't happen, we should not be here unless we already checked this
-      throw new Error('No coupon prices available')
+      throw new Error("No coupon prices available")
     }
     const couponPrice = couponPrices.pricesInclCouponByProgram.get(program.id)
     if (!couponPrice) {

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -137,8 +137,6 @@ export default class CourseRow extends React.Component {
       showStaffView
     } = this.props
 
-    const coupon = this.getCourseCoupon()
-
     return (
       <div className="enrolled-course-info">
         <Grades
@@ -162,7 +160,7 @@ export default class CourseRow extends React.Component {
             courseAction={this.courseAction}
             expandedStatuses={ui.expandedCourseStatuses}
             setShowExpandedCourseStatus={setShowExpandedCourseStatus}
-            coupon={coupon}
+            coupon={this.getCourseCoupon()}
           />
         )}
       </div>

--- a/static/js/containers/LearnerPage.js
+++ b/static/js/containers/LearnerPage.js
@@ -14,7 +14,7 @@ import {
   childrenWithProps
 } from "./ProfileFormContainer"
 import ErrorMessage from "../components/ErrorMessage"
-import { fetchDashboard } from "../actions/dashboard"
+import { fetchDashboard, clearDashboard } from "../actions/dashboard"
 import { clearCoupons, fetchCoupons } from "../actions/coupons"
 import { actions } from "../lib/redux_rest"
 import { hasAnyStaffRole } from "../lib/roles"
@@ -68,6 +68,7 @@ class LearnerPage extends React.Component<*, LearnerPageProps, *> {
     }
     dispatch(actions.prices.clear(username))
     dispatch(clearCoupons())
+    dispatch(clearDashboard(username))
   }
 
   getFocusedDashboard() {

--- a/static/js/containers/LearnerPage.js
+++ b/static/js/containers/LearnerPage.js
@@ -15,20 +15,17 @@ import {
 } from "./ProfileFormContainer"
 import ErrorMessage from "../components/ErrorMessage"
 import { fetchDashboard, clearDashboard } from "../actions/dashboard"
-import { clearCoupons, fetchCoupons } from "../actions/coupons"
 import { actions } from "../lib/redux_rest"
 import { hasAnyStaffRole } from "../lib/roles"
 import { getDashboard, getCoursePrices } from "../reducers/util"
-import type { CouponsState } from "../reducers/coupons"
 import { S } from "../lib/sanctuary"
 import { LEARNER_EMAIL_TYPE } from "../components/email/constants"
 import { LEARNER_EMAIL_CONFIG } from "../components/email/lib"
 import { withEmailDialog } from "../components/email/hoc"
 import type { ProfileContainerProps } from "./ProfileFormContainer"
-import type { CoursePrices, DashboardsState } from "../flow/dashboardTypes"
+import type { DashboardsState } from "../flow/dashboardTypes"
 import type { AllEmailsState } from "../flow/emailTypes"
 import { showDialog, hideDialog } from "../actions/ui"
-import type { RestState } from "../flow/restTypes"
 import type { GradeType } from "./DashboardPage"
 import { gradeDetailPopupKey } from "../components/dashboard/courses/Grades"
 
@@ -38,8 +35,6 @@ const notFetchingOrFetched = R.compose(
 )
 
 type LearnerPageProps = ProfileContainerProps & {
-  prices: RestState<CoursePrices>,
-  coupons: CouponsState,
   dashboard: DashboardsState,
   email: AllEmailsState,
   openEmailComposer: (emailType: string, emailOpenParams: any) => void
@@ -50,8 +45,6 @@ class LearnerPage extends React.Component<*, LearnerPageProps, *> {
     const { params: { username }, fetchProfile } = this.props
     fetchProfile(username)
     this.fetchDashboard()
-    this.fetchCoursePrices()
-    this.fetchCoupons()
   }
 
   componentDidUpdate() {
@@ -66,8 +59,6 @@ class LearnerPage extends React.Component<*, LearnerPageProps, *> {
       // don't erase the user's own profile from the state
       dispatch(clearProfile(username))
     }
-    dispatch(actions.prices.clear(username))
-    dispatch(clearCoupons())
     dispatch(clearDashboard(username))
   }
 
@@ -94,21 +85,6 @@ class LearnerPage extends React.Component<*, LearnerPageProps, *> {
       () => this.isPrivileged(username),
       getCoursePrices(username, prices)
     )
-  }
-
-  fetchCoursePrices() {
-    const { dispatch, params: { username } } = this.props
-    R.compose(
-      S.map(() => dispatch(actions.prices.get(username))),
-      S.filter(R.propSatisfies(notFetchingOrFetched, "getStatus"))
-    )(this.getFocusedPrices())
-  }
-
-  fetchCoupons() {
-    const { coupons, dispatch } = this.props
-    if (coupons.fetchGetStatus === undefined) {
-      dispatch(fetchCoupons())
-    }
   }
 
   isPrivileged = (username: string): boolean =>

--- a/static/js/containers/LearnerPage.js
+++ b/static/js/containers/LearnerPage.js
@@ -115,7 +115,7 @@ class LearnerPage extends React.Component<*, LearnerPageProps, *> {
       children,
       profileProps,
       email,
-      openEmailComposer,
+      openEmailComposer
     } = this.props
 
     let profile = {}

--- a/static/js/containers/LearnerPage.js
+++ b/static/js/containers/LearnerPage.js
@@ -15,9 +15,8 @@ import {
 } from "./ProfileFormContainer"
 import ErrorMessage from "../components/ErrorMessage"
 import { fetchDashboard, clearDashboard } from "../actions/dashboard"
-import { actions } from "../lib/redux_rest"
 import { hasAnyStaffRole } from "../lib/roles"
-import { getDashboard, getCoursePrices } from "../reducers/util"
+import { getDashboard } from "../reducers/util"
 import { S } from "../lib/sanctuary"
 import { LEARNER_EMAIL_TYPE } from "../components/email/constants"
 import { LEARNER_EMAIL_CONFIG } from "../components/email/lib"
@@ -79,14 +78,6 @@ class LearnerPage extends React.Component<*, LearnerPageProps, *> {
     )(this.getFocusedDashboard())
   }
 
-  getFocusedPrices() {
-    const { prices, params: { username } } = this.props
-    return S.filter(
-      () => this.isPrivileged(username),
-      getCoursePrices(username, prices)
-    )
-  }
-
   isPrivileged = (username: string): boolean =>
     R.or(
       hasAnyStaffRole(SETTINGS.roles),
@@ -125,27 +116,19 @@ class LearnerPage extends React.Component<*, LearnerPageProps, *> {
       profileProps,
       email,
       openEmailComposer,
-      coupons
     } = this.props
 
     let profile = {}
     let toRender = null
     let loaded = false
-    let couponsLoaded = false
-    let profileLoaded = false
 
     if (profiles[username] !== undefined) {
       profile = profiles[username]
-      profileLoaded = profiles[username].getStatus !== FETCH_PROCESSING
-      couponsLoaded =
-        !R.isEmpty(coupons) && coupons.fetchGetStatus !== FETCH_PROCESSING
-      loaded = R.all(R.equals(true))([profileLoaded, couponsLoaded])
+      loaded = profiles[username].getStatus !== FETCH_PROCESSING
 
       const props = {
         dashboard:                S.maybe({}, R.identity, this.getFocusedDashboard()),
         email:                    email,
-        prices:                   S.maybe({}, R.identity, this.getFocusedPrices()),
-        coupons:                  coupons,
         openLearnerEmailComposer: R.partial(
           openEmailComposer(LEARNER_EMAIL_TYPE),
           [profile.profile]

--- a/static/js/containers/LearnerPage_test.js
+++ b/static/js/containers/LearnerPage_test.js
@@ -40,7 +40,6 @@ import {
   SET_SHOW_EDUCATION_DELETE_DIALOG,
   showDialog
 } from "../actions/ui"
-import { actions } from "../lib/redux_rest"
 
 import { USER_PROFILE_RESPONSE, DASHBOARD_RESPONSE } from "../test_constants"
 import { HIGH_SCHOOL, DOCTORATE } from "../constants"
@@ -66,10 +65,6 @@ import {
   RECEIVE_DASHBOARD_SUCCESS,
   RECEIVE_DASHBOARD_FAILURE
 } from "../actions/dashboard"
-import {
-  RECEIVE_FETCH_COUPONS_SUCCESS,
-  REQUEST_FETCH_COUPONS
-} from "../actions/coupons"
 import Grades, {
   gradeDetailPopupKey
 } from "../components/dashboard/courses/Grades"

--- a/static/js/containers/LearnerPage_test.js
+++ b/static/js/containers/LearnerPage_test.js
@@ -88,7 +88,8 @@ describe("LearnerPage", function() {
     RECEIVE_GET_USER_PROFILE_SUCCESS,
     RECEIVE_FETCH_COUPONS_SUCCESS,
     REQUEST_FETCH_COUPONS,
-    actions.prices.get.requestType
+    actions.prices.get.requestType,
+    actions.prices.get.successType
   ]
 
   const confirmResumeOrder = (

--- a/static/js/containers/LearnerPage_test.js
+++ b/static/js/containers/LearnerPage_test.js
@@ -86,10 +86,6 @@ describe("LearnerPage", function() {
     RECEIVE_GET_USER_PROFILE_SUCCESS,
     REQUEST_GET_USER_PROFILE,
     RECEIVE_GET_USER_PROFILE_SUCCESS,
-    RECEIVE_FETCH_COUPONS_SUCCESS,
-    REQUEST_FETCH_COUPONS,
-    actions.prices.get.requestType,
-    actions.prices.get.successType
   ]
 
   const confirmResumeOrder = (
@@ -1229,8 +1225,6 @@ describe("LearnerPage", function() {
         RECEIVE_GET_USER_PROFILE_SUCCESS,
         REQUEST_GET_USER_PROFILE,
         RECEIVE_GET_USER_PROFILE_SUCCESS,
-        RECEIVE_FETCH_COUPONS_SUCCESS,
-        REQUEST_FETCH_COUPONS
       ]
       return renderComponent(`/learner/other`, actions).then(([, div]) => {
         const count = div
@@ -1343,8 +1337,6 @@ describe("LearnerPage", function() {
     const anonymousUserActions = [
       REQUEST_GET_USER_PROFILE,
       RECEIVE_GET_USER_PROFILE_SUCCESS,
-      RECEIVE_FETCH_COUPONS_SUCCESS,
-      REQUEST_FETCH_COUPONS
     ]
     beforeEach(() => {
       helper = new IntegrationTestHelper()

--- a/static/js/containers/LearnerPage_test.js
+++ b/static/js/containers/LearnerPage_test.js
@@ -85,7 +85,7 @@ describe("LearnerPage", function() {
     REQUEST_GET_USER_PROFILE,
     RECEIVE_GET_USER_PROFILE_SUCCESS,
     REQUEST_GET_USER_PROFILE,
-    RECEIVE_GET_USER_PROFILE_SUCCESS,
+    RECEIVE_GET_USER_PROFILE_SUCCESS
   ]
 
   const confirmResumeOrder = (
@@ -1224,7 +1224,7 @@ describe("LearnerPage", function() {
         REQUEST_GET_USER_PROFILE,
         RECEIVE_GET_USER_PROFILE_SUCCESS,
         REQUEST_GET_USER_PROFILE,
-        RECEIVE_GET_USER_PROFILE_SUCCESS,
+        RECEIVE_GET_USER_PROFILE_SUCCESS
       ]
       return renderComponent(`/learner/other`, actions).then(([, div]) => {
         const count = div
@@ -1336,7 +1336,7 @@ describe("LearnerPage", function() {
   describe("Unauthenticated user page", () => {
     const anonymousUserActions = [
       REQUEST_GET_USER_PROFILE,
-      RECEIVE_GET_USER_PROFILE_SUCCESS,
+      RECEIVE_GET_USER_PROFILE_SUCCESS
     ]
     beforeEach(() => {
       helper = new IntegrationTestHelper()

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -584,10 +584,6 @@ describe("LearnerSearchPage", function() {
       [
         REQUEST_DASHBOARD,
         RECEIVE_DASHBOARD_SUCCESS,
-        RECEIVE_FETCH_COUPONS_SUCCESS,
-        REQUEST_FETCH_COUPONS,
-        actions.prices.get.requestType,
-        actions.prices.get.successType
       ],
       () => {
         helper.browserHistory.push(`/learner/${SETTINGS.user.username}`)

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -19,17 +19,12 @@ import {
 } from "../actions/email"
 import { START_CHANNEL_EDIT } from "../actions/channels"
 import {
-  RECEIVE_FETCH_COUPONS_SUCCESS,
-  REQUEST_FETCH_COUPONS
-} from "../actions/coupons"
-import {
   REQUEST_DASHBOARD,
   RECEIVE_DASHBOARD_SUCCESS
 } from "../actions/dashboard"
 import { SHOW_DIALOG, HIDE_DIALOG } from "../actions/ui"
 import { EMAIL_COMPOSITION_DIALOG } from "../components/email/constants"
 import { CHANNEL_CREATE_DIALOG } from "../constants"
-import { actions } from "../lib/redux_rest"
 import { modifyTextField } from "../util/test_utils"
 import EmailCompositionDialog from "../components/email/EmailCompositionDialog"
 

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -18,9 +18,18 @@ import {
   UPDATE_EMAIL_EDIT
 } from "../actions/email"
 import { START_CHANNEL_EDIT } from "../actions/channels"
+import {
+  RECEIVE_FETCH_COUPONS_SUCCESS,
+  REQUEST_FETCH_COUPONS
+} from "../actions/coupons"
+import {
+  REQUEST_DASHBOARD,
+  RECEIVE_DASHBOARD_SUCCESS
+} from "../actions/dashboard"
 import { SHOW_DIALOG, HIDE_DIALOG } from "../actions/ui"
 import { EMAIL_COMPOSITION_DIALOG } from "../components/email/constants"
 import { CHANNEL_CREATE_DIALOG } from "../constants"
+import { actions } from "../lib/redux_rest"
 import { modifyTextField } from "../util/test_utils"
 import EmailCompositionDialog from "../components/email/EmailCompositionDialog"
 
@@ -567,5 +576,24 @@ describe("LearnerSearchPage", function() {
       assert(wrapper.find(".sk-search-box"), "Unable to find textbox")
       assert.equal(wrapper.find(".filter-visibility-toggle").length, 9)
     })
+  })
+
+  it("navigates between the learner search page and the profile page without error", async () => {
+    await renderSearch()
+    await listenForActions(
+      [
+        REQUEST_DASHBOARD,
+        RECEIVE_DASHBOARD_SUCCESS,
+        RECEIVE_FETCH_COUPONS_SUCCESS,
+        REQUEST_FETCH_COUPONS,
+        actions.prices.get.requestType,
+        actions.prices.get.successType
+      ],
+      () => {
+        helper.browserHistory.push(`/learner/${SETTINGS.user.username}`)
+      }
+    )
+    helper.browserHistory.push("/learners")
+    helper.browserHistory.push(`/learner/${SETTINGS.user.username}`)
   })
 })

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -581,10 +581,7 @@ describe("LearnerSearchPage", function() {
   it("navigates between the learner search page and the profile page without error", async () => {
     await renderSearch()
     await listenForActions(
-      [
-        REQUEST_DASHBOARD,
-        RECEIVE_DASHBOARD_SUCCESS,
-      ],
+      [REQUEST_DASHBOARD, RECEIVE_DASHBOARD_SUCCESS],
       () => {
         helper.browserHistory.push(`/learner/${SETTINGS.user.username}`)
       }

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -86,7 +86,6 @@ export type CourseRun = {
   course_start_date?:           ?string,
   course_end_date?:             string,
   course_upgrade_deadline?:     string,
-  price?:                       number,
   enrollment_url?:              ?string,
   has_paid:                     boolean,
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3608 

#### What's this PR do?
Clears the dashboard data when a user leaves learner page. This fixes the error caused by the consistency check for price calculation.

#### How should this be manually tested?
See repro steps in #3608 
