### PR TITLE
Override ALLOWED_HOSTS for snapshot states tests

### DIFF
--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -448,7 +448,7 @@ def test_data(django_db_blocker, seeded_database_loader):
     'not RUNNING_DASHBOARD_STATES',
     reason='DashboardStates test suite is only meant to be run via management command',
 )
-def test_dashboard_states(browser, seeded_database_loader, django_db_blocker, test_data):
+def test_dashboard_states(browser, override_allowed_hosts, seeded_database_loader, django_db_blocker, test_data):
     """Iterate through all possible dashboard states and save screenshots/API results of each one"""
     output_directory = DASHBOARD_STATES_OPTIONS.get('output_directory')
     use_learner_page = DASHBOARD_STATES_OPTIONS.get('learner')

--- a/selenium_tests/management/commands/snapshot_learners_states.py
+++ b/selenium_tests/management/commands/snapshot_learners_states.py
@@ -179,7 +179,7 @@ class LearnersStates:
     'not RUNNING_DASHBOARD_STATES',
     reason='DashboardStates test suite is only meant to be run via management command',
 )
-def test_learners_states(browser, seeded_database_loader, django_db_blocker, test_data):
+def test_learners_states(browser, override_allowed_hosts, seeded_database_loader, django_db_blocker, test_data):
     """Iterate through all possible dashboard states and save screenshots/API results of each one"""
     output_directory = DASHBOARD_STATES_OPTIONS.get('output_directory')
     os.makedirs(output_directory, exist_ok=True)


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #3855

#### What's this PR do?
Fixed the bug where ALLOWED_HOSTS does not get overridden for dashboard and learner states tests.

#### How should this be manually tested?
Running `./scripts/test/run_snapshot_dashboard_states.sh` should run successfully 

