### PR TITLE
add .pytest_cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 .hypothesis/
 coverage/
 .nyc_output/
+.pytest_cache/
 
 # Translations
 *.mo


### PR DESCRIPTION
I'm not sure if we upgraded a version or what, but I've just noticed this new directory being written.