### PR TITLE
Increased the buffer size in uWSGI to address wagtail preview issue

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -44,3 +44,4 @@ endif =
 if-not-env = UWSGI_SOCKET_TIMEOUT
 socket-timeout = 3
 endif =
+buffer-size = 65535


### PR DESCRIPTION
#### What are the relevant tickets?
#3453 

#### What's this PR do?
uWSGI allocates a default buffer size of 4096 for request headers. When using the preview functionality the header is much larger than that buffer size so we raise a 502 error due to uWSGI failing to process the request. Increasing the buffer size allows for larger header values, preventing the failure on draft previews.

#### How should this be manually tested?
Set this value in uWSGI and generate a large diff in Wagtail, then try to view the preview.

#### Where should the reviewer start?
uwsgi.ini