### PR TITLE
Count cache update failure for user

### DIFF
--- a/backends/views.py
+++ b/backends/views.py
@@ -4,6 +4,8 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 from social_django.views import complete as social_complete
 from social_django.utils import psa
+from django_redis import get_redis_connection
+from dashboard.api import CACHE_KEY_FAILURE_NUMS_BY_USER, FIELD_USER_ID_BASE_STR, CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE
 
 
 @never_cache
@@ -24,4 +26,13 @@ def complete(request, *args, **kwargs):
         request.session[key] = backend_state
 
     # Continue with social_core pipeline
-    return social_complete(request, *args, **kwargs)
+    social_complete_rtn = social_complete(request, *args, **kwargs)
+
+    # Update redis cache if user had invalid credentials
+    con = get_redis_connection("redis")
+    user_key = FIELD_USER_ID_BASE_STR.format(request.user.id)
+    if con.hexists(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key):
+        con.hdel(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key)
+        con.srem(CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE, user_key)
+
+    return social_complete_rtn

--- a/backends/views.py
+++ b/backends/views.py
@@ -29,10 +29,11 @@ def complete(request, *args, **kwargs):
     social_complete_rtn = social_complete(request, *args, **kwargs)
 
     # Update redis cache if user had invalid credentials
-    con = get_redis_connection("redis")
-    user_key = FIELD_USER_ID_BASE_STR.format(request.user.id)
-    if con.hexists(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key):
-        con.hdel(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key)
-        con.srem(CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE, user_key)
+    if request.user.is_authenticated():
+        con = get_redis_connection("redis")
+        user_key = FIELD_USER_ID_BASE_STR.format(request.user.id)
+        if con.hexists(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key):
+            con.hdel(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key)
+            con.srem(CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE, user_key)
 
     return social_complete_rtn

--- a/backends/views.py
+++ b/backends/views.py
@@ -32,8 +32,7 @@ def complete(request, *args, **kwargs):
     if request.user.is_authenticated():
         con = get_redis_connection("redis")
         user_key = FIELD_USER_ID_BASE_STR.format(request.user.id)
-        if con.hexists(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key):
-            con.hdel(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key)
-            con.srem(CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE, user_key)
+        con.hdel(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key)
+        con.srem(CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE, user_key)
 
     return social_complete_rtn

--- a/backends/views.py
+++ b/backends/views.py
@@ -33,6 +33,6 @@ def complete(request, *args, **kwargs):
         con = get_redis_connection("redis")
         user_key = FIELD_USER_ID_BASE_STR.format(request.user.id)
         con.hdel(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key)
-        con.srem(CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE, user_key)
+        con.srem(CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE, request.user.id)
 
     return social_complete_rtn

--- a/backends/views_test.py
+++ b/backends/views_test.py
@@ -33,7 +33,7 @@ class BackendViewTest(MockedESTestCase, APITestCase):
         """
         def log_user_again(request, *args, **kwargs):  # pylint: disable=unused-argument
             """mock function to login the user again"""
-            self.client.force_login(request.user)
+            request.user = self.user
             return HttpResponse()
 
         mocked_complete.side_effect = log_user_again

--- a/backends/views_test.py
+++ b/backends/views_test.py
@@ -1,0 +1,47 @@
+"""
+Tests for backends views
+"""
+from unittest.mock import patch
+from django.http import HttpResponse
+from rest_framework.test import APITestCase
+from django.core.urlresolvers import reverse
+from django_redis import get_redis_connection
+
+from dashboard.factories import UserCacheRefreshTimeFactory
+from dashboard.api import CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE
+from micromasters.factories import SocialUserFactory
+from search.base import MockedESTestCase
+
+
+class BackendViewTest(MockedESTestCase, APITestCase):
+    """
+    Tests for dashboard Rest API
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super(BackendViewTest, cls).setUpTestData()
+        # create a user
+        cls.user = SocialUserFactory.create()
+        UserCacheRefreshTimeFactory(user=cls.user, unexpired=True)
+        cls.url = reverse('social:complete', args=['edxorg'])
+
+    @patch('backends.views.social_complete', autospec=True)
+    def test_redis_cache_updated(self, mocked_complete):
+        """
+        Test
+        """
+
+        def log_user_again(request, *args, **kwargs):
+            self.client.force_login(request.user)
+            return HttpResponse()
+
+        mocked_complete.side_effect = log_user_again
+
+        con = get_redis_connection("redis")
+        con.sadd(CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE, self.user.id)
+        assert con.sismember(CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE, self.user.id) is True
+
+        self.client.get(self.url)
+        assert mocked_complete.call_count == 1
+        assert con.sismember(CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE, self.user.id) is False

