### PR TITLE
Snapshots: add more failed course states

### DIFF
--- a/seed_data/management/commands/alter_data.py
+++ b/seed_data/management/commands/alter_data.py
@@ -257,6 +257,7 @@ def set_to_offered(user=None, course_run=None, now=None,  # pylint: disable=unus
         course_run.fuzzy_start_date = fuzzy_date_string
         course_run.fuzzy_enrollment_start_date = fuzzy_date_string
         course_run.start_date = None
+        course_run.enrollment_start = None
         course_run.end_date = None
         course_run.enrollment_end = None
     elif in_future:

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -250,7 +250,7 @@ class DashboardStates:
             tier_program__discount_amount=50,
         )
 
-    def create_paid_failed_course_run(self, current, in_future, fuzzy):
+    def create_paid_failed_course_run(self, *, current, in_future, fuzzy):
         """Make paid failed course run, and offer another run"""
         self.make_fa_program_enrollment(FinancialAidStatus.AUTO_APPROVED)
         call_command(
@@ -351,7 +351,7 @@ class DashboardStates:
         for tup in itertools.product([True, False], repeat=3):
             current, in_future, fuzzy = tup
 
-            yield (bind_args(self.create_paid_failed_course_run, current, in_future, fuzzy),
+            yield (bind_args(self.create_paid_failed_course_run, current=current, in_future=in_future, fuzzy=fuzzy),
                    'create_paid_failed_course_run{current}{in_future}{fuzzy}'.format(
                        current='_offered_now' if current else '',
                        in_future='_offered_in_future' if in_future else '',

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -250,7 +250,7 @@ class DashboardStates:
             tier_program__discount_amount=50,
         )
 
-    def create_paid_failed_course_run(self, in_future, fuzzy):
+    def create_paid_failed_course_run(self, current, in_future, fuzzy):
         """Make paid failed course run, and offer another run"""
         self.make_fa_program_enrollment(FinancialAidStatus.AUTO_APPROVED)
         call_command(
@@ -258,17 +258,22 @@ class DashboardStates:
             '--course-title', 'Digital Learning 200', '--grade', '45',
         )
         course = Course.objects.get(title='Digital Learning 200')
-        # create another offered run
-        CourseRunFactory.create(course=course)
 
-        alter_arg_list = [
-            "alter_data", 'set_to_offered', '--username', 'staff', '--course-title', 'Digital Learning 200'
-        ]
+        if current:
+            CourseRunFactory.create(course=course)
+
         if in_future:
-            alter_arg_list.append('--in-future')
+            course_run = CourseRunFactory.create(course=course, edx_course_key='course-in-future')
+            call_command(
+                "alter_data", 'set_to_offered', '--username', 'staff',
+                '--course-run-key', course_run.edx_course_key, '--in-future'
+            )
         if fuzzy:
-            alter_arg_list.append('--fuzzy')
-        call_command(*alter_arg_list)
+            course_run = CourseRunFactory.create(course=course, edx_course_key='course-fuzzy')
+            call_command(
+                "alter_data", 'set_to_offered', '--username', 'staff',
+                '--course-run-key', course_run.edx_course_key, '--fuzzy'
+            )
 
     def create_paid_but_no_enrollable_run(self, in_future, fuzzy):
         """Make paid but not enrolled, with offered currently, in future, and fuzzy """
@@ -343,11 +348,12 @@ class DashboardStates:
                 ),
             )
 
-        for tup in itertools.product([True, False], repeat=2):
-            in_future, fuzzy = tup
+        for tup in itertools.product([True, False], repeat=3):
+            current, in_future, fuzzy = tup
 
-            yield (bind_args(self.create_paid_failed_course_run, in_future, fuzzy),
-                   'create_paid_failed_course_run{in_future}{fuzzy}'.format(
+            yield (bind_args(self.create_paid_failed_course_run, current, in_future, fuzzy),
+                   'create_paid_failed_course_run{current}{in_future}{fuzzy}'.format(
+                       current='_offered_now' if current else '',
                        in_future='_offered_in_future' if in_future else '',
                        fuzzy='_offered_fuzzy' if fuzzy else ''
                    ))

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -368,15 +368,17 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
           !R.isNil(run.enrollment_start_date) &&
           !R.isEmpty(run.enrollment_start_date)
         ) {
-          const start_text = isEnrollableRun(run) ? 'started' : 'starts'
-          enrollmentDateMessage = ` Enrollment ${start_text} ${formatDate(
+          const startText = isEnrollableRun(run) ? "started" : "starts"
+          enrollmentDateMessage = ` Enrollment ${startText} ${formatDate(
             run.enrollment_start_date
           )}`
         } else if (run.fuzzy_enrollment_start_date) {
           enrollmentDateMessage = `Enrollment starts ${run.fuzzy_enrollment_start_date}`
         }
         if (run.course_start_date) {
-          courseStartMessage = `Next course starts ${formatDate(run.course_start_date)}.`
+          courseStartMessage = `Next course starts ${formatDate(
+            run.course_start_date
+          )}.`
         } else if (run.fuzzy_start_date) {
           courseStartMessage = `Next course starts ${run.fuzzy_start_date}.`
         }

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -371,9 +371,9 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
           const startText = isEnrollableRun(run) ? "started" : "starts"
           enrollmentDateMessage = ` Enrollment ${startText} ${formatDate(
             run.enrollment_start_date
-          )}`
+          )}.`
         } else if (run.fuzzy_enrollment_start_date) {
-          enrollmentDateMessage = `Enrollment starts ${run.fuzzy_enrollment_start_date}`
+          enrollmentDateMessage = `Enrollment starts ${run.fuzzy_enrollment_start_date}.`
         }
         if (run.course_start_date) {
           courseStartMessage = `Next course starts ${formatDate(

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -361,21 +361,26 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     }
   } else {
     if (hasFailedCourseRun(course) && !hasPassedCourseRun(course)) {
-      const date = run => formatDate(run.course_start_date)
       const msg = run => {
         let enrollmentDateMessage = ""
+        let courseStartMessage = ""
         if (
           !R.isNil(run.enrollment_start_date) &&
-          !R.isEmpty(run.enrollment_start_date) &&
-          !isEnrollableRun(run)
+          !R.isEmpty(run.enrollment_start_date)
         ) {
-          enrollmentDateMessage = ` Enrollment starts ${formatDate(
+          const start_text = isEnrollableRun(run) ? 'started' : 'starts'
+          enrollmentDateMessage = ` Enrollment ${start_text} ${formatDate(
             run.enrollment_start_date
           )}`
+        } else if (run.fuzzy_enrollment_start_date) {
+          enrollmentDateMessage = `Enrollment starts ${run.fuzzy_enrollment_start_date}`
         }
-        return `You did not pass the edX course, but you can re-enroll. Next course starts ${date(
-          run
-        )}.${enrollmentDateMessage}`
+        if (run.course_start_date) {
+          courseStartMessage = `Next course starts ${formatDate(run.course_start_date)}.`
+        } else if (run.fuzzy_start_date) {
+          courseStartMessage = `Next course starts ${run.fuzzy_start_date}.`
+        }
+        return `You did not pass the edX course, but you can re-enroll. ${courseStartMessage} ${enrollmentDateMessage}`
       }
       return S.Just(
         S.maybe(

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -380,7 +380,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
         } else if (run.fuzzy_start_date) {
           courseStartMessage = `Next course starts ${run.fuzzy_start_date}.`
         }
-        return `You did not pass the edX course, but you can re-enroll. ${courseStartMessage} ${enrollmentDateMessage}`
+        return `You did not pass the edX course, but you can re-enroll. ${courseStartMessage}${enrollmentDateMessage}`
       }
       return S.Just(
         S.maybe(

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -660,14 +660,15 @@ describe("Course Status Messages", () => {
       const date = moment(course.runs[1].course_start_date).format(
         DASHBOARD_FORMAT
       )
-      const enrollmentDate = moment(course.runs[1].enrollment_start_date).format(
-        DASHBOARD_FORMAT
-      )
+      const enrollmentDate = moment(
+        course.runs[1].enrollment_start_date
+      ).format(DASHBOARD_FORMAT)
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
-          message: "You did not pass the edX course, but you can re-enroll." +
-          ` Next course starts ${date}. Enrollment started ${enrollmentDate}`,
-          action:  "course action was called"
+          message:
+            "You did not pass the edX course, but you can re-enroll." +
+            ` Next course starts ${date}. Enrollment started ${enrollmentDate}`,
+          action: "course action was called"
         }
       ])
       assert(

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -660,9 +660,13 @@ describe("Course Status Messages", () => {
       const date = moment(course.runs[1].course_start_date).format(
         DASHBOARD_FORMAT
       )
+      const enrollmentDate = moment(course.runs[1].enrollment_start_date).format(
+        DASHBOARD_FORMAT
+      )
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
-          message: `You did not pass the edX course, but you can re-enroll. Next course starts ${date}.`,
+          message: "You did not pass the edX course, but you can re-enroll." +
+          ` Next course starts ${date}. Enrollment started ${enrollmentDate}`,
           action:  "course action was called"
         }
       ])

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -667,7 +667,7 @@ describe("Course Status Messages", () => {
         {
           message:
             "You did not pass the edX course, but you can re-enroll." +
-            ` Next course starts ${date}. Enrollment started ${enrollmentDate}`,
+            ` Next course starts ${date}. Enrollment started ${enrollmentDate}.`,
           action: "course action was called"
         }
       ])
@@ -685,7 +685,7 @@ describe("Course Status Messages", () => {
         moment()
           .add(10, "days")
           .toISOString(),
-        ` Enrollment starts ${formatDate(moment().add(10, "days"))}`
+        ` Enrollment starts ${formatDate(moment().add(10, "days"))}.`
       ]
     ]) {
       it(`should inform next enrollment date after failing edx course when date is ${nextEnrollmentStart[0]}`, () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #3545

#### What's this PR do?
Add more states for failed course run state with other course runs offered in the future.

#### How should this be manually tested?
Run ./scripts/test/run_snapshot_dashboard_states.sh --match "paid_failed"

Here are some of the states:
This is a state with course runs in the future and fuzzy enrollment dates (both types exist).
<img width="661" alt="screen shot 2018-03-15 at 3 05 21 pm" src="https://user-images.githubusercontent.com/7574259/37485599-506f7f4c-2862-11e8-9712-0cf43712914a.png">

With currently enrollable run
<img width="671" alt="screen shot 2018-03-15 at 3 07 24 pm" src="https://user-images.githubusercontent.com/7574259/37485697-9b984d0a-2862-11e8-955e-e79aa8530001.png">

Course run with fuzzy start date
<img width="687" alt="screen shot 2018-03-15 at 3 00 43 pm" src="https://user-images.githubusercontent.com/7574259/37485489-f80dedca-2861-11e8-9a5c-67b8f416eae0.png">

No more course runs
<img width="664" alt="screen shot 2018-03-15 at 3 00 31 pm" src="https://user-images.githubusercontent.com/7574259/37485466-e8f53b22-2861-11e8-8a8f-ae8c0c48994e.png">
