### PR TITLE
Lower elasticsearch memory usage limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "6379"
 
   elastic:
-    image: elasticsearch:5.6.6
+    build: elastic
     command: elasticsearch -E network.host=0.0.0.0 -E http.cors.enabled=true -E http.cors.allow-origin=* -E rest.action.multi.allow_explicit_index=false
     ports:
       - "9100:9200"

--- a/elastic/Dockerfile
+++ b/elastic/Dockerfile
@@ -1,0 +1,5 @@
+FROM elasticsearch:5.6.6
+
+# Lower elasticsearch memory usage limit
+RUN sed -i 's/-Xms2g/-Xms512m/' /etc/elasticsearch/jvm.options
+RUN sed -i 's/-Xmx2g/-Xmx512m/' /etc/elasticsearch/jvm.options


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3835 

#### What's this PR do?
Updates Elasticsearch configuration files to use 512mb of memory instead of 2g

#### How should this be manually tested?
Nothing should break. You will need to run `./manage.py recreate_index` first since the existing container won't be preserved (I think)
