### PR TITLE
Snapshots: Add more PAID_BUT_NOT_ENROLLED states for FA program

### DIFF
--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -258,6 +258,23 @@ class DashboardStates:
         # create another offered run
         CourseRunFactory.create(course=course)
 
+    def create_paid_but_no_enrollable_run(self, in_future, fuzzy):
+        self.make_fa_program_enrollment(FinancialAidStatus.AUTO_APPROVED)
+        course = Course.objects.get(title='Digital Learning 200')
+        course_run = course.courserun_set.order_by('start_date').first()
+        LineFactory.create(
+            order__status=Order.FULFILLED,
+            course_key=course_run
+        )
+        alter_arg_list = [
+            "alter_data", 'set_to_offered', '--username', 'staff', '--course-title', 'Digital Learning 200'
+        ]
+        if in_future:
+            alter_arg_list.append('--in-future')
+        if fuzzy:
+            alter_arg_list.append('--fuzzy')
+        call_command(*alter_arg_list)
+
     def __iter__(self):
         """
         Iterator over all dashboard states supported by this command.
@@ -294,6 +311,16 @@ class DashboardStates:
             )
 
         yield (self.create_paid_failed_course_run, 'failed_paid_run_another_offered')
+
+        # Add scenarios for paid and course run offered [now, in future, fuzzy future]
+        for tup in itertools.product([True, False], repeat=2):
+            in_future, fuzzy = tup
+
+            yield (bind_args(self.create_paid_but_no_enrollable_run, in_future, fuzzy),
+                   'paid_but_not_enrolled{in_future}{fuzzy}'.format(
+                       in_future='_offered_in_future' if in_future else '',
+                       fuzzy='_offered_fuzzy' if fuzzy else ''
+                   ))
 
         # Also test for two different passing and failed runs on the same course
         yield (self.with_prev_passed_run, 'failed_with_prev_passed_run')

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -259,6 +259,7 @@ class DashboardStates:
         CourseRunFactory.create(course=course)
 
     def create_paid_but_no_enrollable_run(self, in_future, fuzzy):
+        """Make paid but not enrolled, with offered currently, in future, and fuzzy """
         self.make_fa_program_enrollment(FinancialAidStatus.AUTO_APPROVED)
         course = Course.objects.get(title='Digital Learning 200')
         course_run = course.courserun_set.order_by('start_date').first()


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
This adds more states where user is enrolled in a Financial Aid program and has paid for a course but is not enrolled currently. The states include cases where there is a currently offered course run, offered in certain future, with fuzzy date, or not offered at all.

#### How should this be manually tested?
Delete the folder `output/dashboard_states`.
Run the command `./scripts/test/run_snapshot_dashboard_states.sh --match "paid_but"`
Look at the generated output images

