### PR TITLE
fix financial aid skip bug

### DIFF
--- a/static/js/components/SkipFinancialAidDialog.js
+++ b/static/js/components/SkipFinancialAidDialog.js
@@ -7,7 +7,7 @@ import { dialogActions } from "./inputs/util"
 
 type SkipProps = {
   cancel: () => void,
-  skip: () => void,
+  skip: () => Promise<*>,
   open: boolean,
   fullPrice: React$Element<*>,
   fetchAddStatus?: string,

--- a/static/js/components/dashboard/FinancialAidCard.js
+++ b/static/js/components/dashboard/FinancialAidCard.js
@@ -39,7 +39,7 @@ export default class FinancialAidCard extends React.Component {
     setConfirmSkipDialogVisibility: (b: boolean) => void,
     setDocsInstructionsVisibility: (b: boolean) => void,
     setDocumentSentDate: (sentDate: string) => void,
-    skipFinancialAid: (p: number) => void,
+    skipFinancialAid: (p: number) => Promise<*>,
     ui: UIState,
     updateDocumentSentDate: (
       financialAidId: number,

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -465,7 +465,7 @@ class DashboardPage extends React.Component {
     )
   }
 
-  skipFinancialAid = programId => {
+  skipFinancialAid = async programId => {
     const { dispatch, financialAid } = this.props
 
     const program = this.getCurrentlyEnrolledProgram()
@@ -477,20 +477,18 @@ class DashboardPage extends React.Component {
       ) &&
       financialAid.fetchSkipStatus === undefined
     ) {
-      dispatch(skipFinancialAid(programId)).then(
-        () => {
-          this.setConfirmSkipDialogVisibility(false)
-        },
-        () => {
-          this.setConfirmSkipDialogVisibility(false)
-          dispatch(
-            setToastMessage({
-              message: "Failed to skip financial aid.",
-              icon:    TOAST_FAILURE
-            })
-          )
-        }
-      )
+      try {
+        await dispatch(skipFinancialAid(programId))
+        this.setConfirmSkipDialogVisibility(false)
+      } catch (_) {
+        this.setConfirmSkipDialogVisibility(false)
+        dispatch(
+          setToastMessage({
+            message: "Failed to skip financial aid.",
+            icon:    TOAST_FAILURE
+          })
+        )
+      }
     }
   }
 

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -192,7 +192,7 @@ export function getCoursePrices(username: string): Promise<CoursePrices> {
 }
 
 export function skipFinancialAid(programId: number): Promise<*> {
-  return fetchJSONWithCSRF(`/api/v0/financial_aid_skip/${programId}/`, {
+  return fetchWithCSRF(`/api/v0/financial_aid_skip/${programId}/`, {
     method: "PATCH"
   })
 }

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -387,11 +387,11 @@ describe("api", function() {
     describe("for skipping financial aid", () => {
       const programId = 2
       it("successfully skips financial aid", () => {
-        fetchJSONStub.returns(Promise.resolve())
+        fetchStub.returns(Promise.resolve())
 
         return skipFinancialAid(programId).then(() => {
           assert.ok(
-            fetchJSONStub.calledWith("/api/v0/financial_aid_skip/2/", {
+            fetchStub.calledWith("/api/v0/financial_aid_skip/2/", {
               method: "PATCH"
             })
           )
@@ -399,11 +399,11 @@ describe("api", function() {
       })
 
       it("fails to skip financial aid", () => {
-        fetchJSONStub.returns(Promise.reject())
+        fetchStub.returns(Promise.reject())
 
         return assert.isRejected(skipFinancialAid(programId)).then(() => {
           assert.ok(
-            fetchJSONStub.calledWith("/api/v0/financial_aid_skip/2/", {
+            fetchStub.calledWith("/api/v0/financial_aid_skip/2/", {
               method: "PATCH"
             })
           )


### PR DESCRIPTION
#### What are the relevant tickets?

closes #3803 

#### What's this PR do?

fixes a bug! the bug was due to our use of the `fetchJSONWithCSRF` function for skipping financial aid. The `fetchJSONWithCSRF` function assumes that the response has a JSON payload, and it tries to parse the payload. If it doesn't parse correctly it throws an error.

The `skipFinancialAid` endpoint doesn't return a JSON payload when it is `PATCH`'ed, so we were trying to parse JSON where there was none to be parsed. Anyway, this meant that basically after the request came back as a 200 but before the 'success' action could be dispatched to the redux store we were throwing an error in the `fetchJSONWithCSRF` function that was causing the failure-case toast message to pop-up.

So, to fix it I just changed the API function to use `fetchWithCSRF` instead, which doesn't assume the body of the request contains anything in particular, and will only reject if HTTP code is an error code. This should fix the error in production. I also did a small bit of cleanup to the relevant function in the `DashboardPage` component.

#### How should this be manually tested?

Delete your financial aid or otherwise do something to get rid of it. Confirm that, on master, if you try to skip financial aid it will a) work successfully and return a 200 and b) show the 'failure' message and fail to go on to refresh the dashboard and course price information.

Then, get rid of your financial aid again, check out this branch, and confirm that my changes fix the issue. So skipping financial aid should work, and after it goes through successfully you should see the dashboard refresh so that the new course price information can be reflected in the UI.