### PR TITLE
Refactor celery locking

### DIFF
--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -1,49 +1,46 @@
 """
 Periodic task that updates user data.
 """
+from datetime import (
+    datetime,
+    timedelta,
+)
 import logging
 
 from celery import group
-from django.core.cache import caches
+import pytz
 
 from dashboard.api import (
     calculate_users_to_refresh_in_bulk,
     refresh_user_data,
 )
 from micromasters.celery import app
-from micromasters.utils import chunks
+from micromasters.locks import (
+    Lock,
+    release_lock,
+)
+from micromasters.utils import (
+    chunks,
+    now_in_utc,
+)
 
 
 log = logging.getLogger(__name__)
-cache_redis = caches['redis']
 
 
 PARALLEL_RATE_LIMIT = '10/m'
-LOCK_EXPIRE = 60 * 60 * 2  # Lock expires in 2 hrs
 LOCK_ID = 'batch_update_user_data_lock'
 
 
-def _acquire_lock():
-    """
-    create lock by adding a key to storage.
-    """
-    # lock will expire if 2 hrs are pass and task is not complete.
-    return cache_redis.add(LOCK_ID, 'true', LOCK_EXPIRE)
-
-
-def _release_lock():
-    """
-    remove lock by deleting key from storage.
-    """
-    return cache_redis.delete(LOCK_ID)
-
-
 @app.task
-def release_batch_update_user_data_lock(*args):  # pylint: disable=unused-argument
+def release_batch_update_user_data_lock(*args, token):  # pylint: disable=unused-argument
     """
     Task which releases the lock acquired in batch_update_user_data
+
+    Args:
+        token (str): The token used with the lock
     """
-    _release_lock()
+    release_lock(LOCK_ID, token.encode())
     log.info("Released batch_update_user_data lock")
 
 
@@ -56,34 +53,40 @@ def batch_update_user_data():
     Create sub tasks to update user data like enrollments,
     certificates and grades from edX platform.
     """
-    if not _acquire_lock():
-        # Should not usually happen. This task executes every 6 hours and the lock expires after 2.
-        log.error("Unable to acquire lock to batch_update_user_data.")
+    expiration = now_in_utc() + timedelta(hours=5)
+    lock = Lock(LOCK_ID, expiration)
+    if not lock.acquire():
+        # Lock should have expired by now
+        log.error("Unable to acquire lock for batch_update_user_data")
         return
 
     users_to_refresh = calculate_users_to_refresh_in_bulk()
 
-    if len(users_to_refresh) > 0:
-        job = group(
-            batch_update_user_data_subtasks.s(list_users)
-            for list_users in chunks(users_to_refresh)
-        )
-        # release_batch_update_user_data_lock will not get executed if any of the subtasks error,
-        # but we handle all exceptions in the subtask so that shouldn't happen
-        jobs = job | release_batch_update_user_data_lock.s()
-    else:
-        # celery requires at least one item in a group(...)
-        jobs = release_batch_update_user_data_lock
-    jobs.delay()
+    jobs = release_batch_update_user_data_lock.s(token=lock.token.decode())
+    try:
+        if len(users_to_refresh) > 0:
+            user_id_chunks = chunks(users_to_refresh)
+
+            job = group(
+                batch_update_user_data_subtasks.s(user_id_chunk, expiration.timestamp())
+                for user_id_chunk in user_id_chunks
+            )
+            jobs = job | jobs
+    finally:
+        jobs.delay()
 
 
 @app.task(rate_limit=PARALLEL_RATE_LIMIT)
-def batch_update_user_data_subtasks(students):
+def batch_update_user_data_subtasks(students, expiration_timestamp):
     """
     Update user data like enrollments, certificates and grades from edX platform.
 
     Args:
         students (list of int): List of user ids for students.
