### PR TITLE
Fixed document deletion issue appears when user upload exact same document in edit view

### DIFF
--- a/app.json
+++ b/app.json
@@ -31,6 +31,10 @@
     "AWS_ACCESS_KEY_ID": {
       "description": "AWS Access Key for S3 storage."
     },
+    "AWS_S3_FILE_OVERWRITE": {
+      "description": "Allow S3 storage to overwrite files.",
+      "value": "False"
+    },
     "AWS_SECRET_ACCESS_KEY": {
       "description": "AWS Secret Key for S3 storage."
     },

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -436,6 +436,7 @@ MICROMASTERS_USE_S3 = get_bool('MICROMASTERS_USE_S3', False)
 AWS_ACCESS_KEY_ID = get_string('AWS_ACCESS_KEY_ID', False)
 AWS_SECRET_ACCESS_KEY = get_string('AWS_SECRET_ACCESS_KEY', False)
 AWS_STORAGE_BUCKET_NAME = get_string('AWS_STORAGE_BUCKET_NAME', False)
+AWS_S3_FILE_OVERWRITE = get_bool('AWS_S3_FILE_OVERWRITE', False)
 AWS_QUERYSTRING_AUTH = get_string('AWS_QUERYSTRING_AUTH', False)
 # Provide nice validation of the configuration
 if (


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/3943
https://github.com/wagtail/wagtail/issues/4512
https://github.com/wagtail/wagtail/pull/4502#issuecomment-386641100

#### What's this PR do?
it fixes an issue which appears when user re uploads exact same file on edit file. App was delete that file all together which was casing issue/exception mention on #4512

#### How should this be manually tested?
1. Login as admin (super user)
2. Go to documents and add a document lets say `x.pdf`
3. After uploading document go back to document listing page
4. Select the document from list that you just added
5. On edit page upload same document (exact same document) and press save
6. You will be navigate to the document listing page
7. Click edit on header notification or click same document that you just update

##### Expected behaviour:
- User should be able to download file that we just reupload.
- User should be able to open edit document view page.

##### Actual behaviour:
App is crashing on edit view page or downloading file.

@pdpinch 

#### Screenshots (if appropriate)
<img width="1173" alt="screen shot 2018-04-30 at 1 55 25 pm" src="https://user-images.githubusercontent.com/10431250/39420485-2b1ce4e2-4c7e-11e8-8489-6a56a31304d4.png">


