### PR TITLE
This fixes a mobile layout issue with edit icons on profile page

### DIFF
--- a/static/scss/profile.scss
+++ b/static/scss/profile.scss
@@ -96,6 +96,7 @@
     align-items: center;
     justify-content: space-between;
     flex-wrap: wrap;
+    position: relative;
 
     &.row-with-border {
       border-bottom: 1px #e2e2e2 solid;

--- a/static/scss/user-page.scss
+++ b/static/scss/user-page.scss
@@ -25,6 +25,9 @@
 
   .edit-profile-holder, .edit-about-me-holder {
     text-align: right;
+    position: absolute;
+    top: 15px;
+    right: 0;
   }
 
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #3699

#### What's this PR do?
This fixes an issue where the edit icons were not lining up correctly on the user profile.

#### How should this be manually tested?
See that the layout matches the screenshot below in mobile views.

![image](https://user-images.githubusercontent.com/20047260/33629892-8b46cac2-d9d3-11e7-8c55-8445d30f9379.png)
