### PR TITLE
Fixed ipad layout bug with background-attachment: fixed

### DIFF
--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -145,7 +145,6 @@ body.app-media {
   background-repeat: no-repeat;
   background-color: #222;
   background-size: cover;
-  background-attachment: fixed;
   margin: 0 auto;
   width: 100%;
   min-height: 620px;
@@ -156,7 +155,6 @@ body.app-media {
   @include breakpoint(phone) {
     height: calc(100vh - 200px);
     min-height: 0;
-    background-attachment: scroll;
   }
 
   .banner-wrapper-content {


### PR DESCRIPTION
#### What are the relevant tickets?
Closed #3965

#### What's this PR do?
This fixed a bug on the ipad, where the hero image was not displaying correctly on the micromasters homepage. There is a bug with mobile browsers that disable the background:fixed style. So I got rid of that style for the hero image.

#### How should this be manually tested?
This should be tested on the ipad. You can look at the micromasters home page in Safari to see the current problem.
