### PR TITLE
Disable re-enroll button for courses with future enrollment start date

### DIFF
--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -3,7 +3,6 @@
 import React from "react"
 import PropTypes from "prop-types"
 import Button from "react-mdl/lib/Button"
-import _ from "lodash"
 import R from "ramda"
 
 import SpinnerButton from "../SpinnerButton"
@@ -90,15 +89,12 @@ export default class CourseAction extends React.Component {
     }
   }
 
-  shouldDisableEnrollBtn = (run: CourseRun): boolean =>
-    R.not(isEnrollableRun(run)) || _.isEmpty(run.course_id)
-
   renderEnrollButton(run: CourseRun, actionType: string): React$Element<*> {
     return (
       <div className="course-action">
         <SpinnerButton
           className="dashboard-button enroll-button"
-          disabled={this.shouldDisableEnrollBtn(run)}
+          disabled={R.not(isEnrollableRun(run))}
           component={Button}
           spinning={run.status === STATUS_PENDING_ENROLLMENT}
           onClick={() => this.handleEnrollButtonClick(run)}

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -90,7 +90,7 @@ export default class CourseAction extends React.Component {
     }
   }
 
-  isFutureCourse = (run: CourseRun): boolean =>
+  shouldDisableEnrollBtn = (run: CourseRun): boolean =>
     R.not(isEnrollableRun(run)) || _.isEmpty(run.course_id)
 
   renderEnrollButton(run: CourseRun, actionType: string): React$Element<*> {
@@ -98,7 +98,7 @@ export default class CourseAction extends React.Component {
       <div className="course-action">
         <SpinnerButton
           className="dashboard-button enroll-button"
-          disabled={this.isFutureCourse(run)}
+          disabled={this.shouldDisableEnrollBtn(run)}
           component={Button}
           spinning={run.status === STATUS_PENDING_ENROLLMENT}
           onClick={() => this.handleEnrollButtonClick(run)}

--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -3,6 +3,8 @@
 import React from "react"
 import PropTypes from "prop-types"
 import Button from "react-mdl/lib/Button"
+import _ from "lodash"
+import R from "ramda"
 
 import SpinnerButton from "../SpinnerButton"
 import type { Coupon } from "../../flow/couponTypes"
@@ -18,6 +20,7 @@ import {
   COURSE_ACTION_REENROLL
 } from "../../constants"
 import { isFreeCoupon } from "../../lib/coupon"
+import { isEnrollableRun } from "./courses/util"
 
 export default class CourseAction extends React.Component {
   static contextTypes = {
@@ -87,11 +90,15 @@ export default class CourseAction extends React.Component {
     }
   }
 
+  isFutureCourse = (run: CourseRun): boolean =>
+    R.not(isEnrollableRun(run)) || _.isEmpty(run.course_id)
+
   renderEnrollButton(run: CourseRun, actionType: string): React$Element<*> {
     return (
       <div className="course-action">
         <SpinnerButton
           className="dashboard-button enroll-button"
+          disabled={this.isFutureCourse(run)}
           component={Button}
           spinning={run.status === STATUS_PENDING_ENROLLMENT}
           onClick={() => this.handleEnrollButtonClick(run)}

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -1,7 +1,7 @@
 /* global SETTINGS: false */
 import React from "react"
 import { shallow } from "enzyme"
-import moment from "moment"
+import moment from "moment-timezone"
 import { assert } from "chai"
 import sinon from "sinon"
 import Button from "react-mdl/lib/Button"
@@ -93,6 +93,52 @@ describe("CourseAction", () => {
       const wrapper = renderCourseAction({ actionType: COURSE_ACTION_REENROLL })
       assert.equal(wrapper.find(SpinnerButton).props().children, "Re-Enroll")
     })
+
+    for (const data of [
+      ["", "", true],
+      ["foo/bar/baz", "", true],
+      [
+        "foo/bar/baz",
+        moment()
+          .add(10, "days")
+          .toISOString(),
+        true
+      ],
+      [
+        "",
+        moment()
+          .add(10, "days")
+          .toISOString(),
+        true
+      ],
+      [
+        "",
+        moment()
+          .subtract(10, "days")
+          .toISOString(),
+        true
+      ],
+      [
+        "foo/bar/baz",
+        moment()
+          .subtract(10, "days")
+          .toISOString(),
+        false
+      ]
+    ]) {
+      it(`should ${data[2] ? "disable" : "enable"} Re-Enroll button`, () => {
+        const run = course.runs[0]
+        run.status = STATUS_OFFERED
+        run.course_id = data[0]
+        run.enrollment_start_date = data[1]
+
+        const wrapper = renderCourseAction({
+          actionType: COURSE_ACTION_REENROLL,
+          courseRun:  run
+        })
+        assert.equal(wrapper.find(SpinnerButton).props().disabled, data[2])
+      })
+    }
   })
 
   describe("course payment", () => {
@@ -131,6 +177,7 @@ describe("CourseAction", () => {
       const firstRun = alterFirstRun(course, {
         enrollment_start_date: now.toISOString()
       })
+      firstRun.status = STATUS_OFFERED
 
       const wrapper = renderCourseAction({
         courseRun:    firstRun,
@@ -142,7 +189,7 @@ describe("CourseAction", () => {
         actionType:      COURSE_ACTION_ENROLL
       })
       const button = wrapper.find(SpinnerButton)
-      assert.isUndefined(button.props().disabled)
+      assert.isFalse(button.props().disabled)
       assert.equal(button.props().children, "Enroll")
     })
 

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -272,10 +272,20 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
         paymentDueDate.isBefore(moment())
       ) {
         const date = run => formatDate(run.course_start_date)
-        const msg = run =>
-          `You missed the payment deadline, but you can re-enroll. Next course starts ${date(
+        const msg = run => {
+          let enrollmentDateMessage = ""
+          if (
+            !R.isNil(run.enrollment_start_date) &&
+            R.not(isEnrollableRun(run))
+          ) {
+            enrollmentDateMessage = ` Enrollment starts ${formatDate(
+              run.enrollment_start_date
+            )}`
+          }
+          return `You missed the payment deadline, but you can re-enroll. Next course starts ${date(
             run
-          )}`
+          )}.${enrollmentDateMessage}`
+        }
         messages.push(
           S.maybe(
             {

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -276,7 +276,8 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
           let enrollmentDateMessage = ""
           if (
             !R.isNil(run.enrollment_start_date) &&
-            R.not(isEnrollableRun(run))
+            !R.isEmpty(run.enrollment_start_date) &&
+            !isEnrollableRun(run)
           ) {
             enrollmentDateMessage = ` Enrollment starts ${formatDate(
               run.enrollment_start_date
@@ -321,15 +322,28 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   } else {
     if (hasFailedCourseRun(course) && !hasPassedCourseRun(course)) {
       const date = run => formatDate(run.course_start_date)
+      const msg = run => {
+        let enrollmentDateMessage = ""
+        if (
+          !R.isNil(run.enrollment_start_date) &&
+          !R.isEmpty(run.enrollment_start_date) &&
+          !isEnrollableRun(run)
+        ) {
+          enrollmentDateMessage = ` Enrollment starts ${formatDate(
+            run.enrollment_start_date
+          )}`
+        }
+        return `You did not pass the edX course, but you can re-enroll. Next course starts ${date(
+          run
+        )}.${enrollmentDateMessage}`
+      }
       return S.Just(
         S.maybe(
           messages.concat({ message: "You did not pass the edX course." }),
           run =>
             messages.concat({
-              message: `You did not pass the edX course, but you can re-enroll. Next course starts ${date(
-                run
-              )}.`,
-              action: courseAction(run, COURSE_ACTION_REENROLL)
+              message: msg(run),
+              action:  courseAction(run, COURSE_ACTION_REENROLL)
             }),
           futureEnrollableRun(course)
         )

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -392,6 +392,9 @@ describe("Course Status Messages", () => {
       makeRunPassed(course.runs[0])
       makeRunOverdue(course.runs[0])
       makeRunFuture(course.runs[1])
+      course.runs[1].enrollment_start_date = moment()
+        .subtract(10, "days")
+        .toISOString()
       const date = formatDate(course.runs[1].course_start_date)
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
@@ -412,15 +415,11 @@ describe("Course Status Messages", () => {
       [
         moment()
           .add(10, "days")
-          .format(),
-        ` Enrollment starts ${formatDate(
-          moment()
-            .add(10, "days")
-            .format()
-        )}`
+          .toISOString(),
+        ` Enrollment starts ${formatDate(moment().add(10, "days"))}`
       ]
     ]) {
-      it("should nag about missing the payment deadline and future re-enrollments", () => {
+      it(`should nag about missing the payment deadline when future re-enrollments and date is ${nextEnrollmentStart[0]}`, () => {
         makeRunPast(course.runs[0])
         makeRunPassed(course.runs[0])
         makeRunOverdue(course.runs[0])
@@ -540,6 +539,9 @@ describe("Course Status Messages", () => {
       makeRunPast(course.runs[0])
       makeRunFailed(course.runs[0])
       makeRunFuture(course.runs[1])
+      course.runs[1].enrollment_start_date = moment()
+        .subtract(10, "days")
+        .toISOString()
       const date = moment(course.runs[1].course_start_date).format("MM/DD/YYYY")
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
@@ -560,15 +562,11 @@ describe("Course Status Messages", () => {
       [
         moment()
           .add(10, "days")
-          .format(),
-        ` Enrollment starts ${formatDate(
-          moment()
-            .add(10, "days")
-            .format()
-        )}`
+          .toISOString(),
+        ` Enrollment starts ${formatDate(moment().add(10, "days"))}`
       ]
     ]) {
-      it("should inform next enrollment date after failing edx course", () => {
+      it(`should inform next enrollment date after failing edx course when date is ${nextEnrollmentStart[0]}`, () => {
         makeRunPast(course.runs[0])
         makeRunFailed(course.runs[0])
         makeRunFuture(course.runs[1])

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -93,5 +93,6 @@ export const futureEnrollableRun = R.compose(
 // checks if a run is enrollable
 export const isEnrollableRun = (run: CourseRun): boolean =>
   !R.isNil(run.enrollment_start_date) &&
+  !R.isEmpty(run.enrollment_start_date) &&
   moment(run.enrollment_start_date).isSameOrBefore(moment(), "day") &&
   run.status === STATUS_OFFERED

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -1,5 +1,5 @@
 // @flow
-import moment from "moment"
+import moment from "moment-timezone"
 import R from "ramda"
 
 import type { CourseRun } from "../../../flow/programTypes"
@@ -92,6 +92,7 @@ export const futureEnrollableRun = R.compose(
 
 // checks if a run is enrollable
 export const isEnrollableRun = (run: CourseRun): boolean =>
+  !R.isEmpty(run.course_id) &&
   !R.isNil(run.enrollment_start_date) &&
   !R.isEmpty(run.enrollment_start_date) &&
   moment(run.enrollment_start_date).isSameOrBefore(moment(), "day") &&

--- a/static/js/components/dashboard/courses/util_test.js
+++ b/static/js/components/dashboard/courses/util_test.js
@@ -1,6 +1,6 @@
 // @flow
 import { assert } from "chai"
-import moment from "moment"
+import moment from "moment-timezone"
 
 import { makeCourse, makeRun } from "../../../factories/dashboard"
 import {
@@ -339,5 +339,10 @@ describe("dashboard course utilities", () => {
         assert.equal(isEnrollableRun(course.runs[0]), data[1])
       })
     }
+
+    it("should return false when course id is empty", () => {
+      course.runs[0].course_id = ""
+      assert.isFalse(isEnrollableRun(course.runs[0]))
+    })
   })
 })

--- a/static/js/components/dashboard/courses/util_test.js
+++ b/static/js/components/dashboard/courses/util_test.js
@@ -14,7 +14,8 @@ import {
   hasFailedCourseRun,
   futureEnrollableRun,
   hasEnrolledInAnyRun,
-  hasPassedCourseRun
+  hasPassedCourseRun,
+  isEnrollableRun
 } from "./util"
 import {
   STATUS_PASSED,
@@ -304,5 +305,39 @@ describe("dashboard course utilities", () => {
     it("should return false if the user has never enrolled", () => {
       assert.isFalse(hasEnrolledInAnyRun(course))
     })
+  })
+
+  describe("isEnrollableRun", () => {
+    const now = moment()
+    let course
+
+    beforeEach(() => {
+      course = makeCourse(0)
+    })
+
+    for (const data of [
+      ["", false],
+      [now.toISOString(), true],
+      [
+        moment()
+          .add(10, "days")
+          .toISOString(),
+        false
+      ],
+      [
+        moment()
+          .subtract(10, "days")
+          .toISOString(),
+        true
+      ]
+    ]) {
+      it(`should return ${data[1]
+        ? "true"
+        : "false"} for enrollment_start_date = ${data[0]}`, () => {
+        course.runs[0].status = STATUS_OFFERED
+        course.runs[0].enrollment_start_date = data[0]
+        assert.equal(isEnrollableRun(course.runs[0]), data[1])
+      })
+    }
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3688

#### What's this PR do?
It disables re enroll button and adds next enrollment start date for courses with future enrollment start date

#### How should this be manually tested?
- Go to admin dashboard then course and change the enrollment start date of run to some future date.
- open MM dashboard and check the re-enroll button it should be disable, and see the text with it, it shall have new enrollment start date

<img width="724" alt="screen shot 2017-11-06 at 6 41 00 pm" src="https://user-images.githubusercontent.com/10431250/32444142-51f6646a-c323-11e7-896a-5119a9b81489.png">


@pdpinch 
#### Screenshots (if appropriate)
<img width="677" alt="screen shot 2017-11-06 at 6 40 03 pm" src="https://user-images.githubusercontent.com/10431250/32444077-2171baba-c323-11e7-8e00-be9fec2b4d7a.png">

