### PR TITLE
restrict channel creation to superusers

### DIFF
--- a/discussions/permissions.py
+++ b/discussions/permissions.py
@@ -1,25 +1,12 @@
 """Permissions for discussions"""
 
-from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import BasePermission
-
-from roles.models import Role
-from roles.roles import Permissions
 
 
 class CanCreateChannel(BasePermission):
     """
-    Only the staff for a program can create channels
+    Only a django superuser can create channels
     """
 
     def has_permission(self, request, view):
-        try:
-            program_id = int(request.data['program_id'])
-        except (KeyError, ValueError) as ex:
-            raise ValidationError("missing or invalid program id") from ex
-
-        return Role.objects.filter(
-            user=request.user,
-            program_id=program_id,
-            role__in=Role.permission_to_roles[Permissions.CAN_CREATE_FORUMS]
-        ).exists()
+        return request.user.is_superuser

--- a/static/js/components/channels/ChannelCreateDialog.js
+++ b/static/js/components/channels/ChannelCreateDialog.js
@@ -35,13 +35,19 @@ export default class ChannelCreateDialog extends React.Component {
     closeAndCreateDialog()
   }
 
-  showValidationError = (fieldName: string): ?React$Element<*> => {
+  showValidationError = (
+    fieldName: string,
+    ignoreVisibility: boolean = false
+  ): ?React$Element<*> => {
     const {
       channelDialog: { validationErrors, validationVisibility }
     } = this.props
     const isVisible = R.propOr(false, fieldName)
     const val = validationErrors[fieldName]
-    if (isVisible(validationVisibility) && val !== undefined) {
+    if (
+      (isVisible(validationVisibility) && val !== undefined) ||
+      ignoreVisibility
+    ) {
       return <span className="validation-error">{val}</span>
     }
   }
@@ -137,6 +143,8 @@ export default class ChannelCreateDialog extends React.Component {
               maxLength={500}
             />
             {this.showValidationError("description")}
+            {/* 'detail' is the key for a backend permission error */}
+            {this.showValidationError("detail", true)}
           </Cell>
         </Grid>
       </Dialog>

--- a/static/js/components/channels/ChannelCreateDialog_test.js
+++ b/static/js/components/channels/ChannelCreateDialog_test.js
@@ -102,6 +102,18 @@ describe("ChannelCreateDialog", () => {
     })
   }
 
+  it("should show a validation error for a 403", () => {
+    renderDialog({
+      validationErrors: {
+        detail: "You do not have permission to perform this action."
+      }
+    })
+    assert.equal(
+      getDialog().querySelector(".validation-error").textContent,
+      "You do not have permission to perform this action."
+    )
+  })
+
   it("should show all users in program if no filters", () => {
     renderDialog()
     assert.equal(


### PR DESCRIPTION
#### What are the relevant tickets?

closes #3784 

#### What's this PR do?

This changes the permission for channel creation to just check if the user is a django superuser, instead of looking to see if they have a staff role on the program in question.

I also added a little thing to display the error that is returned by the backend if you try to create a channel but do not have permission.

![youdonthaveperms](https://user-images.githubusercontent.com/6207644/35631707-8f5e8840-0672-11e8-93bf-227acf4ce888.png)

#### How should this be manually tested?

Few things to check:

- if your django user has `is_superuser` you should be able to create a channel
- if you do not, you should see the above permission error when you try

um, that's it.