### PR TITLE
fix date formatting to be less US-centric

### DIFF
--- a/static/js/components/dashboard/FinancialAidCard_test.js
+++ b/static/js/components/dashboard/FinancialAidCard_test.js
@@ -271,7 +271,7 @@ describe("FinancialAidCard", () => {
           const wrapper = renderCard({ program })
           assert.include(
             wrapper.text(),
-            "Documents mailed/faxed on Mar 3, 2003"
+            "Documents mailed/faxed on March 3, 2003"
           )
         })
       }

--- a/static/js/components/dashboard/courses/ProgressMessage.js
+++ b/static/js/components/dashboard/courses/ProgressMessage.js
@@ -15,7 +15,7 @@ import {
   STATUS_CURRENTLY_ENROLLED,
   STATUS_PAID_BUT_NOT_ENROLLED,
   EDX_LINK_BASE,
-  COURSE_CARD_FORMAT
+  DASHBOARD_FORMAT
 } from "../../../constants"
 import { renderSeparatedComponents } from "../../../util/util"
 import { hasAnyStaffRole } from "../../../lib/roles"
@@ -63,7 +63,7 @@ export const staffCourseInfo = (courseRun: CourseRun, course: Course) => {
       if (courseCurrentlyInProgress(courseRun)) {
         return `Auditing (Upgrade deadline ${moment(
           courseRun.course_upgrade_deadline
-        ).format(COURSE_CARD_FORMAT)})`
+        ).format(DASHBOARD_FORMAT)})`
       }
       return "Auditing"
     }

--- a/static/js/components/dashboard/courses/ProgressMessage_test.js
+++ b/static/js/components/dashboard/courses/ProgressMessage_test.js
@@ -18,7 +18,7 @@ import {
 import {
   EDX_LINK_BASE,
   STATUS_CAN_UPGRADE,
-  COURSE_CARD_FORMAT,
+  DASHBOARD_FORMAT,
   STATUS_MISSED_DEADLINE,
   STATUS_PAID_BUT_NOT_ENROLLED,
   STATUS_PASSED,
@@ -142,7 +142,7 @@ describe("Course ProgressMessage", () => {
         staffCourseInfo(course.runs[0], course),
         `Auditing (Upgrade deadline ${moment(
           course.runs[0].course_upgrade_deadline
-        ).format(COURSE_CARD_FORMAT)})`
+        ).format(DASHBOARD_FORMAT)})`
       )
     })
 

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -21,7 +21,7 @@ import {
   STATUS_PAID_BUT_NOT_ENROLLED,
   STATUS_CAN_UPGRADE,
   COURSE_ACTION_CALCULATE_PRICE,
-  COURSE_CARD_FORMAT,
+  DASHBOARD_FORMAT,
   COURSE_DEADLINE_FORMAT
 } from "../../../constants"
 import { S } from "../../../lib/sanctuary"
@@ -58,7 +58,7 @@ export const formatMessage = (message: Message, index?: number) => (
 )
 
 export const formatDate = (date: ?string) =>
