### PR TITLE
Update emails and email optin flag of existing users in OD

### DIFF
--- a/discussions/api.py
+++ b/discussions/api.py
@@ -118,12 +118,13 @@ def create_discussion_user(discussion_user):
     discussion_user.save()
 
 
-def update_discussion_user(discussion_user):
+def update_discussion_user(discussion_user, allow_email_optin=False):
     """
     Updates the user's discussion user profile
 
     Args:
         discussion_user (profiles.models.DiscussionUser): discussion user to update
+        allow_email_optin (bool): if True send email_optin in profile dict on users.update call
 
     Raises:
         DiscussionUserSyncException: if there was an error syncing the profile
@@ -134,15 +135,20 @@ def update_discussion_user(discussion_user):
         return
 
     api = get_staff_client()
+    profile_dict = dict(
+        name=profile.full_name,
+        image=profile.image.url if profile.image else None,
+        image_small=profile.image_small.url if profile.image_small else None,
+        image_medium=profile.image_medium.url if profile.image_medium else None,
+    )
+
+    if allow_email_optin:
+        profile_dict["email_optin"] = profile.email_optin
+
     result = api.users.update(
         discussion_user.username,
         email=profile.user.email,
-        profile=dict(
-            name=profile.full_name,
-            image=profile.image.url if profile.image else None,
-            image_small=profile.image_small.url if profile.image_small else None,
-            image_medium=profile.image_medium.url if profile.image_medium else None,
-        )
+        profile=profile_dict
     )
 
     try:

--- a/discussions/api.py
+++ b/discussions/api.py
@@ -124,7 +124,7 @@ def update_discussion_user(discussion_user, allow_email_optin=False):
     Updates the user's discussion user profile
 
     Args:
-        discussion_user (profiles.models.DiscussionUser): discussion user to update
+        discussion_user (discussions.models.DiscussionUser): discussion user to update
         allow_email_optin (bool): if True send email_optin in profile dict on users.update call
 
     Raises:

--- a/discussions/api.py
+++ b/discussions/api.py
@@ -133,9 +133,9 @@ def update_discussion_user(discussion_user, allow_email_optin=False):
     profile = discussion_user.user.profile
 
     if (
-        not allow_email_optin and
-        discussion_user.last_sync is not None and
-        profile.updated_on <= discussion_user.last_sync
+            not allow_email_optin and
+            discussion_user.last_sync is not None and
+            profile.updated_on <= discussion_user.last_sync
     ):
         return
 

--- a/discussions/api.py
+++ b/discussions/api.py
@@ -132,7 +132,11 @@ def update_discussion_user(discussion_user, allow_email_optin=False):
     """
     profile = discussion_user.user.profile
 
-    if discussion_user.last_sync is not None and profile.updated_on <= discussion_user.last_sync:
+    if (
+        not allow_email_optin and
+        discussion_user.last_sync is not None and
+        profile.updated_on <= discussion_user.last_sync
+    ):
         return
 
     api = get_staff_client()

--- a/discussions/api.py
+++ b/discussions/api.py
@@ -54,12 +54,13 @@ def get_staff_client():
     )
 
 
