### PR TITLE
Update pylint, django-webpack-loader and remove DeprecationWarning filter

### DIFF
--- a/courses/factories.py
+++ b/courses/factories.py
@@ -32,6 +32,7 @@ class FullProgramFactory(ProgramFactory):
                 from financialaid.factories import TierProgramFactory
                 TierProgramFactory.create_properly_configured_batch(2, program=self)
             return self
+        return None
 
 
 class CourseFactory(DjangoModelFactory):

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -30,7 +30,7 @@ class ProgramSerializer(serializers.ModelSerializer):
                 return page.external_program_page_url
             return page.url
         except ProgramPage.DoesNotExist:
-            return
+            return None
 
     def get_enrolled(self, program):
         """

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -411,7 +411,7 @@ def format_courserun_for_dashboard(course_run, status_for_user, mmtrack, positio
         dict: a dictionary containing information about the course
     """
     if course_run is None:
-        return
+        return None
     formatted_run = {
         'id': course_run.id,
         'course_id': course_run.edx_course_key,

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1845,7 +1845,9 @@ def test_calculate_up_to_date(users_without_with_cache):
     for users whose cache has expired or who are not cached
     """
     needs_update, _ = users_without_with_cache
-    assert api.calculate_users_to_refresh_in_bulk() == [user.id for user in needs_update]
+    assert sorted(api.calculate_users_to_refresh_in_bulk()) == sorted(
+        [user.id for user in needs_update]
+    )
 
 
 def test_calculate_missing_cache(users_without_with_cache):

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -379,6 +379,9 @@ class MMTrack:
     def calculate_final_grade_average(self):
         """
         Calculates an average grade (integer) from the program final grades
+
+        Returns:
+            float: The average final grade or None if no final grades
         """
         final_grades = self.final_grade_qset.for_course_run_keys(self.edx_course_keys)
         if final_grades:
@@ -386,6 +389,7 @@ class MMTrack:
                 sum(Decimal(final_grade.grade_percent) for final_grade in final_grades) /
                 len(final_grades)
             )
+        return None
 
     def get_current_grade(self, edx_course_key):
         """
@@ -397,10 +401,10 @@ class MMTrack:
             float: the current grade of the user in the course run
         """
         if not self.is_enrolled(edx_course_key):
-            return
+            return None
         current_grade = self.current_grades.get_current_grade(edx_course_key)
         if current_grade is None:
-            return
+            return None
         return float(current_grade.percent) * 100
 
     def count_courses_passed(self):

--- a/discussions/api.py
+++ b/discussions/api.py
@@ -7,6 +7,7 @@ from django.db import transaction
 from open_discussions_api.client import OpenDiscussionsApi
 from open_discussions_api.constants import ROLE_STAFF
 from requests.exceptions import HTTPError
+from rest_framework import status as statuses
 
 from discussions.models import (
     Channel,
@@ -22,7 +23,6 @@ from discussions.exceptions import (
     ModeratorSyncException,
     SubscriberSyncException,
 )
-from rest_framework import status as statuses
 from roles.models import Role
 from roles.roles import Permissions
 from search.api import adjust_search_for_percolator
@@ -60,7 +60,7 @@ def create_or_update_discussion_user(user_id, allow_email_optin=False):
 
     Args:
         user_id (int): user id of the user to sync
-         allow_email_optin (bool): if True send email_optin in profile dict on users.update call
+        allow_email_optin (bool): if True send email_optin in profile dict on users.update call
 
     Returns:
         DiscussionUser: The DiscussionUser connected to the user

--- a/exams/tasks.py
+++ b/exams/tasks.py
@@ -43,7 +43,7 @@ def export_exam_profiles(self):
     Sync any outstanding profiles
     """
     if not settings.FEATURES.get("PEARSON_EXAMS_SYNC", False):
-        return None
+        return
 
     exam_profiles = ExamProfile.objects.filter(
         status=ExamProfile.PROFILE_PENDING).select_related('profile')
@@ -122,7 +122,7 @@ def export_exam_authorizations(self):
     Sync any outstanding profiles
     """
     if not settings.FEATURES.get("PEARSON_EXAMS_SYNC", False):
-        return None
+        return
 
     exam_authorizations = ExamAuthorization.objects.filter(
         status=ExamAuthorization.STATUS_PENDING).prefetch_related('user__profile', 'course__program')

--- a/financialaid/views_test.py
+++ b/financialaid/views_test.py
@@ -4,13 +4,13 @@ Tests for financialaid view
 from decimal import Decimal
 from unittest.mock import Mock, patch
 
-from backends.edxorg import EdxOrgOAuth2
 import ddt
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
+from backends.edxorg import EdxOrgOAuth2
 from courses.models import Program
 from dashboard.models import ProgramEnrollment
 from financialaid.api import (

--- a/grades/api.py
+++ b/grades/api.py
@@ -145,9 +145,10 @@ def freeze_user_final_grade(user, course_run, raise_on_exception=False):
     Args:
         user (User): a django User
         course_run (CourseRun): a course run model object
+        raise_on_exception (bool): If true, raise an exception on error. Else create a warning and exit
 
     Returns:
-        None
+        FinalGrade: The final grade created, or None if there was an exception but raise_on_exception was False
     """
     # no need to do anything if the course run is not ready
     if not course_run.can_freeze_grades:
@@ -156,7 +157,7 @@ def freeze_user_final_grade(user, course_run, raise_on_exception=False):
                 'The grade for user "%s" course "%s" cannot be frozen yet',
                 user.username, course_run.edx_course_key
             )
