### PR TITLE
Check freeze status show correct enrollment numbers

### DIFF
--- a/grades/management/commands/check_final_grade_freeze_status.py
+++ b/grades/management/commands/check_final_grade_freeze_status.py
@@ -7,7 +7,7 @@ from django.core.management import BaseCommand, CommandError
 from django_redis import get_redis_connection
 
 from courses.models import CourseRun
-from dashboard.models import CachedEnrollment
+from dashboard.models import CachedEnrollment, CachedCurrentGrade
 from grades.api import CACHE_KEY_FAILED_USERS_BASE_STR
 from grades.models import CourseRunGradingStatus, FinalGrade
 from grades.tasks import CACHE_ID_BASE_STR
@@ -74,11 +74,14 @@ class Command(BaseCommand):
                 )
             )
         message_detail = ', where {0} failed authentication'.format(failed_users_count) if failed_users_count else ''
+        users_in_cache = set(CachedEnrollment.get_cached_users(run)).intersection(
+            set(CachedCurrentGrade.get_cached_users(run))
+        )
         self.stdout.write(
             self.style.SUCCESS(
                 'The students with a final grade are {0}/{1}{2}'.format(
                     FinalGrade.objects.filter(course_run=run).count(),
-                    CachedEnrollment.objects.filter(course_run=run).count(),
+                    users_in_cache,
                     message_detail
                 )
             )

--- a/grades/management/commands/check_final_grade_freeze_status.py
+++ b/grades/management/commands/check_final_grade_freeze_status.py
@@ -81,7 +81,7 @@ class Command(BaseCommand):
             self.style.SUCCESS(
                 'The students with a final grade are {0}/{1}{2}'.format(
                     FinalGrade.objects.filter(course_run=run).count(),
-                    users_in_cache,
+                    len(users_in_cache),
                     message_detail
                 )
             )


### PR DESCRIPTION
#### What are the relevant tickets?
None
There are users that un-enrolled from course run and have CachedEnrollment, but do not have CachedCurrentGrade, we do not want to count them in the process of freezing grades.

#### What's this PR do?
In the status massage reports the number of enrollments intersected with current grades.

#### How should this be manually tested?
Run this command for a frozen run:
`python manage.py check_final_grade_freeze_status <edx_course_key>`

