### PR TITLE
Serialize all semesters enrolled

### DIFF
--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -56,7 +56,7 @@ class UserProgramSearchSerializer:
         }
 
     @classmethod
-    def serialize_semesters_enrolled(cls, mmtrack):
+    def serialize_course_runs_enrolled(cls, mmtrack):
         """
         Serializes information about a user's semester enrollments
 
@@ -65,10 +65,9 @@ class UserProgramSearchSerializer:
         Returns:
             list: Serialized all semester enrollments
         """
-        serialized_enrollments = []
-        for course_run in mmtrack.get_all_enrolled_course_runs():
-            serialized_enrollments.append({'semester': cls.serialize_semester(course_run)})
-        return serialized_enrollments
+        return [
+            {'semester': cls.serialize_semester(course_run)} for course_run in mmtrack.get_all_enrolled_course_runs()
+        ]
 
     @classmethod
     def serialize_semester(cls, course_run):
@@ -97,7 +96,7 @@ class UserProgramSearchSerializer:
         return {
             'id': program.id,
             'courses': cls.serialize_enrollments(mmtrack),
-            'course_runs': cls.serialize_semesters_enrolled(mmtrack),
+            'course_runs': cls.serialize_course_runs_enrolled(mmtrack),
             'grade_average': mmtrack.calculate_final_grade_average(),
             'is_learner': is_learner(user, program),
             'num_courses_passed': mmtrack.count_courses_passed(),

--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -97,7 +97,7 @@ class UserProgramSearchSerializer:
         return {
             'id': program.id,
             'courses': cls.serialize_enrollments(mmtrack),
-            'semesters': cls.serialize_semesters_enrolled(mmtrack),
+            'course_runs': cls.serialize_semesters_enrolled(mmtrack),
             'grade_average': mmtrack.calculate_final_grade_average(),
             'is_learner': is_learner(user, program),
             'num_courses_passed': mmtrack.count_courses_passed(),

--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -56,7 +56,7 @@ class UserProgramSearchSerializer:
         }
 
     @classmethod
-    def semesters_enrolled(cls, mmtrack):
+    def serialize_semesters_enrolled(cls, mmtrack):
         """
         Serializes information about a user's semester enrollments
 
@@ -96,8 +96,8 @@ class UserProgramSearchSerializer:
 
         return {
             'id': program.id,
-            'enrollments': cls.serialize_enrollments(mmtrack),
-            'semesters': cls.semesters_enrolled(mmtrack),
+            'courses': cls.serialize_enrollments(mmtrack),
+            'semesters': cls.serialize_semesters_enrolled(mmtrack),
             'grade_average': mmtrack.calculate_final_grade_average(),
             'is_learner': is_learner(user, program),
             'num_courses_passed': mmtrack.count_courses_passed(),

--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -49,13 +49,26 @@ class UserProgramSearchSerializer:
         payment_status = cls.PAID_STATUS if has_paid else cls.UNPAID_STATUS
 
         final_grade = mmtrack.get_final_grades_for_course(course_run.course).first()
-        semester = cls.serialize_semester(course_run)
         return {
             'final_grade': final_grade.grade_percent if final_grade else None,
-            'semester': semester,
             'course_title': course_title,
             'payment_status': payment_status,
         }
+
+    @classmethod
+    def semesters_enrolled(cls, mmtrack):
+        """
+        Serializes information about a user's semester enrollments
+
+        Args:
+            mmtrack (MMTrack): An MMTrack object
+        Returns:
+            list: Serialized all semester enrollments
+        """
+        serialized_enrollments = []
+        for course_run in mmtrack.get_all_enrolled_course_runs():
+            serialized_enrollments.append({'semester': cls.serialize_semester(course_run)})
+        return serialized_enrollments
 
     @classmethod
     def serialize_semester(cls, course_run):
@@ -84,6 +97,7 @@ class UserProgramSearchSerializer:
         return {
             'id': program.id,
             'enrollments': cls.serialize_enrollments(mmtrack),
+            'semesters': cls.semesters_enrolled(mmtrack),
             'grade_average': mmtrack.calculate_final_grade_average(),
             'is_learner': is_learner(user, program),
             'num_courses_passed': mmtrack.count_courses_passed(),

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -116,7 +116,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         non_fa_cached_edx_data = CachedEdxUserData(cls.user, program=program)
         non_fa_mmtrack = MMTrack(cls.user, program, non_fa_cached_edx_data)
         cls.serialized_enrollments = UserProgramSearchSerializer.serialize_enrollments(non_fa_mmtrack)
-        cls.semester_enrollments = UserProgramSearchSerializer.semesters_enrolled(non_fa_mmtrack)
+        cls.semester_enrollments = UserProgramSearchSerializer.serialize_semesters_enrolled(non_fa_mmtrack)
         cls.program_enrollment = ProgramEnrollment.objects.create(user=cls.user, program=program)
         # create a financial aid program
         cls.fa_program, _ = create_program()

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -116,7 +116,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         non_fa_cached_edx_data = CachedEdxUserData(cls.user, program=program)
         non_fa_mmtrack = MMTrack(cls.user, program, non_fa_cached_edx_data)
         cls.serialized_enrollments = UserProgramSearchSerializer.serialize_enrollments(non_fa_mmtrack)
-        cls.semester_enrollments = UserProgramSearchSerializer.serialize_semesters_enrolled(non_fa_mmtrack)
+        cls.semester_enrollments = UserProgramSearchSerializer.serialize_course_runs_enrolled(non_fa_mmtrack)
         cls.program_enrollment = ProgramEnrollment.objects.create(user=cls.user, program=program)
         # create a financial aid program
         cls.fa_program, _ = create_program()

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -116,6 +116,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         non_fa_cached_edx_data = CachedEdxUserData(cls.user, program=program)
         non_fa_mmtrack = MMTrack(cls.user, program, non_fa_cached_edx_data)
         cls.serialized_enrollments = UserProgramSearchSerializer.serialize_enrollments(non_fa_mmtrack)
+        cls.semester_enrollments = UserProgramSearchSerializer.semesters_enrolled(non_fa_mmtrack)
         cls.program_enrollment = ProgramEnrollment.objects.create(user=cls.user, program=program)
         # create a financial aid program
         cls.fa_program, _ = create_program()
@@ -157,6 +158,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         expected_values = {
             'id': program.id,
             'enrollments': self.serialized_enrollments,
+            'semesters': self.semester_enrollments,
             'grade_average': 75,
             'is_learner': True,
             'num_courses_passed': 1,
@@ -176,6 +178,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         expected_result = {
             'id': self.fa_program.id,
             'enrollments': self.fa_serialized_enrollments,
+            'semesters': self.semester_enrollments,
             'grade_average': 95,
             'is_learner': True,
             'num_courses_passed': 1,
@@ -198,6 +201,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         expected_result = {
             'id': program.id,
             'enrollments': self.serialized_enrollments,
+            'semesters': self.semester_enrollments,
             'grade_average': 75,
             'is_learner': False,
             'num_courses_passed': 1,
@@ -217,6 +221,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
             expected_result = {
                 'id': program.id,
                 'enrollments': self.serialized_enrollments,
+                'semesters': self.semester_enrollments,
                 'grade_average': 75,
                 'is_learner': True,
                 'num_courses_passed': 0,
@@ -431,8 +436,8 @@ class UserProgramSerializerSemesterTests(MockedESTestCase):
             serialized_program_user = UserProgramSearchSerializer.serialize(self.program_enrollment)
         assert len(serialized_program_user['enrollments']) == num_courses
         assert all(
-            enrollment['semester'] == '2017 - Spring'
-            for enrollment in serialized_program_user['enrollments']
+            semester_enrollment['semester'] == '2017 - Spring'
+            for semester_enrollment in serialized_program_user['semesters']
         )
         assert get_year_season_patch.call_count == num_courses
 

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -157,7 +157,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         program = self.program_enrollment.program
         expected_values = {
             'id': program.id,
-            'enrollments': self.serialized_enrollments,
+            'courses': self.serialized_enrollments,
             'semesters': self.semester_enrollments,
             'grade_average': 75,
             'is_learner': True,
@@ -177,7 +177,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         self.profile.refresh_from_db()
         expected_result = {
             'id': self.fa_program.id,
-            'enrollments': self.fa_serialized_enrollments,
+            'courses': self.fa_serialized_enrollments,
             'semesters': self.semester_enrollments,
             'grade_average': 95,
             'is_learner': True,
@@ -200,7 +200,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         )
         expected_result = {
             'id': program.id,
-            'enrollments': self.serialized_enrollments,
+            'courses': self.serialized_enrollments,
             'semesters': self.semester_enrollments,
             'grade_average': 75,
             'is_learner': False,
@@ -220,7 +220,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
             program = self.program_enrollment.program
             expected_result = {
                 'id': program.id,
-                'enrollments': self.serialized_enrollments,
+                'courses': self.serialized_enrollments,
                 'semesters': self.semester_enrollments,
                 'grade_average': 75,
                 'is_learner': True,
@@ -325,7 +325,7 @@ class UserProgramSerializerEnrollmentsTests(MockedESTestCase):
         """
         for program_enrollment in (self.non_fa_program_enrollment, self.fa_program_enrollment):
             serialized_program_user = UserProgramSearchSerializer.serialize(program_enrollment)
-            serialized_enrollments = serialized_program_user['enrollments']
+            serialized_enrollments = serialized_program_user['courses']
             assert self.all_courses_serialized(serialized_enrollments, program_enrollment.program.course_set.all())
 
     def test_course_serialization_format(self):
@@ -348,7 +348,7 @@ class UserProgramSerializerEnrollmentsTests(MockedESTestCase):
                 self.unverified_enroll(self.user, course_run=course_run)
             # Serialize the program enrollment and make sure each course is serialized properly
             serialized_program_user = UserProgramSearchSerializer.serialize(program_enrollment)
-            serialized_enrollments = serialized_program_user['enrollments']
+            serialized_enrollments = serialized_program_user['courses']
             assert len(serialized_enrollments) == 2
             # A course with a mix of verified and unverified course runs should be serialized as verified
             assert self.is_course_serialized_with_status(serialized_enrollments, existing_course, is_verified=True)
@@ -368,7 +368,7 @@ class UserProgramSerializerEnrollmentsTests(MockedESTestCase):
             serialized_program_user = UserProgramSearchSerializer.serialize(program_enrollment_to_test)
             # If the new course's program is the same one we just serialized, we expect the course to be serialized.
             course_is_expected_serialized = program == program_enrollment_to_test.program
-            course_is_serialized = self.is_course_serialized(serialized_program_user['enrollments'], course)
+            course_is_serialized = self.is_course_serialized(serialized_program_user['courses'], course)
             assert course_is_serialized == course_is_expected_serialized
 
     def test_course_enrollments_serialized_unique(self):
@@ -377,13 +377,13 @@ class UserProgramSerializerEnrollmentsTests(MockedESTestCase):
         """
         # Create an enrollment for a different course run of an already-enrolled course
         serialized_program_user = UserProgramSearchSerializer.serialize(self.non_fa_program_enrollment)
-        serialized_count_before_addition = len(serialized_program_user['enrollments'])
+        serialized_count_before_addition = len(serialized_program_user['courses'])
         first_enrollment = self.non_fa_enrollments[0]
         new_course_run = CourseRunFactory.create(course=first_enrollment.course_run.course)
         self.verified_enroll(self.user, course_run=new_course_run)
         serialized_program_user = UserProgramSearchSerializer.serialize(self.non_fa_program_enrollment)
         # Number of serialized enrollments should be unaffected
-        assert len(serialized_program_user['enrollments']) == serialized_count_before_addition
+        assert len(serialized_program_user['courses']) == serialized_count_before_addition
 
     def test_course_final_grade_serialization(self):
         """
@@ -391,12 +391,12 @@ class UserProgramSerializerEnrollmentsTests(MockedESTestCase):
         """
         # Final grades should all be None since none have been created yet
         serialized_program_user = UserProgramSearchSerializer.serialize(self.fa_program_enrollment)
-        assert all(enrollment['final_grade'] is None for enrollment in serialized_program_user['enrollments'])
+        assert all(enrollment['final_grade'] is None for enrollment in serialized_program_user['courses'])
         # Add some final grades and test that their values are properly serialized
         for enrollment in self.fa_enrollments:
             FinalGradeFactory.create(user=self.user, course_run=enrollment.course_run, grade=0.8, passed=True)
         serialized_program_user = UserProgramSearchSerializer.serialize(self.fa_program_enrollment)
-        assert all(enrollment['final_grade'] == 80.0 for enrollment in serialized_program_user['enrollments'])
+        assert all(enrollment['final_grade'] == 80.0 for enrollment in serialized_program_user['courses'])
 
 
 class UserProgramSerializerSemesterTests(MockedESTestCase):
@@ -434,7 +434,7 @@ class UserProgramSerializerSemesterTests(MockedESTestCase):
             'dashboard.serializers.get_year_season_from_course_run', autospec=True, return_value=(2017, 'Spring')
         ) as get_year_season_patch:
             serialized_program_user = UserProgramSearchSerializer.serialize(self.program_enrollment)
-        assert len(serialized_program_user['enrollments']) == num_courses
+        assert len(serialized_program_user['courses']) == num_courses
         assert all(
             semester_enrollment['semester'] == '2017 - Spring'
             for semester_enrollment in serialized_program_user['semesters']

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -158,7 +158,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         expected_values = {
             'id': program.id,
             'courses': self.serialized_enrollments,
-            'semesters': self.semester_enrollments,
+            'course_runs': self.semester_enrollments,
             'grade_average': 75,
             'is_learner': True,
             'num_courses_passed': 1,
@@ -178,7 +178,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         expected_result = {
             'id': self.fa_program.id,
             'courses': self.fa_serialized_enrollments,
-            'semesters': self.semester_enrollments,
+            'course_runs': self.semester_enrollments,
             'grade_average': 95,
             'is_learner': True,
             'num_courses_passed': 1,
@@ -201,7 +201,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         expected_result = {
             'id': program.id,
             'courses': self.serialized_enrollments,
-            'semesters': self.semester_enrollments,
+            'course_runs': self.semester_enrollments,
             'grade_average': 75,
             'is_learner': False,
             'num_courses_passed': 1,
@@ -221,7 +221,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
             expected_result = {
                 'id': program.id,
                 'courses': self.serialized_enrollments,
-                'semesters': self.semester_enrollments,
+                'course_runs': self.semester_enrollments,
                 'grade_average': 75,
                 'is_learner': True,
                 'num_courses_passed': 0,
@@ -437,7 +437,7 @@ class UserProgramSerializerSemesterTests(MockedESTestCase):
         assert len(serialized_program_user['courses']) == num_courses
         assert all(
             semester_enrollment['semester'] == '2017 - Spring'
-            for semester_enrollment in serialized_program_user['semesters']
+            for semester_enrollment in serialized_program_user['course_runs']
         )
         assert get_year_season_patch.call_count == num_courses
 

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -92,7 +92,7 @@ PUBLIC_ENROLLMENT_MAPPING = {
                     'id': LONG_TYPE,
                     'total_courses': LONG_TYPE,
                     'is_learner': BOOL_TYPE,
-                    'semesters': {
+                    'course_runs': {
                         'type': 'nested',
                         'properties': {
                             'semester': KEYWORD_TYPE,
@@ -180,7 +180,7 @@ PRIVATE_ENROLLMENT_MAPPING = {
                     'num_courses_passed': LONG_TYPE,
                     'total_courses': LONG_TYPE,
                     'is_learner': BOOL_TYPE,
-                    'semesters': {
+                    'course_runs': {
                         'type': 'nested',
                         'properties': {
                             'semester': KEYWORD_TYPE,
@@ -300,15 +300,15 @@ def serialize_public_enrolled_user(serialized_enrolled_user):
     # filter out grades, courses passed, etc
     program = dict_with_keys(
         serialized_enrolled_user['program'],
-        ['id', 'courses', 'is_learner', 'total_courses', 'semesters']
+        ['id', 'courses', 'is_learner', 'total_courses', 'course_runs']
     )
     program['courses'] = [
         dict_with_keys(enrollment, ['course_title', ])
         for enrollment in program['courses']
     ]
-    program['semesters'] = [
+    program['course_runs'] = [
         dict_with_keys(enrollment, ['semester'])
-        for enrollment in program['semesters']
+        for enrollment in program['course_runs']
     ]
     # filter out private profile information
     profile = dict_with_keys(

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -98,7 +98,7 @@ PUBLIC_ENROLLMENT_MAPPING = {
                             'semester': KEYWORD_TYPE,
                         }
                     },
-                    'enrollments': {
+                    'courses': {
                         'type': 'nested',
                         'properties': {
                             'course_title': KEYWORD_TYPE,
@@ -186,7 +186,7 @@ PRIVATE_ENROLLMENT_MAPPING = {
                             'semester': KEYWORD_TYPE,
                         }
                     },
-                    'enrollments': {
+                    'courses': {
                         'type': 'nested',
                         'properties': {
                             'final_grade': LONG_TYPE,
@@ -300,11 +300,11 @@ def serialize_public_enrolled_user(serialized_enrolled_user):
     # filter out grades, courses passed, etc
     program = dict_with_keys(
         serialized_enrolled_user['program'],
-        ['id', 'enrollments', 'is_learner', 'total_courses', 'semesters']
+        ['id', 'courses', 'is_learner', 'total_courses', 'semesters']
     )
-    program['enrollments'] = [
+    program['courses'] = [
         dict_with_keys(enrollment, ['course_title', ])
-        for enrollment in program['enrollments']
+        for enrollment in program['courses']
     ]
     program['semesters'] = [
         dict_with_keys(enrollment, ['semester'])

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -92,10 +92,15 @@ PUBLIC_ENROLLMENT_MAPPING = {
                     'id': LONG_TYPE,
                     'total_courses': LONG_TYPE,
                     'is_learner': BOOL_TYPE,
-                    'enrollments': {
+                    'semesters': {
                         'type': 'nested',
                         'properties': {
                             'semester': KEYWORD_TYPE,
+                        }
+                    },
+                    'enrollments': {
+                        'type': 'nested',
+                        'properties': {
                             'course_title': KEYWORD_TYPE,
                         }
                     },
@@ -175,11 +180,16 @@ PRIVATE_ENROLLMENT_MAPPING = {
                     'num_courses_passed': LONG_TYPE,
                     'total_courses': LONG_TYPE,
                     'is_learner': BOOL_TYPE,
+                    'semesters': {
+                        'type': 'nested',
+                        'properties': {
+                            'semester': KEYWORD_TYPE,
+                        }
+                    },
                     'enrollments': {
                         'type': 'nested',
                         'properties': {
                             'final_grade': LONG_TYPE,
-                            'semester': KEYWORD_TYPE,
                             'course_title': KEYWORD_TYPE,
                             'status': KEYWORD_TYPE,
                             'payment_status': KEYWORD_TYPE,
@@ -290,11 +300,15 @@ def serialize_public_enrolled_user(serialized_enrolled_user):
     # filter out grades, courses passed, etc
     program = dict_with_keys(
         serialized_enrolled_user['program'],
-        ['id', 'enrollments', 'is_learner', 'total_courses', ]
+        ['id', 'enrollments', 'is_learner', 'total_courses', 'semesters']
     )
     program['enrollments'] = [
-        dict_with_keys(enrollment, ['course_title', 'semester', ])
+        dict_with_keys(enrollment, ['course_title', ])
         for enrollment in program['enrollments']
+    ]
+    program['semesters'] = [
+        dict_with_keys(enrollment, ['semester'])
+        for enrollment in program['semesters']
     ]
     # filter out private profile information
     profile = dict_with_keys(

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -581,9 +581,9 @@ class SerializerTests(ESTestCase):
             },
             'program': {
                 'id': program_enrollment.program.id,
-                'enrollments': [{
+                'courses': [{
                     'course_title': enrollment['course_title']
-                } for enrollment in serialized['program']['enrollments']],
+                } for enrollment in serialized['program']['courses']],
                 'semesters': [{
                     'semester': semester_enrolled['semester']
 

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -582,9 +582,12 @@ class SerializerTests(ESTestCase):
             'program': {
                 'id': program_enrollment.program.id,
                 'enrollments': [{
-                    'course_title': enrollment['course_title'],
-                    'semester': enrollment['semester'],
+                    'course_title': enrollment['course_title']
                 } for enrollment in serialized['program']['enrollments']],
+                'semesters': [{
+                    'semester': semester_enrolled['semester']
+
+                } for semester_enrolled in serialized['program']['semesters']],
                 'is_learner': True,
                 'total_courses': 1,
             }
@@ -844,10 +847,10 @@ class PercolateQueryTests(ESTestCase):
                                 "must": [
                                     {
                                         "nested": {
-                                            "path": "program.enrollments",
+                                            "path": "program.semesters",
                                             "filter": {
                                                 "term": {
-                                                    "program.enrollments.semester": "2015 - Summer"
+                                                    "program.semesters.semester": "2015 - Summer"
                                                 }
                                             }
                                         }
@@ -931,13 +934,18 @@ class PercolateQueryTests(ESTestCase):
                                                             "term": {
                                                                 "program.enrollments.payment_status": "Auditing"
                                                             }
-                                                        },
-                                                        {
-                                                            "term": {
-                                                                "program.enrollments.semester": "2017 - Spring"
-                                                            }
                                                         }
                                                     ]
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        'nested': {
+                                            'path': "program.semesters",
+                                            'query': {
+                                                'term': {
+                                                    'program.semesters.semester': "2016 - Summer"
                                                 }
                                             }
                                         }

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -920,19 +920,19 @@ class PercolateQueryTests(ESTestCase):
                                 "must": [
                                     {
                                         "nested": {
-                                            "path": "program.enrollments",
+                                            "path": "program.courses",
                                             "query": {
                                                 "bool": {
                                                     "must": [
                                                         {
                                                             "term": {
-                                                                "program.enrollments.course_title":
+                                                                "program.courses.course_title":
                                                                     "Supply Chain Fundamentals  (SC1x)"
                                                             }
                                                         },
                                                         {
                                                             "term": {
-                                                                "program.enrollments.payment_status": "Auditing"
+                                                                "program.courses.payment_status": "Auditing"
                                                             }
                                                         }
                                                     ]

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -584,10 +584,10 @@ class SerializerTests(ESTestCase):
                 'courses': [{
                     'course_title': enrollment['course_title']
                 } for enrollment in serialized['program']['courses']],
-                'semesters': [{
+                'course_runs': [{
                     'semester': semester_enrolled['semester']
 
-                } for semester_enrolled in serialized['program']['semesters']],
+                } for semester_enrolled in serialized['program']['course_runs']],
                 'is_learner': True,
                 'total_courses': 1,
             }
@@ -847,10 +847,10 @@ class PercolateQueryTests(ESTestCase):
                                 "must": [
                                     {
                                         "nested": {
-                                            "path": "program.semesters",
+                                            "path": "program.course_runs",
                                             "filter": {
                                                 "term": {
-                                                    "program.semesters.semester": "2015 - Summer"
+                                                    "program.course_runs.semester": "2015 - Summer"
                                                 }
                                             }
                                         }
@@ -942,10 +942,10 @@ class PercolateQueryTests(ESTestCase):
                                     },
                                     {
                                         'nested': {
-                                            'path': "program.semesters",
+                                            'path': "program.course_runs",
                                             'query': {
                                                 'term': {
-                                                    'program.semesters.semester': "2016 - Summer"
+                                                    'program.course_runs.semester': "2016 - Summer"
                                                 }
                                             }
                                         }

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -274,10 +274,10 @@ export default class LearnerSearch extends SearchkitComponent {
           disabled={this.isFilterSelected("program.enrollments.semester")}
         >
           <NestedAggregatingMenuFilter
-            field="program.enrollments.course_title"
+            field="program.courses.course_title"
             fieldOptions={{
               type:    "nested",
-              options: { path: "program.enrollments" }
+              options: { path: "program.courses" }
             }}
             title=""
             id="courses"
@@ -286,10 +286,10 @@ export default class LearnerSearch extends SearchkitComponent {
         {isStaff ? (
           <div className="final-grade-wrapper">
             <FinalGradeRangeFilter
-              field="program.enrollments.final_grade"
+              field="program.courses.final_grade"
               fieldOptions={{
                 type:    "nested",
-                options: { path: "program.enrollments" }
+                options: { path: "program.courses" }
               }}
               id="final-grade"
               min={0}
@@ -306,10 +306,10 @@ export default class LearnerSearch extends SearchkitComponent {
             title="Payment Status"
           >
             <NestedAggregatingMenuFilter
-              field="program.enrollments.payment_status"
+              field="program.courses.payment_status"
               fieldOptions={{
                 type:    "nested",
-                options: { path: "program.enrollments" }
+                options: { path: "program.courses" }
               }}
               title=""
               orderKey="_term"

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -328,9 +328,9 @@ export default class LearnerSearch extends SearchkitComponent {
             title=""
             fieldOptions={{
               type:    "nested",
-              options: { path: "program.enrollments" }
+              options: { path: "program.semesters" }
             }}
-            field="program.enrollments.semester"
+            field="program.semesters.semester"
             operator="OR"
             itemComponent={CheckboxItem}
             listComponent={MultiSelectCheckboxItemList}

--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -328,9 +328,9 @@ export default class LearnerSearch extends SearchkitComponent {
             title=""
             fieldOptions={{
               type:    "nested",
-              options: { path: "program.semesters" }
+              options: { path: "program.course_runs" }
             }}
-            field="program.semesters.semester"
+            field="program.course_runs.semester"
             operator="OR"
             itemComponent={CheckboxItem}
             listComponent={MultiSelectCheckboxItemList}

--- a/static/js/components/channels/ChannelCreateDialog_test.js
+++ b/static/js/components/channels/ChannelCreateDialog_test.js
@@ -127,7 +127,7 @@ describe("ChannelCreateDialog", () => {
       filters: [
         {
           id:    "course",
-          name:  "program.enrollments.course_title",
+          name:  "program.courses.course_title",
           value: "Test Course 100"
         }
       ]

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -258,7 +258,7 @@ describe("EmailCompositionDialog", () => {
         filters: [
           {
             id:    "1",
-            name:  "program.semesters.semester",
+            name:  "program.course_runs.semester",
             value: "2015"
           },
           {

--- a/static/js/components/email/EmailCompositionDialog_test.js
+++ b/static/js/components/email/EmailCompositionDialog_test.js
@@ -258,7 +258,7 @@ describe("EmailCompositionDialog", () => {
         filters: [
           {
             id:    "1",
-            name:  "program.enrollments.semester",
+            name:  "program.semesters.semester",
             value: "2015"
           },
           {

--- a/static/js/components/email/lib_test.js
+++ b/static/js/components/email/lib_test.js
@@ -78,10 +78,10 @@ describe("Specific email config", () => {
       "must":[
         { 
           "nested": {
-            "path": "program.enrollments",
+            "path": "program.courses",
             "filter": {
               "term": {
-                "program.enrollments.payment_status": "Paid"
+                "program.courses.payment_status": "Paid"
               }
             }
           }
@@ -265,8 +265,8 @@ describe("Specific email config", () => {
         const filters = getFilters(JSON.parse(queryFilters))
         assert.deepEqual(filters, [
           {
-            id:    "program.enrollments.payment_status",
-            name:  "program.enrollments.payment_status",
+            id:    "program.courses.payment_status",
+            name:  "program.courses.payment_status",
             value: "Paid"
           }
         ])
@@ -277,8 +277,8 @@ describe("Specific email config", () => {
           const filters = getFilters(JSON.parse(queryFilters))
           assert.deepEqual(filters, [
             {
-              id:    "program.enrollments.payment_status",
-              name:  "program.enrollments.payment_status",
+              id:    "program.courses.payment_status",
+              name:  "program.courses.payment_status",
               value: "Paid"
             }
           ])
@@ -344,18 +344,18 @@ describe("Specific email config", () => {
               "must": [
                 {
                   "nested": {
-                    "path": "program.enrollments",
+                    "path": "program.courses",
                     "filter": {
                       "bool": {
                         "must": [
                           {
                             "term": {
-                              "program.enrollments.course_title": "Digital Learning 100"
+                              "program.courses.course_title": "Digital Learning 100"
                             }
                           },
                           {
                             "range": {
-                              "program.enrollments.final_grade": {
+                              "program.courses.final_grade": {
                                 "gte": 0,
                                 "lte": 89
                               }
@@ -363,12 +363,12 @@ describe("Specific email config", () => {
                           },
                           {
                             "term": {
-                              "program.enrollments.payment_status": "Paid"
+                              "program.courses.payment_status": "Paid"
                             }
                           },
                           {
                             "term": {
-                              "program.enrollments.semester": "2016 - Summer"
+                              "program.courses.semester": "2016 - Summer"
                             }
                           }
                         ]
@@ -381,10 +381,10 @@ describe("Specific email config", () => {
           }`
           const filters = findFilters(JSON.parse(query))
           assert.deepEqual(filters, [
-            { "program.enrollments.course_title": "Digital Learning 100" },
-            { "program.enrollments.final_grade": { gte: 0, lte: 89 } },
-            { "program.enrollments.payment_status": "Paid" },
-            { "program.enrollments.semester": "2016 - Summer" }
+            { "program.courses.course_title": "Digital Learning 100" },
+            { "program.courses.final_grade": { gte: 0, lte: 89 } },
+            { "program.courses.payment_status": "Paid" },
+            { "program.courses.semester": "2016 - Summer" }
           ])
         })
 
@@ -394,13 +394,13 @@ describe("Specific email config", () => {
               "must": [
                 {
                   "nested": {
-                    "path": "program.enrollments",
+                    "path": "program.courses",
                     "filter": {
                       "bool": {
                         "must": [
                           {
                             "term": {
-                              "program.enrollments.course_title": "Digital Learning 100"
+                              "program.courses.course_title": "Digital Learning 100"
                             }
                           }
                         ]
@@ -438,7 +438,7 @@ describe("Specific email config", () => {
           }`
           const filters = findFilters(JSON.parse(query))
           assert.deepEqual(filters, [
-            { "program.enrollments.course_title": "Digital Learning 100" },
+            { "program.courses.course_title": "Digital Learning 100" },
             { "profile.education.degree_name": "b" },
             { "profile.work_history.company_name": "Volvo" }
           ])

--- a/static/js/components/search/FilterVisibilityToggle.js
+++ b/static/js/components/search/FilterVisibilityToggle.js
@@ -7,8 +7,8 @@ import Icon from "react-mdl/lib/Icon"
 import { getAppliedFilterValue, matchFieldName } from "./util"
 
 export const FILTER_ID_ADJUST = {
-  courses:        "program.enrollments.course_title",
-  payment_status: "program.enrollments.payment_status"
+  courses:        "program.courses.course_title",
+  payment_status: "program.courses.payment_status"
 }
 
 export default class FilterVisibilityToggle extends SearchkitComponent {

--- a/static/js/components/search/FinalGradeRangeFilter.js
+++ b/static/js/components/search/FinalGradeRangeFilter.js
@@ -71,7 +71,7 @@ class FinalGradeRangeAccessor extends NestedAccessorMixin(
 
   /**
    * Creates the appropriate query element for this filter type
-   * (e.g.: {"range": {"program.enrollments.final_grade": {"gte": 64, "lte": 100}}})
+   * (e.g.: {"range": {"program.courses.final_grade": {"gte": 64, "lte": 100}}})
    */
   createQueryFilter(appliedFilterValue) {
     return RangeQuery(this.options.field, {

--- a/static/js/components/search/NestedAggregatingMenuFilter.js
+++ b/static/js/components/search/NestedAggregatingMenuFilter.js
@@ -19,7 +19,7 @@ const INNER_TERMS_AGG_KEY = "nested_terms"
  * Example return value: {
  *   "nested_terms": {
  *     "terms":{
- *       "field":"program.enrollments.course_title", ...
+ *       "field":"program.courses.course_title", ...
  *     },
  *     "aggs":{
  *       "top_level_doc_count":{"reverse_nested":{}}
@@ -92,7 +92,7 @@ class NestedAggregatingFacetAccessor extends NestedAccessorMixin(
   getFilterMapKey = () => this.uuid
 
   /**
-   * Creates the appropriate query element for this filter type (e.g.: {'term': 'program.enrollments.course_title'})
+   * Creates the appropriate query element for this filter type (e.g.: {'term': 'program.courses.course_title'})
    */
   createQueryFilter(appliedFilterValue) {
     return TermQuery(this.key, appliedFilterValue)

--- a/static/js/components/search/util.js
+++ b/static/js/components/search/util.js
@@ -53,10 +53,10 @@ export const NestedAccessorMixin = BaseSearchkitAccessorClass =>
       return query
     }
 
-    /** Returns the ES path for this nested document type (eg: 'program.enrollments') */
+    /** Returns the ES path for this nested document type (eg: 'program.courses') */
     getNestedPath = () => this.fieldContext.fieldOptions.options.path
 
-    /** Returns the full ES path for this nested document (eg: 'program.enrollments.course_title') */
+    /** Returns the full ES path for this nested document (eg: 'program.courses.course_title') */
     getFieldKey = () => this.fieldContext.fieldOptions.field
 
     /**
@@ -119,7 +119,7 @@ export const NestedAccessorMixin = BaseSearchkitAccessorClass =>
      *
      * Example return value: {
      *   "nested": {
-     *     "path": "program.enrollments",
+     *     "path": "program.courses",
      *     "filter": {
      *       "bool": {
      *         "must":[{"term": ... }, {"range": ... }]
@@ -173,8 +173,8 @@ export const NestedAccessorMixin = BaseSearchkitAccessorClass =>
      * filters are applied on this element's nested path.
      *
      * Example return value: [
-     *   {'term': {'program.enrollments.course_title': 'Some Course Title'},
-     *   {'term': {'program.enrollments.payment_status': 'Paid'}
+     *   {'term': {'program.courses.course_title': 'Some Course Title'},
+     *   {'term': {'program.courses.payment_status': 'Paid'}
      * ]
      */
     getAllFiltersOnPath(query) {
@@ -202,7 +202,7 @@ export const NestedAccessorMixin = BaseSearchkitAccessorClass =>
      * Example return value: {
      *   'bool': {
      *     'must': [
-     *       {'term': {'program.enrollments.course_title': 'Some Course Title'}}
+     *       {'term': {'program.courses.course_title': 'Some Course Title'}}
      *     ]
      *   }
      * }

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -26,17 +26,17 @@ export const EDUCATION_LEVELS = [
 ]
 
 export const SEARCH_FACET_FIELD_LABEL_MAP = {
-  "program.courses.course_title":   "Course",
-  "program.semesters.semester":         "Semester",
-  "program.courses.payment_status": "Payment Status",
-  "program.grade_average":              "Average Grade in Program",
-  "grade-average":                      "Average Grade in Program",
-  "profile.birth_country":              "Country of Birth",
-  "profile.country":                    "Current Residence",
-  "profile.education.degree_name":      "Degree",
-  "profile.work_history.company_name":  "Company",
-  "num-courses-passed":                 "# of Courses Passed",
-  "program.courses.final_grade":    "Final Grade"
+  "program.courses.course_title":      "Course",
+  "program.semesters.semester":        "Semester",
+  "program.courses.payment_status":    "Payment Status",
+  "program.grade_average":             "Average Grade in Program",
+  "grade-average":                     "Average Grade in Program",
+  "profile.birth_country":             "Country of Birth",
+  "profile.country":                   "Current Residence",
+  "profile.education.degree_name":     "Degree",
+  "profile.work_history.company_name": "Company",
+  "num-courses-passed":                "# of Courses Passed",
+  "program.courses.final_grade":       "Final Grade"
 }
 
 // NOTE: these need to be kept in sync with ui/url_utils.py

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -27,7 +27,7 @@ export const EDUCATION_LEVELS = [
 
 export const SEARCH_FACET_FIELD_LABEL_MAP = {
   "program.enrollments.course_title":   "Course",
-  "program.enrollments.semester":       "Semester",
+  "program.semesters.semester":         "Semester",
   "program.enrollments.payment_status": "Payment Status",
   "program.grade_average":              "Average Grade in Program",
   "grade-average":                      "Average Grade in Program",

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -26,9 +26,9 @@ export const EDUCATION_LEVELS = [
 ]
 
 export const SEARCH_FACET_FIELD_LABEL_MAP = {
-  "program.enrollments.course_title":   "Course",
+  "program.courses.course_title":   "Course",
   "program.semesters.semester":         "Semester",
-  "program.enrollments.payment_status": "Payment Status",
+  "program.courses.payment_status": "Payment Status",
   "program.grade_average":              "Average Grade in Program",
   "grade-average":                      "Average Grade in Program",
   "profile.birth_country":              "Country of Birth",
@@ -36,7 +36,7 @@ export const SEARCH_FACET_FIELD_LABEL_MAP = {
   "profile.education.degree_name":      "Degree",
   "profile.work_history.company_name":  "Company",
   "num-courses-passed":                 "# of Courses Passed",
-  "program.enrollments.final_grade":    "Final Grade"
+  "program.courses.final_grade":    "Final Grade"
 }
 
 // NOTE: these need to be kept in sync with ui/url_utils.py

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -27,7 +27,7 @@ export const EDUCATION_LEVELS = [
 
 export const SEARCH_FACET_FIELD_LABEL_MAP = {
   "program.courses.course_title":      "Course",
-  "program.semesters.semester":        "Semester",
+  "program.course_runs.semester":      "Semester",
   "program.courses.payment_status":    "Payment Status",
   "program.grade_average":             "Average Grade in Program",
   "grade-average":                     "Average Grade in Program",

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -640,8 +640,7 @@ describe("LearnerSearchPage", function() {
                   must: [
                     {
                       term: {
-                        "program.courses.course_title":
-                          "Digital Learning 200"
+                        "program.courses.course_title": "Digital Learning 200"
                       }
                     },
                     {

--- a/static/js/containers/LearnerSearchPage_test.js
+++ b/static/js/containers/LearnerSearchPage_test.js
@@ -469,7 +469,7 @@ describe("LearnerSearchPage", function() {
 
   describe("course enrollment filters", () => {
     it("have the expected aggregations", () => {
-      const innerKey = "program.enrollments.course_title"
+      const innerKey = "program.courses.course_title"
       const topLevelKey = `${innerKey}2`
 
       return renderSearch().then(() => {
@@ -478,7 +478,7 @@ describe("LearnerSearchPage", function() {
         assert.isDefined(body.aggs[topLevelKey])
 
         const innerAggs = body.aggs[topLevelKey].aggs.inner
-        assert.deepEqual(innerAggs.nested, { path: "program.enrollments" })
+        assert.deepEqual(innerAggs.nested, { path: "program.courses" })
         assert.equal(innerAggs.aggs[innerKey].terms.field, innerKey)
         assert.deepEqual(innerAggs.aggs[innerKey].aggs, {
           top_level_doc_count: { reverse_nested: {} }
@@ -634,19 +634,19 @@ describe("LearnerSearchPage", function() {
         must: [
           {
             nested: {
-              path:  "program.enrollments",
+              path:  "program.courses",
               query: {
                 bool: {
                   must: [
                     {
                       term: {
-                        "program.enrollments.course_title":
+                        "program.courses.course_title":
                           "Digital Learning 200"
                       }
                     },
                     {
                       range: {
-                        "program.enrollments.final_grade": {
+                        "program.courses.final_grade": {
                           gte: "40",
                           lte: "100"
                         }

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -262,14 +262,14 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
     ]
   },
   aggregations: {
-    "program.enrollments.course_title2": {
+    "program.courses.course_title2": {
       doc_count: 66,
       inner:     {
         doc_count:                                100,
-        "program.enrollments.course_title_count": {
+        "program.courses.course_title_count": {
           value: 3
         },
-        "program.enrollments.course_title": {
+        "program.courses.course_title": {
           doc_count_error_upper_bound: 0,
           sum_other_doc_count:         0,
           buckets:                     [
@@ -642,14 +642,14 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
         }
       }
     },
-    "program.enrollments.semester5": {
+    "program.courses.semester5": {
       doc_count: 66,
       inner:     {
         doc_count:                            100,
-        "program.enrollments.semester_count": {
+        "program.courses.semester_count": {
           value: 3
         },
-        "program.enrollments.semester": {
+        "program.courses.semester": {
           doc_count_error_upper_bound: 0,
           sum_other_doc_count:         0,
           buckets:                     [
@@ -769,11 +769,11 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
         ]
       }
     },
-    "program.enrollments.payment_status4": {
+    "program.courses.payment_status4": {
       doc_count: 66,
       inner:     {
         doc_count:                            100,
-        "program.enrollments.payment_status": {
+        "program.courses.payment_status": {
           doc_count_error_upper_bound: 0,
           sum_other_doc_count:         0,
           buckets:                     [
@@ -793,7 +793,7 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
             }
           ]
         },
-        "program.enrollments.payment_status_count": {
+        "program.courses.payment_status_count": {
           value: 2
         }
       }
@@ -1433,10 +1433,10 @@ const queryFilters = `{
     "must":[
       { 
         "nested": {
-          "path": "program.enrollments",
+          "path": "program.courses",
           "filter": {
             "term": {
-              "program.enrollments.payment_status": "Paid"
+              "program.courses.payment_status": "Paid"
             }
           }
         }

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -265,7 +265,7 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
     "program.courses.course_title2": {
       doc_count: 66,
       inner:     {
-        doc_count:                                100,
+        doc_count:                            100,
         "program.courses.course_title_count": {
           value: 3
         },
@@ -645,7 +645,7 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
     "program.courses.semester5": {
       doc_count: 66,
       inner:     {
-        doc_count:                            100,
+        doc_count:                        100,
         "program.courses.semester_count": {
           value: 3
         },
@@ -772,7 +772,7 @@ export const ELASTICSEARCH_RESPONSE = deepFreeze({
     "program.courses.payment_status4": {
       doc_count: 66,
       inner:     {
-        doc_count:                            100,
+        doc_count:                        100,
         "program.courses.payment_status": {
           doc_count_error_upper_bound: 0,
           sum_other_doc_count:         0,


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3840

#### What's this PR do?
Serialize  all semester enrollments for users that took the same course multiple times in different semesters.

#### How should this be manually tested?
Have your user enrolled in the same course multiple times, with paid/audited variation. When the user comes up in the search all semesters that the user was enrolled in show up in the Semester facet. 