-def create_or_update_discussion_user(user_id):
+def create_or_update_discussion_user(user_id, allow_email_optin=False):
     """
     Create or update a DiscussionUser record and sync it
 
     Args:
         user_id (int): user id of the user to sync
+         allow_email_optin (bool): if True send email_optin in profile dict on users.update call
 
     Returns:
         DiscussionUser: The DiscussionUser connected to the user
@@ -77,7 +78,7 @@ def create_or_update_discussion_user(user_id):
         if discussion_user.username is None:
             create_discussion_user(discussion_user)
         else:
-            update_discussion_user(discussion_user)
+            update_discussion_user(discussion_user, allow_email_optin=allow_email_optin)
 
         return discussion_user
 

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -163,6 +163,30 @@ def test_update_discussion_user(mock_staff_client):
     )
 
 
+def test_update_discussion_user_with_email_optin(mock_staff_client):
+    """Verify update_discussion_user makes the correct API calls"""
+    mock_response = mock_staff_client.users.update.return_value
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        'username': 'username'
+    }
+    with mute_signals(post_save):
+        profile = ProfileFactory.create()
+    discussion_user = DiscussionUser.objects.create(user=profile.user, username='username')
+    api.update_discussion_user(discussion_user, allow_email_optin=True)
+    mock_staff_client.users.update.assert_called_once_with(
+        discussion_user.username,
+        email=profile.user.email,
+        profile=dict(
+            name=profile.full_name,
+            image=profile.image.url if profile.image else None,
+            image_small=profile.image_small.url if profile.image_small else None,
+            image_medium=profile.image_medium.url if profile.image_medium else None,
+            email_optin=profile.email_optin
+        )
+    )
+
+
 def test_update_discussion_user_no_update(mock_staff_client):
     """Verify update_discussion_user makes the correct API calls"""
     with mute_signals(post_save):

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -574,7 +574,7 @@ def test_add_channel(mock_staff_client, mocker, patched_users_api):
     add_subscriber_stub.assert_called_once_with(channel.name, mod.discussion_user.username)
     add_moderator_stub.assert_called_once_with(channel.name, mod.discussion_user.username)
     _, updated_stub = patched_users_api
-    updated_stub.assert_any_call(mod.discussion_user)
+    updated_stub.assert_any_call(mod.discussion_user, allow_email_optin=False)
 
 
 def test_add_channel_failed_create_channel(mock_staff_client, mocker):
@@ -654,7 +654,7 @@ def test_add_moderators_to_channel(mocker, patched_users_api):
     for mod in mods:
         add_subscriber_stub.assert_any_call(channel.name, mod.discussion_user.username)
         add_moderator_stub.assert_any_call(channel.name, mod.discussion_user.username)
-        updated_stub.assert_any_call(mod.discussion_user)
+        updated_stub.assert_any_call(mod.discussion_user, allow_email_optin=False)
 
     assert add_subscriber_stub.call_count == len(mods)
     assert add_moderator_stub.call_count == len(mods)

--- a/discussions/conftest.py
+++ b/discussions/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 
 # pylint: disable=unused-argument
-def _update_discussion_user(discussion_user):
+def _update_discussion_user(discussion_user, allow_email_optin=False):
     """Helper function to create a DiscussionUser and update its username"""
     if discussion_user.username is None:
         discussion_user.username = Faker('user_name').generate({})

--- a/discussions/management/commands/backfill_discussion_users_with_email_optin.py
+++ b/discussions/management/commands/backfill_discussion_users_with_email_optin.py
@@ -1,0 +1,24 @@
+"""
+Backfills the users
+"""
+from django.conf import settings
+from django.core.management import BaseCommand, CommandError
+
+from discussions.tasks import sync_discussion_users_with_email_optin
+
+
+class Command(BaseCommand):
+    """
+    Submits a celery task to backfill the discussion users.
+    """
+    help = "Submits a celery task to backfill the discussion users with email optin flag."
+
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
+
+        if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
+            raise CommandError('OPEN_DISCUSSIONS_USER_SYNC is set to False (so disabled).')
+
+        sync_discussion_users_with_email_optin.delay()
+        self.stdout.write(
+            self.style.SUCCESS('Async job to backfill users submitted with there email optin')
+        )

--- a/discussions/management/commands/backfill_discussion_users_with_email_optin.py
+++ b/discussions/management/commands/backfill_discussion_users_with_email_optin.py
@@ -4,7 +4,7 @@ Backfills the users
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 
-from discussions.tasks import sync_discussion_users_with_email_optin
+from discussions.tasks import force_sync_discussion_users
 
 
 class Command(BaseCommand):
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
             raise CommandError('OPEN_DISCUSSIONS_USER_SYNC is set to False (so disabled).')
 
-        sync_discussion_users_with_email_optin.delay()
+        force_sync_discussion_users.delay()
         self.stdout.write(
             self.style.SUCCESS('Async job to backfill users submitted with there email optin')
         )

--- a/discussions/tasks.py
+++ b/discussions/tasks.py
@@ -58,15 +58,15 @@ def sync_discussion_users():
 
 
 @app.task()
-def sync_discussion_users_with_email_optin():
+def force_sync_discussion_users():
     """
     Sync the user's profile to open discussions along with email optin flag
     """
     if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
         log.debug('OPEN_DISCUSSIONS_USER_SYNC is set to False (so disabled) in the settings')
         return
-    users_to_backfill = Profile.objects.values_list('user__id', flat=True)
 
+    users_to_backfill = Profile.objects.values_list('user__id', flat=True)
     for user_id in users_to_backfill:
         try:
             api.create_or_update_discussion_user(user_id, allow_email_optin=True)

--- a/discussions/tasks.py
+++ b/discussions/tasks.py
@@ -60,13 +60,12 @@ def sync_discussion_users():
 @app.task()
 def sync_discussion_users_with_email_optin():
     """
