### PR TITLE
Switched create channel to new description field

### DIFF
--- a/discussions/api.py
+++ b/discussions/api.py
@@ -338,7 +338,7 @@ def sync_channel_memberships(membership_ids):
 
 
 def add_channel(
-        original_search, title, name, public_description, channel_type, program_id, creator_id,
+        original_search, title, name, description, channel_type, program_id, creator_id,
 ):  # pylint: disable=too-many-arguments
     """
     Add the channel and associated query
@@ -349,7 +349,7 @@ def add_channel(
             or for percolated queries.
         title (str): Title of the channel
         name (str): Name of the channel
-        public_description (str): Description for the channel
+        description (str): Description for the channel
         channel_type (str): Whether the channel is public or private
         program_id (int): The program id to connect the new channel to
         creator_id (int): The user id of the creator of a channel
@@ -362,7 +362,7 @@ def add_channel(
         client.channels.create(
             title=title,
             name=name,
-            public_description=public_description,
+            description=description,
             channel_type=channel_type,
         ).raise_for_status()
     except HTTPError as ex:

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -487,7 +487,7 @@ def test_add_channel(mock_staff_client, mocker, patched_users_api):
 
     title = "title"
     name = "name"
-    public_description = "public description"
+    description = "description"
     channel_type = "private"
     input_search = Search.from_dict({"unmodified": "search"})
     modified_search = Search.from_dict({"result": "modified"})
@@ -512,7 +512,7 @@ def test_add_channel(mock_staff_client, mocker, patched_users_api):
         original_search=input_search,
         title=title,
         name=name,
-        public_description=public_description,
+        description=description,
         channel_type=channel_type,
         program_id=program.id,
         creator_id=mod.id,
@@ -521,7 +521,7 @@ def test_add_channel(mock_staff_client, mocker, patched_users_api):
     mock_staff_client.channels.create.assert_called_once_with(
         title=title,
         name=name,
-        public_description=public_description,
+        description=description,
         channel_type=channel_type,
     )
     adjust_search_for_percolator_stub.assert_called_once_with(input_search)
@@ -557,7 +557,7 @@ def test_add_channel_failed_create_channel(mock_staff_client, mocker):
             Search.from_dict({}),
             "title",
             "name",
-            "public_description",
+            "description",
             "channel_type",
             123,
             456,
@@ -577,7 +577,7 @@ def test_add_channel_channel_already_exists(mock_staff_client, patched_users_api
 
     title = "title"
     name = "name"
-    public_description = "public description"
+    description = "public description"
     channel_type = "private"
     input_search = Search.from_dict({"unmodified": "search"})
     role = RoleFactory.create()
@@ -588,7 +588,7 @@ def test_add_channel_channel_already_exists(mock_staff_client, patched_users_api
             original_search=input_search,
             title=title,
             name=name,
-            public_description=public_description,
+            description=description,
             channel_type=channel_type,
             program_id=role.program.id,
             creator_id=mod.id,
@@ -597,7 +597,7 @@ def test_add_channel_channel_already_exists(mock_staff_client, patched_users_api
     mock_staff_client.channels.create.assert_called_once_with(
         title=title,
         name=name,
-        public_description=public_description,
+        description=description,
         channel_type=channel_type,
     )
 

--- a/discussions/serializers.py
+++ b/discussions/serializers.py
@@ -14,7 +14,7 @@ class ChannelSerializer(serializers.Serializer):
     """
     title = serializers.CharField()
     name = serializers.CharField()
-    public_description = serializers.CharField(required=False, allow_blank=True)
+    description = serializers.CharField(required=False, allow_blank=True)
     channel_type = serializers.ChoiceField(choices=[
         (choice, choice) for choice in VALID_CHANNEL_TYPES
     ])
@@ -30,14 +30,14 @@ class ChannelSerializer(serializers.Serializer):
         )
         title = validated_data['title']
         name = validated_data['name']
