### PR TITLE
bump react-dropzone version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "react-document-title": "^2.0.3",
     "react-dom": "^15.5.4",
     "react-draft-wysiwyg": "^1.10.0",
-    "react-dropzone": "^3.6.0",
+    "react-dropzone": "^4.2.5",
     "react-ga": "^2.2.0",
     "react-geosuggest": "^2.0.0",
     "react-hot-loader": "^3.0.0-beta.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5436,9 +5436,9 @@ react-draft-wysiwyg@^1.10.0:
     immutable "^4.0.0-rc.1"
     prop-types "^15.5.10"
 
-react-dropzone@^3.6.0:
-  version "3.13.2"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-3.13.2.tgz#318745c03007ca6b948cdd4431abc009b16a6588"
+react-dropzone@^4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-4.2.5.tgz#61f4ea914ac8b0a8c7f39795c74c4718d03b13f1"
   dependencies:
     attr-accept "^1.0.3"
     prop-types "^15.5.7"


### PR DESCRIPTION
#### What are the relevant tickets?

closes #3730 

#### What's this PR do?

This upgrades the react-dropzone package to the latest version, to incorporate a bug fix for an issue we've been seeing with IE and Edge.

#### How should this be manually tested?

Make sure there are no regressions in the functionality of the drop zone (we use it just for uploading a profile image). If you have access to windows, see if you can repro the error on master on there and (hopefully) this should fix it.