### PR TITLE
Fixes toast layout issue

### DIFF
--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -128,7 +128,6 @@ class App extends React.Component {
     const { dispatch } = this.props
     dispatch(
       setToastMessage({
-        title:   "Profile",
         message:
           "We need to know a little bit more about you. Please complete your profile.",
         icon: TOAST_FAILURE

--- a/static/scss/toast.scss
+++ b/static/scss/toast.scss
@@ -4,7 +4,7 @@
   flex-direction: column;
   position: fixed;
   background-color: $black-transparent;
-  color: #c5c5c5;
+  color: #d6d6d6;
   margin: 0 auto;
   width: 90%;
   max-width: 500px;
@@ -21,16 +21,16 @@
 
     .toast-body {
       padding: 0 10px;
-      display: flex;
       align-items: center;
 
       h1 {
-        font-size: 18px;
-        margin: 0;
+        font-size: 16px;
+        margin: 0 0 5px;
       }
 
       p {
-        font-size: 16px;
+        font-size: 15px;
+        line-height: 1.2;
       }
 
       p:last-child {


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #3894

#### What's this PR do?
This fixes the layout of the toast message that has a title. For this particular message I removed the title, but for other toast messages with a title (h1) I removed display: flex, and that fixed the layout. I also did small tweaks to the font and margins.

#### How should this be manually tested?
Cause the toast message to appear, and see that the layout looks correct