-    Sync the user's profile to open discussions
+    Sync the user's profile to open discussions along with email optin flag
     """
     if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
         log.debug('OPEN_DISCUSSIONS_USER_SYNC is set to False (so disabled) in the settings')
         return
-    users_to_backfill = Profile.objects.exclude(
-        user__discussion_user__isnull=False).values_list('user__id', flat=True)
+    users_to_backfill = Profile.objects.values_list('user__id', flat=True)
 
     for user_id in users_to_backfill:
         try:

--- a/discussions/tasks.py
+++ b/discussions/tasks.py
@@ -58,6 +58,24 @@ def sync_discussion_users():
 
 
 @app.task()
+def sync_discussion_users_with_email_optin():
+    """
+    Sync the user's profile to open discussions
+    """
+    if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
+        log.debug('OPEN_DISCUSSIONS_USER_SYNC is set to False (so disabled) in the settings')
+        return
+    users_to_backfill = Profile.objects.exclude(
+        user__discussion_user__isnull=False).values_list('user__id', flat=True)
+
+    for user_id in users_to_backfill:
+        try:
+            api.create_or_update_discussion_user(user_id, allow_email_optin=True)
+        except DiscussionUserSyncException:
+            log.error('Impossible to sync user_id %s to discussions', user_id)
+
+
+@app.task()
 def add_moderators_to_channel(channel_name):
     """
     Add moderators to a open-discussions channel

--- a/discussions/tasks_test.py
+++ b/discussions/tasks_test.py
@@ -83,23 +83,49 @@ def test_sync_discussion_users_sync_enabled(settings, mocker, patched_users_api)
 def test_sync_discussion_users_sync_with_email_optin_enabled(settings, mocker, patched_users_api):
     """
     Test that sync_discussion_users call the api if enabled
-    and for only users with a profile and not already syncronized
+    and for only users with a profile and not already synchronized
     """
     users = [UserFactory.create() for _ in range(5)]
-    for user in users:
+    for user in users[1:]:
         # Delete DiscussionUser so it will get backfilled
         user.discussion_user.delete()
-    UserFactory.create()
     user_no_profile = UserFactory.create()
     user_no_profile.profile.delete()
 
     mock_api = mocker.patch('discussions.api.create_or_update_discussion_user', autospec=True)
     tasks.force_sync_discussion_users()
-    assert mock_api.call_count == len(users) + 1
+    assert mock_api.call_count == len(users)
     for user in users:
         mock_api.assert_any_call(user.id, allow_email_optin=True)
     with pytest.raises(AssertionError):
         mock_api.assert_any_call(user_no_profile.id, allow_email_optin=True)