+        expiration_timestamp (float): A timestamp indicating when the tasks should stop processing
     """
+    expiration = datetime.fromtimestamp(expiration_timestamp, tz=pytz.utc)
     for user_id in students:
-        refresh_user_data(user_id)
+        # if we are past the expiration time we should stop any extra work
+        if expiration > now_in_utc():
+            refresh_user_data(user_id)

--- a/dashboard/tasks_test.py
+++ b/dashboard/tasks_test.py
@@ -1,8 +1,14 @@
 """
 Tests for tasks
 """
-from dashboard.tasks import batch_update_user_data
+from datetime import timedelta
+
+from dashboard.tasks import (
+    batch_update_user_data,
+    LOCK_ID,
+)
 from micromasters.factories import SocialUserFactory
+from micromasters.utils import is_near_now
 
 
 def test_nothing_to_do(mocker):
@@ -10,15 +16,23 @@ def test_nothing_to_do(mocker):
     If there's nothing to update batch_update_user_date should only acquire and release the lock
     """
     calc_mock = mocker.patch('dashboard.tasks.calculate_users_to_refresh_in_bulk', autospec=True, return_value=[])
-    acquire_mock = mocker.patch('dashboard.tasks._acquire_lock', autospec=True, return_value=True)
+    lock_mock_init = mocker.patch('dashboard.tasks.Lock', autospec=True)
+    lock_mock = lock_mock_init.return_value
+    token = b'token'
+    lock_mock.token = token
+    lock_mock.acquire.return_value = True
     refresh_mock = mocker.patch('dashboard.tasks.refresh_user_data', autospec=True)
-    release_mock = mocker.patch('dashboard.tasks._release_lock', autospec=True)
+    release_mock = mocker.patch('dashboard.tasks.release_lock', autospec=True)
 
     batch_update_user_data()
+
+    assert lock_mock_init.call_args[0][0] == LOCK_ID
+    assert is_near_now(lock_mock_init.call_args[0][1] - timedelta(hours=5))
     calc_mock.assert_called_once_with()
-    acquire_mock.assert_called_once_with()
+    lock_mock.acquire.assert_called_once_with()
     assert refresh_mock.called is False
-    release_mock.assert_called_once_with()
+    assert release_mock.call_count == 1
+    release_mock.assert_called_once_with(LOCK_ID, token)
 
 
 def test_batch_update(mocker, db):  # pylint: disable=unused-argument
@@ -29,17 +43,24 @@ def test_batch_update(mocker, db):  # pylint: disable=unused-argument
     calc_mock = mocker.patch('dashboard.tasks.calculate_users_to_refresh_in_bulk', autospec=True, return_value=[
         user.id for user in users
     ])
-    acquire_mock = mocker.patch('dashboard.tasks._acquire_lock', autospec=True, return_value=True)
+    lock_mock_init = mocker.patch('dashboard.tasks.Lock', autospec=True)
+    lock_mock = lock_mock_init.return_value
+    token = b'token'
+    lock_mock.token = token
+    lock_mock.acquire.return_value = True
     refresh_mock = mocker.patch('dashboard.tasks.refresh_user_data', autospec=True)
-    release_mock = mocker.patch('dashboard.tasks._release_lock', autospec=True)
+    release_mock = mocker.patch('dashboard.tasks.release_lock', autospec=True)
 
     batch_update_user_data()
+
+    assert lock_mock_init.call_args[0][0] == LOCK_ID
+    assert is_near_now(lock_mock_init.call_args[0][1] - timedelta(hours=5))
     calc_mock.assert_called_once_with()
-    acquire_mock.assert_called_once_with()
+    lock_mock.acquire.assert_called_once_with()
     assert refresh_mock.call_count == len(users)
     for user in users:
         refresh_mock.assert_any_call(user.id)
-    release_mock.assert_called_once_with()
+    release_mock.assert_called_once_with(LOCK_ID, token)
 
 
 def test_failed_to_acquire(mocker):
