### PR TITLE
Freeze grades only for users that have cached current grade

### DIFF
--- a/grades/api.py
+++ b/grades/api.py
@@ -119,7 +119,8 @@ def get_final_grade(user, course_run):
 def get_users_without_frozen_final_grade(course_run):
     """
     Public function to extract all the users that need a final grade freeze for a course run.
-    All the users that are enrolled in a course run must have frozen final grade.
+    All the users that are enrolled in a course run and have a
+    current grade must have frozen final grade.
 
     Args:
         course_run (CourseRun): a course run model object
@@ -127,7 +128,7 @@ def get_users_without_frozen_final_grade(course_run):
     Returns:
         queryset: a queryset of users
     """
-    # get the list of users enrolled in the course
+    # get the list of users enrolled in the course and have current grade
     users_in_cache = set(CachedEnrollment.get_cached_users(course_run)).intersection(
         set(CachedCurrentGrade.get_cached_users(course_run))
     )

--- a/grades/api.py
+++ b/grades/api.py
@@ -9,7 +9,7 @@ from django.contrib.auth.models import User
 from django_redis import get_redis_connection
 
 from dashboard.api_edx_cache import CachedEdxUserData, CachedEdxDataApi
-from dashboard.models import CachedEnrollment
+from dashboard.models import CachedEnrollment, CachedCurrentGrade
 from dashboard.utils import get_mmtrack
 from grades.exceptions import FreezeGradeFailedException
 from grades.models import (
@@ -128,7 +128,9 @@ def get_users_without_frozen_final_grade(course_run):
         queryset: a queryset of users
     """
     # get the list of users enrolled in the course
-    users_in_cache = set(CachedEnrollment.get_cached_users(course_run))
+    users_in_cache = set(CachedEnrollment.get_cached_users(course_run)).intersection(
+        set(CachedCurrentGrade.get_cached_users(course_run))
+    )
     # get all the users with already frozen final grade
     users_already_processed = set(FinalGrade.get_frozen_users(course_run))
     return User.objects.filter(pk__in=users_in_cache.difference(users_already_processed))

--- a/grades/api_test.py
+++ b/grades/api_test.py
@@ -286,6 +286,11 @@ class GradeAPITests(MockedESTestCase):
         CachedEnrollmentFactory.create(user=other_user, course_run=self.run_fa)
         assert sorted(
             [user.pk for user in api.get_users_without_frozen_final_grade(self.run_fa)]
+        ) == sorted([self.user.pk])
+
+        CachedCurrentGradeFactory.create(user=other_user, course_run=self.run_fa)
+        assert sorted(
+            [user.pk for user in api.get_users_without_frozen_final_grade(self.run_fa)]
         ) == sorted([self.user.pk, other_user.pk])
 
         # add the user to the FinalGrade model as in progress

--- a/grades/tasks_test.py
+++ b/grades/tasks_test.py
@@ -8,7 +8,7 @@ from django.core.cache import caches
 from django_redis import get_redis_connection
 
 from courses.factories import CourseRunFactory
-from dashboard.factories import CachedEnrollmentFactory
+from dashboard.factories import CachedEnrollmentFactory, CachedCurrentGradeFactory
 from grades import tasks
 from grades.api import CACHE_KEY_FAILED_USERS_BASE_STR
 from grades.models import (
@@ -48,6 +48,7 @@ class GradeTasksTests(MockedESTestCase):
 
         for user in cls.users:
             CachedEnrollmentFactory.create(user=user, course_run=cls.course_run1)
+            CachedCurrentGradeFactory.create(user=user, course_run=cls.course_run1)
 
     @patch('grades.tasks.freeze_course_run_final_grades', autospec=True)
     def test_find_course_runs_and_freeze_grades(self, mock_freeze):


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3735

#### What's this PR do?
Makes sure that the freeze_final_grades task chooses users to freeze based on `CachedEnrollment` and `CachedCurrentGrade` data. 

#### How should this be manually tested?
Tests should pass
