### PR TITLE
Fixed search do not expand every two-letter abbreviation into a country name

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -47,7 +47,7 @@ import {
   hasStaffForProgram
 } from "../lib/roles"
 
-export const makeCountryNameTranslations: () => Object = () => {
+export const makeTranslations: () => Object = () => {
   const translations = {}
   for (const code of Object.keys(iso3166.data)) {
     translations[code] = iso3166.data[code].name
@@ -141,7 +141,7 @@ export default class LearnerSearch extends SearchkitComponent {
     { value: "dob", label: "Sort: dob" }
   ]
 
-  countryNameTranslations: Object = makeCountryNameTranslations()
+  countryNameTranslations: Object = makeTranslations()
 
   constructor(props: Object) {
     super(props)

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -141,7 +141,7 @@ export default class LearnerSearch extends SearchkitComponent {
     { value: "dob", label: "Sort: dob" }
   ]
 
-  countryNameTranslations: Object = makeTranslations()
+  translations: Object = makeTranslations()
 
   constructor(props: Object) {
     super(props)
@@ -370,7 +370,7 @@ export default class LearnerSearch extends SearchkitComponent {
             fields={["profile.country", "profile.state_or_territory"]}
             title=""
             id="country"
-            translations={this.countryNameTranslations}
+            translations={this.translations}
             size={0}
           />
         </FilterVisibilityToggle>

--- a/static/js/components/channels/ChannelCreateDialog_test.js
+++ b/static/js/components/channels/ChannelCreateDialog_test.js
@@ -125,4 +125,20 @@ describe("ChannelCreateDialog", () => {
       "Course: Test Course 100"
     )
   })
+
+  it("should render company name same as state abbr. correct", () => {
+    renderDialog({
+      filters: [
+        {
+          id:    "company_name",
+          name:  "profile.work_history.company_name",
+          value: "US-ME"
+        }
+      ]
+    })
+    assert.equal(
+      getDialog().querySelector(".sk-selected-filters-list").textContent,
+      "Company: US-ME"
+    )
+  })
 })

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -19,12 +19,12 @@ import type {
 } from "../../flow/emailTypes"
 import { actions } from "../../lib/redux_rest.js"
 import { SEARCH_FACET_FIELD_LABEL_MAP } from "../../constants"
-import { makeCountryNameTranslations } from "../LearnerSearch"
+import { makeTranslations } from "../LearnerSearch"
 
 // NOTE: getEmailSendFunction is a function that returns a function. It is implemented this way
 // so that we can stub/mock the function that it returns (as we do in integration_test_helper.js)
 
-const countryNameTranslations: Object = makeCountryNameTranslations()
+const countryNameTranslations: Object = makeTranslations()
 export const renderFilterOptions = R.map(filter => {
   let labelKey, labelValue
   if (R.isEmpty(filter.name)) {

--- a/static/js/components/email/lib.js
+++ b/static/js/components/email/lib.js
@@ -23,20 +23,27 @@ import { makeTranslations } from "../LearnerSearch"
 
 // NOTE: getEmailSendFunction is a function that returns a function. It is implemented this way
 // so that we can stub/mock the function that it returns (as we do in integration_test_helper.js)
+export const isLocation = (labelKey: string) =>
+  R.or(_.includes(labelKey, "Country"), _.includes(labelKey, "Residence"))
 
-const countryNameTranslations: Object = makeTranslations()
+const translations: Object = makeTranslations()
 export const renderFilterOptions = R.map(filter => {
   let labelKey, labelValue
+  let isTranslated = false
   if (R.isEmpty(filter.name)) {
     labelKey = SEARCH_FACET_FIELD_LABEL_MAP[filter.id]
   } else if (filter.name in SEARCH_FACET_FIELD_LABEL_MAP) {
     labelKey = SEARCH_FACET_FIELD_LABEL_MAP[filter.name]
-  } else if (filter.name in countryNameTranslations) {
-    labelKey = countryNameTranslations[filter.name]
+  } else if (filter.name in translations) {
+    labelKey = translations[filter.name]
+    isTranslated = true
   }
 
-  if (filter.value in countryNameTranslations) {
-    labelValue = countryNameTranslations[filter.value]
+  if (
+    R.or(isLocation(labelKey), isTranslated) &&
+    filter.value in translations
+  ) {
+    labelValue = translations[filter.value]
   } else {
     labelValue = filter.value
   }

--- a/static/js/components/search/ModifiedSelectedFilter.js
+++ b/static/js/components/search/ModifiedSelectedFilter.js
@@ -4,6 +4,7 @@ import _ from "lodash"
 
 import { SEARCH_FACET_FIELD_LABEL_MAP } from "../../constants"
 import { makeTranslations } from "../LearnerSearch"
+import { isLocation } from "../email/lib"
 
 export default class ModifiedSelectedFilter extends React.Component {
   props: {
@@ -16,12 +17,9 @@ export default class ModifiedSelectedFilter extends React.Component {
 
   translations: Object = makeTranslations()
 
-  isLocation = (labelKey: string) =>
-    R.or(_.includes(labelKey, "Country"), _.includes(labelKey, "Residence"))
-
   render() {
     let { labelKey, labelValue } = this.props
-    let isLabelCountryName = false
+    let isTranslated = false
     const { removeFilter, bemBlocks, filterId } = this.props
     if (R.isEmpty(labelKey)) {
       labelKey = SEARCH_FACET_FIELD_LABEL_MAP[filterId]
@@ -29,10 +27,10 @@ export default class ModifiedSelectedFilter extends React.Component {
       labelKey = SEARCH_FACET_FIELD_LABEL_MAP[labelKey]
     } else if (labelKey in this.translations) {
       labelKey = this.translations[labelKey]
-      isLabelCountryName = true
+      isTranslated = true
     }
     if (
-      R.or(this.isLocation(labelKey), isLabelCountryName) &&
+      R.or(isLocation(labelKey), isTranslated) &&
       _.hasIn(this.translations, labelValue)
     ) {
       labelValue = this.translations[labelValue]

--- a/static/js/components/search/ModifiedSelectedFilter.js
+++ b/static/js/components/search/ModifiedSelectedFilter.js
@@ -3,7 +3,7 @@ import R from "ramda"
 import _ from "lodash"
 
 import { SEARCH_FACET_FIELD_LABEL_MAP } from "../../constants"
-import { makeCountryNameTranslations } from "../LearnerSearch"
+import { makeTranslations } from "../LearnerSearch"
 
 export default class ModifiedSelectedFilter extends React.Component {
   props: {
@@ -14,29 +14,28 @@ export default class ModifiedSelectedFilter extends React.Component {
     filterId: string
   }
 
-  countryNameTranslations: Object = makeCountryNameTranslations()
-  countryNameList: string = _.values(this.countryNameTranslations)
+  translations: Object = makeTranslations()
 
-  isResidence = (labelKey: string) =>
+  isLocation = (labelKey: string) =>
     R.or(_.includes(labelKey, "Country"), _.includes(labelKey, "Residence"))
-
-  isState = (labelKey: string) => _.indexOf(this.countryNameList, labelKey) > -1
 
   render() {
     let { labelKey, labelValue } = this.props
+    let isLabelCountryName = false
     const { removeFilter, bemBlocks, filterId } = this.props
     if (R.isEmpty(labelKey)) {
       labelKey = SEARCH_FACET_FIELD_LABEL_MAP[filterId]
     } else if (labelKey in SEARCH_FACET_FIELD_LABEL_MAP) {
       labelKey = SEARCH_FACET_FIELD_LABEL_MAP[labelKey]
-    } else if (labelKey in this.countryNameTranslations) {
-      labelKey = this.countryNameTranslations[labelKey]
+    } else if (labelKey in this.translations) {
+      labelKey = this.translations[labelKey]
+      isLabelCountryName = true
     }
     if (
-      R.or(this.isResidence(labelKey), this.isState(labelKey)) &&
-      _.hasIn(this.countryNameTranslations, labelValue)
+      R.or(this.isLocation(labelKey), isLabelCountryName) &&
+      _.hasIn(this.translations, labelValue)
     ) {
-      labelValue = this.countryNameTranslations[labelValue]
+      labelValue = this.translations[labelValue]
     }
     // This comes from searchkit documentation on "Overriding Selected Filter Component"
     return (

--- a/static/js/components/search/ModifiedSelectedFilter.js
+++ b/static/js/components/search/ModifiedSelectedFilter.js
@@ -1,5 +1,7 @@
 import React from "react"
 import R from "ramda"
+import _ from "lodash"
+
 import { SEARCH_FACET_FIELD_LABEL_MAP } from "../../constants"
 import { makeCountryNameTranslations } from "../LearnerSearch"
 
@@ -14,6 +16,13 @@ export default class ModifiedSelectedFilter extends React.Component {
 
   countryNameTranslations: Object = makeCountryNameTranslations()
 
+  isResidence = (labelKey: string) => (
+    R.or(
+      _.includes(labelKey, 'Country'),
+      _.includes(labelKey, 'Residence')
+    )
+  )
+
   render() {
     let { labelKey, labelValue } = this.props
     const { removeFilter, bemBlocks, filterId } = this.props
@@ -24,7 +33,7 @@ export default class ModifiedSelectedFilter extends React.Component {
     } else if (labelKey in this.countryNameTranslations) {
       labelKey = this.countryNameTranslations[labelKey]
     }
-    if (labelValue in this.countryNameTranslations) {
+    if (this.isResidence(labelValue) && labelValue in this.countryNameTranslations) {
       labelValue = this.countryNameTranslations[labelValue]
     }
     // This comes from searchkit documentation on "Overriding Selected Filter Component"

--- a/static/js/components/search/ModifiedSelectedFilter.js
+++ b/static/js/components/search/ModifiedSelectedFilter.js
@@ -15,13 +15,12 @@ export default class ModifiedSelectedFilter extends React.Component {
   }
 
   countryNameTranslations: Object = makeCountryNameTranslations()
+  countryNameList: string = _.values(this.countryNameTranslations)
 
-  isResidence = (labelKey: string) => (
-    R.or(
-      _.includes(labelKey, 'Country'),
-      _.includes(labelKey, 'Residence')
-    )
-  )
+  isResidence = (labelKey: string) =>
+    R.or(_.includes(labelKey, "Country"), _.includes(labelKey, "Residence"))
+
+  isState = (labelKey: string) => _.indexOf(this.countryNameList, labelKey) > -1
 
   render() {
     let { labelKey, labelValue } = this.props
@@ -33,7 +32,10 @@ export default class ModifiedSelectedFilter extends React.Component {
     } else if (labelKey in this.countryNameTranslations) {
       labelKey = this.countryNameTranslations[labelKey]
     }
-    if (this.isResidence(labelValue) && labelValue in this.countryNameTranslations) {
+    if (
+      R.or(this.isResidence(labelKey), this.isState(labelKey)) &&
+      _.hasIn(this.countryNameTranslations, labelValue)
+    ) {
       labelValue = this.countryNameTranslations[labelValue]
     }
     // This comes from searchkit documentation on "Overriding Selected Filter Component"

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -540,6 +540,31 @@ describe("LearnerSearchPage", function() {
         ])
       })
     })
+
+    it("has proper filter titles when company name and state name are same", () => {
+      const query = {
+        courses:         ["Digital Learning 200"],
+        birth_location:  ["US"],
+        country:         [["US"], ["US-ME"]],
+        education_level: ["hs"],
+        company_name:    ["US-ME"]
+      }
+      return renderSearch().then(([wrapper]) => {
+        const searchkit = wrapper.find("SearchkitProvider").props().searchkit
+        searchkit.searchFromUrlQuery(query)
+
+        const titles = wrapper
+          .find(".mm-filters .sk-selected-filters-option__name")
+          .map(filter => filter.text())
+        assert.deepEqual(titles, [
+          "Course: Digital Learning 200",
+          "Country of Birth: United States",
+          "United States: Maine",
+          "Degree: High school",
+          "Company: US-ME"
+        ])
+      })
+    })
   })
 
   it("shows filters and the textbox even if there are no results", () => {


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3645

#### What's this PR do?
It fixes a bug where filters are assuming every two characters a country 

#### How should this be manually tested?
- Go to search and filter `http://192.168.99.100:8079/learners/?company_name[0]=ME`,
- it should show me in filter list.

@pdpinch 
#### Screenshots (if appropriate)
<img width="837" alt="screen shot 2017-10-20 at 5 56 15 pm" src="https://user-images.githubusercontent.com/10431250/31821904-1fc7434e-b5c0-11e7-9790-8f29992230a6.png">
