### PR TITLE
When creating discussion user, added email address to OD

### DIFF
--- a/discussions/api.py
+++ b/discussions/api.py
@@ -96,12 +96,14 @@ def create_discussion_user(discussion_user):
 
     api = get_staff_client()
     result = api.users.create(
-        name=profile.full_name,
         email=profile.user.email,
-        email_optin=profile.email_optin,
-        image=profile.image.url if profile.image else None,
-        image_small=profile.image_small.url if profile.image_small else None,
-        image_medium=profile.image_medium.url if profile.image_medium else None,
+        profile=dict(
+            name=profile.full_name,
+            image=profile.image.url if profile.image else None,
+            image_small=profile.image_small.url if profile.image_small else None,
+            image_medium=profile.image_medium.url if profile.image_medium else None,
+            email_optin=profile.email_optin
+        )
     )
 
     try:
@@ -134,11 +136,13 @@ def update_discussion_user(discussion_user):
     api = get_staff_client()
     result = api.users.update(
         discussion_user.username,
-        name=profile.full_name,
         email=profile.user.email,
-        image=profile.image.url if profile.image else None,
-        image_small=profile.image_small.url if profile.image_small else None,
-        image_medium=profile.image_medium.url if profile.image_medium else None,
+        profile=dict(
+            name=profile.full_name,
+            image=profile.image.url if profile.image else None,
+            image_small=profile.image_small.url if profile.image_small else None,
+            image_medium=profile.image_medium.url if profile.image_medium else None,
+        )
     )
 
     try:

--- a/discussions/api.py
+++ b/discussions/api.py
@@ -97,6 +97,8 @@ def create_discussion_user(discussion_user):
     api = get_staff_client()
     result = api.users.create(
         name=profile.full_name,
+        email=profile.user.email,
+        email_optin=profile.email_optin,
         image=profile.image.url if profile.image else None,
         image_small=profile.image_small.url if profile.image_small else None,
         image_medium=profile.image_medium.url if profile.image_medium else None,
@@ -133,6 +135,7 @@ def update_discussion_user(discussion_user):
     result = api.users.update(
         discussion_user.username,
         name=profile.full_name,
+        email=profile.user.email,
         image=profile.image.url if profile.image else None,
         image_small=profile.image_small.url if profile.image_small else None,
         image_medium=profile.image_medium.url if profile.image_medium else None,

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -118,6 +118,8 @@ def test_create_discussion_user(mock_staff_client):
     assert discussion_user.username == 'username'
     mock_staff_client.users.create.assert_called_once_with(
         name=profile.full_name,
+        email=profile.user.email,
+        email_optin=profile.email_optin,
         image=profile.image.url,
         image_small=profile.image_small.url,
         image_medium=profile.image_medium.url,
@@ -150,6 +152,7 @@ def test_update_discussion_user(mock_staff_client):
     mock_staff_client.users.update.assert_called_once_with(
         discussion_user.username,
         name=profile.full_name,
+        email=profile.user.email,
         image=profile.image.url,
         image_small=profile.image_small.url,
         image_medium=profile.image_medium.url,

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -117,12 +117,14 @@ def test_create_discussion_user(mock_staff_client):
     api.create_discussion_user(discussion_user)
     assert discussion_user.username == 'username'
     mock_staff_client.users.create.assert_called_once_with(
-        name=profile.full_name,
         email=profile.user.email,
-        email_optin=profile.email_optin,
-        image=profile.image.url,
-        image_small=profile.image_small.url,
-        image_medium=profile.image_medium.url,
+        profile=dict(
+            name=profile.full_name,
+            image=profile.image.url if profile.image else None,
+            image_small=profile.image_small.url if profile.image_small else None,
+            image_medium=profile.image_medium.url if profile.image_medium else None,
+            email_optin=profile.email_optin
+        )
     )
 
 
@@ -151,11 +153,13 @@ def test_update_discussion_user(mock_staff_client):
     api.update_discussion_user(discussion_user)
     mock_staff_client.users.update.assert_called_once_with(
         discussion_user.username,
-        name=profile.full_name,
         email=profile.user.email,
-        image=profile.image.url,
-        image_small=profile.image_small.url,
-        image_medium=profile.image_medium.url,
+        profile=dict(
+            name=profile.full_name,
+            image=profile.image.url if profile.image else None,
+            image_small=profile.image_small.url if profile.image_small else None,
+            image_medium=profile.image_medium.url if profile.image_medium else None,
+        )
     )
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ ipython
 jsonfield==1.0.3
 jsonpatch==1.16
 newrelic
-open-discussions-client==0.3.0
+open-discussions-client==0.4.0
 phonenumbers==8.3.2
 psycopg2==2.7.3.2
 pycountry==16.11.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ jsonpointer==1.12         # via jsonpatch
 kombu==4.1.0              # via celery, django-server-status
 newrelic==2.88.1.73
 oauthlib==2.0.2           # via requests-oauthlib, social-auth-core
-open-discussions-client==0.3.0
+open-discussions-client==0.4.0
 paramiko==2.2.1           # via pysftp
 pbr==3.1.1                # via stevedore
 pexpect==4.2.1            # via ipython


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3783

#### What's this PR do?
passes email address and email optin flag to OD user api

#### How should this be manually tested?
- set `-e git+https://github.com/mitodl/open-discussions-client.git@master#egg=open-discussions-client` in requirments
- You should be able to go to /discussions/ in MM and that view will force-create it
@pdpinch 
