### PR TITLE
Don't create extra RedeemedCoupon objects if the coupon is not being applied

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -475,9 +475,16 @@ def calculate_run_price(course_run, user):
     enrollment = get_object_or_404(ProgramEnrollment, program=program, user=user)
     price = get_formatted_course_price(enrollment)['price']
     coupons = [coupon for coupon in pick_coupons(user) if coupon.program == program]
+
     if not coupons:
+        # There is no coupon for this program
         return price, None
     coupon = coupons[0]
+
+    if course_run.edx_course_key not in coupon.course_keys:
+        # coupon does not apply to this particular course run
+        return price, None
+
     price = calculate_coupon_price(coupon, price, course_run.edx_course_key)
     return price, coupon
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3741 

#### What's this PR do?
Adds a check that the coupon can be applied to the course run whose price is being calculated. We already do this check when calculating the price but we did not do it when creating the `RedeemedCoupon` object

#### How should this be manually tested?
 - Set up two courses to be offered in your program.
 - Create a coupon via the shell, for example:

        cr = CourseRun.objects.filter(title__startswith='Digital Learning 100').first()
        Coupon.objects.create(content_object=cr.course, coupon_type=Coupon.STANDARD, amount_type=Coupon.FIXED_DISCOUNT, amount=25, coupon_code='xyz')

 - Then go to http://your.local.micromasters:8079/dashboard/coupon=xyz. You should see a dialog saying that your coupon is applied. Click 'Enroll' then 'Pay Now' then 'Continue'. You should be redirected to Cybersource. You don't have to actually make a purchase here, just go back to the dashboard.
 - In your Django shell run `RedeemedCoupon.objects.all()`. You should see a `RedeemedCoupon` object for the course you attempted to purchase.
 - Try to purchase the other course. You should not see any reference to a coupon in the order summary page. When you're redirected to cybersource go back to the dashboard. In the Django shell run `RedeemedCoupon.objects.all()`. You should see only the `RedeemedCoupon` from earlier.