### PR TITLE
Redirect user to profile wizard if residence is missing

### DIFF
--- a/financialaid/serializers.py
+++ b/financialaid/serializers.py
@@ -37,6 +37,7 @@ from financialaid.models import (
 from mail.api import MailgunClient
 from mail.utils import generate_financial_aid_email
 from micromasters.utils import now_in_utc
+from profiles.util import is_profile_filled_out
 
 
 log = logging.getLogger(__name__)
@@ -59,6 +60,8 @@ class FinancialAidRequestSerializer(serializers.Serializer):
             raise ValidationError("Financial aid not available for this program.")
         if not ProgramEnrollment.objects.filter(program=attrs["program"], user=self.context["request"].user).exists():
             raise ValidationError("User not in program.")
+        if not is_profile_filled_out(self.context["request"].user.profile):
+            raise ValidationError("Profile is not complete")
         return attrs
 
     def save(self, **kwargs):

--- a/profiles/util.py
+++ b/profiles/util.py
@@ -16,6 +16,10 @@ IMAGE_PATH_MAX_LENGTH = 100
 # Max dimension of either height or width for small and medium images
 IMAGE_SMALL_MAX_DIMENSION = 64
 IMAGE_MEDIUM_MAX_DIMENSION = 128
+COMPULSORY_FIELDS = [
+    'first_name', 'last_name', 'preferred_name', 'date_of_birth', 'gender',
+    'country', 'state_or_territory', 'city', 'nationality', 'preferred_language'
+]
 
 
 def split_name(name):
@@ -189,3 +193,19 @@ def make_temp_image_file(*, width=500, height=500):
         image.save(image_file, 'png')
         image_file.seek(0)
         yield image_file
+
+
+def is_profile_filled_out(profile):
+    """
+    check if profile is filled
+
+    Args:
+        profile (Profile): User profile object
+    Returns:
+        bool
+    """
+    for field in profile._meta.get_fields():
+        # is empty string
+        if field.name in COMPULSORY_FIELDS and not getattr(profile, field.name):
+            return False
+    return True

--- a/static/js/actions/financial_aid.js
+++ b/static/js/actions/financial_aid.js
@@ -54,7 +54,7 @@ export const addFinancialAid = (
       err => {
         dispatch(
           receiveAddFinancialAidFailure({
-            message: err[0],
+            message: err[0] || err["non_field_errors"][0],
             code:    err.errorStatusCode
           })
         )

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -24,6 +24,7 @@ import {
   fetchDashboard,
   clearDashboard
 } from "../actions/dashboard"
+import { clearProfile } from "../actions/profile"
 import {
   COUPON_CONTENT_TYPE_COURSE,
   COUPON_CONTENT_TYPE_PROGRAM,
@@ -53,6 +54,7 @@ import {
   setShowExpandedCourseStatus
 } from "../actions/ui"
 import { showEnrollPayLaterSuccessMessage } from "../actions/course_enrollments"
+import { clearCalculatorEdit } from "../actions/financial_aid"
 import { findCourseRun } from "../util/util"
 import CourseListCard from "../components/dashboard/CourseListCard"
 import DashboardUserCard from "../components/dashboard/DashboardUserCard"
@@ -88,6 +90,7 @@ import {
   pearsonSSOFailure,
   setPearsonError
 } from "../actions/pearson"
+import { INCOME_DIALOG } from "./FinancialAidCalculator"
 import { processCheckout } from "./OrderSummaryPage"
 import { generateSSOForm } from "../lib/pearson"
 import { getOwnDashboard, getOwnCoursePrices } from "../reducers/util"
@@ -294,6 +297,17 @@ class DashboardPage extends React.Component {
     this.fetchCoupons()
     this.handleOrderStatus()
     this.fetchDiscussionsFrontpage()
+    this.checkFinancialAidError()
+  }
+
+  checkFinancialAidError = () => {
+    const { financialAid: { fetchError }, dispatch } = this.props
+    if (fetchError && fetchError.message === "Profile is not complete") {
+      dispatch(clearProfile(SETTINGS.user.username))
+      this.context.router.push(`/profile/`)
+      dispatch(hideDialog(INCOME_DIALOG))
+      dispatch(clearCalculatorEdit())
+    }
   }
 
   fetchDashboard() {


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3607

#### What's this PR do?
it fixes `api/v0/financial_aid_request/` api to move user to profile wizard if country is missing

#### How should this be manually tested?
- open a tab and type:
```python
docker-compose run web ./manage.py shell
from django.contrib.auth.models import User
u = User.objects.get(id=122)
u.profile.country = None
u.profile.save()
u.profile.country == None
```
- with out refreshing dashboard page , submit income

@pdpinch 


