### PR TITLE
Create DiscussionUser on attempted navigation to open-discussions

### DIFF
--- a/discussions/views.py
+++ b/discussions/views.py
@@ -60,7 +60,8 @@ def discussions_redirect(request):
     """
     View for setting discussions JWT token and redirecting to discussions
     """
-    token = get_token_for_request(request)
+    token = get_token_for_request(request, force_create=True)
+
     if token is not None:
         response = redirect(settings.OPEN_DISCUSSIONS_REDIRECT_URL)
         _set_jwt_cookie(response, token)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3736 

#### What's this PR do?
Whenever a user goes to /discussions, we will now block and force creation of the discussion user. The reason to do this is to address a race condition between user signup and syncing on the new user.This only fixes the user issue, they would more than likely not see any channels, which we may have to fix separately.

#### How should this be manually tested?
To reliably reproduce, delete your discussion user and navigate to /discussions

