### PR TITLE
count_courses_passed for courses with exams

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -8,7 +8,7 @@ from django.db import transaction
 from django.db.models import Q, Count
 from django.urls import reverse
 
-from courses.models import CourseRun, Course
+from courses.models import CourseRun
 from dashboard.api_edx_cache import CachedEdxUserData
 from ecommerce.models import Order, Line
 from grades.constants import FinalGradeStatus

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -372,12 +372,12 @@ class MMTrack:
         if self.financial_aid_available:
             return sum([
                 CombinedFinalGrade.objects.filter(user=self.user, course__program=self.program).count(),
-                self.count_passing_final_grades_for_keys(self.edx_course_keys_no_exam)
+                self.count_passing_courses_for_keys(self.edx_course_keys_no_exam)
             ])
         else:
-            return self.count_passing_final_grades_for_keys(self.edx_course_keys)
+            return self.count_passing_courses_for_keys(self.edx_course_keys)
 
-    def count_passing_final_grades_for_keys(self, edx_course_keys):
+    def count_passing_courses_for_keys(self, edx_course_keys):
         """
         Calculate the number of passed courses for a given list of edx_course_keys
 
@@ -388,8 +388,8 @@ class MMTrack:
         """
         return (
             self.final_grade_qset.for_course_run_keys(edx_course_keys).passed()
-                .values_list('course_run__course__id', flat=True)
-                .distinct().count()
+            .values_list('course_run__course__id', flat=True)
+            .distinct().count()
         )
 
     def get_pearson_exam_status(self):  # pylint: disable=too-many-return-statements


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3777

#### What's this PR do?
Changes the logic of count_courses_passed in MMTrack to count differently for financial aid programs. If a course has exam then existence of the CombinedFinalGrade counts, if the course doesn't have an exam then we check for a passing FinalGrade.

#### How should this be manually tested?
Set a course run to past_passed, create ExamRun, create CombinedFinalGrade.
Run recreate index.
You learner should appear in the search results when you slide the "# of courses passed" facet.
