### PR TITLE
Generate ELASTICSEARCH_INDEX value for PR builds

### DIFF
--- a/app.json
+++ b/app.json
@@ -104,6 +104,12 @@
       "description": "API key for accessing Google services",
       "required": true
     },
+    "HEROKU_APP_NAME": {
+      "required": true
+    },
+    "HEROKU_PARENT_APP_NAME": {
+      "required": true
+    },
     "MAILGUN_KEY": {
       "description": "The token for authenticating against the Mailgun API"
     },
@@ -231,7 +237,7 @@
   "name": "micromasters",
   "repository": "https://github.com/mitodl/micromasters",
   "scripts": {
-    "postdeploy": "./manage.py migrate"
+    "postdeploy": "./scripts/postdeploy.sh"
   },
   "success_url": "/",
   "website": "https://github.com/mitodl/micromasters"

--- a/scripts/postdeploy.sh
+++ b/scripts/postdeploy.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+echo "Running migrations..."
+./manage.py migrate --noinput
+
+echo "Checking if app is a review app..."
+if [[ ! -z "$HEROKU_PARENT_APP_NAME" ]]
+then
+    echo "App is a review app: ${HEROKU_APP_NAME}"
+    # Review app, we need to tweak the Elasticsearch index a bit
+    NEW_INDEX="${ELASTICSEARCH_INDEX}-${HEROKU_APP_NAME}"
+
+    # Patch environment variable for this PR build
+    echo "Updating ELASTICSEARCH_INDEX to $NEW_INDEX"
+    curl -n -X PATCH https://api.heroku.com/apps/"$HEROKU_APP_NAME"/config-vars/ \
+        -d "{\"ELASTICSEARCH_INDEX\": \"$NEW_INDEX\"}" \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/vnd.heroku+json; version=3" --fail
+
+    # Set up the index
+    ELASTICSEARCH_INDEX=$NEW_INDEX ./manage.py recreate_index
+else
+    echo "App is not a review app"
+fi
+
+echo "Done with postdeploy"


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2342

#### What's this PR do?
Updates the postdeploy script to check if the deploy is for a PR build, and if so change the `ELASTICSEARCH_INDEX` environment variable to be different from the `micromasters-ci` default

#### How should this be manually tested?
Go to the heroku dashboard and verify that `ELASTICSEARCH_INDEX` starts with `micromasters-ci` and contains this PR number. There should be no edits for `ELASTICSEARCH_INDEX` by me.