### PR TITLE
Added django-hijack for user masquerading

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -91,6 +91,11 @@ INSTALLED_APPS = (
     'modelcluster',
     'taggit',
 
+    # Hijack
+    'hijack',
+    'compat',
+    'hijack_admin',
+
     # other third party APPS
     'rolepermissions',
     'raven.contrib.django.raven_compat',
@@ -426,6 +431,10 @@ GA_TRACKING_ID = get_string("GA_TRACKING_ID", "")
 GOOGLE_API_KEY = get_string("GOOGLE_API_KEY", "")
 SL_TRACKING_ID = get_string("SL_TRACKING_ID", "")
 REACT_GA_DEBUG = get_bool("REACT_GA_DEBUG", False)
+
+# Hijack
+HIJACK_ALLOW_GET_REQUESTS = True
+HIJACK_LOGOUT_REDIRECT_URL = '/admin/auth/user'
 
 # Wagtail
 WAGTAIL_SITE_NAME = "MIT MicroMasters"

--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -31,6 +31,8 @@ urlpatterns += [
     url('', include('discussions.urls')),
     url(r'^status/', include('server_status.urls')),
     url('', include('ui.urls')),
+    # Hijack
+    url(r'^hijack/', include('hijack.urls', namespace='hijack')),
     # Wagtail
     url(r'^cms/', include(wagtailadmin_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),

--- a/requirements.in
+++ b/requirements.in
@@ -6,6 +6,9 @@ certifi==2018.1.18
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-cors-headers==2.1.0
+django-compat==1.0.15
+django-hijack==2.1.7
+django-hijack-admin==2.1.7
 django-redis==4.7.0
 django-role-permissions==2.2.0
 django-server-status==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,9 @@ defusedxml==0.5.0         # via python3-openid, social-auth-core
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-cors-headers==2.1.0
+django-compat==1.0.15
+django-hijack==2.1.7
+django-hijack-admin==2.1.7
 django-discover-runner==1.0  # via django-role-permissions
 django-modelcluster==4.1  # via wagtail
 django-redis==4.7.0

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -3,6 +3,7 @@
   <head>
     {% spaceless %}
     {% load static %}
+    {% load hijack_tags %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,400i,500,700" />
@@ -37,6 +38,7 @@
     {% endspaceless %}
   </head>
   <body class="{% block bodyclass %}{% endblock %}">
+    {% hijack_notification %}
     {% block content %}
     {% endblock %}
     <script type="text/javascript">

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,400i,500,700" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" type="text/css" href="{% url 'background-images-css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'hijack/hijack-styles.css' %}" />
     {% load raven %}
     <link rel="icon" href="{% static 'images/favicon.ico' %}" />
     <script type="text/javascript">


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3329

#### What's this PR do?
You can masquerade login user with you super admin credentials 

#### How should this be manually tested?
- GO to http://192.168.99.100:8079/admin/auth/user/
- You will see buttons `Login as`
- click button, you will be taken to new tab with that person login

##### OR
you can use these URLs for masquerade 
```
/hijack/<user id>
/hijack/username/<username>
/hijack/email/<user email>
```
- open this link in browser http://192.168.99.100:8079/hijack/username/<username how you want to see in action>
- It will take you to admin site login, user super admin credentials.
- Then you will be redirect to Micromasters app

cc @pdpinch 

#### Screenshots (if appropriate)
- http://192.168.99.100:8079/hijack/email/satff@example.com
- <img width="639" alt="screen shot 2018-05-25 at 6 11 12 pm" src="https://user-images.githubusercontent.com/10431250/40546005-49f775a8-6047-11e8-8109-65f2538d3538.png">
- <img width="1083" alt="screen shot 2018-05-25 at 6 40 36 pm" src="https://user-images.githubusercontent.com/10431250/40547386-29db9584-604b-11e8-9820-994db545679c.png">
- <img width="1179" alt="screen shot 2018-05-25 at 6 15 48 pm" src="https://user-images.githubusercontent.com/10431250/40546112-b83c6fc8-6047-11e8-987b-7c87e2eb08ff.png">


