### PR TITLE
Fix profile image upload layout on mobile

### DIFF
--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -21,11 +21,12 @@ const dropZone = (startPhotoEdit, setPhotoError) => (
     accept="image/*"
     onDropRejected={() => setPhotoError("Please select a valid photo")}
   >
-    <div>Drag a photo here or click to select a photo.</div>
+    <div className="desktop-upload-message">Drag a photo here or click to select a photo.</div>
+    <div className="mobile-upload-message">Click to select a photo.</div>
   </Dropzone>
 )
 
-const uploaderBodyHeight = (): number => R.min(500, window.innerHeight / 2)
+const uploaderBodyHeight = (): number => R.min(500, window.innerHeight * .44)
 
 const imageError = err => <div className="img-error">{err}</div>
 

--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -21,20 +21,14 @@ const dropZone = (startPhotoEdit, setPhotoError) => (
     accept="image/*"
     onDropRejected={() => setPhotoError("Please select a valid photo")}
   >
-    <div
-      className="desktop-upload-message"
-    >
-        Drag a photo here or click to select a photo.
+    <div className="desktop-upload-message">
+      Drag a photo here or click to select a photo.
     </div>
-    <div
-      className="mobile-upload-message"
-    >
-      Click to select a photo.
-    </div>
+    <div className="mobile-upload-message">Click to select a photo.</div>
   </Dropzone>
 )
 
-const uploaderBodyHeight = (): number => R.min(500, window.innerHeight * .44)
+const uploaderBodyHeight = (): number => R.min(500, window.innerHeight * 0.44)
 
 const imageError = err => <div className="img-error">{err}</div>
 

--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -21,8 +21,16 @@ const dropZone = (startPhotoEdit, setPhotoError) => (
     accept="image/*"
     onDropRejected={() => setPhotoError("Please select a valid photo")}
   >
-    <div className="desktop-upload-message">Drag a photo here or click to select a photo.</div>
-    <div className="mobile-upload-message">Click to select a photo.</div>
+    <div
+      className="desktop-upload-message"
+    >
+        Drag a photo here or click to select a photo.
+    </div>
+    <div
+      className="mobile-upload-message"
+    >
+      Click to select a photo.
+    </div>
   </Dropzone>
 )
 

--- a/static/scss/profile-image-uploader.scss
+++ b/static/scss/profile-image-uploader.scss
@@ -20,6 +20,7 @@
       text-align: center;
       color: $font-black;
     }
+
     .mobile-upload-message  {
       display: none;
     }
@@ -28,6 +29,7 @@
       .desktop-upload-message {
         display: none;
       }
+
       .mobile-upload-message  {
         display: block;
       }

--- a/static/scss/profile-image-uploader.scss
+++ b/static/scss/profile-image-uploader.scss
@@ -11,7 +11,17 @@
 
   .photo-dropzone {
     font-size: 20px;
-    font-weight: 300;
+    font-weight: 400;
+
+    .desktop-upload-message, .mobile-upload-message {
+      font-size: 16px;
+    }
+    .mobile-upload-message  {display: none;}
+
+    @include breakpoint(mobile) {
+      .desktop-upload-message {display: none;}
+      .mobile-upload-message  {display: block;}
+    }
   }
 
   .photo-active-item {
@@ -25,6 +35,11 @@
     display: flex;
     align-items: center;
     justify-content: space-around;
+
+    @include breakpoint(mobile) {
+      border: none;
+      border-radius: 0;
+    }
   }
 
   .spinner {

--- a/static/scss/profile-image-uploader.scss
+++ b/static/scss/profile-image-uploader.scss
@@ -14,7 +14,11 @@
     font-weight: 400;
 
     .desktop-upload-message, .mobile-upload-message {
-      font-size: 16px;
+      font-size: 17px;
+      width: 85%;
+      margin: 0 auto;
+      text-align: center;
+      color: $font-black;
     }
     .mobile-upload-message  {display: none;}
 

--- a/static/scss/profile-image-uploader.scss
+++ b/static/scss/profile-image-uploader.scss
@@ -20,11 +20,17 @@
       text-align: center;
       color: $font-black;
     }
-    .mobile-upload-message  {display: none;}
+    .mobile-upload-message  {
+      display: none;
+    }
 
     @include breakpoint(mobile) {
-      .desktop-upload-message {display: none;}
-      .mobile-upload-message  {display: block;}
+      .desktop-upload-message {
+        display: none;
+      }
+      .mobile-upload-message  {
+        display: block;
+      }
     }
   }
 

--- a/static/scss/profile-image.scss
+++ b/static/scss/profile-image.scss
@@ -13,9 +13,9 @@
       background-color: rgba(0, 0, 0, 0.3);
       position: absolute;
       top: 0;
-      right: -2px;
+      right: 0;
       text-align: center;
-      line-height: 46px;
+      line-height: 41px;
 
       img {
         width: 22px;

--- a/static/scss/responsive-styles.scss
+++ b/static/scss/responsive-styles.scss
@@ -71,7 +71,7 @@
   }
 
   div.dialog {
-    width: 87% !important;
+    width: 94% !important;
     /* The dialog class is applied to Dialog components from Material UI
     (http://www.material-ui.com/#/components/dialog). Material UI styles its components by setting inline
     styles on the DOM nodes it creates. The CSS cascade defines inline styles to have a higher priority


### PR DESCRIPTION
#### What are the relevant tickets?
#3992

#### What's this PR do?
This fixes a layout and copy issue in the profile image uploader on mobile. The profile image uploader on mobile currently has a clunky layout with no left/right margins. Also the copy is wrong, as it says to "drag a photo" into the box, which is impossible on mobile.

![image](https://user-images.githubusercontent.com/20047260/40558505-83ee6bca-6021-11e8-969c-2cd1aef912d0.png)

#### How should this be manually tested?
See that it looks correct as in the screenshot above.
