### PR TITLE
Fixes a layout fix with radio buttons on the profile pages in Chrome

### DIFF
--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -118,7 +118,7 @@ class EducationForm extends ProfileFormFields {
     const valueSelected = level.value in educationLevelAnswers ? "false" : null
     return (
       <RadioButtonGroup
-        className={`profile-radio-switch ${level.value}`}
+        className={`profile-radio-group ${level.value}`}
         id={`profile-tab-education-switch-${level.value}`}
         name={`profile-tab-education-switch-${level.value}`}
         onChange={(event, value) => this.handleRadioClick(value, level.value)}

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -285,7 +285,7 @@ class EmploymentForm extends ProfileFormFields {
     const radioIconStyle = { marginRight: "8px" }
     return (
       <RadioButtonGroup
-        className="profile-radio-switch"
+        className="profile-radio-group"
         name="work-history-switch"
         onChange={(event, value) => this.handleRadioClick(value)}
         valueSelected={valueSelected}

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -116,7 +116,7 @@ describe("ProfilePage", function() {
 
     it("should launch a dialog to add an entry when an education switch is set to Yes", () => {
       const dialogTest = ([, div]) => {
-        const toggle = radioToggles(div, ".profile-radio-switch")
+        const toggle = radioToggles(div, ".profile-radio-group")
         ReactTestUtils.Simulate.change(toggle[0])
         activeDialog("education-dialog-wrapper")
       }
@@ -127,7 +127,7 @@ describe("ProfilePage", function() {
 
     it("should launch a dialog to add an entry when an employment switch is set to Yes", () => {
       const dialogTest = ([, div]) => {
-        const toggle = radioToggles(div, ".profile-radio-switch")
+        const toggle = radioToggles(div, ".profile-radio-group")
         ReactTestUtils.Simulate.change(toggle[0])
         activeDialog("employment-dialog-wrapper")
       }

--- a/static/scss/profile.scss
+++ b/static/scss/profile.scss
@@ -41,6 +41,10 @@
     font-size: 14px;
     display: flex;
 
+    div {
+      display: block !important;
+    }
+
     .profile-radio-button {
       margin-bottom: 8px;
     }

--- a/static/scss/profile.scss
+++ b/static/scss/profile.scss
@@ -39,6 +39,7 @@
 
   .profile-radio-switch, .profile-radio-group {
     font-size: 14px;
+    display: flex;
 
     .profile-radio-button {
       margin-bottom: 8px;


### PR DESCRIPTION
#### What are the relevant tickets?
#3665 

#### What's this PR do?
This fixes a layout bug in Chrome where the radio buttons on the profile education and employment tabs were overlapping with the labels. 

#### How should this be manually tested?
I think this bug may have been introduced with the most recent version of Chrome, so it should be tested there. But if you have a not-up-to-date version of Chrome, test it there first, then update, then test again.

BUG:
![image](https://user-images.githubusercontent.com/20047260/32015645-b3a766d4-b98f-11e7-87f8-c0ae5a90378b.png)

FIX:
![image](https://user-images.githubusercontent.com/20047260/32015666-c5e257aa-b98f-11e7-9152-1b53efaab6a2.png)

