### PR TITLE
Forward port 7000 to allow inspection of selenium images

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,11 +321,16 @@ If a test errors but selenium is still working, it will take
 a screenshot of the browser at the point of the error and write it
 as a png file in the project directory.
 
-#### Generating screenshots
+##### Generating screenshots
 
 To generate screenshots of various dashboard states, run this command:
 
     ./scripts/test/run_snapshot_dashboard_states.sh
+
+##### Viewing tests via browser
+
+Selenium tests run locally will forward port 7000 to the inner container. To
+view the test server with your browser, go to [http://your_mm_ip_address:7000](http://your_mm_ip_address:7000).
 
 ## Connecting to external services
 

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -5,7 +5,7 @@ services:
     extends:
       service: python
     environment:
-      DJANGO_LIVE_TEST_SERVER_ADDRESS: '0.0.0.0:7000-8000'
+      DJANGO_LIVE_TEST_SERVER_ADDRESS: '0.0.0.0:7000'
       ELASTICSEARCH_INDEX: 'testindex'
       DEBUG: 'False'
       ELASTICSEARCH_DEFAULT_PAGE_SIZE: '5'
@@ -19,6 +19,8 @@ services:
       - redis
       - hub
       - chrome
+    ports:
+      - "7000:7000"
 
   hub:
     image: selenium/hub:3.4.0-chromium

--- a/scripts/test/run_selenium_tests_dev.sh
+++ b/scripts/test/run_selenium_tests_dev.sh
@@ -25,4 +25,5 @@ docker-compose ${YML_ARGS} run -v "$PWD:/src" \
    -e MICROMASTERS_USE_WEBPACK_DEV_SERVER=True \
    -e FEATURE_OPEN_DISCUSSIONS_POST_UI=false \
    -e WEBPACK_DEV_SERVER_HOST="$WEBPACK_SELENIUM_DEV_SERVER_HOST" \
+   --service-ports \
    selenium py.test ${@-./selenium_tests}

--- a/scripts/test/run_snapshot_dashboard_states.sh
+++ b/scripts/test/run_snapshot_dashboard_states.sh
@@ -27,4 +27,5 @@ docker-compose ${YML_ARGS} run -v "$PWD:/src" \
    -e RUNNING_SELENIUM=true \
    -e FEATURE_OPEN_DISCUSSIONS_POST_UI=false \
    -e WEBPACK_DEV_SERVER_HOST="$WEBPACK_SELENIUM_DEV_SERVER_HOST" \
+   --service-ports \
    selenium ./manage.py snapshot_dashboard_states $@

--- a/scripts/test/run_snapshot_learners_states.sh
+++ b/scripts/test/run_snapshot_learners_states.sh
@@ -27,4 +27,5 @@ docker-compose ${YML_ARGS} run -v "$PWD:/src" \
    -e RUNNING_SELENIUM=true \
    -e FEATURE_OPEN_DISCUSSIONS_POST_UI=false \
    -e WEBPACK_DEV_SERVER_HOST="$WEBPACK_SELENIUM_DEV_SERVER_HOST" \
+   --service-ports \
    selenium ./manage.py snapshot_learners_states $@


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Adjusts dev selenium scripts to forward port 7000. When used in conjuction with a breakpoint this should allow developers to browse the machines with the test data loaded on it.

#### How should this be manually tested?
See instructions added to README