--- a/backends/views_test.py
+++ b/backends/views_test.py
@@ -3,9 +3,9 @@ Tests for backends views
 """
 from unittest.mock import patch
 from django.http import HttpResponse
-from rest_framework.test import APITestCase
 from django.core.urlresolvers import reverse
 from django_redis import get_redis_connection
+from rest_framework.test import APITestCase
 
 from dashboard.factories import UserCacheRefreshTimeFactory
 from dashboard.api import CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE
@@ -29,10 +29,10 @@ class BackendViewTest(MockedESTestCase, APITestCase):
     @patch('backends.views.social_complete', autospec=True)
     def test_redis_cache_updated(self, mocked_complete):
         """
-        Test
+        Test when user logs in again redis cache entry for that user is cleared
         """
-
-        def log_user_again(request, *args, **kwargs):
+        def log_user_again(request, *args, **kwargs):  # pylint: disable=unused-argument
+            """mock function to login the user again"""
             self.client.force_login(request.user)
             return HttpResponse()
 

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -622,9 +622,6 @@ def save_cache_update_failure(user_id):
     """
     con = get_redis_connection("redis")
     user_key = FIELD_USER_ID_BASE_STR.format(user_id)
-    if con.hexists(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key):
-        new_value = con.hincrby(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key, 1)
-        if int(new_value) >= 3:
-            con.sadd(CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE, user_id)
-    else:
-        con.hset(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key, 1)
+    new_value = con.hincrby(CACHE_KEY_FAILURE_NUMS_BY_USER, user_key, 1)
+    if int(new_value) >= 3:
+        con.sadd(CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE, user_id)

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -33,7 +33,9 @@ ATTEMPTS_PER_PAID_RUN = 2
 COURSE_GRADE_WEIGHT = 0.4
 EXAM_GRADE_WEIGHT = 0.6
 
+# key that stores user_key and number of failures in a hash
 CACHE_KEY_FAILURE_NUMS_BY_USER = "update_cache_401_failure_numbers"
+# key that stores user ids to exclude from cache update
 CACHE_KEY_FAILED_USERS_NOT_TO_UPDATE = "failed_cache_update_users_not_to_update"
 FIELD_USER_ID_BASE_STR = "user_{0}"
 

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -2012,7 +2012,7 @@ def test_refresh_update_cache(db, mocker, failed_cache_type):
     edx_api = mocker.Mock()
     edx_api_init = mocker.patch('dashboard.api.EdxApi', autospec=True, return_value=edx_api)
 
-    def _update_cache(self, user, edx_client, cache_type):
+    def _update_cache(user, edx_client, cache_type):
         """Fail updating the cache for only the given cache type"""
         if cache_type == failed_cache_type:
             raise KeyError()
@@ -2020,12 +2020,12 @@ def test_refresh_update_cache(db, mocker, failed_cache_type):
     update_cache_mock = mocker.patch(
         'dashboard.api.CachedEdxDataApi.update_cache_if_expired', side_effect=_update_cache,
     )
-    save_failure_mock = mocker.patch('dashboard.api.save_cache_update_failure')
+    save_failure_mock = mocker.patch('dashboard.api.save_cache_update_failure', autospec=True)
 
     api.refresh_user_data(user.id)
 
     refresh_user_token_mock.assert_called_once_with(user_social)
     edx_api_init.assert_called_once_with(user_social.extra_data, settings.EDXORG_BASE_URL)
-    assert save_failure_mock.call_count == 3
+    assert save_failure_mock.call_count == 1
     for cache_type in CachedEdxDataApi.SUPPORTED_CACHES:
         update_cache_mock.assert_any_call(user, edx_api, cache_type)


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #2383 
Fix #2132

#### What's this PR do?
Count the number of authentication failures per student, and after the third one do not try to update cache for that user until that user logs in and updates the credentials.

#### How should this be manually tested?
Play around with making your user credentials invalid, and then calling `refresh_user_data`.

