### PR TITLE
Serialize best final grades for search

### DIFF
--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -12,7 +12,6 @@ from unittest.mock import (
 import ddt
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
-from django.test import override_settings
 from django_redis import get_redis_connection
 import pytest
 from rest_framework import status as http_status
@@ -39,7 +38,7 @@ from exams.factories import ExamRunFactory, ExamAuthorizationFactory
 from grades.constants import FinalGradeStatus
 from grades.exceptions import FreezeGradeFailedException
 from grades.factories import ProctoredExamGradeFactory, FinalGradeFactory, MicromastersCourseCertificateFactory
-from grades.models import FinalGrade, CourseRunGradingStatus, ProctoredExamGrade, CombinedFinalGrade
+from grades.models import FinalGrade, CourseRunGradingStatus, ProctoredExamGrade
 from grades.serializers import ProctoredExamGradeSerializer
 from micromasters.factories import UserFactory
 from micromasters.utils import (
@@ -806,7 +805,6 @@ class CourseRunTest(CourseTests):
 
 
 @ddt.ddt
-@patch('dashboard.api.get_overall_final_grade_for_course', return_value="")
 @patch('dashboard.api.get_certificate_url', return_value="")
 @patch('dashboard.api.get_future_exam_runs', return_value=[])
 @patch('dashboard.api.has_to_pay_for_exam', return_value=False)
@@ -868,6 +866,7 @@ class InfoCourseTest(CourseTests):
         super().setUp()
         # default behavior for some mmtrack mocked methods
         self.mmtrack.get_course_proctorate_exam_results.return_value = []
+        self.mmtrack.get_overall_final_grade_for_course.return_value = ""
 
     def assert_course_equal(
             self,
@@ -920,7 +919,7 @@ class InfoCourseTest(CourseTests):
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_no_runs(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay
     ):
         """test for get_info_for_course for course with no runs"""
         self.assert_course_equal(
@@ -932,12 +931,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_with_contact_email(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay
     ):  # pylint: disable=no-self-use
         """test that get_info_for_course indicates that a course has a contact_email """
         course = CourseFactory.create(contact_email="abc@example.com")
@@ -948,12 +946,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.is_exam_schedulable')
     @ddt.data((True), (False))
     def test_info_returns_exam_schedulable(
-            self, boolean, mock_schedulable, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, boolean, mock_schedulable, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test that get_info_for_course returns whether the exam is schedulable"""
         course = CourseFactory.create(contact_email=None)
         mock_schedulable.return_value = boolean
@@ -962,11 +959,10 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_returns_has_exam(
-            self, mock_schedulable, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay
+            self, mock_schedulable, mock_get_cert, mock_future_exams, mock_has_to_pay
     ):
         """test that get_info_for_course returns whether the course has an exam module or not"""
         course = CourseFactory.create(contact_email=None)
@@ -984,12 +980,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 2
         assert mock_future_exams.call_count == 2
         assert mock_get_cert.call_count == 2
-        assert mock_grade.call_count == 2
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_without_contact_email(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay
     ):  # pylint: disable=no-self-use
         """test that get_info_for_course indicates that a course has no contact_email """
         course = CourseFactory.create(contact_email=None)
@@ -1000,12 +995,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_not_enrolled_offered(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with with an offered run"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1024,12 +1018,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_not_enrolled_but_paid(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with with a paid but not enrolled run"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1053,12 +1046,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_not_passed_offered(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with a run not passed and another offered"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1079,12 +1071,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_not_enrolled_not_passed_not_offered(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with run not passed and nothing offered"""
         self.mmtrack.configure_mock(**{'has_passed_course.return_value': False})
         with patch(
@@ -1103,12 +1094,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_grade(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with a course current and another not passed"""
         self.mmtrack.configure_mock(**{'has_passed_course.return_value': False})
         with patch(
@@ -1127,12 +1117,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_check_but_not_passed(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay,):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay,):
         """
         test for get_info_for_course in case a check if the course has been passed is required
         """
@@ -1153,12 +1142,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_missed_deadline(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course with a missed upgrade deadline
         """
@@ -1178,12 +1166,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_check_but_not_passed_no_next(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course in case a check if the course has been passed
         is required for the course, the course has not been passed and there is no next run
@@ -1205,12 +1192,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_check_passed(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course in case a check if the course has been passed
         is required for the course and the course has been passed
@@ -1236,12 +1222,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_will_attend(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with enrolled run that will happen in the future"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1258,12 +1243,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_upgrade(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with a run that needs to be upgraded"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1280,12 +1264,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_upgrade_in_past(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course for course with a run
         that needs to be upgraded but before a current enrolled one
@@ -1306,12 +1289,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_default_should_not_happen(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course for course with a run with an
         unexpected state but that can be offered
@@ -1331,12 +1313,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_default_should_not_happen_no_next(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course with no next and weird status"""
         with patch(
             'dashboard.api.get_status_for_courserun',
@@ -1353,12 +1334,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_info_read_cert_for_all_no_next(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         test for get_info_for_course in case the less recent course is flagged to be checked if passed
         """
@@ -1384,12 +1364,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_course_run_end_date_mixed(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         Test with a mix of end_date being None and also a valid date
         """
@@ -1429,12 +1408,11 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
 
     @patch('dashboard.api.format_courserun_for_dashboard', autospec=True)
     @patch('dashboard.api.is_exam_schedulable', return_value=False)
     def test_course_with_proctorate_exam(
-            self, mock_schedulable, mock_format, mock_grade, mock_get_cert, mock_future_exams, mock_has_to_pay):
+            self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """
         Test with proctorate exam results
         """
@@ -1453,7 +1431,6 @@ class InfoCourseTest(CourseTests):
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1
         assert mock_get_cert.call_count == 1
-        assert mock_grade.call_count == 1
         self.mmtrack.get_course_proctorate_exam_results.assert_called_once_with(self.course_noruns)
 
 

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1828,30 +1828,6 @@ class GetCertificateForCourseTests(CourseTests):
         assert api.get_certificate_url(self.mmtrack, self.course) == certificate_url
 
 
-class GetOverallGradeForCourseTests(CourseTests):
-    """Tests get_overall_final_grade_for_course for a course"""
-
-    def setUp(self):
-        super().setUp()
-        self.mmtrack.user = self.user
-        self.mmtrack.financial_aid_available = True
-
-        self.course_run = self.create_run(course=self.course)
-        self.final_grade = FinalGradeFactory.create(
-            user=self.user,
-            course_run=self.course_run,
-            grade=0.8,
-            passed=True
-        )
-
-    @override_settings(FEATURES={"USE_COMBINED_FINAL_GRADE": True})
-    def test_get_overall_final_grade_for_course(self):
-        """Test get_overall_final_grade_for_course return overall grade"""
-        assert api.get_overall_final_grade_for_course(self.mmtrack, self.course) == ""
-        CombinedFinalGrade.objects.create(user=self.user, course=self.course, grade="74")
-        assert api.get_overall_final_grade_for_course(self.mmtrack, self.course) == "74"
-
-
 # pylint: disable=unused-argument, redefined-outer-name
 def _make_fake_real_user():
     """Make a User whose profile.fake_user is False"""

--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -48,14 +48,10 @@ class UserProgramSearchSerializer:
         has_paid = mmtrack.has_paid(course_run.edx_course_key)
         payment_status = cls.PAID_STATUS if has_paid else cls.UNPAID_STATUS
 
-        # find the best final grade or overall grade for course (with exams)
-        final_grade = mmtrack.get_best_final_grade_for_course(course_run.edx_course_key)
-        if mmtrack.financial_aid_available:
-            if course_run.course.has_exam:
-                final_grade = mmtrack.get_overall_final_grade_for_course(course_run.course)
+        final_grade = mmtrack.get_final_grades_for_course(course_run.course).first()
         semester = cls.serialize_semester(course_run)
         return {
-            'final_grade': final_grade,
+            'final_grade': final_grade.grade_percent if final_grade else None,
             'semester': semester,
             'course_title': course_title,
             'payment_status': payment_status,

--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -3,7 +3,6 @@ Provides functionality for serializing a ProgramEnrollment for the ES index
 """
 from courses.utils import get_year_season_from_course_run
 from dashboard.utils import get_mmtrack
-from dashboard.api import get_overall_final_grade_for_course
 from roles.api import is_learner
 
 
@@ -53,7 +52,7 @@ class UserProgramSearchSerializer:
         final_grade = mmtrack.get_best_final_grade_for_course(course_run.edx_course_key)
         if mmtrack.financial_aid_available:
             if course_run.course.has_exam:
-                final_grade = get_overall_final_grade_for_course(mmtrack, course_run.course)
+                final_grade = mmtrack.get_overall_final_grade_for_course(course_run.course)
         semester = cls.serialize_semester(course_run)
         return {
             'final_grade': final_grade,

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -308,6 +308,18 @@ class MMTrack:
         )
         return {grade.course_run.edx_course_key: grade for grade in grades}
 
+    def get_final_grades_for_course(self, course):
+        """
+
+        Args:
+            course (courses.models.Course): a course
+        Returns:
+            qset: a queryset of all final grades for course
+        """
+        return self.final_grade_qset.for_course_run_keys(
+            list(course.courserun_set.values_list('edx_course_key', flat=True))
+        ).order_by('-grade')
+
     def get_best_final_grade_for_course(self, course):
         """
         Return the best final grade for given course
@@ -315,11 +327,9 @@ class MMTrack:
         Args:
             course (courses.models.Course): a course
         Returns:
-            grades.models.FinalGrade: the best exam grade
+            grades.models.FinalGrade: the best final grade
         """
-        return self.final_grade_qset.for_course_run_keys(
-            list(course.courserun_set.values_list('edx_course_key', flat=True))
-        ).passed().order_by('-grade').first()
+        return self.get_final_grades_for_course(course).passed().first()
 
     def get_overall_final_grade_for_course(self, course):
         """

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -7,6 +7,8 @@ from unittest.mock import (
     MagicMock,
     PropertyMock
 )
+
+from django.test import override_settings
 from django.urls import reverse
 
 import pytz
@@ -732,6 +734,21 @@ class MMTrackTest(MockedESTestCase):
             )
             FinalGradeFactory.create(user=self.user, course_run=course_run, grade=grade, passed=True)
         assert mmtrack.get_best_final_grade_for_course(finaid_course).grade == 0.8
+
+    @override_settings(FEATURES={"USE_COMBINED_FINAL_GRADE": True})
+    def test_get_overall_final_grade_for_course(self):
+        """
+        Test for get_overall_final_grade_for_course to return CombinedFinalGrade for course
+        """
+        mmtrack = MMTrack(
+            user=self.user,
+            program=self.program_financial_aid,
+            edx_user_data=self.cached_edx_user_data
+        )
+        finaid_course = self.crun_fa.course
+        assert mmtrack.get_overall_final_grade_for_course(finaid_course) == ""
+        CombinedFinalGrade.objects.create(user=self.user, course=finaid_course, grade="74")
+        assert mmtrack.get_overall_final_grade_for_course(finaid_course) == "74"
 
     def test_get_best_proctored_exam_grade(self):
         """

--- a/grades/api.py
+++ b/grades/api.py
@@ -11,6 +11,7 @@ from django_redis import get_redis_connection
 from dashboard.api_edx_cache import CachedEdxUserData, CachedEdxDataApi
 from dashboard.models import CachedEnrollment, CachedCurrentGrade
 from dashboard.utils import get_mmtrack
+from grades.constants import EXAM_GRADE_WEIGHT, COURSE_GRADE_WEIGHT
 from grades.exceptions import FreezeGradeFailedException
 from grades.models import (
     FinalGrade,
@@ -23,9 +24,6 @@ CACHE_KEY_FAILED_USERS_BASE_STR = "failed_users_{0}"
 log = logging.getLogger(__name__)
 
 UserFinalGrade = namedtuple('UserFinalGrade', ['grade', 'passed', 'payed_on_edx'])
-
-COURSE_GRADE_WEIGHT = 0.4
-EXAM_GRADE_WEIGHT = 0.6
 
 
 def _compute_grade_for_fa(user_edx_run_data):

--- a/grades/constants.py
+++ b/grades/constants.py
@@ -2,6 +2,9 @@
 Constants for the grades app
 """
 
+COURSE_GRADE_WEIGHT = 0.4
+EXAM_GRADE_WEIGHT = 0.6
+
 
 class FinalGradeStatus:
     """


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3810

#### What's this PR do?
Change the serialization for enrollments to include the best passing grade for the course.

#### How should this be manually tested?
Run an alter data command for you learner to set few enrollments to 'passed', you can pass the desired grade as an argument. Then make sure the highest grade appears in the final grade facet.
