### PR TITLE
Refactor batch_update_user_data, fix lock behavior

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -7,11 +7,15 @@ from urllib.parse import urljoin
 import pytz
 
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 from django.urls import reverse
+from edx_api.client import EdxApi
+from social_django.models import UserSocialAuth
 
 from backends.exceptions import InvalidCredentialStored
+from backends import utils
 from courses.models import Program
 from dashboard.api_edx_cache import CachedEdxDataApi, CachedEdxUserData
 from dashboard.utils import MMTrack
@@ -20,6 +24,8 @@ from grades import api
 from grades.models import FinalGrade
 from grades.serializers import ProctoredExamGradeSerializer
 from exams.models import ExamAuthorization, ExamRun
+from micromasters.utils import now_in_utc
+from profiles.api import get_social_auth
 
 # maximum number of exam attempts per payment
 ATTEMPTS_PER_PAID_RUN = 2
@@ -524,3 +530,74 @@ def get_overall_final_grade_for_course(mmtrack, course):
         return ""
 
     return str(round(best_grade.grade_percent * COURSE_GRADE_WEIGHT + best_exam.score * EXAM_GRADE_WEIGHT))
+
+
+def calculate_users_to_refresh_in_bulk():
+    """
+    Calculate the set of user ids which would be updated when running a bulk update. This uses a 6 hour delta
+    because this is a bulk operation. For individual updates see CachedEdxDataApi.is_cache_fresh.
+
+    Returns:
+        list of int: A list of user ids which need to be updated
+    """
+    refresh_time_limit = now_in_utc() - datetime.timedelta(hours=6)
+
+    all_users = User.objects.filter(is_active=True, profile__fake_user=False).exclude(social_auth=None)
+
+    # If one of these fields is null in the database the gte expression will be false, so we will refresh those users
+    users_not_expired = all_users.filter(
+        usercacherefreshtime__enrollment__gte=refresh_time_limit,
+        usercacherefreshtime__certificate__gte=refresh_time_limit,
+        usercacherefreshtime__current_grade__gte=refresh_time_limit
+    )
+
+    return list(all_users.exclude(id__in=users_not_expired.values_list("id", flat=True)).values_list("id", flat=True))
+
+
+def refresh_user_data(user_id):
+    """
+    Refresh the edx cache data for a user.
+
+    Note that this function will not raise an exception on error, instead the errors are logged.
+
+    Args:
+        user_id (int): The user id
+    """
+    # pylint: disable=bare-except
+    try:
+        user = User.objects.get(pk=user_id)
+    except:
+        log.exception('edX data refresh task: unable to get user "%s"', user_id)
+        return
+
+    try:
+        UserSocialAuth.objects.get(user=user)
+    except:
+        log.exception('user "%s" does not have python social auth object', user.username)
+        return
+
+    # get the credentials for the current user for edX
+    try:
+        user_social = get_social_auth(user)
+    except:
+        log.exception('user "%s" does not have edX credentials', user.username)
+        return
+
+    try:
+        utils.refresh_user_token(user_social)
+    except:
+        log.exception("Unable to refresh token for student %s", user.username)
+        return
+
+    try:
+        edx_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL)
+    except:
+        log.exception("Unable to create an edX client object for student %s", user.username)
+        return
+
+    for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
+        try:
+            CachedEdxDataApi.update_cache_if_expired(user, edx_client, cache_type)
+        except:
+            log.exception("Unable to refresh cache %s for student %s", cache_type, user.username)
+            continue

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -12,7 +12,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 from django.urls import reverse
 from edx_api.client import EdxApi
-from social_django.models import UserSocialAuth
 
 from backends.exceptions import InvalidCredentialStored
 from backends import utils
@@ -568,12 +567,6 @@ def refresh_user_data(user_id):
         user = User.objects.get(pk=user_id)
     except:
         log.exception('edX data refresh task: unable to get user "%s"', user_id)
