### PR TITLE
Fixed Cybersource Redirect fails on Safari

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - "9100:9200"
 
   nginx:
-    image: nginx
+    image: nginx:1.11
     ports:
       - "8079:8079"
     links:


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3619

#### What's this PR do?
Configure nginx to add  setting `keepalive_disable safari;` This will disable keep alive connection, helps in redirect. Also add SSL shared memory cache of 10 MB. 

> 1down vote | One of the reasons why it might happen is the way Safari handles some SSL certificated (mainly, LetsEncrypt). The solution is to put the line:

- https://stackoverflow.com/questions/33895463/safari-ajax-request-failed-to-load-resource-the-network-connection-was-lost
- http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_disable

#### How should this be manually tested?
(Required)

#### Where should the reviewer start?
(Optional)

@pdpinch 

<img width="1253" alt="screen shot 2017-10-26 at 5 36 25 pm" src="https://user-images.githubusercontent.com/10431250/32053272-3fce5ec6-ba74-11e7-949a-34ad6ac3ef5b.png">
