### PR TITLE
Displayed learner's exam eligibility for staff on profile page

### DIFF
--- a/static/js/components/dashboard/courses/ProgressMessage.js
+++ b/static/js/components/dashboard/courses/ProgressMessage.js
@@ -75,7 +75,9 @@ export const staffCourseInfo = (courseRun: CourseRun, course: Course) => {
     }
   } else {
     if (hasPassedCourseRun(course)) {
-      if (course.has_exam && !hasPassingExamGrade(course)) {
+      if (course.has_exam && course.can_schedule_exam) {
+        return "Passed edX course. Authorized to schedule exam."
+      } else if (course.has_exam && !hasPassingExamGrade(course)) {
         return "Passed edX course, did not pass exam"
       }
       return "Passed"

--- a/static/js/components/dashboard/courses/ProgressMessage_test.js
+++ b/static/js/components/dashboard/courses/ProgressMessage_test.js
@@ -161,9 +161,21 @@ describe("Course ProgressMessage", () => {
       assert.equal(staffCourseInfo(course.runs[0], course), "Passed")
     })
 
+    it("should describe passing the edX course and can schedule an exam", () => {
+      makeRunPast(course.runs[0])
+      course.runs[0].status = STATUS_PASSED
+      course.can_schedule_exam = true
+      course.has_exam = true
+      assert.equal(
+        staffCourseInfo(course.runs[0], course),
+        "Passed edX course. Authorized to schedule exam."
+      )
+    })
+
     it("should describe passing the edX course but not the exam", () => {
       makeRunPast(course.runs[0])
       course.runs[0].status = STATUS_PASSED
+      course.can_schedule_exam = false
       course.has_exam = true
       assert.equal(
         staffCourseInfo(course.runs[0], course),


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3722

#### What's this PR do?
Allow staff to see if leaner is authorize for exam or not

#### How should this be manually tested?
Authorize a learner, see this learner profile

```python
from courses.models import *
from django.contrib.auth.models import User
from exams.factories import ExamRunFactory
from exams.models import *
from exams.factories import ExamAuthorizationFactory
from exams.factories import ExamProfileFactory

user = User.objects.filter(username='username')[0]
course = Course.objects.filter(title='Digital Learning 100')[0]

# create an exam
exam_run=ExamRunFactory.create(course=course, authorized=True)
au=ExamAuthorizationFactory.create(user=user, course=course, exam_run=exam_run, status= 'success', exam_taken=False)
exam_profile= ExamProfileFactory.create(status='success', profile=user.profile)
```

@pdpinch 
#### Screenshots (if appropriate)
<img width="1104" alt="screen shot 2018-01-26 at 3 32 40 pm" src="https://user-images.githubusercontent.com/10431250/35436069-d38932b2-02ae-11e8-98bc-31bb21bac3b0.png">

