### PR TITLE
CourseCertificates: create if final grade is complete

### DIFF
--- a/grades/tasks.py
+++ b/grades/tasks.py
@@ -12,6 +12,7 @@ from django_redis import get_redis_connection
 
 from courses.models import CourseRun
 from grades import api
+from grades.constants import FinalGradeStatus
 from grades.models import (
     FinalGrade,
     ProctoredExamGrade,
@@ -39,6 +40,7 @@ def generate_course_certificates_for_fa_students():
         FinalGrade.objects
         .filter(
             course_run__course__program__financial_aid_availability=True,
+            status=FinalGradeStatus.COMPLETE,
             passed=True,
         )
         .annotate(certificate_count=Count('certificate'))

--- a/grades/tasks_pytest_test.py
+++ b/grades/tasks_pytest_test.py
@@ -44,6 +44,7 @@ def test_generate_course_certificates():
     )
     FinalGradeFactory.create(course_run__course=non_fa_course, passed=True)
     FinalGradeFactory.create(course_run__course=course, passed=False)
+    FinalGradeFactory.create(course_run__course=course, passed=True, status='pending')
     # Create ProctoredExamGrade records with a mix of passed and failed outcomes, and exam grade availability
     final_grades_with_passed_exam = passed_final_grades_with_exam[:2]
     final_grades_with_passed_exam_no_grades = passed_final_grades_with_exam[2:4]

--- a/grades/tasks_pytest_test.py
+++ b/grades/tasks_pytest_test.py
@@ -72,8 +72,8 @@ def test_generate_course_certificates():
 
     tasks.generate_course_certificates_for_fa_students.delay()
 
-    # Make sure that certificates were created only for passed FinalGrades that either had no course exam, or had
-    # a passed ProctoredExamGrade.
+    # Make sure that certificates were created only for passed and 'complete' status FinalGrades that either
+    # had no course exam, or had a passed ProctoredExamGrade.
     created_certificates = MicromastersCourseCertificate.objects.all()
     assert len(created_certificates) == 6
     certificate_grade_ids = set([certificate.final_grade.id for certificate in created_certificates])


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Add a filter to `FinalGrade`s when creating `MicromastersCourseCertificate`. This will prevent the certificates creation before the freeze of final grades.

#### How should this be manually tested?
The test creates a final grade with `passed=True` and `status='pending'` and checks that no course certificate is created for it.

