### PR TITLE
Add email footer

### DIFF
--- a/mail/utils.py
+++ b/mail/utils.py
@@ -105,3 +105,20 @@ def filter_recipient_variables(text):
         text = text.replace('[{}]'.format(key), '%recipient.{}%'.format(value))
 
     return text
+
+
+def get_email_footer(url):
+    """
+    Construct a footer for email
+    Args:
+        url: To change the settings
+    Returns:
+        string: with the html styled footer
+    """
+    text = ("You are receiving this e-mail because you signed up for MITx"
+            " MicroMasters. If you don't want to receive these emails in the"
+            " future, you can <a href='{0}'>edit your settings</a>"
+            " or <a href='{0}'>unsubscribe</a>").format(url)
+    return ("<div style='margin-top:80px'>"
+            "<p style='margin:auto; color: #757575; max-width:60%; text-align: center;'>{0}</p>"
+            "</div>").format(text)

--- a/mail/views.py
+++ b/mail/views.py
@@ -126,10 +126,8 @@ class SearchResultMailView(APIView):
         """
         POST method handler
         """
-        url = request.build_absolute_uri('/settings')
-        email_footer = get_email_footer(url)
         email_subject = request.data['email_subject']
-        email_body = request.data['email_body'] + email_footer
+        email_body = request.data['email_body'] + get_email_footer(request.build_absolute_uri('/settings'))
         sender_name = full_name(request.user)
         search_obj = create_search_obj(
             request.user,

--- a/mail/views.py
+++ b/mail/views.py
@@ -32,7 +32,7 @@ from mail.permissions import (
     MailGunWebHookPermission,
 )
 from mail.serializers import GenericMailSerializer, AutomaticEmailSerializer
-from mail.utils import generate_mailgun_response_json
+from mail.utils import generate_mailgun_response_json, get_email_footer
 from mail.models import AutomaticEmail
 from profiles.models import Profile
 from profiles.util import full_name
@@ -126,8 +126,10 @@ class SearchResultMailView(APIView):
         """
         POST method handler
         """
+        url = request.build_absolute_uri('/settings')
+        email_footer = get_email_footer(url)
         email_subject = request.data['email_subject']
-        email_body = request.data['email_body']
+        email_body = request.data['email_body'] + email_footer
         sender_name = full_name(request.user)
         search_obj = create_search_obj(
             request.user,
@@ -140,7 +142,7 @@ class SearchResultMailView(APIView):
             automatic_email = add_automatic_email(
                 search_obj,
                 email_subject=request.data['email_subject'],
-                email_body=request.data['email_body'],
+                email_body=email_body,
                 sender_name=sender_name,
                 staff_user=request.user,
             )


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3806

#### What's this PR do?
Add a footer to emails

#### How should this be manually tested?
Try to send an email to your student account through the search results, the email that you receive should have a footer.

<img width="919" alt="screen shot 2018-03-21 at 1 56 06 pm" src="https://user-images.githubusercontent.com/7574259/37728054-a9ae4ac8-2d0f-11e8-95ef-6d26173899b9.png">
