### PR TITLE
Added contact us link on mm footer

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -56,7 +56,7 @@ class HomePage(Page):
         program_pairs = [(program, get_program_page(program)) for program in programs]
         context["programs"] = program_pairs
         context["is_public"] = True
-        context["has_zendesk_widget"] = False
+        context["has_zendesk_widget"] = True
         context["google_maps_api"] = False
         context["authenticated"] = not request.user.is_anonymous
         context["is_staff"] = has_role(request.user, [Staff.ROLE_ID, Instructor.ROLE_ID])

--- a/ui/templates/footer.html
+++ b/ui/templates/footer.html
@@ -14,7 +14,9 @@
           </div>
         {% endif %}
         <div class="footer-links">
-          <a href="javascript:window.zE.activate();" rel="noopener noreferrer">Contact Us</a>
+          {% if has_zendesk_widget %}
+            <a href="javascript:window.zE.activate();" rel="noopener noreferrer">Contact Us</a>
+          {% endif %}
           <a href="https://www.edx.org/" target="_blank" rel="noopener noreferrer">edX</a>
           <a href="/terms_of_service/" target="_blank" rel="noopener noreferrer">MicroMasters Terms of Service</a>
           <a href="https://odl.mit.edu/" target="_blank" rel="noopener noreferrer">Office of Digital Learning</a>

--- a/ui/templates/footer.html
+++ b/ui/templates/footer.html
@@ -14,6 +14,7 @@
           </div>
         {% endif %}
         <div class="footer-links">
+          <a href="javascript:window.zE.activate();" rel="noopener noreferrer">Contact Us</a>
           <a href="https://www.edx.org/" target="_blank" rel="noopener noreferrer">edX</a>
           <a href="/terms_of_service/" target="_blank" rel="noopener noreferrer">MicroMasters Terms of Service</a>
           <a href="https://odl.mit.edu/" target="_blank" rel="noopener noreferrer">Office of Digital Learning</a>

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -132,13 +132,14 @@ class TestHomePage(ViewsTests):
                 'sentry_client',
                 'style',
                 'style_public',
+                'zendesk_widget',
             }
 
             assert response.context['authenticated'] is False
             assert response.context['username'] is None
             assert response.context['title'] == HomePage.objects.first().title
             assert response.context['is_public'] is True
-            assert response.context['has_zendesk_widget'] is False
+            assert response.context['has_zendesk_widget'] is True
             assert response.context['is_staff'] is False
             assert response.context['programs'] == []
             self.assertContains(response, 'Share this page')
@@ -164,13 +165,14 @@ class TestHomePage(ViewsTests):
                 'sentry_client',
                 'style',
                 'style_public',
+                'zendesk_widget',
             }
 
             assert response.context['authenticated'] is True
             assert response.context['username'] == get_social_username(user)
             assert response.context['title'] == HomePage.objects.first().title
             assert response.context['is_public'] is True
-            assert response.context['has_zendesk_widget'] is False
+            assert response.context['has_zendesk_widget'] is True
             assert response.context['is_staff'] is False
             assert response.context['programs'] == []
             self.assertContains(response, 'Share this page')
@@ -198,13 +200,14 @@ class TestHomePage(ViewsTests):
                 'sentry_client',
                 'style',
                 'style_public',
+                'zendesk_widget',
             }
 
             assert response.context['authenticated'] is True
             assert response.context['username'] is None
             assert response.context['title'] == HomePage.objects.first().title
             assert response.context['is_public'] is True
-            assert response.context['has_zendesk_widget'] is False
+            assert response.context['has_zendesk_widget'] is True
             assert response.context['is_staff'] is False
             assert response.context['programs'] == []
             self.assertContains(response, 'Share this page')
@@ -237,7 +240,7 @@ class TestHomePage(ViewsTests):
             assert response.context['username'] is None
             assert response.context['title'] == HomePage.objects.first().title
             assert response.context['is_public'] is True
-            assert response.context['has_zendesk_widget'] is False
+            assert response.context['has_zendesk_widget'] is True
             assert response.context['is_staff'] is True
             assert response.context['programs'] == [
                 (program, None),


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3891

#### What's this PR do?
invokes help widget on contact us link click.

#### How should this be manually tested?
Go to footer and click contact us

@pdpinch 
#### Screenshots (if appropriate)
<img width="1259" alt="screen shot 2018-04-03 at 11 47 15 pm" src="https://user-images.githubusercontent.com/10431250/38269359-bc3aad64-3799-11e8-95c1-a575150402bc.png">

