### PR TITLE
Propagate 409 response from open-discussions when creating a channel

### DIFF
--- a/discussions/exceptions.py
+++ b/discussions/exceptions.py
@@ -13,6 +13,10 @@ class ChannelCreationException(DiscussionSyncException):
     """Exception which occurs when an error happens on open-discussions when creating a channel"""
 
 
+class ChannelAlreadyExistsException(ChannelCreationException):
+    """Exception which occurs when an error happens on open-discussions when creating a channel that already exists"""
+
+
 class ContributorSyncException(DiscussionSyncException):
     """Exception indicating failure to add or remove a contributor"""
 


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #3618 

#### What's this PR do?
Propagates the 409 response from open-discussions to micromasters. This is necessary for handling the error in the front end in a future PR

#### How should this be manually tested?
Attempt to create a channel that already exists. You should see a 409 response in the network tab