### PR TITLE
Turn off codecov status updates

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        enabled: no
+    patch:
+      default:
+        enabled: no
+    changes:
+      default:
+        enabled: no


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Disables the codecov status checks. Coverage will still get uploaded to codecov and I think codecov will still comment on the PR. This is needed to prevent failed code coverage from getting in the way of the automatic heroku deploys.

#### How should this be manually tested?
N/A
