### PR TITLE
upgrade psycopg version to 2.7

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ jsonpatch==1.16
 newrelic
 open-discussions-client==0.2.2
 phonenumbers==8.3.2
-psycopg2==2.6
+psycopg2==2.7
 pycountry==16.11.27.1
 pysftp==0.2.9
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ pickleshare==0.7.4        # via ipython
 pillow==3.4.2
 prompt-toolkit==1.0.15    # via ipython
 psutil==5.2.2             # via gnupg
-psycopg2==2.6
+psycopg2==2.7
 ptyprocess==0.5.2         # via pexpect
 pyasn1==0.3.1             # via paramiko
 pycountry==16.11.27.1


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

fixes an issue where the dev environment python and web containers wouldn't build

#### How should this be manually tested?

you should be able to run `docker-compose build --no-cache web` without seeing any errors.