### PR TITLE
Pinned astroid to 1.5.3 to fix lints locally

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
+astroid==1.5.3 # fix https://github.com/PyCQA/pylint/issues/1609
 bpython
 codecov
 ddt


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes lint failures locally

#### How should this be manually tested?
`tox` passes locally.
