### PR TITLE
Synchronized email address with email address from edX

### DIFF
--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -55,14 +55,6 @@ def update_profile_from_edx(backend, user, response, is_new, *args, **kwargs):  
         log.error('Missing access token for the user %s', user.username)
         return
 
-    try:
-        user_profile = Profile.objects.get(user=user)
-    except Profile.DoesNotExist:
-        # this should never happen, since the profile is created with a signal
-        # right after the user is created
-        log.error('No profile found for the user %s', user.username)
-        return
-
     username = get_social_username(user)
     user_profile_edx = backend.get_json(
         urljoin(backend.EDXORG_BASE_URL, '/api/user/v1/accounts/{0}'.format(username)),
@@ -73,6 +65,14 @@ def update_profile_from_edx(backend, user, response, is_new, *args, **kwargs):  
 
     if not is_new:
         update_email(user_profile_edx, user)
+        return
+
+    try:
+        user_profile = Profile.objects.get(user=user)
+    except Profile.DoesNotExist:
+        # this should never happen, since the profile is created with a signal
+        # right after the user is created
+        log.error('No profile found for the user %s', user.username)
         return
 
     name = user_profile_edx.get('name', "")

--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -63,8 +63,8 @@ def update_profile_from_edx(backend, user, response, is_new, *args, **kwargs):  
         }
     )
 
+    update_email(user_profile_edx, user)
     if not is_new:
-        update_email(user_profile_edx, user)
         return
 
     try:
@@ -94,7 +94,6 @@ def update_profile_from_edx(backend, user, response, is_new, *args, **kwargs):  
     user_profile.agreed_to_terms_of_service = True
 
     user_profile.save()
-    update_email(user_profile_edx, user)
 
     log.debug(
         'Profile for user "%s" updated with values from EDX %s',

--- a/backends/pipeline_api_test.py
+++ b/backends/pipeline_api_test.py
@@ -211,6 +211,27 @@ class EdxPipelineApiTest(MockedESTestCase):
         assert self.user_profile.date_of_birth is None
 
     @mock.patch('backends.edxorg.EdxOrgOAuth2.get_json')
+    def test_update_email(self, mocked_get_json):
+        """
+        Assert email change.
+        """
+        mocked_content = {
+            'email': 'foo@example.com'
+        }
+        mocked_get_json.return_value = mocked_content
+        pipeline_api.update_profile_from_edx(
+            edxorg.EdxOrgOAuth2(strategy=mock.Mock()), self.user, {'access_token': 'foo_token'}, True)
+        mocked_get_json.assert_called_once_with(
+            urljoin(
+                edxorg.EdxOrgOAuth2.EDXORG_BASE_URL,
+                '/api/user/v1/accounts/{0}'.format(get_social_username(self.user))
+            ),
+            headers={'Authorization': 'Bearer foo_token'}
+        )
+
+        assert self.user.email == mocked_content['email']
+
+    @mock.patch('backends.edxorg.EdxOrgOAuth2.get_json')
     def test_preferred_language(self, mocked_get_json):
         """
         If language_proficiencies is missing or invalid, we should not set

--- a/backends/pipeline_api_test.py
+++ b/backends/pipeline_api_test.py
@@ -3,6 +3,7 @@ Tests for the pipeline APIs
 """
 from unittest import mock
 from urllib.parse import urljoin
+import ddt
 
 from backends import pipeline_api, edxorg
 from courses.factories import ProgramFactory
@@ -18,6 +19,7 @@ from roles.models import (
 from search.base import MockedESTestCase
 
 
+@ddt.ddt
 class EdxPipelineApiTest(MockedESTestCase):
     """
     Test class for APIs run during the Python Social Auth
@@ -129,10 +131,12 @@ class EdxPipelineApiTest(MockedESTestCase):
         self.user_profile.refresh_from_db()
         self.check_empty_profile(self.user_profile)
 
-    def test_update_profile_old_user(self):
+    @mock.patch('backends.edxorg.EdxOrgOAuth2.get_json')
+    def test_update_profile_old_user(self, mocked_get_json):
         """
         Only new users are updated
         """
+        mocked_get_json.return_value = self.mocked_edx_profile
         self.check_empty_profile(self.user_profile)
         pipeline_api.update_profile_from_edx(
             edxorg.EdxOrgOAuth2(strategy=mock.Mock()), self.user, {'access_token': 'foo'}, False)
@@ -152,11 +156,13 @@ class EdxPipelineApiTest(MockedESTestCase):
         self.user_profile.refresh_from_db()
         self.check_empty_profile(self.user_profile)
 
-    def test_update_profile_no_existing_profile(self):
+    @mock.patch('backends.edxorg.EdxOrgOAuth2.get_json')
+    def test_update_profile_no_existing_profile(self, mocked_get_json):
         """
         The profile did not exist for the user
         """
         self.user_profile.delete()
+        mocked_get_json.return_value = self.mocked_edx_profile
 
         with self.assertRaises(Profile.DoesNotExist):
             Profile.objects.get(user=self.user)
@@ -210,17 +216,18 @@ class EdxPipelineApiTest(MockedESTestCase):
         # We do not set the date_of_birth using year_of_birth
         assert self.user_profile.date_of_birth is None
 
+    @ddt.data(True, False)
     @mock.patch('backends.edxorg.EdxOrgOAuth2.get_json')
-    def test_update_email(self, mocked_get_json):
+    def test_update_email(self, is_new, mocked_get_json):
         """
-        Assert email change.
+        Test email changed for new user.
         """
         mocked_content = {
             'email': 'foo@example.com'
         }
         mocked_get_json.return_value = mocked_content
         pipeline_api.update_profile_from_edx(
-            edxorg.EdxOrgOAuth2(strategy=mock.Mock()), self.user, {'access_token': 'foo_token'}, True)
+            edxorg.EdxOrgOAuth2(strategy=mock.Mock()), self.user, {'access_token': 'foo_token'}, is_new)
         mocked_get_json.assert_called_once_with(
             urljoin(
                 edxorg.EdxOrgOAuth2.EDXORG_BASE_URL,


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3795

#### What's this PR do?
- it updates pipeline api so that user can update email from edx

#### How should this be manually tested?
- Login to admin site, go to users and change email
- On micromasters site logout user and login it,  and go to admin site email should be up to date

@pdpinch 

