### PR TITLE
Move root logger to proper place

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -356,10 +356,6 @@ LOGGING = {
         }
     },
     'loggers': {
-        'root': {
-            'handlers': ['console', 'syslog'],
-            'level': LOG_LEVEL,
-        },
         'django': {
             'propagate': True,
             'level': DJANGO_LOG_LEVEL,
@@ -384,6 +380,10 @@ LOGGING = {
             'handlers': ['console'],
             'level': 'ERROR',
         },
+    },
+    'root': {
+        'handlers': ['console', 'syslog'],
+        'level': LOG_LEVEL,
     },
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #3591 

#### What's this PR do?
The root logging configuration was specified incorrectly. The `root` configuration is at a separate level from `handlers`: https://docs.python.org/2/library/logging.config.html#dictionary-schema-details

#### How should this be manually tested?
Run `docker-compose run ./repl.py`, type `import logging` and `logging.getLogger('ui.views').info('hello')`. You should see `hello` formatted like a logging message