@@ -47,12 +68,17 @@ def test_failed_to_acquire(mocker):
     If the lock is held there should be nothing else done
     """
     calc_mock = mocker.patch('dashboard.tasks.calculate_users_to_refresh_in_bulk', autospec=True, return_value=[])
-    acquire_mock = mocker.patch('dashboard.tasks._acquire_lock', autospec=True, return_value=False)
+    lock_mock_init = mocker.patch('dashboard.tasks.Lock', autospec=True)
+    lock_mock = lock_mock_init.return_value
+    lock_mock.acquire.return_value = False
     refresh_mock = mocker.patch('dashboard.tasks.refresh_user_data', autospec=True)
-    release_mock = mocker.patch('dashboard.tasks._release_lock', autospec=True)
+    release_mock = mocker.patch('dashboard.tasks.release_lock', autospec=True)
 
     batch_update_user_data()
+
+    assert lock_mock_init.call_args[0][0] == LOCK_ID
+    assert is_near_now(lock_mock_init.call_args[0][1] - timedelta(hours=5))
     assert calc_mock.called is False
-    acquire_mock.assert_called_once_with()
+    lock_mock.acquire.assert_called_once_with()
     assert refresh_mock.called is False
     assert release_mock.called is False

--- a/micromasters/locks.py
+++ b/micromasters/locks.py
@@ -1,0 +1,130 @@
+"""Code relating to redis locks"""
+from contextlib import AbstractContextManager
+
+from django.core.cache import caches
+from redis.exceptions import LockError
+from redis.lock import LuaLock
+
+from micromasters.utils import now_in_utc
+
+
+def _get_lock(lock_name, expiration):
+    """
+    Creates a new redis LuaLock
+
+    Args:
+        lock_name (str): The name of the lock
+        expiration (datetime.datetime): The expiration datetime
+
+    Returns:
+        redis.lock.LuaLock: a redis lua-based lock
+    """
+    timeout = int((expiration - now_in_utc()).total_seconds())
+
+    # this is a StrictRedis instance, we need this for the script installation that LuaLock uses
+    redis = caches['redis'].client.get_client()
+    # don't block acquiring the lock, the task will need to try again later
+    return LuaLock(redis, lock_name, timeout=timeout, blocking=False, thread_local=False)
+
+
+def release_lock(lock_name, token):
+    """
+    Release a lock
+
+    Args:
+        lock_name (str): The lock key in redis
+        token (bytes): The unique id used
+
+    Returns:
+        bool: True if the lock was successfully released
+    """
+    # this is a StrictRedis instance, we need this for the script installation that LuaLock uses
+    redis = caches['redis'].client.get_client()
+    lock = LuaLock(redis, lock_name)
+    try:
+        lock.do_release(token)
+    except LockError:
+        # If the lock is expired we don't want to raise an error
+        pass
+
+
+class Lock(AbstractContextManager):
+    """
+    Attempt to acquire a lock. If so is_still_locked is yielded to the with block
+    """
+
+    def __init__(self, lock_name, expiration):
+        """
+        Initialize the Lock
+
+        Args:
+            lock_name (str): The name of the lock
+            expiration (datetime.datetime): The expiration datetime
+        """
+        self.lock = _get_lock(lock_name, expiration)
+        self.expiration = expiration
+        self.acquired = False
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Release the lock. This doesn't deal with the exception arguments, instead None is implicitly returned
+        indicating that the exception will be propagated.
+        """
+        self.release()
+
+    def acquire(self):
+        """
+        Acquire a lock
+        """
+        if not self.acquired:
+            self.acquired = self.lock.acquire()
+            return self.acquired
+        else:
+            return False
+
+    def release(self):
+        """
+        Release the lock
+        """
+        if self.acquired:
+            try:
+                self.lock.release()
+            except LockError:
+                pass  # expected if we don't own the lock anymore
+            finally:
+                self.acquired = False
+
+    def is_still_locked(self, *args, **kwargs):  # pylint: disable=unused-argument
+        """
+        Is the lock held?
+
+        Arguments are ignored to allow for easier use with itertools.takewhile
+
+        Returns:
+            bool: True if the lock is held
+        """
+        return self.acquired and self.expiration > now_in_utc()
+
+    @property
+    def token(self):
+        """
+        Return the token used to lock the value, if any was set
+
+        Returns:
+            bytes: The token used for the redis lock
+        """
+        return self.lock.local.token
+
+    @property
+    def name(self):
+        """
+        Return the key used for the lock
+
+        Returns:
+            str: The key used for the lock
+        """
+        return self.lock.name

