### PR TITLE
Add users missing grades to the cached list

### DIFF
--- a/grades/api.py
+++ b/grades/api.py
@@ -172,7 +172,11 @@ def freeze_user_final_grade(user, course_run, raise_on_exception=False):
         con = get_redis_connection("redis")
         con.lpush(CACHE_KEY_FAILED_USERS_BASE_STR.format(course_run.edx_course_key), user.id)
         if not raise_on_exception:
-            log.exception('Impossible to refresh the edX cache for user "%s"', user.username)
+            log.exception(
+                'Impossible to refresh the edX cache for user "%s" in course %s',
+                user.username,
+                course_run.edx_course_key
+            )
             return None
         else:
             raise FreezeGradeFailedException(
@@ -181,6 +185,9 @@ def freeze_user_final_grade(user, course_run, raise_on_exception=False):
     try:
         final_grade = get_final_grade(user, course_run)
     except Exception as ex:  # pylint: disable=broad-except
+        # If user doesn't have a grade no need to freeze
+        con = get_redis_connection("redis")
+        con.lpush(CACHE_KEY_FAILED_USERS_BASE_STR.format(course_run.edx_course_key), user.id)
         if not raise_on_exception:
             log.exception(
                 'Impossible to get final grade for user "%s" in course %s', user.username, course_run.edx_course_key)

--- a/grades/api.py
+++ b/grades/api.py
@@ -180,7 +180,11 @@ def freeze_user_final_grade(user, course_run, raise_on_exception=False):
             return None
         else:
             raise FreezeGradeFailedException(
-                'Impossible to refresh the edX cache for user "{0}"'.format(user.username)) from ex
+                'Impossible to refresh the edX cache for user "{0}" in course {1}'.format(
+                    user.username,
+                    course_run.edx_course_key
+                )
+            ) from ex
     # get the final grade for the user in the program
     try:
         final_grade = get_final_grade(user, course_run)

--- a/grades/api_test.py
+++ b/grades/api_test.py
@@ -383,6 +383,12 @@ class GradeAPITests(MockedESTestCase):
         mock_get_fg.assert_called_once_with(self.user, self.run_fa)
         assert FinalGrade.objects.filter(user=self.user, course_run=self.run_fa).exists() is False
 
+        con = get_redis_connection("redis")
+        failed_users_cache_key = api.CACHE_KEY_FAILED_USERS_BASE_STR.format(self.run_fa.edx_course_key)
+        failed_users_count = con.llen(failed_users_cache_key)
+        failed_users_list = list(map(int, con.lrange(failed_users_cache_key, 0, failed_users_count)))
+        assert self.user.id in failed_users_list
+
     @patch('dashboard.api_edx_cache.CachedEdxDataApi.update_all_cached_grade_data', new_callable=MagicMock)
     def test_freeze_user_final_grade(self, mock_refr):
         """


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #3968

#### What's this PR do?
2 things:
Add info about what course was being processed when 'InvalidCredentialStored' is thrown.
Add users that don't have current grade to the cached users list, then the next time the task is run it will be able to set the status to COMPLETE, if no other errors occur.

#### How should this be manually tested?

Create a CachedEnrollment but no CachedCurrentGrade for a user and try to freeze grades for that course. The second time you run it should say `Final grades for course <edx_course_key> are complete`.

