### PR TITLE
Add postal address to email footer

### DIFF
--- a/mail/utils.py
+++ b/mail/utils.py
@@ -116,9 +116,11 @@ def get_email_footer(url):
         string: with the html styled footer
     """
     text = ("You are receiving this e-mail because you signed up for MITx"
-            " MicroMasters. If you don't want to receive these emails in the"
-            " future, you can <a href='{0}'>edit your settings</a>"
-            " or <a href='{0}'>unsubscribe</a>").format(url)
-    return ("<div style='margin-top:80px'>"
-            "<p style='margin:auto; color: #757575; max-width:60%; text-align: center;'>{0}</p>"
-            "</div>").format(text)
+            " MicroMasters.<br/> If you don't want to receive these emails in the"
+            " future, you can<br/> <a href='{0}'>edit your settings</a>"
+            " or <a href='{0}'>unsubscribe</a>.").format(url)
+    return ("<div style='margin-top:80px; text-align: center; color: #757575;'>"
+            "<div style='margin:auto; max-width:50%;'><p>{0}</p>"
+            "<p>MIT Office of Digital Learning<br/>"
+            "600 Technology Square, 2nd Floor, Cambridge, MA 02139</p>"
+            "</div></div>").format(text)


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3806 

#### What's this PR do?
Add postal address to email footer

#### How should this be manually tested?
Try to send an email to your student account through the search results, the email that you receive should have a footer.

<img width="697" alt="screen shot 2018-03-29 at 11 18 05 am" src="https://user-images.githubusercontent.com/7574259/38097403-4bdd04fe-3343-11e8-9932-7b8e3d91a1cd.png">