-            return
+            return None
         else:
             raise FreezeGradeFailedException(
                 'The grade for user "{0}" course "{1}" cannot be frozen yet'.format(
@@ -172,7 +173,7 @@ def freeze_user_final_grade(user, course_run, raise_on_exception=False):
         con.lpush(CACHE_KEY_FAILED_USERS_BASE_STR.format(course_run.edx_course_key), user.id)
         if not raise_on_exception:
             log.exception('Impossible to refresh the edX cache for user "%s"', user.username)
-            return
+            return None
         else:
             raise FreezeGradeFailedException(
                 'Impossible to refresh the edX cache for user "{0}"'.format(user.username)) from ex
@@ -183,7 +184,7 @@ def freeze_user_final_grade(user, course_run, raise_on_exception=False):
         if not raise_on_exception:
             log.exception(
                 'Impossible to get final grade for user "%s" in course %s', user.username, course_run.edx_course_key)
-            return
+            return None
         else:
             raise FreezeGradeFailedException(
                 'Impossible to get final grade for user "{0}" in course {1}'.format(

--- a/micromasters/utils.py
+++ b/micromasters/utils.py
@@ -115,6 +115,7 @@ def custom_exception_handler(exc, context):
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             data=[formatted_exception_string]
         )
+    return None
 
 
 def serialize_model_object(obj):

--- a/pylintrc
+++ b/pylintrc
@@ -19,4 +19,4 @@ ignored-modules=
 	six.moves,
 
 [MESSAGES CONTROL]
-disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors, line-too-long, no-self-use, len-as-condition, no-else-return
+disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors, line-too-long, no-self-use, len-as-condition, no-else-return, unpacking-non-sequence, not-an-iterable, unsupported-membership-test

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,10 +4,3 @@ norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.e
 pep8ignore =
    */migrations/* ALL
 pep8maxlinelength = 119
-filterwarnings =
-    error
-    ignore::DeprecationWarning
-    ignore::django.utils.deprecation.RemovedInDjango20Warning
-    ignore::ImportWarning
-    ignore::PendingDeprecationWarning
-    ignore:Failed to load HostKeys

--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,7 @@ django-redis==4.7.0
 django-role-permissions==2.2.0
 django-server-status==0.4.0
 django-storages-redux==1.3.2
-django-webpack-loader==0.4.1
+django-webpack-loader==0.5.0
 djangorestframework==3.5.2
 edx-api-client==0.4.0
 edx-opaque-keys==0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ django-server-status==0.4.0
 django-storages-redux==1.3.2
 django-taggit==0.22.1     # via wagtail
 django-treebeard==4.1.2   # via wagtail
-django-webpack-loader==0.4.1
+django-webpack-loader==0.5.0
 django==1.10.5
 djangorestframework==3.5.2
 edx-api-client==0.4.0

--- a/seed_data/management/commands/seed_db.py
+++ b/seed_data/management/commands/seed_db.py
@@ -251,7 +251,7 @@ class Command(BaseCommand):
             ProgramEnrollment.objects.create(user=staff_user, program=program)
             Role.objects.create(user=staff_user, program=program, role=Staff.ROLE_ID)
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # pylint: disable=too-many-locals
         program_data_list = load_json_from_file(PROGRAM_DATA_PATH)
         user_data_list = load_json_from_file(USER_DATA_PATH)
         existing_fake_user_count = User.objects.filter(username__startswith=FAKE_USER_USERNAME_PREFIX).count()

--- a/selenium_tests/conftest.py
+++ b/selenium_tests/conftest.py
@@ -207,3 +207,11 @@ def logged_in_student(browser, base_test_data):
         User: User object
     """
     return LoginPage(browser).log_in_via_admin(base_test_data.student_user, DEFAULT_PASSWORD)
+
+
+@pytest.fixture(autouse=True)
+def warnings_as_errors():
+    """
+    Override other fixture to disable it. For some reason warnings as errors isn't working in selenium
+    tests.
+    """

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,3 @@
-astroid==1.5.3 # fix https://github.com/PyCQA/pylint/issues/1609
 bpython
 codecov
 ddt
@@ -7,8 +6,8 @@ ipdb
 nplusone>=0.8.1
 pdbpp
 pip-tools
-pylint==1.7.2
--e git+git://github.com/mitodl/pylint-django.git@2c7136f1cb3ff618aa08189c7fab4f8e08772eae#egg=pylint-django-0.7.2fix
+pylint==1.8.2
+pylint-django==0.9.0
 pytest
 pytest-cov
 pytest-django

--- a/ui/templatetags/render_bundle.py
+++ b/ui/templatetags/render_bundle.py
@@ -3,8 +3,8 @@
 from django import template
 from django.conf import settings
 from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.utils.safestring import mark_safe
 
-from webpack_loader.templatetags.webpack_loader import render_as_tags
 from webpack_loader.utils import get_loader
 
 from micromasters.utils import webpack_dev_server_url
@@ -31,6 +31,15 @@ def public_path(request):
 def _get_bundle(request, bundle_name):
     """
     Update bundle URLs to handle webpack hot reloading correctly if DEBUG=True
+
+    Args:
+        request (django.http.request.HttpRequest): A request
+        bundle_name (str): The name of the webpack bundle
+
+    Returns:
+        iterable of dict:
+            The chunks of the bundle. Usually there's only one but I suppose you could have
+            CSS and JS chunks for one bundle for example
     """
     if not settings.DISABLE_WEBPACK_LOADER_STATS:
         for chunk in get_loader('DEFAULT').get_bundle(bundle_name):
@@ -46,9 +55,46 @@ def _get_bundle(request, bundle_name):
 def render_bundle(context, bundle_name):
     """
     Render the script tags for a Webpack bundle
+
+    We use this instead of webpack_loader.templatetags.webpack_loader.render_bundle because we want to substitute
+    a dynamic URL for webpack dev environments. Maybe in the future we should refactor to use publicPath
+    instead for this.
+
+    Args:
+        context (dict): The context for rendering the template (includes request)
+        bundle_name (str): The name of the bundle to render
+
+    Returns:
+        django.utils.safestring.SafeText: The tags for JS and CSS
     """
     try:
-        return render_as_tags(_get_bundle(context['request'], bundle_name), '')
+        bundle = _get_bundle(context['request'], bundle_name)
+        return _render_tags(bundle)
     except OSError:
         # webpack-stats.json doesn't exist
-        return ''
+        return mark_safe('')
+
+
+def _render_tags(bundle):
+    """
+    Outputs tags for template rendering.
+    Adapted from webpack_loader.utils.get_as_tags and webpack_loader.templatetags.webpack_loader.
+
+    Args:
+        bundle (iterable of dict): The information about a webpack bundle
+
+    Returns:
+        django.utils.safestring.SafeText: HTML for rendering bundles
+    """
+
+    tags = []
+    for chunk in bundle:
+        if chunk['name'].endswith(('.js', '.js.gz')):
+            tags.append((
+                '<script type="text/javascript" src="{}" ></script>'
+            ).format(chunk['url']))
+        elif chunk['name'].endswith(('.css', '.css.gz')):
+            tags.append((
+                '<link type="text/css" href="{}" rel="stylesheet" />'
+            ).format(chunk['url']))
+    return mark_safe('\n'.join(tags))

--- a/ui/templatetags/render_bundle_test.py
+++ b/ui/templatetags/render_bundle_test.py
@@ -21,6 +21,12 @@ FAKE_COMMON_BUNDLE = [
         "name": "common-1f11431a92820b453513.js",
         "path": "/project/static/bundles/common-1f11431a92820b453513.js"
     },
+    {
+        "name": "styles-style-933338dc60803c41d467cfdd05585354.css",
+        "path": "/tmp/build_6f6b143c978a6d77b7a59b158d3579e4/"
+                "mitodl-micromasters-9f03ab4/static/bundles/"
+                "styles-style-933338dc60803c41d467cfdd05585354.css",
+    },
 ]
 
 
@@ -45,17 +51,18 @@ class TestRenderBundle(TestCase):
         bundle_name = 'bundle_name'
         with patch('ui.templatetags.render_bundle.get_loader', return_value=loader) as get_loader:
             assert render_bundle(context, bundle_name) == (
-                '<script type="text/javascript" src="{base}/{filename}" >'
-                '</script>'.format(
+                '<script type="text/javascript" src="{base}/{js}" ></script>\n'
+                '<link type="text/css" href="{base}/{css}" rel="stylesheet" />'.format(
                     base=webpack_dev_server_url(request),
-                    filename=FAKE_COMMON_BUNDLE[0]['name'],
+                    js=FAKE_COMMON_BUNDLE[0]['name'],
+                    css=FAKE_COMMON_BUNDLE[1]['name'],
                 )
             )
 
-            assert public_path(request) == webpack_dev_server_url(request) + "/"
+        assert public_path(request) == webpack_dev_server_url(request) + "/"
 
-            get_bundle.assert_called_with(bundle_name)
-            get_loader.assert_called_with('DEFAULT')
+        get_bundle.assert_called_with(bundle_name)
+        get_loader.assert_called_with('DEFAULT')
 
     @override_settings(USE_WEBPACK_DEV_SERVER=False)
     def test_production(self):
@@ -72,17 +79,18 @@ class TestRenderBundle(TestCase):
         bundle_name = 'bundle_name'
         with patch('ui.templatetags.render_bundle.get_loader', return_value=loader) as get_loader:
             assert render_bundle(context, bundle_name) == (
-                '<script type="text/javascript" src="{base}/{filename}" >'
-                '</script>'.format(
+                '<script type="text/javascript" src="{base}/{js}" ></script>\n'
+                '<link type="text/css" href="{base}/{css}" rel="stylesheet" />'.format(
                     base="/static/bundles",
-                    filename=FAKE_COMMON_BUNDLE[0]['name'],
+                    js=FAKE_COMMON_BUNDLE[0]['name'],
+                    css=FAKE_COMMON_BUNDLE[1]['name'],
                 )
             )
 
-            assert public_path(request) == "/static/bundles/"
+        assert public_path(request) == "/static/bundles/"
 
-            get_bundle.assert_called_with(bundle_name)
-            get_loader.assert_called_with('DEFAULT')
+        get_bundle.assert_called_with(bundle_name)
+        get_loader.assert_called_with('DEFAULT')
 
     def test_missing_file(self):
         """
@@ -97,5 +105,5 @@ class TestRenderBundle(TestCase):
         with patch('ui.templatetags.render_bundle.get_loader', return_value=loader) as get_loader:
             assert render_bundle(context, bundle_name) == ''
 
-            get_bundle.assert_called_with(bundle_name)
-            get_loader.assert_called_with('DEFAULT')
+        get_bundle.assert_called_with(bundle_name)
+        get_loader.assert_called_with('DEFAULT')

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -707,6 +707,7 @@ class TestProgramPage(ViewsTests):
             self.assertEqual(course.url, js_course["url"])
 
 
+# pylint: disable=too-many-locals
 class TestUsersPage(ViewsTests):
     """
     Tests for user page


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #3746 

#### What's this PR do?
Updates pylint, fixes warnings, updates django-webpack-loader and finally removes the filter on all `DeprecationWarning`s, replacing it with more targeted filters.

#### How should this be manually tested?
Nothing should break
