### PR TITLE
fix learner search email send error

### DIFF
--- a/mail/views.py
+++ b/mail/views.py
@@ -170,7 +170,7 @@ class SearchResultMailView(APIView):
                 sender_name=sender_name,
             )
 
-        return Response(status=status.HTTP_200_OK)
+        return Response(status=status.HTTP_200_OK, data={})
 
 
 class CourseTeamMailView(GenericAPIView):

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -110,6 +110,7 @@ class SearchResultMailViewsTests(SearchResultMailViewsBase):
             mock_mailgun_client.send_batch.return_value = [Response()]
             resp_post = self.client.post(self.search_result_mail_url, data=self.request_data, format='json')
         assert resp_post.status_code == status.HTTP_200_OK
+        assert resp_post.data == {}
         assert mock_get_emails.called
         assert mock_get_emails.call_args[0][0].to_dict() == create_search_obj(
             user=self.staff,


### PR DESCRIPTION
#### What are the relevant tickets?

closes #3851 

#### What's this PR do?

This PR makes it so that sending a search result email doesn't result in a failure redux action being dispatched. This was happening because the frontend was expecting a valid JSON payload in the response, but the backend wasn't keeping up it's end of the (read the issue for some specifics).

#### How should this be manually tested?

On master send a learner search email. Confirm that the email works and goes through, but that you see the `SEND_EMAIL_FAILURE` action get dispatched in the JS console.

Then checkout this branch and do the same thing. Confirm that it doesn't dispatch the failure action.