### PR TITLE
Log a diff of the ES document and serialized enrollment

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ Django==1.10.5
 Pillow==3.4.2
 boto==2.39.0
 celery==4.0.2
+deepdiff==3.3.0
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-cors-headers==2.1.0
@@ -21,10 +22,11 @@ gnupg==2.2.0
 html5lib==0.999999999
 ipython
 jsonfield==1.0.3
+jsonpatch==1.16
 newrelic
 open-discussions-client==0.2.2
 phonenumbers==8.3.2
-psycopg2==2.6
+psycopg2==2.7.3.1
 pycountry==16.11.27.1
 pysftp==0.2.9
 python-dateutil

--- a/requirements.in
+++ b/requirements.in
@@ -26,7 +26,7 @@ jsonpatch==1.16
 newrelic
 open-discussions-client==0.2.2
 phonenumbers==8.3.2
-psycopg2==2.7.3.1
+psycopg2==2.6
 pycountry==16.11.27.1
 pysftp==0.2.9
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ cffi==1.10.0              # via bcrypt, cryptography, pynacl
 contextlib2==0.5.5        # via raven
 cryptography==2.0.2       # via paramiko
 decorator==4.1.2          # via ipython, traitlets
+deepdiff==3.3.0
 defusedxml==0.5.0         # via python3-openid, social-auth-core
 dj-database-url==0.3.0
 dj-static==0.0.6
@@ -43,6 +44,8 @@ ipython-genutils==0.2.0   # via traitlets
 ipython==6.1.0
 jedi==0.10.2              # via ipython
 jsonfield==1.0.3
+jsonpatch==1.16
+jsonpointer==1.12         # via jsonpatch
 kombu==4.1.0              # via celery, django-server-status
 newrelic==2.88.1.73
 oauthlib==2.0.2           # via requests-oauthlib, social-auth-core
@@ -55,7 +58,7 @@ pickleshare==0.7.4        # via ipython
 pillow==3.4.2
 prompt-toolkit==1.0.15    # via ipython
 psutil==5.2.2             # via gnupg
-psycopg2==2.6
+psycopg2==2.7.3.1
 ptyprocess==0.5.2         # via pexpect
 pyasn1==0.3.1             # via paramiko
 pycountry==16.11.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ pickleshare==0.7.4        # via ipython
 pillow==3.4.2
 prompt-toolkit==1.0.15    # via ipython
 psutil==5.2.2             # via gnupg
-psycopg2==2.7.3.1
+psycopg2==2.6
 ptyprocess==0.5.2         # via pexpect
 pyasn1==0.3.1             # via paramiko
 pycountry==16.11.27.1


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3654 

#### What's this PR do?
Log a diff of the difference between the Elasticsearch document and the serialized enrollment

#### How should this be manually tested?
Make a change to a `Profile` and save it using `with mute_signals(post_save)` to prevent Elasticsearch from updating. In the Django shell run `profile.save()` and verify that you see a logging message with a diff of the field that was changed.
