### PR TITLE
Updated heroku stack in app.js file

### DIFF
--- a/app.json
+++ b/app.json
@@ -249,6 +249,7 @@
     "Office of Digital Learning"
   ],
   "name": "micromasters",
+  "stack": "heroku-16",
   "repository": "https://github.com/mitodl/micromasters",
   "scripts": {
     "postdeploy": "./manage.py migrate --noinput && ./manage.py recreate_index"


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3918

#### Run these commands from hero cli:
```cli
heroku stack:set heroku-16 -a <app name>
git commit --allow-empty -m "Upgrading to heroku-16"
git push heroku master
```
https://devcenter.heroku.com/articles/heroku-16-stack#upgrading-an-app-to-heroku-16

#### Form heroku dashboard
> To upgrade via the Heroku Dashboard, navigate to your app settings page. Click the Upgrade Stack > button. Confirm that you want to upgrade, which will set the stack to the latest version. You will see > that the stack upgrade is pending; the upgrade with take affect on the next deploy.

I dont have permission but admin need to go to app (lets say micromasters-ci) settings and
<img width="1249" alt="screen shot 2018-04-20 at 3 55 55 pm" src="https://user-images.githubusercontent.com/10431250/39047510-93d69708-44b3-11e8-9b54-bf39417332fd.png">
 inside info section press the button



cc @mitodl/devops 

#### What's this PR do?
it updates heroku stack.

#### How should this be manually tested?
see the heroku version of this PR

@pdpinch 