-        public_description = validated_data['public_description']
+        description = validated_data['description']
         channel_type = validated_data['channel_type']
         program_id = validated_data['program_id']
         channel = add_channel(
             original_search=search_obj,
             title=title,
             name=name,
-            public_description=public_description,
+            description=description,
             channel_type=channel_type,
             program_id=program_id,
             creator_id=user.id,
@@ -46,7 +46,7 @@ class ChannelSerializer(serializers.Serializer):
             "title": title,
             "name": name,
             "query": channel.query.query,
-            "public_description": public_description,
+            "description": description,
             "channel_type": channel_type,
             "program_id": program_id,
         }

--- a/discussions/views_test.py
+++ b/discussions/views_test.py
@@ -93,7 +93,7 @@ def _make_create_channel_input(program_id, description="default description"):
     return {
         "title": "title",
         "name": "name",
-        "public_description": description,
+        "description": description,
         "channel_type": "public",
         "query": {},
         "program_id": program_id,
@@ -120,7 +120,7 @@ def test_create_channel(description, mocker, patched_users_api):
     assert resp.json() == {
         "name": channel.name,
         "title": create_channel_input['title'],
-        "public_description": create_channel_input['public_description'],
+        "description": create_channel_input['description'],
         "channel_type": create_channel_input['channel_type'],
         "query": channel.query.query,
         "program_id": role.program.id,
@@ -129,7 +129,7 @@ def test_create_channel(description, mocker, patched_users_api):
     kwargs = add_channel_mock.call_args[1]
     assert kwargs['title'] == create_channel_input['title']
     assert kwargs['name'] == channel.name
-    assert kwargs['public_description'] == create_channel_input['public_description']
+    assert kwargs['description'] == create_channel_input['description']
     assert kwargs['channel_type'] == create_channel_input['channel_type']
     assert kwargs['original_search'].to_dict() == {
         'query': {

--- a/requirements.in
+++ b/requirements.in
@@ -23,7 +23,7 @@ ipython
 jsonfield==1.0.3
 jsonpatch==1.16
 newrelic
-open-discussions-client==0.2.2
+open-discussions-client==0.3.0
 phonenumbers==8.3.2
 psycopg2==2.7.3.2
 pycountry==16.11.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ jsonpointer==1.12         # via jsonpatch
 kombu==4.1.0              # via celery, django-server-status
 newrelic==2.88.1.73
 oauthlib==2.0.2           # via requests-oauthlib, social-auth-core
-open-discussions-client==0.2.2
+open-discussions-client==0.3.0
 paramiko==2.2.1           # via pysftp
 pbr==3.1.1                # via stevedore
 pexpect==4.2.1            # via ipython

--- a/static/js/components/channels/ChannelCreateDialog.js
+++ b/static/js/components/channels/ChannelCreateDialog.js
@@ -128,14 +128,14 @@ export default class ChannelCreateDialog extends React.Component {
           <Cell col={12}>
             <TextField
               floatingLabelText="Description"
-              name="public_description"
-              value={inputs.public_description || ""}
-              onChange={updateEmailFieldEdit("public_description")}
+              name="description"
+              value={inputs.description || ""}
+              onChange={updateEmailFieldEdit("description")}
               fullWidth={true}
               multiLine={true}
               maxLength={500}
             />
-            {this.showValidationError("public_description")}
+            {this.showValidationError("description")}
           </Cell>
         </Grid>
       </Dialog>

--- a/static/js/components/channels/ChannelCreateDialog_test.js
+++ b/static/js/components/channels/ChannelCreateDialog_test.js
@@ -80,12 +80,12 @@ describe("ChannelCreateDialog", () => {
   }
   it(`should trigger updates on the description field`, () => {
     renderDialog()
-    const input = getDialog().querySelector(`textarea[name=public_description]`)
+    const input = getDialog().querySelector(`textarea[name=description]`)
     ReactTestUtils.Simulate.change(input)
     assert.isTrue(updateEmailFieldEditStub.called, "called send handler")
   })
 
-  for (const field of ["title", "name", "public_description"]) {
+  for (const field of ["title", "name", "description"]) {
     it(`should show validation error on the ${field} field`, () => {
       renderDialog({
         validationErrors: {

--- a/static/js/components/channels/withChannelCreateDialog_test.js
+++ b/static/js/components/channels/withChannelCreateDialog_test.js
@@ -125,10 +125,10 @@ describe("withChannelCreateDialog higher-order component", () => {
       channelDialog: {
         ...INITIAL_CHANNEL_STATE,
         inputs: {
-          name:               "name",
-          title:              "title",
-          public_description: "public_description",
-          channel_type:       "private"
+          name:         "name",
+          title:        "title",
+          description:  "description",
+          channel_type: "private"
         }
       }
     })

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -17,10 +17,10 @@ export type Post = {
 type ChannelType = "private" | "public";
 
 export type ChannelInputs = {
-  name:               string,
-  title:              string,
-  public_description: string,
-  channel_type:       ChannelType,
+  name:         string,
+  title:        string,
+  description:  string,
+  channel_type: ChannelType,
 };
 
 export type Filter = {
@@ -32,7 +32,7 @@ export type Filter = {
 export type ChannelValidationErrors = {
   name?:               string,
   title?:              string,
-  public_description?: string,
+  description?: string,
 };
 
 export type ChannelState = {
@@ -47,7 +47,7 @@ export type ChannelState = {
 export type CreateChannelResponse = {
   name:               string,
   title:              string,
-  public_description: string,
+  description: string,
   channel_type:       ChannelType,
   query:              Object
 };

--- a/static/js/lib/validation/discussions_test.js
+++ b/static/js/lib/validation/discussions_test.js
@@ -14,9 +14,9 @@ describe("Discussion validation functions", () => {
     it(`should return an error for invalid channel name: ${invalidName}`, () => {
       assert.deepEqual(
         discussionErrors({
-          name:               invalidName,
-          title:              "valid",
-          public_description: "valid"
+          name:        invalidName,
+          title:       "valid",
+          description: "valid"
         }),
         {
           name: CHANNEL_NAME_ERROR
@@ -40,9 +40,9 @@ describe("Discussion validation functions", () => {
     it(`should not return an error for valid channel name: ${validName}`, () => {
       assert.deepEqual(
         discussionErrors({
-          name:               validName,
-          title:              "valid",
-          public_description: "valid"
+          name:        validName,
+          title:       "valid",
+          description: "valid"
         }),
         {}
       )

--- a/static/js/reducers/channel_dialog.js
+++ b/static/js/reducers/channel_dialog.js
@@ -16,10 +16,10 @@ import type { Action } from "../flow/reduxTypes"
 import type { ChannelInputs, ChannelState } from "../flow/discussionTypes"
 
 export const NEW_CHANNEL_EDIT: ChannelInputs = {
-  name:               "",
-  title:              "",
-  public_description: "",
-  channel_type:       "private"
+  name:         "",
+  title:        "",
+  description:  "",
+  channel_type: "private"
 }
 
 export const INITIAL_CHANNEL_STATE: ChannelState = {

--- a/static/js/reducers/channel_dialog_test.js
+++ b/static/js/reducers/channel_dialog_test.js
@@ -69,10 +69,10 @@ describe("channel_dialog reducers for the createChannel action", () => {
   let helper, createFuncStub, dispatchThen
   const createArgs = [
     {
-      name:               "name",
-      title:              "title",
-      public_description: "public_description",
-      channel_type:       "private"
+      name:         "name",
+      title:        "title",
+      description:  "description",
+      channel_type: "private"
     }
   ]
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #3715 

#### What's this PR do?
Switches to the new field we're using for channel descriptions

#### How should this be manually tested?
Create a new channel using markdown in description, ensure this shows up in the channel sidebar once created.
