### PR TITLE
Fixed discussion user sync issue for users with no profile

### DIFF
--- a/discussions/api.py
+++ b/discussions/api.py
@@ -275,6 +275,7 @@ def get_membership_ids_needing_sync():
     """
     return PercolateQueryMembership.objects.filter(
         query__source_type=PercolateQuery.DISCUSSION_CHANNEL_TYPE,
+        user__profile__isnull=False,
         needs_update=True
     ).values_list("id", flat=True)
 


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
This fixes edge cases where a user has no profile. This would only happen for admin users or simialr edge cases.

#### How should this be manually tested?
Tests should pass