### PR TITLE
Fix run_snapshot_dashboard_states.sh to use new docker-compose files

### DIFF
--- a/scripts/test/run_selenium_tests_dev.sh
+++ b/scripts/test/run_selenium_tests_dev.sh
@@ -23,5 +23,6 @@ docker-compose ${YML_ARGS} up -d
 # Run tests
 docker-compose ${YML_ARGS} run -v "$PWD:/src" \
    -e MICROMASTERS_USE_WEBPACK_DEV_SERVER=True \
+   -e FEATURE_OPEN_DISCUSSIONS_POST_UI=false \
    -e WEBPACK_DEV_SERVER_HOST="$WEBPACK_SELENIUM_DEV_SERVER_HOST" \
    selenium py.test ${@-./selenium_tests}

--- a/scripts/test/run_snapshot_dashboard_states.sh
+++ b/scripts/test/run_snapshot_dashboard_states.sh
@@ -16,7 +16,13 @@ then
     exit 1
 fi
 
-docker-compose run \
+# Start hub and chrome containers
+YML_ARGS="-f docker-compose.yml -f docker-compose.override.yml -f docker-compose.selenium.yml"
+
+docker-compose ${YML_ARGS} up -d
+
+# Run tests
+docker-compose ${YML_ARGS} run -v "$PWD:/src" \
    -e RUNNING_SELENIUM=true \
    -e DEBUG=false \
    -e WEBPACK_DEV_SERVER_HOST="$WEBPACK_SELENIUM_DEV_SERVER_HOST" \

--- a/scripts/test/run_snapshot_dashboard_states.sh
+++ b/scripts/test/run_snapshot_dashboard_states.sh
@@ -23,7 +23,8 @@ docker-compose ${YML_ARGS} up -d
 
 # Run tests
 docker-compose ${YML_ARGS} run -v "$PWD:/src" \
+   -e MICROMASTERS_USE_WEBPACK_DEV_SERVER=True \
    -e RUNNING_SELENIUM=true \
-   -e DEBUG=false \
+   -e FEATURE_OPEN_DISCUSSIONS_POST_UI=false \
    -e WEBPACK_DEV_SERVER_HOST="$WEBPACK_SELENIUM_DEV_SERVER_HOST" \
    selenium ./manage.py snapshot_dashboard_states $@

--- a/selenium_tests/util.py
+++ b/selenium_tests/util.py
@@ -40,6 +40,7 @@ class Browser:
         "Warning: Accessing PropTypes via the main React package is deprecated.",
         "Warning: ReactTelephoneInput: React.createClass is deprecated",
         ".jpg - Failed to load resource",
+        "smartlook",
     }
 
     def __init__(self, driver, live_server_url):

--- a/selenium_tests/util.py
+++ b/selenium_tests/util.py
@@ -38,7 +38,8 @@ class Browser:
         "zendesk",
         "__webpack_hmr",
         "Warning: Accessing PropTypes via the main React package is deprecated.",
-        "Warning: ReactTelephoneInput: React.createClass is deprecated"
+        "Warning: ReactTelephoneInput: React.createClass is deprecated",
+        ".jpg - Failed to load resource",
     }
 
     def __init__(self, driver, live_server_url):


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes error with `run_snapshot_dashboard_states.sh`. The layout of docker-compose files changed but this script was not updated accordingly

#### How should this be manually tested?
Run `./scripts/test/run_snapshot_dashboard_states.sh`
