### PR TITLE
Style and layout tweaks to Micromasters program pages

### DIFF
--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -4,6 +4,7 @@
 $font-black: rgba(0,0,0,.87);
 $font-gray: #6f6f6f;
 $font-gray-light: #a0a0a0;
+$font-gray-dark: #444;
 $font-gray-disabled: rgba(0,0,0,.2);
 $link-text: #217dd4;
 $link-hover: #0074e1;

--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -401,7 +401,7 @@ body.app-media {
     }
 
     blockquote.quote-text {
-      color: $font-gray;
+      color: $font-gray-dark;
       font-size: 24px;
       font-style: normal;
       font-weight: 300;
@@ -419,7 +419,7 @@ body.app-media {
     }
 
     p.quote-author {
-      color: $font-gray;
+      color: $font-gray-dark;
       font-size: 22px;
       font-weight: 300;
       font-style: italic;
@@ -461,6 +461,14 @@ body.app-media {
     width: 92%;
     max-width: 2000px;
     margin: 0 auto;
+
+    @media (max-width: 1420px) {
+      max-width: 1100px;
+    }
+
+    include breakpoint(phone) {
+      width: 100%;
+    }
 
     li {
       padding-bottom: 2.5em;
@@ -527,7 +535,7 @@ body.app-media {
 
     .program-description {
       padding: 20px 10px;
-      height: 20em;
+      height: 15em;
 
       @include breakpoint(phone) {
         padding: 20px 3px 30px;
@@ -564,9 +572,13 @@ body.app-media {
     max-width: 870px;
     text-align: center;
 
+    @include breakpoint(phone) {
+      padding: 33px 16px 17px;
+    }
+
     p {
-      font-size: 17px;
-      color: #6f6f6f;
+      font-size: 16px;
+      color: $font-black;
       line-height: 23px;
       margin: 0 0 22px;
       font-weight: 400;
@@ -654,7 +666,7 @@ body.app-media {
   }
 
   p {
-    color: rgba(255,255,255,.45);
+    color: rgba(255,255,255,.6);
 
     @include breakpoint(phone) {
       color: rgba(255,255,255,.7);

--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -459,7 +459,7 @@ body.app-media {
       width: 82%;
     }
 
-    include breakpoint(phone) {
+    @include breakpoint(phone) {
       width: 100%;
     }
 

--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -295,10 +295,6 @@ body.app-media {
         font-weight: 400;
         color: rgba(0,0,0,.87);
         margin-bottom: 2.1em;
-
-        @media (min-width: 1200px) {
-          font-size: 1.4vw;
-        }
       }
 
       .sub-banner-logos {
@@ -324,10 +320,6 @@ body.app-media {
           font-size: 16px;
           font-weight: 400;
           color: rgba(0, 0, 0, 0.87);
-
-          @media (min-width: 1200px) {
-            font-size: 1.4vw;
-          }
 
           @include breakpoint(phone) {
             display: block;
@@ -462,8 +454,9 @@ body.app-media {
     max-width: 2000px;
     margin: 0 auto;
 
-    @media (max-width: 1420px) {
+    @media (max-width: 1599px) {
       max-width: 1100px;
+      width: 82%;
     }
 
     include breakpoint(phone) {

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -20,7 +20,7 @@
 
     @media (max-width: 479px) {
       height: 460px;
-      padding: 90px 5% 0;
+      padding: 60px 5% 0;
     }
 
     .title {
@@ -30,6 +30,7 @@
       max-width: 700px;
       @include breakpoint(phone) {
         font-size: 26px;
+        line-height: 1.25;
       }
     }
 
@@ -41,9 +42,11 @@
         font-size: 23px;
         @include breakpoint(phone) {
           font-size: 18px;
+          line-height: 1.2;
+          font-weight: 400;
         }
         font-weight: 300;
-        line-height: 1.3em;
+        line-height: 1.3;
         color: rgba(255,255,255,1);
       }
     }


### PR DESCRIPTION
#### What are the relevant tickets?
closes #3961

#### What's this PR do?
Now that we have 4 MM programs, we have switched from a 3 column layout to a 2 or 4 column layout, depending on the browser width. This change was made when the new program page launched, but in the 2 column layout, the thumbnails are too wide and tight on the page. This issue decreases the width of the columns in the 2-column layout.

In addition, I got rid of the "vh"-unit font-sizing at large browser widths because it looked awkward.

#### How should this be manually tested?
See that nothing breaks at various layouts.
