### PR TITLE
Updated create channel UI to handle backend errors (#3618)

### DIFF
--- a/discussions/views.py
+++ b/discussions/views.py
@@ -90,7 +90,10 @@ class ChannelsView(APIView):
         try:
             serializer.save()
         except ChannelAlreadyExistsException:
-            return Response(status=status.HTTP_409_CONFLICT)
+            return Response(
+                {"name": "A channel with that name already exists"},
+                status=status.HTTP_409_CONFLICT,
+            )
 
         return Response(
             serializer.data,

--- a/discussions/views_test.py
+++ b/discussions/views_test.py
@@ -219,3 +219,4 @@ def test_create_channel_duplicate(mocker, patched_users_api):
         "name": channel.name,
     }, format="json")
     assert resp.status_code == statuses.HTTP_409_CONFLICT
+    assert resp.json() == {"name": "A channel with that name already exists"}

--- a/static/js/actions/channels.js
+++ b/static/js/actions/channels.js
@@ -1,10 +1,6 @@
 // @flow
 import { createAction } from "redux-actions"
 
-import type { Dispatch } from "redux"
-import type { Dispatcher } from "../flow/reduxTypes"
-import type { CreateChannelResponse } from "../flow/discussionTypes"
-
 export const qualifiedName = (name: string) => `CHANNEL_DIALOG_${name}`
 
 export const START_CHANNEL_EDIT = qualifiedName("START_CHANNEL_EDIT")
@@ -13,33 +9,8 @@ export const startChannelEdit = createAction(START_CHANNEL_EDIT)
 export const UPDATE_CHANNEL_EDIT = qualifiedName("UPDATE_CHANNEL_EDIT")
 export const updateChannelEdit = createAction(UPDATE_CHANNEL_EDIT)
 
+export const UPDATE_CHANNEL_ERRORS = qualifiedName("UPDATE_CHANNEL_ERRORS")
+export const updateChannelErrors = createAction(UPDATE_CHANNEL_ERRORS)
+
 export const CLEAR_CHANNEL_EDIT = qualifiedName("CLEAR_CHANNEL_EDIT")
 export const clearChannelEdit = createAction(CLEAR_CHANNEL_EDIT)
-
-export const INITIATE_CREATE_CHANNEL = qualifiedName("INITIATE_CREATE_CHANNEL")
-export const initiateCreateChannel = createAction(INITIATE_CREATE_CHANNEL)
-
-export const CREATE_CHANNEL_SUCCESS = qualifiedName("CREATE_CHANNEL_SUCCESS")
-export const createChannelSuccess = createAction(CREATE_CHANNEL_SUCCESS)
-
-export const CREATE_CHANNEL_FAILURE = qualifiedName("CREATE_CHANNEL_FAILURE")
-export const createChannelFailure = createAction(CREATE_CHANNEL_FAILURE)
-
-export function createChannel(
-  createFunc: () => Promise<CreateChannelResponse>,
-  createFunctionParams: Array<*>
-): Dispatcher<*> {
-  return (dispatch: Dispatch) => {
-    dispatch(initiateCreateChannel())
-    return createFunc(...createFunctionParams).then(
-      response => {
-        dispatch(createChannelSuccess())
-        return Promise.resolve(response)
-      },
-      error => {
-        dispatch(createChannelFailure({ error: error }))
-        return Promise.reject(error)
-      }
-    )
-  }
-}

--- a/static/js/actions/channels_test.js
+++ b/static/js/actions/channels_test.js
@@ -3,15 +3,9 @@ import {
   startChannelEdit,
   updateChannelEdit,
   clearChannelEdit,
-  initiateCreateChannel,
-  createChannelSuccess,
-  createChannelFailure,
   START_CHANNEL_EDIT,
   UPDATE_CHANNEL_EDIT,
-  CLEAR_CHANNEL_EDIT,
-  INITIATE_CREATE_CHANNEL,
-  CREATE_CHANNEL_SUCCESS,
-  CREATE_CHANNEL_FAILURE
+  CLEAR_CHANNEL_EDIT
 } from "./channels"
 import { assertCreatedActionHelper } from "./test_util"
 
