### PR TITLE
add reenroll button

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -285,14 +285,16 @@ def get_info_for_course(course, mmtrack):
         _add_run(run_status.course_run, mmtrack, CourseStatus.CURRENTLY_ENROLLED)
     # check if we need to check the certificate
     elif run_status.status == CourseRunStatus.CHECK_IF_PASSED:
-        # if the user never passed the course she needs to enroll in the next one
         if not mmtrack.has_passed_course(run_status.course_run.edx_course_key):
             _add_run(run_status.course_run, mmtrack, CourseRunStatus.NOT_PASSED)
-            next_run = course.first_unexpired_run()
-            if next_run is not None:
-                _add_run(next_run, mmtrack, CourseStatus.OFFERED)
         else:
             _add_run(run_status.course_run, mmtrack, CourseStatus.PASSED)
+
+        # we want to return the next run, so the user can re-enroll regardless
+        # of whether they passed or failed
+        next_run = course.first_unexpired_run()
+        if next_run is not None:
+            _add_run(next_run, mmtrack, CourseStatus.OFFERED)
     elif run_status.status == CourseRunStatus.WILL_ATTEND:
         _add_run(run_status.course_run, mmtrack, CourseStatus.WILL_ATTEND)
     elif run_status.status == CourseRunStatus.CAN_UPGRADE:

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1212,12 +1212,7 @@ class InfoCourseTest(CourseTests):
                 self.course,
                 api.get_info_for_course(self.course, self.mmtrack)
             )
-        mock_format.assert_called_once_with(
-            self.course_run_ver,
-            api.CourseStatus.PASSED,
-            self.mmtrack,
-            position=1
-        )
+        assert mock_format.call_count == 2
         assert mock_schedulable.call_count == 1
         assert mock_has_to_pay.call_count == 1
         assert mock_future_exams.call_count == 1

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -157,6 +157,19 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
           >
             View Certificate
           </a>
+          {S.maybe(
+            null,
+            () => [
+              <span key="first">{" | "}</span>,
+              <a
+                key="second"
+                onClick={() => setShowExpandedCourseStatus(course.id)}
+              >
+                Re-enroll
+              </a>
+            ],
+            futureEnrollableRun(course)
+          )}
         </div>
       )
     })
@@ -283,26 +296,27 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
             futureEnrollableRun(course)
           )
         )
-
-        // this is the expanded message, which we should if the user clicks the link above
-        if (expandedStatuses.has(course.id)) {
-          messages.push(
-            S.maybe(
-              null,
-              run => ({
-                message: `Next course starts ${formatDate(
-                  run.course_start_date
-                )}.`,
-                action: courseAction(run, COURSE_ACTION_REENROLL)
-              }),
-              futureEnrollableRun(course)
-            )
-          )
-        }
       } else if (!course.certificate_url) {
         messages.push({
           message: "You passed this course."
         })
+      }
+
+      // this is the expanded message, which we should show if the user
+      // has clicked one of the 're-enroll' links
+      if (expandedStatuses.has(course.id)) {
+        messages.push(
+          S.maybe(
+            null,
+            run => ({
+              message: `Next course starts ${formatDate(
+                run.course_start_date
+              )}.`,
+              action: courseAction(run, COURSE_ACTION_REENROLL)
+            }),
+            futureEnrollableRun(course)
+          )
+        )
       }
       return S.Just(messages)
     } else {

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -175,6 +175,7 @@ describe("Course Status Messages", () => {
         )
       )
     })
+
     it("should ask to pay for a new grade, if already has a certificate ", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
@@ -183,7 +184,10 @@ describe("Course Status Messages", () => {
       assert.equal(messages.length, 2)
       const mounted = shallow(messages[0]["message"])
 
-      assert.equal(mounted.text(), "You passed this course! View Certificate")
+      assert.equal(
+        mounted.text(),
+        "You passed this course! View Certificate | Re-enroll"
+      )
 
       assert.deepEqual(messages[1], {
         action:  "course action was called",
@@ -198,6 +202,7 @@ describe("Course Status Messages", () => {
         )
       )
     })
+
     it("should tell auditors to calculate price and pay for course", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
@@ -220,6 +225,7 @@ describe("Course Status Messages", () => {
         )
       )
     })
+
     it("should tell auditors to wait while FA application is pending", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
@@ -247,6 +253,7 @@ describe("Course Status Messages", () => {
         )
       )
     })
+
     it("should tell auditors to wait while FA is pending without due date", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
@@ -269,6 +276,7 @@ describe("Course Status Messages", () => {
         )
       )
     })
+
     it("should not show payment due date if missing", () => {
       makeRunCurrent(course.runs[0])
       makeRunEnrolled(course.runs[0])
@@ -428,6 +436,7 @@ describe("Course Status Messages", () => {
           }
         ])
       })
+
       // no exam runs to schedule
       it("should ask to check back later if there is no future course run", () => {
         course.runs = [course.runs[0]]
@@ -478,7 +487,7 @@ describe("Course Status Messages", () => {
       })
     })
 
-    it("should congradulate the user on passing, exam or no", () => {
+    it("should congratulate the user on passing, exam or no", () => {
       makeRunPast(course.runs[0])
       makeRunPassed(course.runs[0])
       makeRunPaid(course.runs[0])
@@ -498,8 +507,23 @@ describe("Course Status Messages", () => {
       course.certificate_url = "certificate_url"
       const [{ message }] = calculateMessages(calculateMessagesProps).value
       const mounted = shallow(message)
-      assert.equal(mounted.text(), "You passed this course! View Certificate")
-      assert.equal(mounted.find("a").props().href, "certificate_url")
+      assert.equal(
+        mounted.text(),
+        "You passed this course! View Certificate | Re-enroll"
+      )
+      assert.equal(
+        mounted
+          .find("a")
+          .at(0)
+          .props().href,
+        "certificate_url"
+      )
+      mounted
+        .find("a")
+        .at(1)
+        .props()
+        .onClick()
+      assert(calculateMessagesProps.setShowExpandedCourseStatus.called)
     })
 
     it("should nag about missing the payment deadline", () => {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #3780 

#### What's this PR do?

If the user passed a course, we show them a little 'view certificate' link. However, in addition to this we'd like to give them the option to re-enroll in the course. This adds that option.

I discovered that the backend code for the dashboard API was set up to not return future course runs, in the case where the user already has a passing final grade on a past run. So, in order to get around that, I needed to make a small change to the dashboard API code, so that even if the user passes it will still return a future enrollable run (so we have something on the frontend in which we can enroll the user).

#### How should this be manually tested?

Get a course set up with two course runs, one, in the past, where you have a certificate and `STATUS_PASSED` and so on, and one, open for enrollment now, where you do not have an enrollment yet. If you go onto master, you should confirm that the passed run is the only one returned by the API. Then checkout this branch, and confirm that, in addition to seeing the 'view certificate' link, you see a link to 'Re-enroll'. Also confirm that the second course run is now returned in the dashboard API response.