### PR TITLE
add status message for course run with fuzzy start date

### DIFF
--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -32,7 +32,8 @@ import {
   hasFailedCourseRun,
   futureEnrollableRun,
   isEnrollableRun,
-  userIsEnrolled
+  userIsEnrolled,
+  isOfferedInUncertainFuture
 } from "./util"
 import {
   hasPassingExamGrade,
@@ -127,11 +128,19 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
 
   // Course run isn't enrollable, user never enrolled
   if (!isEnrollableRun(firstRun) && !R.any(userIsEnrolled, course.runs)) {
-    return S.Just([
-      {
-        message: "There are no future course runs scheduled."
-      }
-    ])
+    if(isOfferedInUncertainFuture(firstRun)){
+      return S.Just([
+        {
+          message: `Course starts ${formatDate(firstRun.fuzzy_start_date)}.`
+        }
+      ])
+    } else {
+      return S.Just([
+        {
+          message: "There are no future course runs scheduled."
+        }
+      ])
+    }
   }
 
   // Course is running, user has already paid,

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -128,7 +128,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
 
   // Course run isn't enrollable, user never enrolled
   if (!isEnrollableRun(firstRun) && !R.any(userIsEnrolled, course.runs)) {
-    if (isOfferedInUncertainFuture(firstRun)) {
+    if (firstRun.fuzzy_start_date && isOfferedInUncertainFuture(firstRun)) {
       return S.Just([
         {
           message: `Course starts ${firstRun.fuzzy_start_date}.`

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -128,10 +128,10 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
 
   // Course run isn't enrollable, user never enrolled
   if (!isEnrollableRun(firstRun) && !R.any(userIsEnrolled, course.runs)) {
-    if(isOfferedInUncertainFuture(firstRun)){
+    if (isOfferedInUncertainFuture(firstRun)) {
       return S.Just([
         {
-          message: `Course starts ${formatDate(firstRun.fuzzy_start_date)}.`
+          message: `Course starts ${firstRun.fuzzy_start_date}.`
         }
       ])
     } else {

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -125,7 +125,7 @@ describe("Course Status Messages", () => {
 
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
-          message: "Course starts Fall 2018"
+          message: "Course starts Fall 2018."
         }
       ])
     })

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -120,6 +120,16 @@ describe("Course Status Messages", () => {
       )
     })
 
+    it("should show next promised course", () => {
+      course.runs[0].fuzzy_start_date = "Fall 2018"
+
+      assertIsJust(calculateMessages(calculateMessagesProps), [
+        {
+          message: "Course starts Fall 2018"
+        }
+      ])
+    })
+
     it("should include information about a course coupon", () => {
       const makeAmountMessageStub = sandbox
         .stub(libCoupon, "makeAmountMessage")

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -97,3 +97,9 @@ export const isEnrollableRun = (run: CourseRun): boolean =>
   !R.isEmpty(run.enrollment_start_date) &&
   moment(run.enrollment_start_date).isSameOrBefore(moment(), "day") &&
   run.status === STATUS_OFFERED
+
+export const isOfferedInUncertainFuture = (run: CourseRun): boolean =>
+  R.isNil(run.course_start_date) &&
+  !R.isNil(run.fuzzy_start_date) &&
+  !R.isEmpty(run.fuzzy_start_date) &&
+  run.status === STATUS_OFFERED

--- a/static/js/components/dashboard/courses/util_test.js
+++ b/static/js/components/dashboard/courses/util_test.js
@@ -360,10 +360,10 @@ describe("dashboard course utilities", () => {
         [STATUS_WILL_ATTEND, "Fuzzy date", null, false],
         [STATUS_OFFERED, "Fuzzy date", moment(), false],
         [STATUS_OFFERED, "", null, false]
-      ].forEach(([status, fuzzy_date, start_date, result]) => {
+      ].forEach(([status, fuzzyDate, startDate, result]) => {
         course.runs[0].status = status
-        course.runs[0].fuzzy_start_date = fuzzy_date
-        course.runs[0].course_start_date = start_date
+        course.runs[0].fuzzy_start_date = fuzzyDate
+        course.runs[0].course_start_date = startDate
         assert.equal(isOfferedInUncertainFuture(course.runs[0]), result)
       })
     })

--- a/static/js/components/dashboard/courses/util_test.js
+++ b/static/js/components/dashboard/courses/util_test.js
@@ -15,7 +15,8 @@ import {
   futureEnrollableRun,
   hasEnrolledInAnyRun,
   hasPassedCourseRun,
-  isEnrollableRun
+  isEnrollableRun,
+  isOfferedInUncertainFuture
 } from "./util"
 import {
   STATUS_PASSED,
@@ -343,6 +344,28 @@ describe("dashboard course utilities", () => {
     it("should return false when course id is empty", () => {
       course.runs[0].course_id = ""
       assert.isFalse(isEnrollableRun(course.runs[0]))
+    })
+  })
+
+  describe("isOfferedInUncertainFuture", () => {
+    let course
+
+    beforeEach(() => {
+      course = makeCourse(0)
+    })
+
+    it("should return true if course run is offered in fuzzy future", () => {
+      [
+        [STATUS_OFFERED, "Fuzzy date", null, true],
+        [STATUS_WILL_ATTEND, "Fuzzy date", null, false],
+        [STATUS_OFFERED, "Fuzzy date", moment(), false],
+        [STATUS_OFFERED, "", null, false]
+      ].forEach(([status, fuzzy_date, start_date, result]) => {
+        course.runs[0].status = status
+        course.runs[0].fuzzy_start_date = fuzzy_date
+        course.runs[0].course_start_date = start_date
+        assert.equal(isOfferedInUncertainFuture(course.runs[0]), result)
+      })
     })
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Fix  #3720

#### What's this PR do?
Show on the dashboard course runs offered in the future with only fuzzy start date available.

#### How should this be manually tested?
Create an offered run:
```./manage.py alter_data set_to_offered --username username --course-title 'Digital Learning 300' --fuzzy --in-future```
Wipe out the enrollment start date and upgrade deadline for that course run, or set them to date in the future.


![screen shot 2018-01-19 at 12 37 32 pm](https://user-images.githubusercontent.com/7574259/35163665-902c2c52-fd15-11e7-8482-766a83a6b208.png)