@@ -20,10 +14,7 @@ describe("generated channelsEndpoint action helpers", () => {
     [
       [startChannelEdit, START_CHANNEL_EDIT],
       [updateChannelEdit, UPDATE_CHANNEL_EDIT],
-      [clearChannelEdit, CLEAR_CHANNEL_EDIT],
-      [initiateCreateChannel, INITIATE_CREATE_CHANNEL],
-      [createChannelSuccess, CREATE_CHANNEL_SUCCESS],
-      [createChannelFailure, CREATE_CHANNEL_FAILURE]
+      [clearChannelEdit, CLEAR_CHANNEL_EDIT]
     ].forEach(assertCreatedActionHelper)
   })
 })

--- a/static/js/components/channels/ChannelCreateDialog.js
+++ b/static/js/components/channels/ChannelCreateDialog.js
@@ -8,18 +8,18 @@ import R from "ramda"
 
 import { dialogActions } from "../inputs/util"
 import { renderFilterOptions } from "../email/lib"
-import { FETCH_PROCESSING } from "../../actions"
 
 import type { ChannelState, Filter } from "../../flow/discussionTypes"
 import type { AvailableProgram } from "../../flow/enrollmentTypes"
 
 type ChannelCreateDialogProps = {
   channelDialog: ChannelState,
+  isSavingChannel: boolean,
   dialogVisibility: boolean,
   currentProgramEnrollment: ?AvailableProgram,
   closeAndClearDialog: () => void,
   closeAndCreateDialog: () => void,
-  updateEmailFieldEdit: () => void
+  updateFieldEdit: () => void
 }
 
 export default class ChannelCreateDialog extends React.Component {
@@ -67,10 +67,11 @@ export default class ChannelCreateDialog extends React.Component {
 
   render() {
     const {
-      channelDialog: { inputs, filters, validationErrors, fetchStatus },
+      channelDialog: { inputs, filters, validationErrors },
       dialogVisibility,
       currentProgramEnrollment,
-      updateEmailFieldEdit
+      updateFieldEdit,
+      isSavingChannel
     } = this.props
 
     if (!currentProgramEnrollment) {
@@ -88,7 +89,7 @@ export default class ChannelCreateDialog extends React.Component {
         actions={dialogActions(
           this.closeAndClear,
           this.closeAndCreate,
-          fetchStatus === FETCH_PROCESSING,
+          isSavingChannel,
           "Create",
           "",
           !R.isEmpty(validationErrors)
@@ -105,7 +106,7 @@ export default class ChannelCreateDialog extends React.Component {
               name="title"
               value={inputs.title || ""}
               fullWidth={true}
-              onChange={updateEmailFieldEdit("title")}
+              onChange={updateFieldEdit("title")}
               maxLength={100}
             />
             {this.showValidationError("title")}
@@ -115,7 +116,7 @@ export default class ChannelCreateDialog extends React.Component {
               floatingLabelText="Name"
               name="name"
               value={inputs.name || ""}
-              onChange={updateEmailFieldEdit("name")}
+              onChange={updateFieldEdit("name")}
               fullWidth={true}
               maxLength={21}
             />
@@ -130,7 +131,7 @@ export default class ChannelCreateDialog extends React.Component {
               floatingLabelText="Description"
               name="description"
               value={inputs.description || ""}
-              onChange={updateEmailFieldEdit("description")}
+              onChange={updateFieldEdit("description")}
               fullWidth={true}
               multiLine={true}
               maxLength={500}

--- a/static/js/components/channels/ChannelCreateDialog_test.js
+++ b/static/js/components/channels/ChannelCreateDialog_test.js
@@ -8,12 +8,11 @@ import getMuiTheme from "material-ui/styles/getMuiTheme"
 import ReactTestUtils from "react-dom/test-utils"
 
 import * as inputUtil from "../inputs/util"
-import { FETCH_PROCESSING } from "../../actions"
 import ChannelCreateDialog from "./ChannelCreateDialog"
 import { INITIAL_CHANNEL_STATE } from "../../reducers/channel_dialog"
 
 describe("ChannelCreateDialog", () => {
-  let sandbox, closeAndClearStub, closeAndCreateStub, updateEmailFieldEditStub
+  let sandbox, closeAndClearStub, closeAndCreateStub, updateFieldEditStub
 
   const getDialog = () => document.querySelector(".create-channel-dialog")
 
@@ -21,7 +20,7 @@ describe("ChannelCreateDialog", () => {
     sandbox = sinon.sandbox.create()
     closeAndClearStub = sandbox.stub()
     closeAndCreateStub = sandbox.stub()
-    updateEmailFieldEditStub = sandbox.stub()
+    updateFieldEditStub = sandbox.stub()
   })
 
   afterEach(() => {
@@ -35,8 +34,9 @@ describe("ChannelCreateDialog", () => {
         <ChannelCreateDialog
           closeAndClearDialog={closeAndClearStub}
           closeAndCreateDialog={closeAndCreateStub}
-          updateEmailFieldEdit={updateEmailFieldEditStub}
+          updateFieldEdit={updateFieldEditStub}
           channelDialog={dialogState}
+          isSavingChannel={false}
           dialogVisibility={true}
           currentProgramEnrollment={{
             title: "Test Program"
@@ -59,9 +59,9 @@ describe("ChannelCreateDialog", () => {
     assert.isTrue(closeAndClearStub.called, "called send handler")
   })
 
-  it("should show a disabled spinner button if email send is in progress", () => {
+  it("should show a disabled spinner button if channelCreate is in progress", () => {
     const dialogActionsSpy = sandbox.spy(inputUtil, "dialogActions")
-    renderDialog({ fetchStatus: FETCH_PROCESSING })
+    renderDialog({}, { isSavingChannel: true })
 
     // assert that inFlight is true
     assert.isTrue(
@@ -75,14 +75,14 @@ describe("ChannelCreateDialog", () => {
       renderDialog()
       const input = getDialog().querySelector(`input[name=${field}]`)
       ReactTestUtils.Simulate.change(input)
-      assert.isTrue(updateEmailFieldEditStub.called, "called send handler")
+      assert.isTrue(updateFieldEditStub.called, "called send handler")
     })
   }
   it(`should trigger updates on the description field`, () => {
     renderDialog()
     const input = getDialog().querySelector(`textarea[name=description]`)
     ReactTestUtils.Simulate.change(input)
-    assert.isTrue(updateEmailFieldEditStub.called, "called send handler")
+    assert.isTrue(updateFieldEditStub.called, "called send handler")
   })
 
   for (const field of ["title", "name", "description"]) {

--- a/static/js/components/channels/withChannelCreateDialog_test.js
+++ b/static/js/components/channels/withChannelCreateDialog_test.js
@@ -11,12 +11,7 @@ import IntegrationTestHelper from "../../util/integration_test_helper"
 import { withChannelCreateDialog } from "./withChannelCreateDialog"
 import { actions } from "../../lib/redux_rest"
 import { CHANNEL_CREATE_DIALOG } from "../../constants"
-import {
-  START_CHANNEL_EDIT,
-  CLEAR_CHANNEL_EDIT,
-  INITIATE_CREATE_CHANNEL,
-  CREATE_CHANNEL_SUCCESS
-} from "../../actions/channels"
+import { START_CHANNEL_EDIT, CLEAR_CHANNEL_EDIT } from "../../actions/channels"
 import { SHOW_DIALOG, HIDE_DIALOG } from "../../actions/ui"
 import { INITIAL_CHANNEL_STATE } from "../../reducers/channel_dialog"
 
@@ -59,6 +54,7 @@ describe("withChannelCreateDialog higher-order component", () => {
           ui={{ dialogVisibility: { [CHANNEL_CREATE_DIALOG]: dialogVisible } }}
           channelDialog={{ ...channelDialog, searchkit }}
           currentProgramEnrollment={{}}
+          channels={{ processing: false }}
         />
       </MuiThemeProvider>
     )
@@ -135,10 +131,8 @@ describe("withChannelCreateDialog higher-order component", () => {
 
     const state = await listenForActions(
       [
-        INITIATE_CREATE_CHANNEL,
         actions.channels.post.requestType,
         actions.channels.post.successType,
-        CREATE_CHANNEL_SUCCESS,
         CLEAR_CHANNEL_EDIT,
         HIDE_DIALOG
       ],

--- a/static/js/containers/LearnerSearchPage.js
+++ b/static/js/containers/LearnerSearchPage.js
@@ -86,7 +86,8 @@ const mapStateToProps = (state, props) => {
     ui:                       state.ui,
     email:                    email,
     currentProgramEnrollment: state.currentProgramEnrollment,
-    channelDialog:            state.channelDialog
+    channelDialog:            state.channelDialog,
+    channels:                 state.channels
   }
 }
 

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -32,7 +32,7 @@ export type Filter = {
 export type ChannelValidationErrors = {
   name?:               string,
   title?:              string,
-  description?: string,
+  description?:        string,
 };
 
 export type ChannelState = {
@@ -40,14 +40,13 @@ export type ChannelState = {
   validationErrors:     ChannelValidationErrors,
   validationVisibility: { [string]: bool },
   filters:              ?Array<Filter>,
-  searchkit:            Object,
-  fetchStatus:          string
+  searchkit:            Object
 };
 
 export type CreateChannelResponse = {
   name:               string,
   title:              string,
-  description: string,
+  description:        string,
   channel_type:       ChannelType,
   query:              Object
 };

--- a/static/js/reducers/channel_dialog.js
+++ b/static/js/reducers/channel_dialog.js
@@ -4,13 +4,10 @@ import R from "ramda"
 import {
   START_CHANNEL_EDIT,
   UPDATE_CHANNEL_EDIT,
-  CLEAR_CHANNEL_EDIT,
-  INITIATE_CREATE_CHANNEL,
-  CREATE_CHANNEL_SUCCESS,
-  CREATE_CHANNEL_FAILURE
+  UPDATE_CHANNEL_ERRORS,
+  CLEAR_CHANNEL_EDIT
 } from "../actions/channels"
 import { discussionErrors } from "../lib/validation/discussions"
-import { FETCH_FAILURE, FETCH_SUCCESS, FETCH_PROCESSING } from "../actions"
 
 import type { Action } from "../flow/reduxTypes"
 import type { ChannelInputs, ChannelState } from "../flow/discussionTypes"
@@ -26,10 +23,8 @@ export const INITIAL_CHANNEL_STATE: ChannelState = {
   inputs:               { ...NEW_CHANNEL_EDIT },
   validationErrors:     {},
   validationVisibility: {},
-  saveError:            {},
   filters:              [],
-  searchkit:            {},
-  fetchStatus:          ""
+  searchkit:            {}
 }
 
 export const channelDialog = (
@@ -51,15 +46,23 @@ export const channelDialog = (
     }
     return newState
   }
+  case UPDATE_CHANNEL_ERRORS: {
+    return {
+      ...state,
+      validationErrors: {
+        ...action.payload
+      }
+    }
+  }
   case UPDATE_CHANNEL_EDIT: {
-    const updatedInputs = {
+    const inputs = {
       ...state.inputs,
       ...action.payload.inputs
     }
     return {
       ...state,
-      inputs:               updatedInputs,
-      validationErrors:     discussionErrors(updatedInputs),
+      inputs:               inputs,
+      validationErrors:     discussionErrors(inputs),
       validationVisibility: {
         ...state.validationVisibility,
         ...action.payload.validationVisibility
@@ -68,24 +71,6 @@ export const channelDialog = (
   }
   case CLEAR_CHANNEL_EDIT:
     return R.clone(INITIAL_CHANNEL_STATE)
-
-  case INITIATE_CREATE_CHANNEL:
-    return {
-      ...state,
-      fetchStatus: FETCH_PROCESSING
-    }
-  case CREATE_CHANNEL_SUCCESS:
-    return {
-      ...state,
-      fetchStatus: FETCH_SUCCESS
-    }
-  case CREATE_CHANNEL_FAILURE:
-    return {
-      ...state,
-      fetchStatus: FETCH_FAILURE,
-      sendError:   action.payload.error
-    }
-
   default:
     return state
   }

--- a/static/js/reducers/channel_dialog_test.js
+++ b/static/js/reducers/channel_dialog_test.js
@@ -3,18 +3,15 @@ import R from "ramda"
 import { assert } from "chai"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
-import { FETCH_SUCCESS, FETCH_FAILURE } from "../actions"
 import {
   startChannelEdit,
   updateChannelEdit,
+  updateChannelErrors,
   clearChannelEdit,
-  createChannel,
   START_CHANNEL_EDIT,
   UPDATE_CHANNEL_EDIT,
-  CLEAR_CHANNEL_EDIT,
-  INITIATE_CREATE_CHANNEL,
-  CREATE_CHANNEL_SUCCESS,
-  CREATE_CHANNEL_FAILURE
+  UPDATE_CHANNEL_ERRORS,
+  CLEAR_CHANNEL_EDIT
 } from "../actions/channels"
 import { INITIAL_CHANNEL_STATE } from "./channel_dialog"
 
@@ -46,66 +43,44 @@ describe("channel_dialog reducers", () => {
 
   it("should let you update a channel_dialog edit in progress", async () => {
     store.dispatch(startChannelEdit({}))
-    const updatedInputs = R.clone(INITIAL_CHANNEL_STATE.inputs)
-    updatedInputs.title = "Channel title"
-    const state = await dispatchThen(
-      updateChannelEdit({ inputs: updatedInputs }),
-      [UPDATE_CHANNEL_EDIT]
-    )
+    const update = {
+      inputs: {
+        title: "Channel title"
+      },
+      validationVisibility: {
+        title: true
+      }
+    }
+    const state = await dispatchThen(updateChannelEdit(update), [
+      UPDATE_CHANNEL_EDIT
+    ])
     assert.deepEqual(state, {
       ...INITIAL_CHANNEL_STATE,
-      inputs:           updatedInputs,
-      validationErrors: R.dissoc("title", VALIDATION_ERRORS)
+      inputs: {
+        ...INITIAL_CHANNEL_STATE.inputs,
+        ...update.inputs
+      },
+      validationErrors:     R.dissoc("title", VALIDATION_ERRORS),
+      validationVisibility: {
+        ...INITIAL_CHANNEL_STATE.validationVisibility,
+        ...update.validationVisibility
+      }
+    })
+  })
+
+  it("should let you update a channel_dialog validation errors", async () => {
+    store.dispatch(startChannelEdit({}))
+    const state = await dispatchThen(updateChannelErrors(VALIDATION_ERRORS), [
+      UPDATE_CHANNEL_ERRORS
+    ])
+    assert.deepEqual(state, {
+      ...INITIAL_CHANNEL_STATE,
+      validationErrors: VALIDATION_ERRORS
     })
   })
 
   it("should clear the channel_dialog edit", async () => {
     const state = await dispatchThen(clearChannelEdit(), [CLEAR_CHANNEL_EDIT])
     assert.deepEqual(state, INITIAL_CHANNEL_STATE)
-  })
-})
-
-describe("channel_dialog reducers for the createChannel action", () => {
-  let helper, createFuncStub, dispatchThen
-  const createArgs = [
-    {
-      name:         "name",
-      title:        "title",
-      description:  "description",
-      channel_type: "private"
-    }
-  ]
-
-  beforeEach(() => {
-    helper = new IntegrationTestHelper()
-    createFuncStub = helper.sandbox.stub()
-    dispatchThen = helper.store.createDispatchThen(state => state.channelDialog)
-  })
-
-  afterEach(() => {
-    helper.cleanup()
-  })
-
-  it("should go through expected state changes when the send function succeeds", async () => {
-    createFuncStub.returns(Promise.resolve(true))
-    const state = await dispatchThen(
-      createChannel(createFuncStub, createArgs),
-      [INITIATE_CREATE_CHANNEL, CREATE_CHANNEL_SUCCESS]
-    )
-    assert.equal(state.fetchStatus, FETCH_SUCCESS)
-    assert.equal(createFuncStub.callCount, 1)
-    assert.deepEqual(createFuncStub.args[0], createArgs)
-  })
-
-  it("should go through expected state changes when the send function fails", async () => {
-    createFuncStub.returns(Promise.reject())
-
-    const state = await dispatchThen(
-      createChannel(createFuncStub, createArgs),
-      [INITIATE_CREATE_CHANNEL, CREATE_CHANNEL_FAILURE]
-    )
-    assert.equal(state.fetchStatus, FETCH_FAILURE)
-    assert.equal(createFuncStub.callCount, 1)
-    assert.deepEqual(createFuncStub.args[0], createArgs)
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3618 

#### What's this PR do?
This adds support for handling backend errors, specifically to handle the error that occurs when a channel with the channel name provided already exists. It also cleans up the `channelDialog` reducer as this reducer was pretty overloaded with unnecessary complexity we don't need here. Also cleaned up a few stray references to the email dialog.

#### How should this be manually tested?
Create a channel. Attempt to create another channel with the same name and verify you see the error displayed. You should be able to change the name to a non-conflicting one and continue creating the channel successfully.