### PR TITLE
Check if document needs updating before reindexing

### DIFF
--- a/dashboard/api_edx_cache.py
+++ b/dashboard/api_edx_cache.py
@@ -187,7 +187,7 @@ class CachedEdxDataApi:
             )
         if index_user:
             # submit a celery task to reindex the user
-            tasks.index_users.delay([user.id])
+            tasks.index_users.delay([user.id], check_if_changed=True)
 
     @classmethod
     def update_cached_enrollments(cls, user, edx_client):
@@ -215,7 +215,7 @@ class CachedEdxDataApi:
             # update the last refresh timestamp
             cls.update_cache_last_access(user, cls.ENROLLMENT)
         # submit a celery task to reindex the user
-        tasks.index_users.delay([user.id])
+        tasks.index_users.delay([user.id], check_if_changed=True)
 
     @classmethod
     def update_cached_certificates(cls, user, edx_client):
@@ -255,7 +255,7 @@ class CachedEdxDataApi:
             # update the last refresh timestamp
             cls.update_cache_last_access(user, cls.CERTIFICATE)
         # submit a celery task to reindex the user
-        tasks.index_users.delay([user.id])
+        tasks.index_users.delay([user.id], check_if_changed=True)
 
     @classmethod
     def update_cached_current_grades(cls, user, edx_client):
@@ -295,7 +295,7 @@ class CachedEdxDataApi:
             # update the last refresh timestamp
             cls.update_cache_last_access(user, cls.CURRENT_GRADE)
         # submit a celery task to reindex the user
-        tasks.index_users.delay([user.id])
+        tasks.index_users.delay([user.id], check_if_changed=True)
 
     @classmethod
     def update_cache_if_expired(cls, user, edx_client, cache_type):

--- a/dashboard/api_edx_cache_test.py
+++ b/dashboard/api_edx_cache_test.py
@@ -294,7 +294,7 @@ class CachedEdxDataApiTests(MockedESTestCase):
         self.assert_cache_in_db(enrollment_keys=[course_id])
         cached_enr.refresh_from_db()
         assert cached_enr.data == enr_json
-        mocked_index.delay.assert_any_call([self.user.id])
+        mocked_index.delay.assert_any_call([self.user.id], check_if_changed=True)
 
     @patch('search.tasks.index_users', autospec=True)
     def test_update_cached_enrollments(self, mocked_index):
@@ -316,7 +316,7 @@ class CachedEdxDataApiTests(MockedESTestCase):
         self.assert_cache_in_db(enrollment_keys=self.enrollment_ids)
         cache_time.refresh_from_db()
         assert cache_time.enrollment >= now
-        mocked_index.delay.assert_called_once_with([self.user.id])
+        mocked_index.delay.assert_called_once_with([self.user.id], check_if_changed=True)
 
     @patch('search.tasks.index_users', autospec=True)
     def test_update_cached_certificates(self, mocked_index):
@@ -340,7 +340,7 @@ class CachedEdxDataApiTests(MockedESTestCase):
         self.assert_cache_in_db(certificate_keys=self.verified_certificates_ids)
         cache_time.refresh_from_db()
         assert cache_time.certificate >= now
-        mocked_index.delay.assert_called_once_with([self.user.id])
+        mocked_index.delay.assert_called_once_with([self.user.id], check_if_changed=True)
 
     @patch('search.tasks.index_users', autospec=True)
     def test_update_cached_current_grades(self, mocked_index):
@@ -362,7 +362,7 @@ class CachedEdxDataApiTests(MockedESTestCase):
         self.assert_cache_in_db(grades_keys=self.grades_ids)
         cache_time.refresh_from_db()
         assert cache_time.current_grade >= now
-        mocked_index.delay.assert_called_once_with([self.user.id])
+        mocked_index.delay.assert_called_once_with([self.user.id], check_if_changed=True)
 
     @patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cached_current_grades')
     @patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cached_certificates')

--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -317,7 +317,7 @@ class UserCourseEnrollmentTest(MockedESTestCase, APITestCase):
         assert mock_edx_enr.call_count == 1
         assert mock_edx_enr.call_args[0][1] == self.course_id
         assert resp.data == enr_json
-        mock_index.delay.assert_called_once_with([self.user.id])
+        mock_index.delay.assert_called_once_with([self.user.id], check_if_changed=True)
 
         cache_enr = CachedEnrollment.objects.filter(
             user=self.user, course_run__edx_course_key=self.course_id).first()

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -217,18 +217,6 @@ def index_program_enrolled_users(program_enrollments, indices=None, chunk_size=1
     return count
 
 
-def index_users(user_ids, chunk_size=100):
-    """
-    Indexes a list of users via their ProgramEnrollments
-
-    Args:
-        user_ids (list of int): A list of User ids to index
-        chunk_size (int): The number of documents in index in one bulk call. Used to keep memory use down.
-    """
-    program_enrollments = ProgramEnrollment.prefetched_qset().filter(user__in=user_ids)
-    return index_program_enrolled_users(program_enrollments, chunk_size=chunk_size)
-
-
 def remove_program_enrolled_user(program_enrollment_id, indices=None):
     """
     Remove a program-enrolled user from Elasticsearch.

--- a/search/signals.py
+++ b/search/signals.py
@@ -33,19 +33,19 @@ log = logging.getLogger(__name__)
 @receiver(post_save, sender=Profile, dispatch_uid="profile_post_save_index")
 def handle_update_profile(sender, instance, **kwargs):
     """Update index when Profile model is updated."""
-    transaction.on_commit(lambda: index_users.delay([instance.user.id]))
+    transaction.on_commit(lambda: index_users.delay([instance.user.id], check_if_changed=True))
 
 
 @receiver(post_save, sender=Education, dispatch_uid="education_post_save_index")
 def handle_update_education(sender, instance, **kwargs):
     """Update index when Education model is updated."""
-    transaction.on_commit(lambda: index_users.delay([instance.profile.user.id]))
+    transaction.on_commit(lambda: index_users.delay([instance.profile.user.id], check_if_changed=True))
 
 
 @receiver(post_save, sender=Employment, dispatch_uid="employment_post_save_index")
 def handle_update_employment(sender, instance, **kwargs):
     """Update index when Employment model is updated."""
-    transaction.on_commit(lambda: index_users.delay([instance.profile.user.id]))
+    transaction.on_commit(lambda: index_users.delay([instance.profile.user.id], check_if_changed=True))
 
 
 @receiver(post_delete, sender=Education, dispatch_uid="education_post_delete_index")


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3634 

#### What's this PR do?
Reduces the number of reindexes and tasks triggered after reindexing

#### How should this be manually tested?
Make sure you have open-discussions set up and you have a channel created. Open your open-discussions logs in a terminal. In micromasters go to your profile and save it without making any changes. You should see only the update of the `api/v0/users/.../` endpoint.

Make a change to your profile and save it. You should see the update to the `api/v0/users/.../` endpoint but also `DELETE` or `POST` to the subscribers and contributors APIs.