### PR TITLE
Fixes overlapping icons on Profile page

### DIFF
--- a/static/scss/profile.scss
+++ b/static/scss/profile.scss
@@ -132,12 +132,8 @@
         width: 50%;
         vertical-align: middle;
         padding-bottom: 13px;
-        display: -webkit-box;
         display: flex;
-        -webkit-box-orient: horizontal;
-        -webkit-box-direction: normal;
         flex-direction: row;
-        -webkit-box-pack: end;
         justify-content: space-between;
 
         &.row-padding {

--- a/static/scss/profile.scss
+++ b/static/scss/profile.scss
@@ -130,9 +130,15 @@
     .col {
       &.user-credentials {
         width: 50%;
-
         vertical-align: middle;
         padding-bottom: 13px;
+        display: -webkit-box;
+        display: flex;
+        -webkit-box-orient: horizontal;
+        -webkit-box-direction: normal;
+        flex-direction: row;
+        -webkit-box-pack: end;
+        justify-content: space-between;
 
         &.row-padding {
           padding-top: 30px;


### PR DESCRIPTION
#### What are the relevant tickets?
#3368 

#### What's this PR do?
This fixes a layout problem in mobile devices where the edit icons on the profile page were overlapping with the center column text. I fixed this by adding flex layout to the columns.

#### How should this be manually tested?
See that it does not overlap in chrome, firefox, or safari on mobile.

![image](https://user-images.githubusercontent.com/20047260/36752309-b01f6388-1bd0-11e8-9d37-7fa5e4defd95.png)

