### PR TITLE
Fixed end date issues on progress messages

### DIFF
--- a/static/js/components/dashboard/courses/ProgressMessage_test.js
+++ b/static/js/components/dashboard/courses/ProgressMessage_test.js
@@ -55,6 +55,13 @@ describe("Course ProgressMessage", () => {
     assert.equal(wrapper.find(".details").text(), "Course in progress")
   })
 
+  it("displays information for an in-progress course run when end date is null", () => {
+    makeRunCurrent(course.runs[0])
+    course.runs[0].course_end_date = null
+    const wrapper = renderCourseDescription()
+    assert.equal(wrapper.find(".details").text(), "Course in progress")
+  })
+
   it("displays a contact link, if appropriate, and a view on edX link", () => {
     makeRunEnrolled(course.runs[0])
     makeRunCurrent(course.runs[0])
@@ -116,6 +123,14 @@ describe("Course ProgressMessage", () => {
     it("should return paid if course current and user has paid", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
+      course.runs[0].has_paid = true
+      assert.equal("Paid", staffCourseInfo(course.runs[0], course))
+    })
+
+    it("should return paid if course current and user has paid and end date is null", () => {
+      makeRunCurrent(course.runs[0])
+      makeRunEnrolled(course.runs[0])
+      course.runs[0].course_end_date = null
       course.runs[0].has_paid = true
       assert.equal("Paid", staffCourseInfo(course.runs[0], course))
     })

--- a/static/js/components/dashboard/courses/ProgressMessage_test.js
+++ b/static/js/components/dashboard/courses/ProgressMessage_test.js
@@ -57,7 +57,7 @@ describe("Course ProgressMessage", () => {
 
   it("displays information for an in-progress course run when end date is null", () => {
     makeRunCurrent(course.runs[0])
-    course.runs[0].course_end_date = null
+    course.runs[0].course_end_date = ""
     const wrapper = renderCourseDescription()
     assert.equal(wrapper.find(".details").text(), "Course in progress")
   })
@@ -127,10 +127,10 @@ describe("Course ProgressMessage", () => {
       assert.equal("Paid", staffCourseInfo(course.runs[0], course))
     })
 
-    it("should return paid if course current and user has paid and end date is null", () => {
+    it("should return paid if course current and user has paid and end date is empty", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
-      course.runs[0].course_end_date = null
+      course.runs[0].course_end_date = ""
       course.runs[0].has_paid = true
       assert.equal("Paid", staffCourseInfo(course.runs[0], course))
     })

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -54,13 +54,14 @@ export const hasEnrolledInAnyRun = R.compose(
 
 export const courseCurrentlyInProgress = (courseRun: CourseRun) => {
   const startDate = moment(courseRun.course_start_date)
-  const endDate = moment(courseRun.course_end_date)
   const now = moment()
-  return now.isAfter(startDate) && now.isBefore(endDate)
+  const endDateNotPass = courseRun.course_end_date ?
+    now.isBefore(moment(courseRun.course_end_date)) : true
+  return now.isAfter(startDate) && endDateNotPass
 }
 
 export const courseUpcomingOrCurrent = (courseRun: CourseRun) =>
-  moment().isBefore(moment(courseRun.course_end_date))
+  courseRun.course_end_date ? moment().isBefore(moment(courseRun.course_end_date)) : true
 
 export const hasPaidForAnyCourseRun = R.compose(
   R.any(R.propEq("has_paid", true)),

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -55,13 +55,16 @@ export const hasEnrolledInAnyRun = R.compose(
 export const courseCurrentlyInProgress = (courseRun: CourseRun) => {
   const startDate = moment(courseRun.course_start_date)
   const now = moment()
-  const endDateNotPass = courseRun.course_end_date ?
-    now.isBefore(moment(courseRun.course_end_date)) : true
+  const endDateNotPass = courseRun.course_end_date
+    ? now.isBefore(moment(courseRun.course_end_date))
+    : true
   return now.isAfter(startDate) && endDateNotPass
 }
 
 export const courseUpcomingOrCurrent = (courseRun: CourseRun) =>
-  courseRun.course_end_date ? moment().isBefore(moment(courseRun.course_end_date)) : true
+  courseRun.course_end_date
+    ? moment().isBefore(moment(courseRun.course_end_date))
+    : true
 
 export const hasPaidForAnyCourseRun = R.compose(
   R.any(R.propEq("has_paid", true)),

--- a/static/js/components/dashboard/courses/util_test.js
+++ b/static/js/components/dashboard/courses/util_test.js
@@ -151,19 +151,19 @@ describe("dashboard course utilities", () => {
       assert.isFalse(courseCurrentlyInProgress(run))
     })
 
-    it("should return true if the start date passed and end date is null", () => {
+    it("should return true if the start date passed and end date is empty", () => {
       run.course_start_date = moment()
         .subtract(5, "days")
         .format()
-      run.course_end_date = null
+      run.course_end_date = ""
       assert.isTrue(courseCurrentlyInProgress(run))
     })
 
-    it("should return false for a future course run end date is null", () => {
+    it("should return false for a future course run end date is empty", () => {
       run.course_start_date = moment()
         .add(5, "days")
         .format()
-      run.course_end_date = null
+      run.course_end_date = ""
       assert.isFalse(courseCurrentlyInProgress(run))
     })
   })
@@ -190,7 +190,7 @@ describe("dashboard course utilities", () => {
     })
 
     it("should return true when no end date is available", () => {
-      run.course_end_date = null
+      run.course_end_date = ""
       assert.isTrue(courseUpcomingOrCurrent(run))
     })
   })

--- a/static/js/components/dashboard/courses/util_test.js
+++ b/static/js/components/dashboard/courses/util_test.js
@@ -150,6 +150,22 @@ describe("dashboard course utilities", () => {
         .format()
       assert.isFalse(courseCurrentlyInProgress(run))
     })
+
+    it("should return true if the start date passed and end date is null", () => {
+      run.course_start_date = moment()
+        .subtract(5, "days")
+        .format()
+      run.course_end_date = null
+      assert.isTrue(courseCurrentlyInProgress(run))
+    })
+
+    it("should return false for a future course run end date is null", () => {
+      run.course_start_date = moment()
+        .add(5, "days")
+        .format()
+      run.course_end_date = null
+      assert.isFalse(courseCurrentlyInProgress(run))
+    })
   })
 
   describe("courseUpcomingOrCurrent", () => {
@@ -171,6 +187,11 @@ describe("dashboard course utilities", () => {
         .subtract(5, "days")
         .format()
       assert.isFalse(courseUpcomingOrCurrent(run))
+    })
+
+    it("should return true when no end date is available", () => {
+      run.course_end_date = null
+      assert.isTrue(courseUpcomingOrCurrent(run))
     })
   })
 


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3807

#### What's this PR do?
it assumes that if `course_end_date` is null that means course is not end. Progress component was crashing without any trace when `course_end_date: null`.

#### How should this be manually tested?
- Checkout master branch.
- From admin dashboard create a current course course without end date
- pay for logged in user
- View progress page, you wont see paid message and course in progress message.
- Now checkout my branch, you will see course in progress and paid status

#### For dummy enrollment and payment follow this script in django shell
```python
from courses.models import *
from django.contrib.auth.models import User
from dashboard.factories import CachedEnrollmentFactory
from ecommerce.factories import (OrderFactory, LineFactory)

user = User.objects.filter(username='username')[0]
course = Course.objects.filter(title='Digital Learning 100')[0]
course_run = CourseRun.objects.get(edx_course_key='course-v1:MITx+Digital+Learning+100+Aug_2016')

# pay for run
order = OrderFactory.create(user=user, status='fulfilled', total_price_paid=1200)
LineFactory.create(order=order, course_key=course_run.edx_course_key)

# enroll for run
CachedEnrollmentFactory.create(user=user, course_run=course_run)
```



@pdpinch 
#### Screenshots (if appropriate)
<img width="921" alt="screen shot 2018-02-21 at 7 53 53 pm" src="https://user-images.githubusercontent.com/10431250/36486715-fb92e73e-1740-11e8-9652-df8e6e750203.png">

