### PR TITLE
Fix redux localstorage persistence

### DIFF
--- a/static/js/store/configureStore.js
+++ b/static/js/store/configureStore.js
@@ -28,7 +28,7 @@ const devTools = () =>
 const storage = paths => compose(filter(paths))(adapter(window.localStorage))
 
 const createPersistentStore = persistence =>
-  compose(persistence, middleware(), devTools())(createStore)
+  compose(middleware(), persistence, devTools())(createStore)
 
 const createPersistentTestStore = persistence =>
   compose(persistence)(configureTestStore)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #2739 

#### What's this PR do?
It looks like the redux-localstorage middleware only persists changes to the redux state for every dispatch call, not necessary every action. By swapping the order of the middleware the thunk middleware handles async actions correctly. When the program enrollments are received they are now immediately serialized to localStorage, fixing the issue.

#### How should this be manually tested?
See the steps in #2739 
