### PR TITLE
Add states for View Certificate and re-enroll

### DIFF
--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -359,7 +359,7 @@ class DashboardStates:  # pylint: disable=too-many-locals
              'create_passed_and_offered_course_run{frozen}{with_certificate}'.format(
                  frozen='_grades_frozen' if frozen else '',
                  with_certificate='_with_certificate' if with_certificate else ''
-            )) for frozen, with_certificate in [(True, True), (True, False), (False, False)]
+             )) for frozen, with_certificate in [(True, True), (True, False), (False, False)]
         )
 
         yield (self.create_passed_enrolled_again, 'passed_and_taking_again')

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -74,7 +74,7 @@ def bind_args(func, *args, **kwargs):
     return lambda: func(*args, **kwargs)
 
 
-class DashboardStates:
+class DashboardStates:  # pylint: disable=too-many-locals
     """Runs through each dashboard state taking a snapshot"""
     def __init__(self, user=None):
         """

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -354,16 +354,13 @@ class DashboardStates:  # pylint: disable=too-many-locals
 
         yield (self.create_paid_failed_course_run, 'failed_paid_run_another_offered')
 
-        for tup in itertools.product([True, False], repeat=2):
-            frozen, with_certificate = tup
-            # can't create a certificate without a frozen grade
-            if not frozen and with_certificate:
-                continue
-            yield (bind_args(self.create_passed_and_offered_course_run, frozen, with_certificate),
-                   'create_passed_and_offered_course_run{frozen}{with_certificate}'.format(
-                       frozen='_grades_frozen' if frozen else '',
-                       with_certificate='_with_certificate' if with_certificate else ''
-                   ))
+        yield from (
+            (bind_args(self.create_passed_and_offered_course_run, frozen, with_certificate),
+             'create_passed_and_offered_course_run{frozen}{with_certificate}'.format(
+                 frozen='_grades_frozen' if frozen else '',
+                 with_certificate='_with_certificate' if with_certificate else ''
+            )) for frozen, with_certificate in [(True, True), (True, False), (False, False)]
+        )
 
         yield (self.create_passed_enrolled_again, 'passed_and_taking_again')
 


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #3901

#### What's this PR do?
Add dashboard states for user that passed a course, has a certificate, and we show re-enroll link.

#### How should this be manually tested?
Run `./scripts/test/run_snapshot_dashboard_states.sh --match "create_passed"` and look at the output folder.

<img width="700" alt="screen shot 2018-03-20 at 10 55 43 am" src="https://user-images.githubusercontent.com/7574259/37662448-7072539a-2c2d-11e8-9a10-df9e2ef5541c.png">
