### PR TITLE
Pin pytest to fix selenium issues

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -8,7 +8,7 @@ pdbpp
 pip-tools
 pylint==1.8.2
 pylint-django==0.9.0
-pytest
+pytest==3.2.2
 pytest-cov
 -e git+https://github.com/pytest-dev/pytest-django.git@e0f59dbe3880a72102a9bb1c94516881d6e6f567#egg=pytest-django==3.1.2dev
 pytest-pep8


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #3937 

#### What's this PR do?
A later version of pytest has a dependency ordering issue (or more likely our code does). For now just pin it to the same version used on Travis.

#### How should this be manually tested?
Run `./scripts/test/run_snapshot_dashboard_states.sh`
