### PR TITLE
Use application log level for celery workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/start-nginx bin/start-pgbouncer-stunnel newrelic-admin run-program uwsgi uwsgi.ini
-worker: celery -A micromasters worker -B
-extra_worker: celery -A micromasters worker
+worker: celery -A micromasters worker -B -l $MICROMASTERS_LOG_LEVEL
+extra_worker: celery -A micromasters worker -l $MICROMASTERS_LOG_LEVEL

--- a/app.json
+++ b/app.json
@@ -162,6 +162,11 @@
     "MICROMASTERS_FROM_EMAIL": {
       "value": "MITx MicroMasters <micromasters-support@mit.edu>"
     },
+    "MICROMASTERS_LOG_LEVEL": {
+      "description": "The logging level for the application",
+      "required": false,
+      "value": "DEBUG"
+    },
     "MICROMASTERS_SECURE_SSL_REDIRECT": {
       "description": "Application-level SSL redirect setting.",
       "required": false,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3684 

#### What's this PR do?
Sets a default log level of `DEBUG` and uses the log level specified in an environment variable for use with celery so its messages can be logged

#### How should this be manually tested?
In the PR build, configure a `CourseRun` to have a `freeze_grade_date` in the future. Open a heroku shell and a heroku log being tailed in a separate terminal window. Run `freeze_course_run_final_grades(course_run_id)` (from `grades.tasks`). You should see an INFO message in the terminal window saying 'the grades course "..." cannot be frozen yet`