--- a/micromasters/locks_test.py
+++ b/micromasters/locks_test.py
@@ -1,0 +1,135 @@
+"""Tests for redis locks"""
+from datetime import timedelta
+from itertools import takewhile
+import time
+import uuid
+
+import pytest
+
+from micromasters.locks import (
+    Lock,
+    release_lock,
+)
+from micromasters.utils import now_in_utc
+
+
+def _make_lock(seconds):
+    """Helper to make a lock"""
+    lock_name = uuid.uuid4().hex
+    expiration = now_in_utc() + timedelta(seconds=seconds)
+    return Lock(lock_name, expiration)
+
+
+@pytest.fixture
+def long_lock():
+    """A lock with a long expiration (relative to unit tests anyway)"""
+    lock = _make_lock(5)
+    yield lock
+    lock.release()
+
+
+@pytest.fixture
+def quick_lock():
+    """A lock with a very short expiration"""
+    lock = _make_lock(0.1)
+    yield lock
+    lock.release()
+
+
+# pylint: disable=redefined-outer-name
+def test_lock_contextmanager():
+    """
+    A lock should hold the lock and release it after the context block is finished
+    """
+    lock_name = "test_lock_contextmanager"
+    expiration = now_in_utc() + timedelta(seconds=0.2)
+    with Lock(lock_name, expiration) as lock:
+        iterable = takewhile(lock.is_still_locked, range(5))
+        assert next(iterable) == 0
+        assert next(iterable) == 1
+        assert lock.is_still_locked() is True
+
+        time.sleep(0.2)
+        assert list(iterable) == []
+        assert lock.is_still_locked() is False
+
+
+def test_lock_acquire(long_lock):
+    """
+    A lock should acquire a lock and release it
+    """
+    assert long_lock.acquired is False
+    assert long_lock.is_still_locked() is False
+
+    assert long_lock.acquire() is True
+    assert long_lock.acquired is True
+    assert long_lock.is_still_locked() is True
+
+    # Acquiring the lock again will not do anything
+    assert long_lock.acquire() is False
+    assert long_lock.acquired is True
+    assert long_lock.is_still_locked() is True
+
+
+def test_lock_release(long_lock):
+    """A lock should get released"""
+    # Releasing a lock before it's acquired should do nothing
+    long_lock.release()
+    assert long_lock.acquired is False
+    assert long_lock.is_still_locked() is False
+
+    assert long_lock.acquire() is True
+    assert long_lock.acquired is True
+    assert long_lock.is_still_locked() is True
+
+    long_lock.release()
+    assert long_lock.acquired is False
+    assert long_lock.is_still_locked() is False
+
+    # Releasing an already released lock should not change anything
+    long_lock.release()
+    assert long_lock.acquired is False
+    assert long_lock.is_still_locked() is False
+
+
+def test_lock_expired(quick_lock):
+    """
+    An expired lock will show up as acquired but is_still_locked is false
+    """
+    assert quick_lock.acquire() is True
+    assert quick_lock.acquired is True
+    assert quick_lock.is_still_locked() is True
+
+    time.sleep(0.2)
+    assert quick_lock.acquired is True
+    assert quick_lock.is_still_locked() is False
+
+    quick_lock.release()
+    assert quick_lock.acquired is False
+    assert quick_lock.is_still_locked() is False
+
+
+def test_release_lock(long_lock):
+    """
+    release_lock can take a separate token and release the lock that way
+    """
+    assert long_lock.token is None
+    assert long_lock.acquire() is True
+    token = long_lock.token
+    assert long_lock.token is not None
+
+    # Releasing a different lock will not do anything
+    release_lock("different", b"token")
+
+    # Since we didn't release the lock acquiring it again will not work
+    assert Lock(long_lock.name, long_lock.expiration).acquire() is False
+
+    wrong_token = b"wrong_token"
+    assert token != wrong_token
+    release_lock(long_lock.name, b"wrong_token")
+    # We had the wrong token, releasing did not work
+    assert Lock(long_lock.name, long_lock.expiration).acquire() is False
+
+    # This release does work because the token matches up
+    release_lock(long_lock.name, token)
+    assert Lock(long_lock.name, long_lock.expiration).acquire() is True


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #3659 

#### What's this PR do?
Refactors the redis lock code to be shared between `batch_user_update_tasks` and `sync_discussion_users`. There is no behavioral change yet

#### How should this be manually tested?

 - pick a real user on your machine and delete the `UserCacheRefreshTime` for that user
 - In `dashboard.api.refresh_user_data` add a `time.sleep(12345)` to the beginning of the function so it takes a really long time
 - Run `batch_update_user_data.delay()` twice. The second time you should see 'Unable to acquire lock for batch_update_user_data'