-        return
-
-    try:
-        UserSocialAuth.objects.get(user=user)
-    except:
-        log.exception('user "%s" does not have python social auth object', user.username)
         return
 
     # get the credentials for the current user for edX

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -12,6 +12,7 @@ from unittest.mock import (
 import ddt
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
+import pytest
 from rest_framework import status as http_status
 
 from backends.exceptions import InvalidCredentialStored
@@ -42,6 +43,7 @@ from micromasters.utils import (
     is_subset_dict,
     now_in_utc,
 )
+from profiles.factories import SocialProfileFactory
 from search.base import MockedESTestCase
 
 
@@ -1819,3 +1821,203 @@ class GetOverallGradeForCourseTests(CourseTests):
         self.mmtrack.get_passing_final_grades_for_course.return_value = FinalGrade.objects.filter(user=self.user)
         self.mmtrack.get_best_proctored_exam_grade.return_value = None
         assert api.get_overall_final_grade_for_course(self.mmtrack, self.course) == ''
+
+
+# pylint: disable=unused-argument, redefined-outer-name
+def _make_fake_real_user():
+    """Make a User whose profile.fake_user is False"""
+    user = SocialProfileFactory.create().user
+    user.profile.fake_user = False
+    user.profile.save()
+    now = now_in_utc()
+    UserCacheRefreshTimeFactory.create(user=user, enrollment=now, certificate=now, current_grade=now)
+    return user
+
+
+@pytest.fixture
+def calc_users(db):
+    """Create users with an empty cache"""
+    up_to_date = [_make_fake_real_user() for _ in range(5)]
+    needs_update = [_make_fake_real_user() for _ in range(5)]
+    for user in needs_update:
+        user.usercacherefreshtime.delete()
+
+    return needs_update, up_to_date
+
+
+def test_calculate_up_to_date(calc_users):
+    """
+    calculate_users_to_refresh should return a list of user ids for users whose cache has expired or who are not cached
+    """
+    needs_update, up_to_date = calc_users
+    assert api.calculate_users_to_refresh_in_bulk() == [user.id for user in needs_update]
+
+
+def test_calculate_missing_cache(calc_users):
+    """
+    If a user's cache is missing they should be part of the list of users to update
+    """
+    needs_update, up_to_date = calc_users
+    up_to_date[0].usercacherefreshtime.delete()
+    assert api.calculate_users_to_refresh_in_bulk() == [user.id for user in needs_update] + [up_to_date[0].id]
+
+
+def test_calculate_fake_user(calc_users):
+    """Fake users should not have their caches updated"""
+    needs_update, up_to_date = calc_users
+    needs_update[0].profile.fake_user = True
+    needs_update[0].profile.save()
+    assert api.calculate_users_to_refresh_in_bulk() == [user.id for user in needs_update[1:]]
+
+
+def test_calculate_inactive(calc_users):
+    """Inactive users should not have their caches updated"""
+    needs_update, up_to_date = calc_users
+    needs_update[0].active = False
+    needs_update[0].profile.save()
+    assert api.calculate_users_to_refresh_in_bulk() == [user.id for user in needs_update[1:]]
+
+
+def test_calculate_missing_social_auth(calc_users):
+    """Users without a linked social auth should not be counted"""
+    needs_update, up_to_date = calc_users
+    needs_update[0].social_auth.all().delete()
+    assert api.calculate_users_to_refresh_in_bulk() == [user.id for user in needs_update[1:]]
+
+
+@pytest.mark.parametrize("enrollment,certificate,current_grade,expired", [
+    [None, 0, 0, True],
+    [0, None, 0, True],
+    [0, 0, None, True],
+    [-5, 0, 0, False],
+    [0, -5, 0, False],
+    [0, 0, -5, False],
+    [5, 0, 0, True],
+    [0, 5, 0, True],
+    [0, 0, 5, True],
+])
+def test_calculate_expired(calc_users, enrollment, certificate, current_grade, expired):
+    """
+    Users with some part of their cache that is expired should show up as needing update
+    """
+    needs_update, up_to_date = calc_users
+    cache = up_to_date[0].usercacherefreshtime
+    cache.enrollment = now_in_utc() - timedelta(hours=6, minutes=enrollment - 1) if enrollment is not None else None
+    cache.certificate = now_in_utc() - timedelta(hours=6, minutes=certificate - 1) if certificate is not None else None
+    cache.current_grade = (
+        now_in_utc() - timedelta(hours=6, minutes=current_grade - 1) if current_grade is not None else None
+    )
+    cache.save()
+
+    expected = needs_update + [up_to_date[0]] if expired else needs_update
+
+    assert sorted(api.calculate_users_to_refresh_in_bulk()) == sorted([user.id for user in expected])
+
+
+def test_refresh_user_data(db, mocker):
+    """refresh_user_data should refresh the cache on all cache types"""
+    user = _make_fake_real_user()
+    user_social = user.social_auth.first()
+    refresh_user_token_mock = mocker.patch('dashboard.api.utils.refresh_user_token', autospec=True)
+    edx_api = mocker.Mock()
+    edx_api_init = mocker.patch('dashboard.api.EdxApi', autospec=True, return_value=edx_api)
+    update_cache_mock = mocker.patch('dashboard.api.CachedEdxDataApi.update_cache_if_expired')
+
+    api.refresh_user_data(user.id)
+
+    refresh_user_token_mock.assert_called_once_with(user_social)
+    edx_api_init.assert_called_once_with(user_social.extra_data, settings.EDXORG_BASE_URL)
+    for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
+        update_cache_mock.assert_any_call(user, edx_api, cache_type)
+
+
+def test_refresh_missing_user(db, mocker):
+    """If the user doesn't exist we should skip the refresh"""
+    refresh_user_token_mock = mocker.patch('dashboard.api.utils.refresh_user_token', autospec=True)
+    edx_api = mocker.Mock()
+    edx_api_init = mocker.patch('dashboard.api.EdxApi', autospec=True, return_value=edx_api)
+    update_cache_mock = mocker.patch('dashboard.api.CachedEdxDataApi.update_cache_if_expired')
+
+    api.refresh_user_data(999)
+
+    assert refresh_user_token_mock.called is False
+    assert edx_api_init.called is False
+    assert update_cache_mock.called is False
+
+
+def test_refresh_missing_social_auth(db, mocker):
+    """If the social auth doesn't exist we should skip the refresh"""
+    user = _make_fake_real_user()
+    user.social_auth.all().delete()
+    refresh_user_token_mock = mocker.patch('dashboard.api.utils.refresh_user_token', autospec=True)
+    edx_api = mocker.Mock()
+    edx_api_init = mocker.patch('dashboard.api.EdxApi', autospec=True, return_value=edx_api)
+    update_cache_mock = mocker.patch('dashboard.api.CachedEdxDataApi.update_cache_if_expired')
+
+    api.refresh_user_data(user.id)
+
+    assert refresh_user_token_mock.called is False
+    assert edx_api_init.called is False
+    assert update_cache_mock.called is False
+
+
+def test_refresh_failed_oauth_update(db, mocker):
+    """If the oauth user token refresh fails, we should skip the edx refresh"""
+    user = _make_fake_real_user()
+    user_social = user.social_auth.first()
+    refresh_user_token_mock = mocker.patch(
+        'dashboard.api.utils.refresh_user_token', autospec=True, side_effect=KeyError,
+    )
+    edx_api = mocker.Mock()
+    edx_api_init = mocker.patch('dashboard.api.EdxApi', autospec=True, return_value=edx_api)
+    update_cache_mock = mocker.patch('dashboard.api.CachedEdxDataApi.update_cache_if_expired')
+
+    api.refresh_user_data(user.id)
+
+    refresh_user_token_mock.assert_called_once_with(user_social)
+    assert edx_api_init.called is False
+    assert update_cache_mock.called is False
+
+
+def test_refresh_failed_edx_client(db, mocker):
+    """If we fail to create the edx client, we should skip the edx refresh"""
+    user = _make_fake_real_user()
+    user_social = user.social_auth.first()
+    refresh_user_token_mock = mocker.patch(
+        'dashboard.api.utils.refresh_user_token', autospec=True,
+    )
+    edx_api_init = mocker.patch('dashboard.api.EdxApi', autospec=True, side_effect=KeyError)
+    update_cache_mock = mocker.patch('dashboard.api.CachedEdxDataApi.update_cache_if_expired')
+
+    api.refresh_user_data(user.id)
+
+    refresh_user_token_mock.assert_called_once_with(user_social)
+    edx_api_init.assert_called_once_with(user_social.extra_data, settings.EDXORG_BASE_URL)
+    assert update_cache_mock.called is False
+
+
+@pytest.mark.parametrize("failed_cache_type", CachedEdxDataApi.SUPPORTED_CACHES)
+def test_refresh_update_cache(db, mocker, failed_cache_type):
+    """If we fail to create the edx client, we should skip the edx refresh"""
+    user = _make_fake_real_user()
+    user_social = user.social_auth.first()
+    refresh_user_token_mock = mocker.patch(
+        'dashboard.api.utils.refresh_user_token', autospec=True,
+    )
+    edx_api = mocker.Mock()
+    edx_api_init = mocker.patch('dashboard.api.EdxApi', autospec=True, return_value=edx_api)
+
+    def _update_cache(self, user, edx_client, cache_type):
+        if cache_type == failed_cache_type:
+            raise KeyError()
+
+    update_cache_mock = mocker.patch(
+        'dashboard.api.CachedEdxDataApi.update_cache_if_expired', side_effect=_update_cache,
+    )
+
+    api.refresh_user_data(user.id)
+
+    refresh_user_token_mock.assert_called_once_with(user_social)
+    edx_api_init.assert_called_once_with(user_social.extra_data, settings.EDXORG_BASE_URL)
+    for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
+        update_cache_mock.assert_any_call(user, edx_api, cache_type)

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1847,7 +1847,8 @@ def users_without_with_cache(db):
 
 def test_calculate_up_to_date(users_without_with_cache):
     """
-    calculate_users_to_refresh should return a list of user ids for users whose cache has expired or who are not cached
+    calculate_users_to_refresh should return a list of user ids
+    for users whose cache has expired or who are not cached
     """
     needs_update, _ = users_without_with_cache
     assert api.calculate_users_to_refresh_in_bulk() == [user.id for user in needs_update]

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -2,36 +2,49 @@
 Periodic task that updates user data.
 """
 import logging
-import uuid
-from datetime import timedelta
 
 from celery import group
-from django.conf import settings
-from django.contrib.auth.models import User
 from django.core.cache import caches
-from django.db.models import Q
-from edx_api.client import EdxApi
-from social_django.models import UserSocialAuth
 
-from backends import utils
-from dashboard.models import UserCacheRefreshTime
-from dashboard.api_edx_cache import CachedEdxDataApi
-from micromasters.celery import app
-from micromasters.utils import (
-    chunks,
-    now_in_utc,
+from dashboard.api import (
+    calculate_users_to_refresh_in_bulk,
+    refresh_user_data,
 )
-from profiles.api import get_social_auth
+from micromasters.celery import app
+from micromasters.utils import chunks
 
 
 log = logging.getLogger(__name__)
 cache_redis = caches['redis']
 
 
-MAX_HRS_MAIN_TASK = 6
 PARALLEL_RATE_LIMIT = '10/m'
 LOCK_EXPIRE = 60 * 60 * 2  # Lock expires in 2 hrs
-lock_id = '{0}-lock'.format(uuid.uuid4())
+LOCK_ID = 'batch_update_user_data_lock'
+
+
+def _acquire_lock():
+    """
+    create lock by adding a key to storage.
+    """
+    # lock will expire if 2 hrs are pass and task is not complete.
+    return cache_redis.add(LOCK_ID, 'true', LOCK_EXPIRE)
+
+
+def _release_lock():
+    """
+    remove lock by deleting key from storage.
+    """
+    return cache_redis.delete(LOCK_ID)
+
+
+@app.task
+def release_batch_update_user_data_lock(*args):  # pylint: disable=unused-argument
+    """
+    Task which releases the lock acquired in batch_update_user_data
+    """
+    _release_lock()
+    log.info("Released batch_update_user_data lock")
 
 
 @app.task
@@ -40,45 +53,25 @@ def batch_update_user_data():
     Create sub tasks to update user data like enrollments,
     certificates and grades from edX platform.
     """
-    def acquire_lock():
-        """
-        create lock by adding a key to storage.
-        """
-        # lock will expire if 2 hrs are pass and task is not complete.
-        return cache_redis.add(lock_id, 'true', LOCK_EXPIRE)
+    if not _acquire_lock():
+        # Should not usually happen. This task executes every 6 hours and the lock expires after 2.
+        log.error("Unable to acquire lock to batch_update_user_data.")
+        return
 
-    def release_lock():
-        """
-        remove lock by deleteing key from storage.
-        """
-        return cache_redis.delete(lock_id)
+    users_to_refresh = calculate_users_to_refresh_in_bulk()
 
-    if acquire_lock():
-        refresh_time_limit = now_in_utc() - timedelta(hours=MAX_HRS_MAIN_TASK)
-
-        users_expired_cache = UserCacheRefreshTime.objects.filter(
-            Q(enrollment__lt=refresh_time_limit) |
-            Q(certificate__lt=refresh_time_limit) |
-            Q(current_grade__lt=refresh_time_limit),
-            user__is_active=True,
-            user__profile__fake_user=False
-        ).values_list('user', flat=True).distinct()
-
-        users_not_in_cache = User.objects.exclude(
-            Q(id__in=users_expired_cache)
-        ).filter(is_active=True, profile__fake_user=False).values_list('id', flat=True)
-
-        users_to_refresh = list(set(users_expired_cache) | set(users_not_in_cache))
-
+    if len(users_to_refresh) > 0:
         job = group(
-            batch_update_user_data_subtasks.s(list_users) for list_users in chunks(users_to_refresh)
+            batch_update_user_data_subtasks.s(list_users)
+            for list_users in chunks(users_to_refresh)
         )
-        result = job.apply_async()
-        result.ready()
-
-        if result.successful():
-            # release lock if all tasks are done.
-            release_lock()
+        # release_batch_update_user_data_lock will not get executed if any of the subtasks error,
+        # but we handle all exceptions in the subtask so that shouldn't happen
+        jobs = job | release_batch_update_user_data_lock.s()
+    else:
+        # celery requires at least one item in a group(...)
+        jobs = release_batch_update_user_data_lock
+    jobs.delay()
 
 
 @app.task(rate_limit=PARALLEL_RATE_LIMIT)
@@ -87,44 +80,7 @@ def batch_update_user_data_subtasks(students):
     Update user data like enrollments, certificates and grades from edX platform.
 
     Args:
-        students (List): List of students.
+        students (list of int): List of user ids for students.
     """
-    # pylint: disable=bare-except
     for user_id in students:
-        try:
-            user = User.objects.get(pk=user_id)
-        except:
-            log.exception('edX data refresh task: unable to get user "%s"', user_id)
-            continue
-
-        try:
-            UserSocialAuth.objects.get(user=user)
-        except:
-            log.exception('user "%s" does not have python social auth object', user.username)
-            continue
-
-        # get the credentials for the current user for edX
-        try:
-            user_social = get_social_auth(user)
-        except:
-            log.exception('user "%s" does not have edX credentials', user.username)
-            continue
-
-        try:
-            utils.refresh_user_token(user_social)
-        except:
-            log.exception("Unable to refresh token for student %s", user.username)
-            continue
-
-        try:
-            edx_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL)
-        except:
-            log.exception("Unable to create an edX client object for student %s", user.username)
-            continue
-
-        for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
-            try:
-                CachedEdxDataApi.update_cache_if_expired(user, edx_client, cache_type)
-            except:
-                log.exception("Unable to refresh cache %s for student %s", cache_type, user.username)
-                continue
+        refresh_user_data(user_id)

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -47,6 +47,9 @@ def release_batch_update_user_data_lock(*args):  # pylint: disable=unused-argume
     log.info("Released batch_update_user_data lock")
 
 
+# This lock is not safe against repeated executions of the task since there is no logic
+# to stop the batch update halfway through and the lock expiration might be shorter than the length of time this
+# executes.
 @app.task
 def batch_update_user_data():
     """

--- a/dashboard/tasks_test.py
+++ b/dashboard/tasks_test.py
@@ -9,7 +9,7 @@ def test_nothing_to_do(mocker):
     """
     If there's nothing to update batch_update_user_date should only acquire and release the lock
     """
-    calc_mock = mocker.patch('dashboard.tasks.calculate_users_to_refresh', autospec=True, return_value=[])
+    calc_mock = mocker.patch('dashboard.tasks.calculate_users_to_refresh_in_bulk', autospec=True, return_value=[])
     acquire_mock = mocker.patch('dashboard.tasks._acquire_lock', autospec=True, return_value=True)
     refresh_mock = mocker.patch('dashboard.tasks.refresh_user_data', autospec=True)
     release_mock = mocker.patch('dashboard.tasks._release_lock', autospec=True)
@@ -26,7 +26,7 @@ def test_batch_update(mocker, db):  # pylint: disable=unused-argument
     batch_update_user_data should create a group of tasks operating on chunks of users to refresh their caches
     """
     users = SocialUserFactory.create_batch(25)
-    calc_mock = mocker.patch('dashboard.tasks.calculate_users_to_refresh', autospec=True, return_value=[
+    calc_mock = mocker.patch('dashboard.tasks.calculate_users_to_refresh_in_bulk', autospec=True, return_value=[
         user.id for user in users
     ])
     acquire_mock = mocker.patch('dashboard.tasks._acquire_lock', autospec=True, return_value=True)
@@ -46,7 +46,7 @@ def test_failed_to_acquire(mocker):
     """
     If the lock is held there should be nothing else done
     """
-    calc_mock = mocker.patch('dashboard.tasks.calculate_users_to_refresh', autospec=True, return_value=[])
+    calc_mock = mocker.patch('dashboard.tasks.calculate_users_to_refresh_in_bulk', autospec=True, return_value=[])
     acquire_mock = mocker.patch('dashboard.tasks._acquire_lock', autospec=True, return_value=False)
     refresh_mock = mocker.patch('dashboard.tasks.refresh_user_data', autospec=True)
     release_mock = mocker.patch('dashboard.tasks._release_lock', autospec=True)

--- a/dashboard/tasks_test.py
+++ b/dashboard/tasks_test.py
@@ -1,137 +1,58 @@
 """
 Tests for tasks
 """
-from itertools import product
-from unittest import mock
-
-from django.conf import settings
-from django.contrib.auth.models import User
-
-from backends.edxorg import EdxOrgOAuth2
-from backends.utils import InvalidCredentialStored
-from dashboard.api_edx_cache import CachedEdxDataApi
-from dashboard.tasks import (
-    batch_update_user_data,
-    batch_update_user_data_subtasks
-)
-from dashboard.factories import UserCacheRefreshTimeFactory
-from micromasters.factories import UserFactory, SocialUserFactory
-from search.base import MockedESTestCase
+from dashboard.tasks import batch_update_user_data
+from micromasters.factories import SocialUserFactory
 
 
-class TasksTest(MockedESTestCase):
+def test_nothing_to_do(mocker):
     """
-    Tests for periodic task which is for updating user data from edx.
+    If there's nothing to update batch_update_user_date should only acquire and release the lock
     """
+    calc_mock = mocker.patch('dashboard.tasks.calculate_users_to_refresh', autospec=True, return_value=[])
+    acquire_mock = mocker.patch('dashboard.tasks._acquire_lock', autospec=True, return_value=True)
+    refresh_mock = mocker.patch('dashboard.tasks.refresh_user_data', autospec=True)
+    release_mock = mocker.patch('dashboard.tasks._release_lock', autospec=True)
 
-    @classmethod
-    def setUpTestData(cls):
-        super(TasksTest, cls).setUpTestData()
+    batch_update_user_data()
+    calc_mock.assert_called_once_with()
+    acquire_mock.assert_called_once_with()
+    assert refresh_mock.called is False
+    release_mock.assert_called_once_with()
 
-        cls.all_working_users = SocialUserFactory.create_batch(2)
-        cls.user1, cls.user2 = cls.all_working_users
-        cls.students = [user.id for user in cls.all_working_users]
-        cls.user_no_social_auth = UserFactory.create()
 
-    def test_celery_task_works(self):
-        """
-        Assert task schedule using celery beat.
-        """
-        self.assertTrue(batch_update_user_data.delay())
+def test_batch_update(mocker, db):  # pylint: disable=unused-argument
+    """
+    batch_update_user_data should create a group of tasks operating on chunks of users to refresh their caches
+    """
+    users = SocialUserFactory.create_batch(25)
+    calc_mock = mocker.patch('dashboard.tasks.calculate_users_to_refresh', autospec=True, return_value=[
+        user.id for user in users
+    ])
+    acquire_mock = mocker.patch('dashboard.tasks._acquire_lock', autospec=True, return_value=True)
+    refresh_mock = mocker.patch('dashboard.tasks.refresh_user_data', autospec=True)
+    release_mock = mocker.patch('dashboard.tasks._release_lock', autospec=True)
 
-    @mock.patch('dashboard.tasks.batch_update_user_data_subtasks.run', autospec=True)
-    def test_batch_update_user_date_for_active_users(self, mocked_subtasks):
-        """
-        Assert batch_update_user_data does not update inactive users
-        """
-        for user in self.all_working_users:
-            user.is_active = False
-            user.save()
-        UserCacheRefreshTimeFactory.create(user=self.user2, unexpired=True)
-        batch_update_user_data.delay()
-        mocked_subtasks.assert_called_with([self.user_no_social_auth.id])
+    batch_update_user_data()
+    calc_mock.assert_called_once_with()
+    acquire_mock.assert_called_once_with()
+    assert refresh_mock.call_count == len(users)
+    for user in users:
+        refresh_mock.assert_any_call(user.id)
+    release_mock.assert_called_once_with()
 
-    @mock.patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cache_if_expired', new_callable=mock.MagicMock)
-    @mock.patch('backends.utils.refresh_user_token', autospec=True)
-    def test_student_enrollments_called_task(self, mocked_refresh, mocked_refresh_cache):
-        """
-        Assert get_student_enrollments is actually called in happy path
-        """
-        batch_update_user_data_subtasks.s([self.user_no_social_auth]+self.students).apply(args=()).get()
-        assert mocked_refresh_cache.call_count == len(self.all_working_users) * len(CachedEdxDataApi.SUPPORTED_CACHES)
-        assert mocked_refresh.call_count == len(self.all_working_users)
-        for user, cache_type in product(self.all_working_users, CachedEdxDataApi.SUPPORTED_CACHES):
-            mocked_refresh_cache.assert_any_call(user, mock.ANY, cache_type)
-            mocked_refresh.assert_any_call(user.social_auth.get(provider=EdxOrgOAuth2.name))
 
-    @mock.patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cache_if_expired', new_callable=mock.MagicMock)
-    @mock.patch('backends.utils.refresh_user_token', autospec=True)
-    def test_subtask_user_does_not_exist(self, mocked_refresh, mocked_refresh_cache):
-        """
-        Test if the user has been deleted between the select and the run of the task,
-        the task still completes.
-        """
-        with mock.patch('django.contrib.auth.models.User.objects.get', autospec=True, side_effect=User.DoesNotExist):
-            batch_update_user_data_subtasks.s(self.students).apply(args=()).get()
-        assert mocked_refresh.called is False
-        assert mocked_refresh_cache.called is False
+def test_failed_to_acquire(mocker):
+    """
+    If the lock is held there should be nothing else done
+    """
+    calc_mock = mocker.patch('dashboard.tasks.calculate_users_to_refresh', autospec=True, return_value=[])
+    acquire_mock = mocker.patch('dashboard.tasks._acquire_lock', autospec=True, return_value=False)
+    refresh_mock = mocker.patch('dashboard.tasks.refresh_user_data', autospec=True)
+    release_mock = mocker.patch('dashboard.tasks._release_lock', autospec=True)
 
-    @mock.patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cache_if_expired', new_callable=mock.MagicMock)
-    @mock.patch('backends.utils.refresh_user_token', autospec=True)
-    def test_subtask_user_no_social_auth(self, mocked_refresh, mocked_refresh_cache):
-        """
-        Test if the user has not a social auth the task still completes
-        """
-        batch_update_user_data_subtasks.s([self.user_no_social_auth]).apply(args=()).get()
-        assert mocked_refresh.called is False
-        assert mocked_refresh_cache.called is False
-
-    @mock.patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cache_if_expired', new_callable=mock.MagicMock)
-    @mock.patch('backends.utils.refresh_user_token', autospec=True)
-    def test_subtask_user_wrong_social_auth(self, mocked_refresh, mocked_refresh_cache):
-        """
-        Test if the user has a wrong social auth the task still completes
-        """
-        user_wrong_social_auth = SocialUserFactory.create(social_auth__provider='foo_provider')
-        batch_update_user_data_subtasks.s([user_wrong_social_auth]).apply(args=()).get()
-        assert mocked_refresh.called is False
-        assert mocked_refresh_cache.called is False
-
-    @mock.patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cache_if_expired', new_callable=mock.MagicMock)
-    @mock.patch('backends.utils.refresh_user_token', autospec=True)
-    def test_subtask_social_auth_refresh_fails(self, mocked_refresh, mocked_refresh_cache):
-        """
-        Test if the refresh for the user's OAUTH token fails the task still completes
-        """
-        mocked_refresh.side_effect = InvalidCredentialStored
-        batch_update_user_data_subtasks.s(self.students).apply(args=()).get()
-        assert mocked_refresh_cache.called is False
-        assert mocked_refresh.call_count == len(self.all_working_users)
-        for user in self.all_working_users:
-            mocked_refresh.assert_any_call(user.social_auth.get(provider=EdxOrgOAuth2.name))
-
-    @mock.patch("edx_api.client.EdxApi.__init__", autospec=True, side_effect=AttributeError)
-    @mock.patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cache_if_expired', new_callable=mock.MagicMock)
-    @mock.patch('backends.utils.refresh_user_token', autospec=True)
-    def test_subtask_api_client_creation_failure(self, mocked_refresh, mocked_refresh_cache, mock_api):
-        """
-        Test if edx_api_client object creation fails the task still completes
-        """
-        batch_update_user_data_subtasks.s(self.students).apply(args=()).get()
-        assert mocked_refresh_cache.called is False
-        for user in self.all_working_users:
-            social_auth = user.social_auth.get(provider=EdxOrgOAuth2.name)
-            mocked_refresh.assert_any_call(social_auth)
-            mock_api.assert_any_call(mock.ANY, social_auth.extra_data, settings.EDXORG_BASE_URL)
-
-    @mock.patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cache_if_expired', new_callable=mock.MagicMock)
-    @mock.patch('backends.utils.refresh_user_token', autospec=True)
-    def test_subtask_user_cache_refresh_fail(self, mocked_refresh, mocked_refresh_cache):
-        """
-        Test if actual cache refresh fails the task still completes
-        """
-        mocked_refresh_cache.side_effect = ZeroDivisionError
-        batch_update_user_data_subtasks.s(self.students).apply(args=()).get()
-        for user, cache_type in product(self.all_working_users, CachedEdxDataApi.SUPPORTED_CACHES):
-            mocked_refresh.assert_any_call(user.social_auth.get(provider=EdxOrgOAuth2.name))
-            mocked_refresh_cache.assert_any_call(user, mock.ANY, cache_type)
+    batch_update_user_data()
+    assert calc_mock.called is False
+    acquire_mock.assert_called_once_with()
+    assert refresh_mock.called is False
+    assert release_mock.called is False


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #3659 

#### What's this PR do?
Refactors code for the `batch_update_user_data` task. Additionally the locking code should be fixed. Neither change should affect behavior since this task is only run once every 6 hours.

#### How should this be manually tested?
Delete the `UserCacheRefreshTime` object for your user. Run the `batch_update_user_data` task. Verify that the logs say that the lock is released and that there is a new `UserCacheRefreshTime` object for your user.