### PR TITLE
Fix celery env vars for travis

### DIFF
--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -4,15 +4,15 @@ services:
     build:
       context: .
       dockerfile: ./travis/Dockerfile-travis-web
-    environment:
-      # for celery, to avoid ImproperlyConfigured
-      MAILGUN_URL: 'http://fake.example.com'
-      MAILGUN_KEY: 'fake'
 
   celery:
     build:
       context: .
       dockerfile: ./travis/Dockerfile-travis-web
+    environment:
+      # for celery, to avoid ImproperlyConfigured
+      MAILGUN_URL: 'http://fake.example.com'
+      MAILGUN_KEY: 'fake'
 
   web:
     build:

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -13,6 +13,7 @@ services:
       # for celery, to avoid ImproperlyConfigured
       MAILGUN_URL: 'http://fake.example.com'
       MAILGUN_KEY: 'fake'
+      ELASTICSEARCH_INDEX: 'testindex'
 
   web:
     build:


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes docker-compose configuration to set env vars correctly on travis. Note that tox sets these env vars for web containers and the selenium container already has these set in `docker-compose.selenium.yml`.

#### How should this be manually tested?
There should be no celery container failure in the Travis logs
