### PR TITLE
Make environment variable to control batch update throttling

### DIFF
--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -8,6 +8,7 @@ from datetime import (
 import logging
 
 from celery import group
+from django.conf import settings
 import pytz
 
 from dashboard.api import (
@@ -28,7 +29,6 @@ from micromasters.utils import (
 log = logging.getLogger(__name__)
 
 
-PARALLEL_RATE_LIMIT = '5/m'
 LOCK_ID = 'batch_update_user_data_lock'
 
 
@@ -76,7 +76,7 @@ def batch_update_user_data():
         jobs.delay()
 
 
-@app.task(rate_limit=PARALLEL_RATE_LIMIT)
+@app.task(rate_limit=settings.BATCH_UPDATE_RATE_LIMIT)
 def batch_update_user_data_subtasks(students, expiration_timestamp):
     """
     Update user data like enrollments, certificates and grades from edX platform.

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -517,6 +517,11 @@ CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TIMEZONE = 'UTC'
 
 
+# Celery parallel rate limit for batch_update_user_data
+# This is the number of tasks per minute, each task updates data for 20 users
+BATCH_UPDATE_RATE_LIMIT = get_string('BATCH_UPDATE_RATE_LIMIT', '5/m')
+
+
 # django cache back-ends
 CACHES = {
     'default': {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3867 

#### What's this PR do?
Adds an environment variable to allow throttling of the batch user updates

#### How should this be manually tested?
Set the environment variable to something like `10/m` and run `dashboard.tasks.batch_update_user_data.delay()`. No errors should occur
