### PR TITLE
fixing auditing status display for paid courses

### DIFF
--- a/static/js/components/dashboard/courses/GradeDetailPopup.js
+++ b/static/js/components/dashboard/courses/GradeDetailPopup.js
@@ -52,9 +52,17 @@ const runStatus = (courseRun: CourseRun): React$Element<*> => {
     return passed()
   }
   if (courseRun.status === STATUS_CURRENTLY_ENROLLED) {
-    return <div className="status audited">Auditing</div>
+    return courseRun.has_paid ? (
+      <div className="status paid">In Progress (paid)</div>
+    ) : (
+      <div className="status audited">Auditing</div>
+    )
   }
-  return <div className="status audited">Audited</div>
+  return courseRun.has_paid ? (
+    <div className="status paid">Paid</div>
+  ) : (
+    <div className="status audited">Audited</div>
+  )
 }
 
 const examStatus = (grade: ProctoredExamResult): React$Element<*> =>

--- a/static/js/components/dashboard/courses/GradeDetailPopup_test.js
+++ b/static/js/components/dashboard/courses/GradeDetailPopup_test.js
@@ -11,7 +11,12 @@ import {
   makeCourse,
   makeProctoredExamResult
 } from "../../../factories/dashboard"
-import { makeRunPassed, makeRunFailed, makeRunEnrolled } from "./test_util"
+import {
+  makeRunPaid,
+  makeRunPassed,
+  makeRunFailed,
+  makeRunEnrolled
+} from "./test_util"
 import { EXAM_GRADE, EDX_GRADE } from "../../../containers/DashboardPage"
 import { formatGrade } from "../util"
 
@@ -48,6 +53,18 @@ describe("GradeDetailPopup", () => {
       )
   })
 
+  it("shows info for a paid course", () => {
+    makeRunPaid(course.runs[0])
+    const wrapper = renderDetailPopup()
+    assert.equal(
+      wrapper
+        .find(".course-run-row")
+        .first()
+        .text(),
+      `${course.runs[0].title}Paid`
+    )
+  })
+
   it("shows info for a currently enrolled course", () => {
     makeRunEnrolled(course.runs[0])
     const wrapper = renderDetailPopup()
@@ -57,6 +74,19 @@ describe("GradeDetailPopup", () => {
         .first()
         .text(),
       `${course.runs[0].title}Auditing`
+    )
+  })
+
+  it("shows info for a currently enrolled paid course", () => {
+    makeRunEnrolled(course.runs[0])
+    makeRunPaid(course.runs[0])
+    const wrapper = renderDetailPopup()
+    assert.equal(
+      wrapper
+        .find(".course-run-row")
+        .first()
+        .text(),
+      `${course.runs[0].title}In Progress (paid)`
     )
   })
 


### PR DESCRIPTION
#### What are the relevant tickets?

closes #3767 

#### What's this PR do?

this PR fixes the grade popup status messages, so that we better take in to account whether the user has paid for the course run in question or not.

See the issue for some more details.

#### How should this be manually tested?

If you have a course run, which you've paid for, you should see different messages for courses which you haven't yet passed or failed. If you have paid and you're enrolled in the course you should see 'In Progress (paid)'. If you have paid but you haven't yet enrolled you should see just 'Paid'. If you are enrolled but have not paid you should still see 'Auditing'.