+
+
+def test_sync_discussion_users_with_email_optin_enabled_no_feature_flag(settings, mocker, patched_users_api):
+    """
+    Test that sync_discussion_users does not call the api when
+    OPEN_DISCUSSIONS_USER_SYNC flag is off
+    """
+    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = False
+    api_stub = mocker.patch('discussions.api.create_or_update_discussion_user', autospec=True)
+    tasks.force_sync_discussion_users.delay()
+    assert api_stub.call_count == 0
+
+
+def test_force_sync_discussion_users_task_api_error(mocker):
+    """
+    Test that sync_discussion_users logs errors if they occur
+    """
+    mock_api = mocker.patch('discussions.api.create_or_update_discussion_user', autospec=True)
+    user = UserFactory.create()
+
+    # don't count the one triggered by signals on UserFactory.create()
+    mock_api.reset_mock()
+    mock_log = mocker.patch('discussions.tasks.log', autospec=True)
+    mock_api.side_effect = DiscussionUserSyncException()
+    tasks.force_sync_discussion_users()
+    mock_api.assert_called_once_with(user.id, allow_email_optin=True)
+    mock_log.error.assert_called_once_with("Impossible to sync user_id %s to discussions", user.id)
 
 
 def test_sync_discussion_users_task_api_error(mocker):

--- a/discussions/tasks_test.py
+++ b/discussions/tasks_test.py
@@ -89,19 +89,17 @@ def test_sync_discussion_users_sync_with_email_optin_enabled(settings, mocker, p
     for user in users:
         # Delete DiscussionUser so it will get backfilled
         user.discussion_user.delete()
-    user_already_sync = UserFactory.create()
+    UserFactory.create()
     user_no_profile = UserFactory.create()
     user_no_profile.profile.delete()
 
     mock_api = mocker.patch('discussions.api.create_or_update_discussion_user', autospec=True)
-    tasks.sync_discussion_users_with_email_optin()
-    assert mock_api.call_count == len(users)
+    tasks.force_sync_discussion_users()
+    assert mock_api.call_count == len(users) + 1
     for user in users:
         mock_api.assert_any_call(user.id, allow_email_optin=True)
     with pytest.raises(AssertionError):
         mock_api.assert_any_call(user_no_profile.id, allow_email_optin=True)
-    with pytest.raises(AssertionError):
-        mock_api.assert_any_call(user_already_sync.id, allow_email_optin=True)
 
 
 def test_sync_discussion_users_task_api_error(mocker):

--- a/discussions/tasks_test.py
+++ b/discussions/tasks_test.py
@@ -80,6 +80,30 @@ def test_sync_discussion_users_sync_enabled(settings, mocker, patched_users_api)
         mock_api.assert_any_call(user_already_sync.id)
 
 
+def test_sync_discussion_users_sync_with_email_optin_enabled(settings, mocker, patched_users_api):
+    """
+    Test that sync_discussion_users call the api if enabled
+    and for only users with a profile and not already syncronized
+    """
+    users = [UserFactory.create() for _ in range(5)]
+    for user in users:
+        # Delete DiscussionUser so it will get backfilled
+        user.discussion_user.delete()
+    user_already_sync = UserFactory.create()
+    user_no_profile = UserFactory.create()
+    user_no_profile.profile.delete()
+
+    mock_api = mocker.patch('discussions.api.create_or_update_discussion_user', autospec=True)
+    tasks.sync_discussion_users_with_email_optin()
+    assert mock_api.call_count == len(users)
+    for user in users:
+        mock_api.assert_any_call(user.id, allow_email_optin=True)
+    with pytest.raises(AssertionError):
+        mock_api.assert_any_call(user_no_profile.id, allow_email_optin=True)
+    with pytest.raises(AssertionError):
+        mock_api.assert_any_call(user_already_sync.id, allow_email_optin=True)
+
+
 def test_sync_discussion_users_task_api_error(mocker):
     """
     Test that sync_discussion_users logs errors if they occur


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3785

#### What's this PR do?
adds a task to bulk update emails and email optin of all user, this might be one time task

#### How should this be manually tested?
- on MM you can make email optin = false from user profile page and save
- Run command `docker-compose run web ./manage.py backfill_discussion_users_with_email_optin`
- check the user profile in OD for update 
- also restart celery if you find any issue with my task

@pdpinch 
