### PR TITLE
fix frontpage api

### DIFF
--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -97,6 +97,8 @@ import Grades, {
 } from "../components/dashboard/courses/Grades"
 import { EDX_GRADE } from "./DashboardPage"
 import DiscussionCard from "../components/DiscussionCard"
+import { makeFrontPageList } from "../factories/posts"
+import { postURL } from "../lib/discussions"
 
 describe("DashboardPage", () => {
   let renderComponent, helper, listenForActions
@@ -168,6 +170,25 @@ describe("DashboardPage", () => {
           assert.lengthOf(wrapper.find(DiscussionCard), 0)
         }
       })
+    })
+  })
+
+  it("should show the frontpage with data", async () => {
+    const posts = makeFrontPageList()
+    helper.discussionsFrontpageStub.returns(Promise.resolve({ posts }))
+    const [wrapper] = await renderComponent(
+      "/dashboard",
+      DASHBOARD_SUCCESS_ACTIONS
+    )
+    const card = wrapper.find(DiscussionCard)
+
+    card.find(".post").forEach((renderedPost, idx) => {
+      const link = renderedPost.find(".post-title")
+      assert.equal(link.text(), posts[idx].title)
+      assert.equal(
+        link.props().href,
+        postURL(posts[idx].id, posts[idx].channel_name)
+      )
     })
   })
 

--- a/static/js/reducers/discussions_frontpage.js
+++ b/static/js/reducers/discussions_frontpage.js
@@ -24,5 +24,5 @@ export const discussionsFrontpageEndpoint: Endpoint = {
       return Promise.resolve([])
     }
   },
-  getSuccessHandler: payload => payload.concat()
+  getSuccessHandler: ({ posts }) => posts.concat()
 }


### PR DESCRIPTION
#### What are the relevant tickets?

#3626 

#### What's this PR do?

the pagination changes for the frontpage API in OD modified the response. MM wasn't updated to account for that change, so this PR just makes the necessary change so that the discussion card works again in MM.

#### How should this be manually tested?

confirm that, with the latest `master` on both MM and OD running, the discussions card is broken (the response should authenticate and come back from OD ok, but MM expects the shape of the data to be different than what it is).

then check out this branch on MM and confirm it fixes the problem.