### PR TITLE
Dashboard Snapshots: Add scenario for FA paid course run 

### DIFF
--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -219,6 +219,17 @@ class DashboardStates:
             tier_program__discount_amount=50,
         )
 
+    def create_paid_failed_course_run(self):
+        """Make paid failed course run, and offer another run"""
+        self.make_fa_program_enrollment(FinancialAidStatus.AUTO_APPROVED)
+        call_command(
+            "alter_data", 'set_to_failed', '--username', 'staff',
+            '--course-title', 'Digital Learning 200', '--grade', '45',
+        )
+        course = Course.objects.get(title='Digital Learning 200')
+        # create another offered run
+        CourseRunFactory.create(course=course)
+
     def __iter__(self):
         """
         Iterator over all dashboard states supported by this command.
@@ -248,6 +259,8 @@ class DashboardStates:
                     new_offering='_with_new_offering' if is_offered else '',
                 ),
             )
+
+        yield (self.create_paid_course_run, 'create_paid_course_run')
 
         # Also test for two different passing and failed runs on the same course
         yield (self.with_prev_passed_run, 'failed_with_prev_passed_run')

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -260,7 +260,7 @@ class DashboardStates:
                 ),
             )
 
-        yield (self.create_paid_course_run, 'create_paid_course_run')
+        yield (self.create_paid_failed_course_run, 'failed_paid_run_another_offered')
 
         # Also test for two different passing and failed runs on the same course
         yield (self.with_prev_passed_run, 'failed_with_prev_passed_run')


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Add a state where user failed a paid course run and there is another offered course run.

#### How should this be manually tested?
Look at the screenshot

<img width="624" alt="screen shot 2018-02-14 at 1 58 28 pm" src="https://user-images.githubusercontent.com/7574259/36222405-2a917648-118f-11e8-9d35-e6d34dde3471.png">


