### PR TITLE
Add creator as moderator

### DIFF
--- a/discussions/serializers.py
+++ b/discussions/serializers.py
@@ -40,6 +40,7 @@ class ChannelSerializer(serializers.Serializer):
             public_description=public_description,
             channel_type=channel_type,
             program_id=program_id,
+            creator_id=user.id,
         )
         return {
             "title": title,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/open-discussions/issues/258

#### What's this PR do?
Adds creator of the channel as a moderator immediately to prevent race condition

#### How should this be manually tested?
Create a channel. When you are redirected to the new channel you should see a no posts page and the page should successfully receive no posts from the API

