### PR TITLE
Fixed an exception, happens when ZenDesk floating widget is not loaded

### DIFF
--- a/static/js/entry/zendesk_widget.js
+++ b/static/js/entry/zendesk_widget.js
@@ -100,6 +100,10 @@ const zendeskCallbacks = {
 
   launcherLoaded: () => {
     const iframe = document.querySelector("iframe.zEWidget-launcher")
+    if (_.isNull(iframe)) {
+      return
+    }
+
     const btn = iframe.contentDocument.querySelector(".u-userLauncherColor")
     if (_.isNull(btn)) {
       return

--- a/static/js/entry/zendesk_widget.js
+++ b/static/js/entry/zendesk_widget.js
@@ -106,7 +106,7 @@ const zendeskCallbacks = {
     }
 
     const regularBackgroundColor = "rgba(0, 0, 0, .14)"
-    const defaultHoverBackgroundColor = "#a31f34"
+    const defaultHoverBackgroundColor = "#a31f34" // fall back color
     const hoverBackgroundColor = window.getComputedStyle(
       btn,
       defaultHoverBackgroundColor

--- a/static/js/entry/zendesk_widget.js
+++ b/static/js/entry/zendesk_widget.js
@@ -1,6 +1,7 @@
 /* global SETTINGS:false zE:false _:false */
 __webpack_public_path__ = `${SETTINGS.public_path}` // eslint-disable-line no-undef, camelcase
 import R from "ramda"
+import _ from "lodash"
 
 import { wait } from "../util/util"
 
@@ -100,9 +101,16 @@ const zendeskCallbacks = {
   launcherLoaded: () => {
     const iframe = document.querySelector("iframe.zEWidget-launcher")
     const btn = iframe.contentDocument.querySelector(".u-userLauncherColor")
+    if (_.isNull(btn)) {
+      return
+    }
 
     const regularBackgroundColor = "rgba(0, 0, 0, .14)"
-    const hoverBackgroundColor = window.getComputedStyle(btn).backgroundColor
+    const defaultHoverBackgroundColor = "#a31f34"
+    const hoverBackgroundColor = window.getComputedStyle(
+      btn,
+      defaultHoverBackgroundColor
+    ).backgroundColor
     // We need to set a new background color, and unfortunately,
     // the existing background color is set with "!important".
     // As a result, the only way to override this existing color is to


### PR DESCRIPTION
#### What are the relevant tickets?
- fixes https://github.com/mitodl/micromasters/issues/3602#event-1308561463
- https://sentry.io/mit-office-of-digital-learning/micromasters/issues/361180415/events/8370678176/

#### What's this PR do?
It adds a checks/conditions to avoid rendering of zenDesk widget button logic, it happens when button is not loaded in document.

#### How should this be manually tested?
- I was not able to produce the issue, but try to refresh page and look for below exception on console.

```trace
TypeError
Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.
```

@pdpinch 

