### PR TITLE
Dashboard: show certificate if user has it

### DIFF
--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -280,6 +280,7 @@ class DashboardStates:
         call_command(*alter_arg_list)
 
     def create_passed_enrolled_again(self):
+        """Make course passed and user retaking/auditing the course again"""
         self.make_fa_program_enrollment(FinancialAidStatus.AUTO_APPROVED)
         course = Course.objects.get(title='Digital Learning 200')
         CourseCertificateSignatoriesFactory.create(course=course)

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -17,6 +17,7 @@ from django.db import connection
 from django.test import override_settings
 from django.contrib.auth.models import User
 
+from cms.factories import CourseCertificateSignatoriesFactory
 from courses.factories import CourseRunFactory
 from courses.models import (
     Course,
@@ -33,9 +34,11 @@ from ecommerce.models import (
 from exams.factories import ExamRunFactory, ExamProfileFactory, ExamAuthorizationFactory
 from financialaid.factories import FinancialAidFactory
 from financialaid.models import FinancialAidStatus
-from grades.factories import ProctoredExamGradeFactory
+from grades.factories import ProctoredExamGradeFactory, MicromastersCourseCertificateFactory
+from grades.models import FinalGrade, CourseRunGradingStatus
 from profiles.api import get_social_username
 from roles.models import Role, Staff
+from seed_data.lib import set_course_run_current, CachedEnrollmentHandler
 from seed_data.management.commands.alter_data import EXAMPLE_COMMANDS
 from selenium_tests.data_util import create_user_for_login
 from selenium_tests.util import (
@@ -276,6 +279,25 @@ class DashboardStates:
             alter_arg_list.append('--fuzzy')
         call_command(*alter_arg_list)
 
+    def create_passed_enrolled_again(self):
+        self.make_fa_program_enrollment(FinancialAidStatus.AUTO_APPROVED)
+        course = Course.objects.get(title='Digital Learning 200')
+        CourseCertificateSignatoriesFactory.create(course=course)
+
+        call_command(
+            "alter_data", 'set_past_run_to_passed', '--username', 'staff',
+            '--course-title', 'Digital Learning 200', '--grade', '87',
+        )
+        final_grade = FinalGrade.objects.filter(
+            course_run__course__title='Digital Learning 200', user=self.user
+        ).first()
+        CourseRunGradingStatus.objects.create(course_run=final_grade.course_run, status='complete')
+        MicromastersCourseCertificateFactory.create(final_grade=final_grade)
+
+        course_run = CourseRunFactory.create(course=course)
+        set_course_run_current(course_run, upgradeable=True, save=True)
+        CachedEnrollmentHandler(self.user).set_or_create(course_run, verified=False)
+
     def __iter__(self):
         """
         Iterator over all dashboard states supported by this command.
@@ -312,6 +334,8 @@ class DashboardStates:
             )
 
         yield (self.create_paid_failed_course_run, 'failed_paid_run_another_offered')
+
+        yield (self.create_passed_enrolled_again, 'passed_and_taking_again')
 
         # Add scenarios for paid and course run offered [now, in future, fuzzy future]
         for tup in itertools.product([True, False], repeat=2):

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -162,10 +162,12 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     })
   }
   // Course is running, user has already paid,
-  if (courseUpcomingOrCurrent(firstRun) && paid && exams) {
-    messages.push({
+  if (courseUpcomingOrCurrent(firstRun) && paid) {
+    if (exams) {
+      messages.push({
         message: messageForNotAttemptedExam(course)
       })
+    }
     return S.Just(messages)
   }
 
@@ -297,6 +299,10 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
             )
           )
         }
+      } else if(!course.certificate_url) {
+          messages.push({
+            message: "You passed this course."
+          })
       }
       return S.Just(messages)
     } else {

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -300,9 +300,9 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
           )
         }
       } else if(!course.certificate_url) {
-          messages.push({
-            message: "You passed this course."
-          })
+        messages.push({
+          message: "You passed this course."
+        })
       }
       return S.Just(messages)
     } else {

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -143,16 +143,32 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     }
   }
 
+  const messages = []
+
+  if (course.certificate_url) {
+    messages.push({
+      message: (
+        <div>
+          {"You passed this course! "}
+          <a
+            href={course.certificate_url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View Certificate
+          </a>
+        </div>
+      )
+    })
+  }
   // Course is running, user has already paid,
-  if (courseUpcomingOrCurrent(firstRun) && paid) {
-    return S.Just([
-      {
+  if (courseUpcomingOrCurrent(firstRun) && paid && exams) {
+    messages.push({
         message: messageForNotAttemptedExam(course)
-      }
-    ])
+      })
+    return S.Just(messages)
   }
 
-  const messages = []
 
   if (
     coupon &&
@@ -169,6 +185,9 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   ) {
     let message =
       "You are auditing. To get credit, you need to pay for the course."
+    if(course.certificate_url) {
+      message = "You are re-taking this course. To get a new grade, you need to pay again."
+    }
     let actionType = COURSE_ACTION_PAY
     if (hasFinancialAid) {
       if (FA_PENDING_STATUSES.includes(financialAid.application_status)) {
@@ -278,25 +297,6 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
             )
           )
         }
-      } else {
-        let message = "You passed this course."
-        if (course.certificate_url) {
-          message = (
-            <div>
-              {"You passed this course! "}
-              <a
-                href={course.certificate_url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                View Certificate
-              </a>
-            </div>
-          )
-        }
-        messages.push({
-          message: message
-        })
       }
       return S.Just(messages)
     } else {

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -171,7 +171,6 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     return S.Just(messages)
   }
 
-
   if (
     coupon &&
     coupon.content_type === COUPON_CONTENT_TYPE_COURSE &&
@@ -187,8 +186,9 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   ) {
     let message =
       "You are auditing. To get credit, you need to pay for the course."
-    if(course.certificate_url) {
-      message = "You are re-taking this course. To get a new grade, you need to pay again."
+    if (course.certificate_url) {
+      message =
+        "You are re-taking this course. To get a new grade, you need to pay again."
     }
     let actionType = COURSE_ACTION_PAY
     if (hasFinancialAid) {
@@ -299,7 +299,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
             )
           )
         }
-      } else if(!course.certificate_url) {
+      } else if (!course.certificate_url) {
         messages.push({
           message: "You passed this course."
         })

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -175,6 +175,28 @@ describe("Course Status Messages", () => {
         )
       )
     })
+    it("should ask to pay for a new grade, if already has a certificate ", () => {
+      makeRunCurrent(course.runs[0])
+      makeRunEnrolled(course.runs[0])
+      course.certificate_url = 'certificate'
+      let messages = calculateMessages(calculateMessagesProps).value
+      assert.equal(messages.length, 2)
+      const mounted = shallow(messages[0]['message'])
+
+      assert.equal(mounted.text(), "You passed this course! View Certificate")
+
+      assert.deepEqual(messages[1], {
+        action:  "course action was called",
+        message: "You are re-taking this course. To get a new grade, you need to pay again."
+      })
+
+      assert(
+        calculateMessagesProps.courseAction.calledWith(
+          course.runs[0],
+          COURSE_ACTION_PAY
+        )
+      )
+    })
     it("should tell auditors to calculate price and pay for course", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -179,7 +179,7 @@ describe("Course Status Messages", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
       course.certificate_url = 'certificate'
-      let messages = calculateMessages(calculateMessagesProps).value
+      const messages = calculateMessages(calculateMessagesProps).value
       assert.equal(messages.length, 2)
       const mounted = shallow(messages[0]['message'])
 

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -178,16 +178,17 @@ describe("Course Status Messages", () => {
     it("should ask to pay for a new grade, if already has a certificate ", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
-      course.certificate_url = 'certificate'
+      course.certificate_url = "certificate"
       const messages = calculateMessages(calculateMessagesProps).value
       assert.equal(messages.length, 2)
-      const mounted = shallow(messages[0]['message'])
+      const mounted = shallow(messages[0]["message"])
 
       assert.equal(mounted.text(), "You passed this course! View Certificate")
 
       assert.deepEqual(messages[1], {
         action:  "course action was called",
-        message: "You are re-taking this course. To get a new grade, you need to pay again."
+        message:
+          "You are re-taking this course. To get a new grade, you need to pay again."
       })
 
       assert(

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -273,6 +273,7 @@ describe("Course Status Messages", () => {
       })
 
       it("should prompt to schedule exam", () => {
+        course.has_exam = true
         course.can_schedule_exam = true
 
         assertIsJust(calculateMessages(calculateMessagesProps), [
@@ -283,6 +284,7 @@ describe("Course Status Messages", () => {
       })
 
       it("should prompt to sign up for future", () => {
+        course.has_exam = true
         course.can_schedule_exam = false
         course.exams_schedulable_in_future = [
           moment()
@@ -300,6 +302,7 @@ describe("Course Status Messages", () => {
       })
 
       it("should inform that no exam is avaiable", () => {
+        course.has_exam = true
         course.can_schedule_exam = false
         course.exams_schedulable_in_future = []
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3862

#### What's this PR do?
Shows the link to certificate for a course if user has it.

Also, fixed a bug where the message about exam was shown even if course didn't have an exam.

#### How should this be manually tested?
Delete folder `output/dashboard_states`
Run ./scripts/test/run_snapshot_dashboard_states.sh --match "taking_again"
Take a look the output

<img width="650" alt="screen shot 2018-03-02 at 2 38 09 pm" src="https://user-images.githubusercontent.com/7574259/36918750-e6276750-1e28-11e8-906f-c9e675dd7eac.png">
