### PR TITLE
Fixed status message of current/future course when status is missed upgrade deadline

### DIFF
--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -194,7 +194,8 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
 
   // handle other 'in-progress' cases
   if (
-    courseUpcomingOrCurrent(firstRun) ||
+    (courseUpcomingOrCurrent(firstRun) &&
+      firstRun.status !== STATUS_MISSED_DEADLINE) ||
     firstRun.status === STATUS_CAN_UPGRADE
   ) {
     let message =

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -550,11 +550,27 @@ describe("Course Status Messages", () => {
       )
     })
 
-    it("should nag about missing the payment deadline for future course", () => {
+    it("should nag about missing the payment deadline for future course with one run", () => {
       course.runs = [course.runs[0]]
       course.runs[0].course_start_date = ""
       course.runs[0].course_end_date = ""
       course.runs[0].fuzzy_start_date = "Spring 2019"
+      course.runs[0].status = STATUS_MISSED_DEADLINE
+      assertIsJust(calculateMessages(calculateMessagesProps), [
+        {
+          message:
+            "You missed the payment deadline and will not receive MicroMasters credit for this course. " +
+            "There are no future runs of this course scheduled at this time."
+        }
+      ])
+    })
+
+    it("should nag about missing the payment deadline for current course with one run", () => {
+      course.runs = [course.runs[0]]
+      course.runs[0].course_start_date = moment()
+        .subtract(5, "days")
+        .toISOString()
+      course.runs[0].course_end_date = ""
       course.runs[0].status = STATUS_MISSED_DEADLINE
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -39,7 +39,8 @@ import {
   DASHBOARD_FORMAT,
   COURSE_DEADLINE_FORMAT,
   STATUS_PAID_BUT_NOT_ENROLLED,
-  FA_STATUS_PENDING_DOCS
+  FA_STATUS_PENDING_DOCS,
+  STATUS_MISSED_DEADLINE
 } from "../../../constants"
 import * as libCoupon from "../../../lib/coupon"
 import { FINANCIAL_AID_PARTIAL_RESPONSE } from "../../../test_constants"
@@ -547,6 +548,21 @@ describe("Course Status Messages", () => {
           COURSE_ACTION_REENROLL
         )
       )
+    })
+
+    it("should nag about missing the payment deadline for future course", () => {
+      course.runs = [course.runs[0]]
+      course.runs[0].course_start_date = ""
+      course.runs[0].course_end_date = ""
+      course.runs[0].fuzzy_start_date = "Spring 2019"
+      course.runs[0].status = STATUS_MISSED_DEADLINE
+      assertIsJust(calculateMessages(calculateMessagesProps), [
+        {
+          message:
+            "You missed the payment deadline and will not receive MicroMasters credit for this course. " +
+            "There are no future runs of this course scheduled at this time."
+        }
+      ])
     })
 
     for (const nextEnrollmentStart of [

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -567,10 +567,7 @@ describe("Course Status Messages", () => {
 
     it("should nag about missing the payment deadline for current course with one run", () => {
       course.runs = [course.runs[0]]
-      course.runs[0].course_start_date = moment()
-        .subtract(5, "days")
-        .toISOString()
-      course.runs[0].course_end_date = ""
+      makeRunCurrent(course.runs[0])
       course.runs[0].status = STATUS_MISSED_DEADLINE
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3406

#### What's this PR do?
fixes a special case when there is only one future/current run in the course and status is`missed-deadline`. This PR restrict user to pay and resume course in this state.

#### How should this be manually tested?
- run ./scripts/test/run_snapshot_dashboard_states.sh --match 009
- create a course with one run and make start, due, enrollment dates null and set upgrade deadline to past date and see dashboard there should be no payment button.

@pdpinch 
#### Screenshots (if appropriate)
![dashboard_state_009_set_to_offered](https://user-images.githubusercontent.com/10431250/38739244-c81ad1c0-3f4d-11e8-8820-872f56e2bb20.png)

