### PR TITLE
Fix percolate doc type for legacy index

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -261,12 +261,13 @@ def _search_percolate_queries(program_enrollment):
         list of int: A list of PercolateQuery ids
     """
     conn = get_conn()
-    index, doc_type = get_default_alias_and_doc_type(PERCOLATE_INDEX_TYPE)
+    percolate_index, _ = get_default_alias_and_doc_type(PERCOLATE_INDEX_TYPE)
+    _, user_doc_type = get_default_alias_and_doc_type(PRIVATE_ENROLLMENT_INDEX_TYPE)
     doc = serialize_program_enrolled_user(program_enrollment)
     # We don't need this to search for percolator queries and
     # it causes a dynamic mapping failure so we need to remove it
     del doc['_id']
-    result = conn.percolate(index, doc_type, body={"doc": doc})
+    result = conn.percolate(percolate_index, user_doc_type, body={"doc": doc})
     failures = result.get('_shards', {}).get('failures', [])
     if len(failures) > 0:
         raise PercolateException("Failed to percolate: {}".format(failures))


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3817  

#### What's this PR do?
Uses percolate doc type 

#### How should this be manually tested?

You will not be able to test this manually, there is no ES instance available for the PR build during the upgrade.

After merging to master we should be able to verify the fix like this:

Open a shell and run

    from search.api import *
    from dashboard.models import *
    from search.models import *
    search_percolate_queries(ProgramEnrollment.objects.first().id, PercolateQuery.AUTOMATIC_EMAIL_TYPE)

You should not get any exception.


#### Any background context you want to provide?
There are no tests because the tests run against an ES5 instance which doesn't support the legacy percolate doc type
