### PR TITLE
display courserun dates in admin list view; make them editable

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -42,11 +42,11 @@ class CourseAdmin(admin.ModelAdmin):
 
 class CourseRunAdmin(admin.ModelAdmin):
     """ModelAdmin for Courses"""
-    list_display = ('title', 'course_number', 'edx_course_key', 'enrollment_start','start_date','enrollment_end',
-        'end_date','upgrade_deadline','freeze_grade_date', )
-    list_filter = ('course__program__live', 'course__program', 'course', 'course__course_number' )
+    list_display = ('title', 'course_number', 'edx_course_key', 'enrollment_start', 'start_date', 'enrollment_end',
+                    'end_date', 'upgrade_deadline', 'freeze_grade_date', )
+    list_filter = ('course__program__live', 'course__program', 'course', 'course__course_number', )
     list_editable = ('enrollment_start', 'start_date', 'enrollment_end', 'end_date', 'upgrade_deadline',
-        'freeze_grade_date', )
+                     'freeze_grade_date', )
     ordering = ('course__title', 'course__program__title', 'course__position_in_program', )
 
     def program(self, run):

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -42,9 +42,12 @@ class CourseAdmin(admin.ModelAdmin):
 
 class CourseRunAdmin(admin.ModelAdmin):
     """ModelAdmin for Courses"""
-    list_display = ('title', 'edx_course_key', 'course', 'program',)
-    list_filter = ('course__program__live',)
-    ordering = ('course__title', 'course__program__title', 'course__position_in_program',)
+    list_display = ('title', 'course_number', 'edx_course_key', 'enrollment_start','start_date','enrollment_end',
+        'end_date','upgrade_deadline','freeze_grade_date', )
+    list_filter = ('course__program__live', 'course__program', 'course', 'course__course_number' )
+    list_editable = ('enrollment_start', 'start_date', 'enrollment_end', 'end_date', 'upgrade_deadline',
+        'freeze_grade_date', )
+    ordering = ('course__title', 'course__program__title', 'course__position_in_program', )
 
     def program(self, run):
         """method to show program for list display."""
@@ -53,6 +56,10 @@ class CourseRunAdmin(admin.ModelAdmin):
     def course(self, run):
         """Getter for course foreign key"""
         return run.course.title
+
+    def course_number(self, run):
+        """Getter for course's course_number"""
+        return run.course.course_number
 
 
 admin.site.register(CourseRun, CourseRunAdmin)


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #3940 

#### What's this PR do?

makes the admin list view for courseruns a little more convenient to use:
- displays all course run dates
- makes the date editable in list view
- adds program and course filters to the courserun list

#### How should this be manually tested?

View /admin/courses/courserun/

You may also want to set the course_number of a few courses (seed_db doesn't do this)

#### Any background context you want to provide?

We're currently scheduling course runs 2-3 years into the future, with 2-3 runs per year. Since we (still) don't have a reliable source for this data, I have to enter it by hand. 
