### PR TITLE
Use HEROKU_APP_NAME as ELASTICSEARCH_INDEX value for PR builds

### DIFF
--- a/app.json
+++ b/app.json
@@ -105,9 +105,11 @@
       "required": true
     },
     "HEROKU_APP_NAME": {
+      "description": "Value provided by Heroku containing the app name (eg micromasters-ci)",
       "required": true
     },
     "HEROKU_PARENT_APP_NAME": {
+      "description": "Value provided by Heroku containing the parent app name (eg micromasters-ci for a PR build)",
       "required": true
     },
     "MAILGUN_KEY": {

--- a/app.json
+++ b/app.json
@@ -104,6 +104,12 @@
       "description": "API key for accessing Google services",
       "required": true
     },
+    "HEROKU_APP_NAME": {
+      "required": true
+    },
+    "HEROKU_PARENT_APP_NAME": {
+      "required": true
+    },
     "MAILGUN_KEY": {
       "description": "The token for authenticating against the Mailgun API"
     },
@@ -231,7 +237,7 @@
   "name": "micromasters",
   "repository": "https://github.com/mitodl/micromasters",
   "scripts": {
-    "postdeploy": "./manage.py migrate"
+    "postdeploy": "./manage.py migrate --noinput && ./manage.py recreate_index"
   },
   "success_url": "/",
   "website": "https://github.com/mitodl/micromasters"

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -518,7 +518,12 @@ CACHES = {
 # Elasticsearch
 ELASTICSEARCH_DEFAULT_PAGE_SIZE = get_int('ELASTICSEARCH_DEFAULT_PAGE_SIZE', 50)
 ELASTICSEARCH_URL = get_string("ELASTICSEARCH_URL", None)
-ELASTICSEARCH_INDEX = get_string('ELASTICSEARCH_INDEX', 'micromasters')
+if get_string("HEROKU_PARENT_APP_NAME", None) is not None:
+    ELASTICSEARCH_INDEX = get_string('HEROKU_APP_NAME', None)
+else:
+    ELASTICSEARCH_INDEX = get_string('ELASTICSEARCH_INDEX', None)
+if not ELASTICSEARCH_INDEX:
+    raise ImproperlyConfigured("Missing ELASTICSEARCH_INDEX")
 ELASTICSEARCH_HTTP_AUTH = get_string("ELASTICSEARCH_HTTP_AUTH", None)
 
 # django-role-permissions

--- a/micromasters/tests/test_settings.py
+++ b/micromasters/tests/test_settings.py
@@ -18,6 +18,7 @@ from search.base import MockedESTestCase
 REQUIRED_SETTINGS = {
     'MAILGUN_URL': 'http://fake.mailgun.url',
     'MAILGUN_KEY': 'fake_mailgun_key',
+    'ELASTICSEARCH_INDEX': 'some_index',
 }
 
 
@@ -138,6 +139,17 @@ class TestSettings(MockedESTestCase):
             missing_param: '',
         }, clear=True), self.assertRaises(ImproperlyConfigured):
             self.reload_settings()
+
+    def test_elasticsearch_index_pr_build(self):
+        """For PR builds we will use the heroku app name instead of the given ELASTICSEARCH_INDEX"""
+        index_name = 'heroku_app_name_as_index'
+        with mock.patch.dict('os.environ', {
+            **REQUIRED_SETTINGS,
+            'HEROKU_APP_NAME': index_name,
+            'HEROKU_PARENT_APP_NAME': 'some_name',
+        }):
+            settings_vars = self.reload_settings()
+            assert settings_vars['ELASTICSEARCH_INDEX'] == index_name
 
     @staticmethod
     def test_semantic_version():


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2342

#### What's this PR do?
If the deployment is a PR build, use the PR build app name in place of the given `ELASTICSEARCH_INDEX` value which is just copied from `micromasters-ci`. This should prevent PR builds from overwriting the index of CI

#### How should this be manually tested?
In a Django shell verify that the `ELASTICSEARCH_INDEX` setting matches the name of the PR build.