### PR TITLE
Don't reference INSTALLED_APPS directly

### DIFF
--- a/micromasters/celery.py
+++ b/micromasters/celery.py
@@ -31,4 +31,4 @@ app = Celery('micromasters')
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
 app.config_from_object('django.conf:settings', namespace='CELERY')
-app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)  # pragma: no cover
+app.autodiscover_tasks()


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Removes function referencing `settings.INSTALLED_APPS`. The Django docs say that `INSTALLED_APPS` should not be referenced, instead we should use `django.apps.apps`. However the Celery docs also say that all tasks in installed apps will be detected if the argument is blank, so we do not need to reference it at all.

#### How should this be manually tested?
In a shell get your user id, then run `search.tasks.index_users.delay([your_user_id])`. Look in the logs and verify that the task was started correctly.
