### PR TITLE
Fix CourseRunStatus for course runs with fuzzy start date

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -219,6 +219,13 @@ class CourseRun(models.Model):
         return self.start_date > now_in_utc()
 
     @property
+    def is_promised(self):
+        """Checks if the course has fuzzy start date"""
+        if not self.start_date:
+            return self.fuzzy_start_date is not None
+        return False
+
+    @property
     def is_future_enrollment_open(self):
         """
         Checks if the course will run in the future and

--- a/courses/models.py
+++ b/courses/models.py
@@ -220,7 +220,12 @@ class CourseRun(models.Model):
 
     @property
     def is_promised(self):
-        """Checks if the course has fuzzy start date"""
+        """
+        Checks if the course has fuzzy start date
+
+        Returns:
+            bool: if the course has only fuzzy start date
+        """
         if not self.start_date:
             return self.fuzzy_start_date is not None
         return False

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -346,7 +346,7 @@ def get_status_for_courserun(course_run, mmtrack):
     if mmtrack.is_enrolled_mmtrack(course_run.edx_course_key):
         if course_run.is_current:
             status = CourseRunStatus.CURRENTLY_ENROLLED
-        elif course_run.is_future:
+        elif course_run.is_future or course_run.is_promised:
             status = CourseRunStatus.WILL_ATTEND
         # the following statement needs to happen only with the new version of the algorithm
         elif course_run.has_frozen_grades:

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -550,6 +550,11 @@ class CourseRunTest(CourseTests):
         run_status = api.get_status_for_courserun(crun, self.mmtrack)
         assert run_status.status == api.CourseRunStatus.WILL_ATTEND
         assert run_status.course_run == crun
+        # promised run in the future
+        crun.start_date = None
+        crun.save()
+        run_status = api.get_status_for_courserun(crun, self.mmtrack)
+        assert run_status.status == api.CourseRunStatus.WILL_ATTEND
 
     def test_enrolled_not_paid_course(self):
         """test for get_status_for_courserun for present and future course with audit enrollment"""
@@ -635,6 +640,8 @@ class CourseRunTest(CourseTests):
             enr_end=None,
             edx_key="course-v1:MITx+8.MechCX+2014_T1"
         )
+        crun.fuzzy_start_date = None
+        crun.save()
         with self.assertRaises(ImproperlyConfigured):
             api.get_status_for_courserun(crun, self.mmtrack)
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3737

#### What's this PR do?
This allows a learner to access the dashboard when enrolled in a course run without a start_date.

#### How should this be manually tested?
Enroll a learner in some course run, then delete the start date and set the fuzzy start date for that course run. You should be able to load the dashboard without errors.
