### PR TITLE
Added timeout to lock

### DIFF
--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1870,7 +1870,7 @@ def test_calculate_fake_user(users_without_with_cache):
     needs_update, _ = users_without_with_cache
     needs_update[0].profile.fake_user = True
     needs_update[0].profile.save()
-    assert api.calculate_users_to_refresh_in_bulk() == [user.id for user in needs_update[1:]]
+    assert sorted(api.calculate_users_to_refresh_in_bulk()) == sorted([user.id for user in needs_update[1:]])
 
 
 def test_calculate_inactive(users_without_with_cache):
@@ -1878,14 +1878,14 @@ def test_calculate_inactive(users_without_with_cache):
     needs_update, _ = users_without_with_cache
     needs_update[0].is_active = False
     needs_update[0].save()
-    assert api.calculate_users_to_refresh_in_bulk() == [user.id for user in needs_update[1:]]
+    assert sorted(api.calculate_users_to_refresh_in_bulk()) == sorted([user.id for user in needs_update[1:]])
 
 
 def test_calculate_missing_social_auth(users_without_with_cache):
     """Users without a linked social auth should not be counted"""
     needs_update, _ = users_without_with_cache
     needs_update[0].social_auth.all().delete()
-    assert api.calculate_users_to_refresh_in_bulk() == [user.id for user in needs_update[1:]]
+    assert sorted(api.calculate_users_to_refresh_in_bulk()) == sorted([user.id for user in needs_update[1:]])
 
 
 @pytest.mark.parametrize("enrollment,certificate,current_grade,expired", [

--- a/discussions/tasks.py
+++ b/discussions/tasks.py
@@ -13,7 +13,7 @@ from micromasters.celery import app
 from micromasters.utils import now_in_utc
 from profiles.models import Profile
 
-SYNC_MEMBERSHIPS_LOCK_NAME = 'sync_memberships_lock'
+SYNC_MEMBERSHIPS_LOCK_NAME = 'discussions.tasks.sync_memberships_lock'
 
 # let it run for up to 2 minutes minus a 5 second buffer
 # we do the buffer so the lock is cleared before the next cron run
@@ -37,7 +37,12 @@ def _get_sync_memberships_lock():
         # this is a StrictRedis instance, we need this for the script installation that LuaLock uses
         redis = caches['redis'].client.get_client()
         # don't block acquiring the lock, this runs on a 1-minute cron so we'll try again later
-        _SYNC_LOCK = LuaLock(redis, SYNC_MEMBERSHIPS_LOCK_NAME, blocking=False)
+        _SYNC_LOCK = LuaLock(
+            redis,
+            SYNC_MEMBERSHIPS_LOCK_NAME,
+            blocking=False,
+            timeout=SYNC_MEMBERSHIPS_LOCK_TTL_SECONDS
+        )
 
     return _SYNC_LOCK
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3691 

#### What's this PR do?
Adds the timeout param so that the lock expires if the worker crashes.

#### How should this be manually tested?
Run the following:
```python
from django.core.cache import caches
from discussions import tasks
redis= caches['redis'].client.get_client()
lock = tasks.tasks._get_sync_memberships_lock() 
lock.acquire()  # should return True
```
Verify the key is present with a value:
```python
redis.get(tasks.SYNC_MEMBERSHIPS_LOCK_NAME)
```
Wait 2 minutes, then the `get` again and verify the value `is None`