-  moment(date).format(COURSE_CARD_FORMAT)
+  moment(date).format(DASHBOARD_FORMAT)
 
 type CalculateMessagesProps = {
   courseAction: (run: CourseRun, actionType: string) => React$Element<*>,
@@ -337,7 +337,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
         )
       } else {
         const dueDate = paymentDueDate.isValid()
-          ? ` (Payment due on ${paymentDueDate.format(COURSE_CARD_FORMAT)})`
+          ? ` (Payment due on ${paymentDueDate.format(DASHBOARD_FORMAT)})`
           : ""
         if (exams) {
           messages.push({

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -36,7 +36,7 @@ import {
   COURSE_ACTION_CALCULATE_PRICE,
   COURSE_ACTION_REENROLL,
   COUPON_CONTENT_TYPE_COURSE,
-  COURSE_CARD_FORMAT,
+  DASHBOARD_FORMAT,
   COURSE_DEADLINE_FORMAT,
   STATUS_PAID_BUT_NOT_ENROLLED,
   FA_STATUS_PENDING_DOCS
@@ -549,7 +549,7 @@ describe("Course Status Messages", () => {
       makeRunPassed(course.runs[0])
       makeRunDueSoon(course.runs[0])
       const date = moment(course.runs[0].course_upgrade_deadline).format(
-        COURSE_CARD_FORMAT
+        DASHBOARD_FORMAT
       )
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
@@ -590,7 +590,7 @@ describe("Course Status Messages", () => {
       makeRunDueSoon(course.runs[0])
       course.has_exam = true
       const date = moment(course.runs[0].course_upgrade_deadline).format(
-        COURSE_CARD_FORMAT
+        DASHBOARD_FORMAT
       )
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
@@ -631,7 +631,9 @@ describe("Course Status Messages", () => {
       course.runs[1].enrollment_start_date = moment()
         .subtract(10, "days")
         .toISOString()
-      const date = moment(course.runs[1].course_start_date).format("MM/DD/YYYY")
+      const date = moment(course.runs[1].course_start_date).format(
+        DASHBOARD_FORMAT
+      )
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
           message: `You did not pass the edX course, but you can re-enroll. Next course starts ${date}.`,
@@ -661,7 +663,7 @@ describe("Course Status Messages", () => {
         makeRunFuture(course.runs[1])
         course.runs[1].enrollment_start_date = nextEnrollmentStart[0]
         const date = moment(course.runs[1].course_start_date).format(
-          "MM/DD/YYYY"
+          DASHBOARD_FORMAT
         )
         assertIsJust(calculateMessages(calculateMessagesProps), [
           {

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -11,7 +11,7 @@ import {
   STATUS_CAN_UPGRADE,
   STATUS_CURRENTLY_ENROLLED,
   STATUS_WILL_ATTEND,
-  COURSE_CARD_FORMAT
+  DASHBOARD_FORMAT
 } from "../../../constants"
 import { S } from "../../../lib/sanctuary"
 
@@ -25,11 +25,11 @@ export const courseStartDateMessage = (courseRun: CourseRun) => {
   if (daysUntilStart === 0) {
     return "Course starts today"
   } else if (daysUntilStart < 0) {
-    return `Course started ${startDate.format(COURSE_CARD_FORMAT)}`
+    return `Course started ${startDate.format(DASHBOARD_FORMAT)}`
   } else if (daysUntilStart < 10) {
     return `Course starts in ${daysUntilStart} days`
   } else {
-    return `Course starts ${startDate.format(COURSE_CARD_FORMAT)}`
+    return `Course starts ${startDate.format(DASHBOARD_FORMAT)}`
   }
 }
 

--- a/static/js/components/dashboard/courses/util_test.js
+++ b/static/js/components/dashboard/courses/util_test.js
@@ -28,7 +28,7 @@ import {
   STATUS_PENDING_ENROLLMENT,
   STATUS_MISSED_DEADLINE,
   STATUS_PAID_BUT_NOT_ENROLLED,
-  COURSE_CARD_FORMAT
+  DASHBOARD_FORMAT
 } from "../../../constants"
 import { assertIsNothing, assertIsJust } from "../../../lib/test_utils"
 
@@ -48,7 +48,7 @@ describe("dashboard course utilities", () => {
         run.course_start_date = inTheFuture.format()
         assert.equal(
           courseStartDateMessage(run),
-          `Course starts ${inTheFuture.format(COURSE_CARD_FORMAT)}`
+          `Course starts ${inTheFuture.format(DASHBOARD_FORMAT)}`
         )
       })
     })

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -8,10 +8,9 @@ export const MASTERS = "m"
 export const DOCTORATE = "p"
 
 export const ISO_8601_FORMAT = "YYYY-MM-DD"
-export const DASHBOARD_FORMAT = "MMM D, Y"
+export const DASHBOARD_FORMAT = "MMMM D, Y"
 export const DASHBOARD_MONTH_FORMAT = "MM[/]YYYY"
-export const COURSE_CARD_FORMAT = "MM/DD/YYYY"
-export const COURSE_DEADLINE_FORMAT = "MM/DD/YYYY [at] hA z"
+export const COURSE_DEADLINE_FORMAT = `${DASHBOARD_FORMAT} [at] hA z`
 
 export const CP1252_REGEX = /^[\u0020-\u00FF]*$/
 // greater-than, comma, quotation-mark


### PR DESCRIPTION
#### What are the relevant tickets?

closes #3866 

#### What's this PR do?

This changes the date formatting for the dashboard stuff so we don't do `MM/DD/YYYY` format (which is not a standard format internationally) and we instead go for a thing like `March 14, 2014`.

#### How should this be manually tested?

Dates should all be formatted with the full, written month as above. The changed formatting shouldn't (I think) cause any spacing / layout issues, but probably good to check that too.