### PR TITLE
change grid from 3 columns to 2 or 4 depending on width

### DIFF
--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -458,8 +458,8 @@ body.app-media {
     list-style: none;
     text-align: left;
     padding: 0;
-    width: 96%;
-    max-width: 1400px;
+    width: 92%;
+    max-width: 2000px;
     margin: 0 auto;
 
     li {
@@ -467,6 +467,16 @@ body.app-media {
 
       @include breakpoint(phone) {
         padding-bottom: 1.5em;
+      }
+    }
+
+    li.col-md-4 {
+      @media (min-width: 992px) {
+        width: 50%;
+      }
+
+      @media (min-width: 1600px) {
+        width: 25%;
       }
     }
 


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
This changes the programs grid on the micromasters homepage from a 3 column layout to a 2 or 4 column layout depending on the width of the browser. At small widths it is 1 column, at >992 px it is 2 columns. At 1600px+ it is 4 columns.

#### How should this be manually tested?
See that it works
