### PR TITLE
Snapshot Dashboard States: add more exam states

### DIFF
--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -5,7 +5,6 @@ import os
 import sys
 from urllib.parse import quote_plus
 
-from datetime import timedelta
 from selenium.webdriver.common.by import By
 from faker.generator import random
 import pytest
@@ -32,7 +31,6 @@ from ecommerce.models import (
     Order,
 )
 from exams.factories import ExamRunFactory, ExamProfileFactory, ExamAuthorizationFactory
-from exams.models import ExamAuthorization
 from financialaid.factories import FinancialAidFactory
 from financialaid.models import FinancialAidStatus
 from grades.factories import ProctoredExamGradeFactory
@@ -84,6 +82,7 @@ class DashboardStates:
 
     def create_exams(self, edx_passed, exam_passed, new_offering, can_schedule, future_exam, need_to_pay):
         """Create an exam and mark it and the related course as passed or not passed"""
+        # pylint: disable-msg=too-many-arguments
         self.make_fa_program_enrollment(FinancialAidStatus.AUTO_APPROVED)
         if edx_passed:
             call_command(

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -269,7 +269,9 @@ class DashboardStates:
             edx_passed, exam_passed, is_offered, can_schedule, future_exam, has_to_pay = tup
 
             yield (
-                bind_args(self.create_exams, edx_passed, exam_passed, is_offered, can_schedule, future_exam, has_to_pay),
+                bind_args(
+                    self.create_exams, edx_passed, exam_passed, is_offered, can_schedule, future_exam, has_to_pay
+                ),
                 'create_exams_{edx_passed}_{exam_passed}{new_offering}{can_schedule}{future_exam}{has_to_pay}'.format(
                     edx_passed='edx_✔' if edx_passed else 'edx_✖',
                     exam_passed='exam_✔' if exam_passed else 'exam_✖',


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Add exam states that have exam run attempts and exam run offerings.
Adds the following conditions:
- can schedule exam 
- the course has exam runs schedulable in the future
- has a failed exam grade 

#### How should this be manually tested?
Before you run this delete the `output/dashboard_states` folder.

Create the snapshots and take a look at the png files
`./scripts/test/run_snapshot_dashboard_states.sh`

This is the state where user has two failed exam grades
<img width="752" alt="screen shot 2018-02-13 at 4 15 28 pm" src="https://user-images.githubusercontent.com/7574259/36174414-3f6106c0-10da-11e8-9804-b10ad2743542.png">
The learner has one failed exam grade and a schedulable exam run
<img width="706" alt="screen shot 2018-02-13 at 4 15 52 pm" src="https://user-images.githubusercontent.com/7574259/36174415-3f73a4c4-10da-11e8-8e55-a5e2676ac882.png">
