### PR TITLE
Upgrade local Elasticsearch to 5.6.6, same version used in production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "6379"
 
   elastic:
-    image: elasticsearch:5.5
+    image: elasticsearch:5.6.6
     command: elasticsearch -E network.host=0.0.0.0 -E http.cors.enabled=true -E http.cors.allow-origin=* -E rest.action.multi.allow_explicit_index=false
     ports:
       - "9100:9200"


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #2867 

#### What's this PR do?
Changes docker image to point to 5.6.6 instead of 5.5

#### How should this be manually tested?
Learner search page should still work locally. This should not affect production at all.
