### PR TITLE
sanitize requirements per pip 10

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,7 +10,7 @@ pylint==1.8.2
 pylint-django==0.9.0
 pytest
 pytest-cov
-git+https://github.com/pytest-dev/pytest-django.git@e0f59dbe3880a72102a9bb1c94516881d6e6f567#egg=pytest-django==3.1.2dev
+-e git+https://github.com/pytest-dev/pytest-django.git@e0f59dbe3880a72102a9bb1c94516881d6e6f567#egg=pytest-django==3.1.2dev
 pytest-pep8
 pytest-mock
 pytest-pylint==0.6.0


### PR DESCRIPTION
#### What are the relevant tickets?
General, no specific ticket.

#### What's this PR do?
Sanitizes requirements files for pip 10.

#### How should this be manually tested?
Just ensure that travis builds complete.

#### Any background context you want to provide?
Motivation: Tox pulls the latest pip when it creates a virtualenv. So, we have to satisfy whatever version of pip it will pull. Since mid-April, it will pull pip 10, which no longer accepts `git+https://....#egg` requirement specs w/out a leading `-e ...`

I haven't found a way to pin pip versions for tox :(