### PR TITLE
Fixes the line height of course names in the course description popover on program page

### DIFF
--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -472,20 +472,22 @@
 }
 
 .program-course-popover {
-  padding: 17px 28px 25px;
+  padding: 31px 32px 25px;
   box-shadow: 0px 1px 15px 6px rgba(0, 0, 0, 0.14) !important;
   /* important is used here to overwrite the inline style in the popover */
 
   .title {
-    font-weight: 500;
-    font-size: 17px;
-    margin: 0 0 6px 0;
+    font-weight: 400;
+    font-size: 18px;
+    margin: 0 0 17px 0;
+    line-height: 1.3;
   }
 
   .description {
     color: $font-black;
     font-size: 15px;
     margin-bottom: 1em;
+    line-height: 1.4;
   }
 
   .edx-link {


### PR DESCRIPTION
#### What's this PR do?
Fixes the line height of course names in the course description popover on program page. There are some other minor font tweaks.

#### How should this be manually tested?
See that the changes match the screenshots below

BEFORE:
![image](https://user-images.githubusercontent.com/20047260/34734609-5695a212-f53a-11e7-995a-85ef7f775e6c.png)

AFTER:
![image](https://user-images.githubusercontent.com/20047260/34734554-24669ae4-f53a-11e7-9eaf-ab3f7a3b6291.png)
