### PR TITLE
Update edx-api-client to 0.5.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ django-server-status==0.5.0
 django-storages-redux==1.3.2
 django-webpack-loader==0.5.0
 djangorestframework==3.7.7
-edx-api-client==0.4.0
+edx-api-client==0.5.0
 edx-opaque-keys==0.4
 elasticsearch-dsl==5.4.0
 elasticsearch==5.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ django-webpack-loader==0.5.0
 django==2.0.2
 djangorestframework==3.7.7
 draftjs-exporter==2.0.0   # via wagtail
-edx-api-client==0.4.0
+edx-api-client==0.5.0
 edx-opaque-keys==0.4
 elasticsearch-dsl==5.4.0
 elasticsearch==5.5.1


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #3928

#### What's this PR do?
Updates edx-api-client which now has a default 25 second timeout. This will result in sentry errors when the timeout is reached instead of silent heroku disconnects