### PR TITLE
Update update_docker_hub.sh to use a new hash for each image

### DIFF
--- a/travis/update-docker-hub.sh
+++ b/travis/update-docker-hub.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 set -eo pipefail
 
-docker build -t mitodl/mm_web_travis_next -f Dockerfile .
-docker build -t mitodl/mm_watch_travis -f travis/Dockerfile-travis-watch-build .
+export NEXT=$(date | md5sum | cut -c -6)
+export PROJECT_NAME="micromasters"
+echo "Next hash is $NEXT"
 
-docker push mitodl/mm_web_travis_next
-docker push mitodl/mm_watch_travis
+export WEB_IMAGE=mitodl/${PROJECT_NAME}_web_travis_${NEXT}
+export WATCH_IMAGE=mitodl/${PROJECT_NAME}_watch_travis_${NEXT}
+
+docker build -t $WEB_IMAGE -f Dockerfile .
+docker build -t $WATCH_IMAGE -f travis/Dockerfile-travis-watch-build .
+
+docker push $WEB_IMAGE
+docker push $WATCH_IMAGE
+
+sed -r -i "s|^FROM mitodl.+$|FROM $WEB_IMAGE|" travis/Dockerfile-travis-web
+sed -r -i "s|^FROM mitodl.+$|FROM $WATCH_IMAGE|" travis/Dockerfile-travis-watch


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/cookiecutter-djangoapp/pull/120

#### What's this PR do?
Updates `update_docker_hub.sh` to generate a new hash for each updated image

#### How should this be manually tested?
N/A