### PR TITLE
Split CSS into separate file for production

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-plugin-mocha": "4.11.0",
     "eslint-plugin-react": "7.1.0",
     "express": "^4.15.3",
+    "extract-text-webpack-plugin": "2",
     "fetch-mock": "^5.11.0",
     "file-loader": "^0.11.1",
     "flow-bin": "^0.43.1",

--- a/static/js/entry/style.js
+++ b/static/js/entry/style.js
@@ -1,30 +1,30 @@
 __webpack_public_path__ = `${SETTINGS.public_path}` // eslint-disable-line no-undef, camelcase
 // bootstrap
-import "style-loader!css-loader!bootstrap/dist/css/bootstrap.min.css"
+import "bootstrap/dist/css/bootstrap.min.css"
 
 // react-mdl material-design-lite file
-import "style-loader!css-loader!react-mdl/extra/material.css"
+import "react-mdl/extra/material.css"
 // react-virtualized requirement
-import "style-loader!css-loader!react-virtualized/styles.css"
-import "style-loader!css-loader!react-virtualized-select/styles.css"
-import "style-loader!css-loader!cropperjs/dist/cropper.css"
+import "react-virtualized/styles.css"
+import "react-virtualized-select/styles.css"
+import "cropperjs/dist/cropper.css"
 
 // react-select styles
-import "style-loader!css-loader!react-select/dist/react-select.css"
+import "react-select/dist/react-select.css"
 // react-slick styles
-import "style-loader!css-loader!slick-carousel/slick/slick.css"
-import "style-loader!css-loader!slick-carousel/slick/slick-theme.css"
+import "slick-carousel/slick/slick.css"
+import "slick-carousel/slick/slick-theme.css"
 
 // react-datepicker styles
-import "style-loader!css-loader!react-datepicker/dist/react-datepicker.css"
+import "react-datepicker/dist/react-datepicker.css"
 
 // react-geosuggest styles
-import "style-loader!css-loader!react-geosuggest/module/geosuggest.css"
+import "react-geosuggest/module/geosuggest.css"
 
 // react-telephone-input stylesheet
-import "style-loader!css-loader!react-telephone-input/css/default.css"
+import "react-telephone-input/css/default.css"
 
-import "style-loader!css-loader!react-draft-wysiwyg/dist/react-draft-wysiwyg.css"
+import "react-draft-wysiwyg/dist/react-draft-wysiwyg.css"
 
 // This should come last to override other styles
 import "../../scss/layout.scss"

--- a/static/js/entry/style_public.js
+++ b/static/js/entry/style_public.js
@@ -7,4 +7,4 @@ window.$ = $
 
 import "../../scss/public_style/web-icons.css"
 import "../../scss/public_style/bootstrap-extend.css"
-import "style-loader!css-loader!rrssb/css/rrssb.css"
+import "rrssb/css/rrssb.css"

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -37,11 +37,21 @@ const devConfig = Object.assign({}, config, {
 });
 
 devConfig.module.rules = [
-  babelSharedLoader, ...config.module.rules
+  babelSharedLoader,
+  ...config.module.rules,
+  {
+    test: /\.css$|\.scss$/,
+    use: [
+      { loader: 'style-loader' },
+      { loader: 'css-loader' },
+      { loader: 'postcss-loader' },
+      { loader: 'sass-loader' },
+    ]
+  },
 ];
 
 const makeDevConfig = (host, port) => (
-  Object.assign({}, devConfig, { 
+  Object.assign({}, devConfig, {
     entry: insertHotReload(host, port, devConfig.entry),
   })
 );

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -57,7 +57,7 @@ module.exports = Object.assign(prodConfig, {
     }),
     new webpack.optimize.AggressiveMergingPlugin(),
     new ExtractTextPlugin({
-      filename: "styles-[contenthash].css",
+      filename: "styles-[name]-[contenthash].css",
       allChunks: true,
       ignoreOrder: false,
     }),

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,6 +1,7 @@
 var webpack = require('webpack');
 var path = require("path");
 var BundleTracker = require('webpack-bundle-tracker');
+const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const { config, babelSharedLoader } = require(path.resolve("./webpack.config.shared.js"));
 
 const prodBabelConfig = Object.assign({}, babelSharedLoader);
@@ -11,7 +12,17 @@ prodBabelConfig.query.plugins.push(
 );
 
 const prodConfig = Object.assign({}, config);
-prodConfig.module.rules = [prodBabelConfig, ...config.module.rules];
+prodConfig.module.rules = [
+  prodBabelConfig,
+  ...config.module.rules,
+  {
+    test: /\.css$|\.scss$/,
+    use:     ExtractTextPlugin.extract({
+      fallback: 'style-loader',
+      use:      ['css-loader', 'postcss-loader', 'sass-loader'],
+    })
+  }
+];
 
 module.exports = Object.assign(prodConfig, {
   context: __dirname,
@@ -45,6 +56,11 @@ module.exports = Object.assign(prodConfig, {
       minimize: true
     }),
     new webpack.optimize.AggressiveMergingPlugin(),
+    new ExtractTextPlugin({
+      filename: "styles-[contenthash].css",
+      allChunks: true,
+      ignoreOrder: false,
+    }),
   ],
   devtool: 'source-map'
 });

--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -18,24 +18,6 @@ module.exports = {
           test: /\.(svg|ttf|woff|woff2|eot|gif)$/,
           use: 'url-loader'
         },
-        {
-          test: /\.scss$/,
-          exclude: /node_modules/,
-          use: [
-            { loader: 'style-loader' },
-            { loader: 'css-loader' },
-            { loader: 'postcss-loader' },
-            { loader: 'sass-loader' },
-          ]
-        },
-        {
-          test: /\.css$/,
-          exclude: /node_modules/,
-          use: [
-            { loader: 'style-loader' },
-            { loader: 'css-loader' }
-          ]
-        },
       ]
     },
     resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2639,6 +2639,15 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
+extract-text-webpack-plugin@2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz#756ef4efa8155c3681833fbc34da53b941746d6c"
+  dependencies:
+    async "^2.1.2"
+    loader-utils "^1.0.2"
+    schema-utils "^0.3.0"
+    webpack-sources "^1.0.1"
+
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
@@ -6373,6 +6382,10 @@ source-list-map@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-1.1.2.tgz#9889019d1024cce55cdc069498337ef6186a11a1"
 
+source-list-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
+
 source-map-support@^0.4.2:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.15.tgz#03202df65c06d2bd8c7ec2362a193056fef8d3b1"
@@ -6975,6 +6988,13 @@ webpack-sources@^0.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-0.2.3.tgz#17c62bfaf13c707f9d02c479e0dcdde8380697fb"
   dependencies:
     source-list-map "^1.1.1"
+    source-map "~0.5.3"
+
+webpack-sources@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.1.tgz#c7356436a4d13123be2e2426a05d1dad9cbe65cf"
+  dependencies:
+    source-list-map "^2.0.0"
     source-map "~0.5.3"
 
 webpack@^2.6.1:


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3485 

#### What's this PR do?
This sets up the extract-text-plugin so that production builds will have separate CSS files which will contain all style information. 

#### How should this be manually tested?
View the PR build, log in, and view the dashboard. Nothing should look odd
