### PR TITLE
Program Page: remove empty courses box

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -87,13 +87,8 @@
       </div>
 
       <div class="mdl-cell mdl-cell--4-col">
-        <div class="info-box course-info">
-          <h3 class="title">
-            Courses
-          </h3>
-          <div id="course-list">
-            <!-- CourseListWithPopover component injected here -->
-          </div>
+        <div id="courses-component">
+          <!-- CourseListWithPopover component injected here -->
         </div>
         {% if page.semester_dates.exists %}
         <div class="info-box">

--- a/static/js/components/CourseListWithPopover.js
+++ b/static/js/components/CourseListWithPopover.js
@@ -18,11 +18,11 @@ export default class CourseListWithPopover extends React.Component {
   render() {
     return (
       <div className="info-box course-info">
-        <h3 className="title">
-          Courses
-        </h3>
+        <h3 className="title">Courses</h3>
         <div id="course-list">
-          <ol className="program-course-list">{listItems(this.props.courses)}</ol>
+          <ol className="program-course-list">
+            {listItems(this.props.courses)}
+          </ol>
         </div>
       </div>
     )

--- a/static/js/components/CourseListWithPopover.js
+++ b/static/js/components/CourseListWithPopover.js
@@ -18,12 +18,12 @@ export default class CourseListWithPopover extends React.Component {
   render() {
     return (
       <div className="info-box course-info">
-          <h3 className="title">
-            Courses
-          </h3>
-          <div id="course-list">
-            <ol className="program-course-list">{listItems(this.props.courses)}</ol>
-          </div>
+        <h3 className="title">
+          Courses
+        </h3>
+        <div id="course-list">
+          <ol className="program-course-list">{listItems(this.props.courses)}</ol>
+        </div>
       </div>
     )
   }

--- a/static/js/components/CourseListWithPopover.js
+++ b/static/js/components/CourseListWithPopover.js
@@ -17,7 +17,14 @@ export default class CourseListWithPopover extends React.Component {
 
   render() {
     return (
-      <ol className="program-course-list">{listItems(this.props.courses)}</ol>
+      <div className="info-box course-info">
+          <h3 className="title">
+            Courses
+          </h3>
+          <div id="course-list">
+            <ol className="program-course-list">{listItems(this.props.courses)}</ol>
+          </div>
+      </div>
     )
   }
 }

--- a/static/js/entry/public.js
+++ b/static/js/entry/public.js
@@ -19,7 +19,7 @@ import { signupDialogStore } from "../store/configureStore"
 import SignupDialog from "../containers/SignupDialog"
 
 // Program Page course list
-const courseListEl = document.querySelector("#course-list")
+const courseListEl = document.querySelector("#courses-component")
 let courseList = null
 if (SETTINGS.program) {
   courseList = SETTINGS.program.courses


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3945 

#### What's this PR do?
If the program doesn't have courses to list don't show the grey box with title Courses.

#### How should this be manually tested?
Look at program page with courses and without.

![screen shot 2018-04-19 at 2 02 15 pm](https://user-images.githubusercontent.com/7574259/39009680-4f1d1760-43da-11e8-8428-eb01761b22bf.png)


