### PR TITLE
Removed recipient email variables from email composer

### DIFF
--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -6,7 +6,7 @@ import { Editor } from "react-draft-wysiwyg"
 // $FlowFixMe: Flow thinks this module isn't present for some reason
 import { EditorState, ContentState, convertFromHTML, Modifier } from "draft-js"
 
-import { AUTOMATIC_EMAIL_ADMIN_TYPE } from "./constants"
+import { AUTOMATIC_EMAIL_ADMIN_TYPE, COURSE_EMAIL_TYPE } from "./constants"
 import AutomaticEmailOptions from "./AutomaticEmailOptions"
 import RecipientVariableButton from "./RecipientVariableButton"
 import { FETCH_PROCESSING } from "../../actions"
@@ -204,6 +204,13 @@ export default class EmailCompositionDialog extends React.Component {
   okButtonLabel = (dialogType: string) =>
     dialogType === AUTOMATIC_EMAIL_ADMIN_TYPE ? "Save Changes" : "Send"
 
+  renderRecipientVariable = () => (
+    <div className="toolbar-below">
+      <div className="insert">Insert:</div>
+      {this.makeCustomToolbarButtons(RECIPIENT_VARIABLE_NAMES)}
+    </div>
+  )
+
   render() {
     if (!this.props.activeEmail) return null
 
@@ -254,10 +261,9 @@ export default class EmailCompositionDialog extends React.Component {
             onEditorStateChange={this.onEditorStateChange}
             toolbar={draftWysiwygToolbar}
           />
-          <div className="toolbar-below">
-            <div className="insert">Insert:</div>
-            {this.makeCustomToolbarButtons(RECIPIENT_VARIABLE_NAMES)}
-          </div>
+          {dialogType !== COURSE_EMAIL_TYPE
+            ? this.renderRecipientVariable()
+            : null}
           {this.showValidationError("body")}
         </div>
       </Dialog>

--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -222,7 +222,7 @@ export default class EmailCompositionDialog extends React.Component {
       updateEmailFieldEdit,
       renderRecipients,
       dialogType,
-      supportBulkEmails = false
+      supportBulkEmails
     } = this.props
     const { editorState } = this.state
 

--- a/static/js/components/email/EmailCompositionDialog.js
+++ b/static/js/components/email/EmailCompositionDialog.js
@@ -6,7 +6,7 @@ import { Editor } from "react-draft-wysiwyg"
 // $FlowFixMe: Flow thinks this module isn't present for some reason
 import { EditorState, ContentState, convertFromHTML, Modifier } from "draft-js"
 
-import { AUTOMATIC_EMAIL_ADMIN_TYPE, COURSE_EMAIL_TYPE } from "./constants"
+import { AUTOMATIC_EMAIL_ADMIN_TYPE } from "./constants"
 import AutomaticEmailOptions from "./AutomaticEmailOptions"
 import RecipientVariableButton from "./RecipientVariableButton"
 import { FETCH_PROCESSING } from "../../actions"
@@ -62,7 +62,8 @@ type EmailDialogProps = {
   updateEmailFieldEdit: () => void,
   renderRecipients?: (filters: ?Array<Filter>) => React$Element<*>,
   updateEmailBody: (e: Object) => void,
-  dialogType: string
+  dialogType: string,
+  supportBulkEmails: boolean
 }
 
 export default class EmailCompositionDialog extends React.Component {
@@ -220,7 +221,8 @@ export default class EmailCompositionDialog extends React.Component {
       dialogVisibility,
       updateEmailFieldEdit,
       renderRecipients,
-      dialogType
+      dialogType,
+      supportBulkEmails = false
     } = this.props
     const { editorState } = this.state
 
@@ -261,9 +263,7 @@ export default class EmailCompositionDialog extends React.Component {
             onEditorStateChange={this.onEditorStateChange}
             toolbar={draftWysiwygToolbar}
           />
-          {dialogType !== COURSE_EMAIL_TYPE
-            ? this.renderRecipientVariable()
-            : null}
+          {supportBulkEmails ? this.renderRecipientVariable() : null}
           {this.showValidationError("body")}
         </div>
       </Dialog>

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -239,8 +239,9 @@ describe("EmailCompositionDialog", () => {
       [COURSE_EMAIL_TYPE, true],
       [SEARCH_EMAIL_TYPE, false]
     ]) {
-      it(`should not insert recipient variables for ${dialogType[0]}`, () => {
-        renderDialog({}, {dialogType: dialogType[0]})
+      it(`should ${!dialogType[1] ? "display" : "not display"} 
+        recipient variables for ${dialogType[0]}`, () => {
+        renderDialog({}, { dialogType: dialogType[0] })
         assert.equal(
           _.isNull(getDialog().querySelector(".toolbar-below")),
           dialogType[1]

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -233,6 +233,20 @@ describe("EmailCompositionDialog", () => {
       ReactTestUtils.Simulate.click(getDialog().querySelector(".button-Email"))
       assert.include(getEditorContents().textContent, "[Email]")
     })
+
+    for (const dialogType of [
+      [LEARNER_EMAIL_TYPE, false],
+      [COURSE_EMAIL_TYPE, true],
+      [SEARCH_EMAIL_TYPE, false]
+    ]) {
+      it(`should not insert recipient variables for ${dialogType[0]}`, () => {
+        renderDialog({}, {dialogType: dialogType[0]})
+        assert.equal(
+          _.isNull(getDialog().querySelector(".toolbar-below")),
+          dialogType[1]
+        )
+      })
+    }
   })
 
   it("should render recipients", () => {

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -62,6 +62,7 @@ describe("EmailCompositionDialog", () => {
           closeAndClearEmailComposer={closeStub}
           closeEmailComposerAndSend={sendStub}
           dialogVisibility={true}
+          dialogType={TEST_EMAIL_TYPE}
           activeEmail={emailState}
           title={TEST_EMAIL_CONFIG.title}
           subheadingRenderer={TEST_EMAIL_CONFIG.renderSubheading}
@@ -229,22 +230,23 @@ describe("EmailCompositionDialog", () => {
     })
 
     it("should insert recipient variables", () => {
-      renderDialog()
+      renderDialog({}, { supportBulkEmails: true })
       ReactTestUtils.Simulate.click(getDialog().querySelector(".button-Email"))
       assert.include(getEditorContents().textContent, "[Email]")
     })
 
     for (const dialogType of [
       [LEARNER_EMAIL_TYPE, false],
-      [COURSE_EMAIL_TYPE, true],
-      [SEARCH_EMAIL_TYPE, false]
+      [COURSE_EMAIL_TYPE, false],
+      [SEARCH_EMAIL_TYPE, true],
+      [AUTOMATIC_EMAIL_ADMIN_TYPE, true]
     ]) {
       it(`should ${!dialogType[1] ? "display" : "not display"} 
         recipient variables for ${dialogType[0]}`, () => {
-        renderDialog({}, { dialogType: dialogType[0] })
+        renderDialog({}, { supportBulkEmails: dialogType[1] })
         assert.equal(
           _.isNull(getDialog().querySelector(".toolbar-below")),
-          dialogType[1]
+          !dialogType[1]
         )
       })
     }

--- a/static/js/components/email/hoc.js
+++ b/static/js/components/email/hoc.js
@@ -130,6 +130,7 @@ export const withEmailDialog = R.curry(
             dialogVisibility={dialogVisibility[EMAIL_COMPOSITION_DIALOG]}
             activeEmail={this.getActiveEmailState()}
             title={emailConfig.title}
+            supportBulkEmails={emailConfig.supportBulkEmails}
             subheadingRenderer={emailConfig.renderSubheading}
             renderRecipients={emailConfig.renderRecipients}
             updateEmailBody={this.updateEmailBody}

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -54,7 +54,8 @@ export const renderFilterOptions = R.map(filter => {
 })
 
 export const COURSE_TEAM_EMAIL_CONFIG: EmailConfig = {
-  title: "Contact the Course Team",
+  title:             "Contact the Course Team",
+  supportBulkEmails: false,
 
   renderSubheading: (activeEmail: EmailState) => (
     <div className="subheading-section">
@@ -84,7 +85,8 @@ export const COURSE_TEAM_EMAIL_CONFIG: EmailConfig = {
 }
 
 export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
-  title: "New Email",
+  title:             "New Email",
+  supportBulkEmails: true,
 
   emailOpenParams: (searchkit: Object) => ({
     subheading:              `${searchkit.getHitsCount() || 0} recipients selected`,
@@ -117,7 +119,8 @@ export const SEARCH_RESULT_EMAIL_CONFIG: EmailConfig = {
 }
 
 export const LEARNER_EMAIL_CONFIG: EmailConfig = {
-  title: "Send a Message",
+  title:             "Send a Message",
+  supportBulkEmails: false,
 
   renderSubheading: (activeEmail: EmailState) => (
     <div className="subheading-section">
@@ -193,9 +196,10 @@ export const getFilters = (root: Object) => {
 }
 
 export const AUTOMATIC_EMAIL_ADMIN_CONFIG: EmailConfig = {
-  title:           "Edit Email Campaign",
-  editEmail:       actions.automaticEmails.patch,
-  emailSendParams: R.compose(convertEmailEdit, R.prop("inputs")),
+  title:             "Edit Email Campaign",
+  editEmail:         actions.automaticEmails.patch,
+  emailSendParams:   R.compose(convertEmailEdit, R.prop("inputs")),
+  supportBulkEmails: true,
 
   emailOpenParams: (emailOpenParams: AutomaticEmail) => ({
     inputs: {

--- a/static/js/flow/emailTypes.js
+++ b/static/js/flow/emailTypes.js
@@ -37,6 +37,7 @@ export type AllEmailsState = {
 
 export type EmailConfig = {
   title: string,
+  supportBulkEmails: boolean,
   renderSubheading: (activeEmail: EmailState) => React$Element<*>,
   emailOpenParams: (args: any) => Object,
   getEmailSendFunction: () => Function,


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3606

#### What's this PR do?
removed email variables display from email composer for course team email only

#### How should this be manually tested?
Go to dashboard as non staff user
```python
from dashboard.models import CachedEnrollment
from courses.models import *
from django.contrib.auth.models import User
from exams.factories import ExamRunFactory
from exams.models import *
from dashboard.factories import CachedEnrollmentFactory
from ecommerce.factories import (OrderFactory, LineFactory)
from exams.factories import ExamAuthorizationFactory
from exams.factories import ExamProfileFactory

user = User.objects.filter(username='username')[0]
course_run = CourseRun.objects.get(edx_course_key='course-v1:MITx+Digital+Learning+100+Aug_2016')

# pay for run
order = OrderFactory.create(user=user, status='fulfilled', total_price_paid=1200)
LineFactory.create(order=order, course_key=course_run.edx_course_key)

# enroll for run
CachedEnrollmentFactory.create(user=user, course_run=course_run)
```

@pdpinch 
#### Screenshots (if appropriate)
<img width="720" alt="screen shot 2017-10-12 at 6 10 49 pm" src="https://user-images.githubusercontent.com/10431250/31497499-b9740174-af78-11e7-98c3-9c259d900bce.png">

