### PR TITLE
First step to update percolate queries that use enrollments nested field

### DIFF
--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -95,6 +95,7 @@ class UserProgramSearchSerializer:
 
         return {
             'id': program.id,
+            'enrollments': cls.serialize_enrollments(mmtrack),
             'courses': cls.serialize_enrollments(mmtrack),
             'course_runs': cls.serialize_course_runs_enrolled(mmtrack),
             'grade_average': mmtrack.calculate_final_grade_average(),

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -157,6 +157,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         program = self.program_enrollment.program
         expected_values = {
             'id': program.id,
+            'enrollments': self.serialized_enrollments,
             'courses': self.serialized_enrollments,
             'course_runs': self.semester_enrollments,
             'grade_average': 75,
@@ -177,6 +178,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         self.profile.refresh_from_db()
         expected_result = {
             'id': self.fa_program.id,
+            'enrollments': self.fa_serialized_enrollments,
             'courses': self.fa_serialized_enrollments,
             'course_runs': self.semester_enrollments,
             'grade_average': 95,
@@ -200,6 +202,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         )
         expected_result = {
             'id': program.id,
+            'enrollments': self.serialized_enrollments,
             'courses': self.serialized_enrollments,
             'course_runs': self.semester_enrollments,
             'grade_average': 75,
@@ -220,6 +223,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
             program = self.program_enrollment.program
             expected_result = {
                 'id': program.id,
+                'enrollments': self.serialized_enrollments,
                 'courses': self.serialized_enrollments,
                 'course_runs': self.semester_enrollments,
                 'grade_average': 75,

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -92,6 +92,12 @@ PUBLIC_ENROLLMENT_MAPPING = {
                     'id': LONG_TYPE,
                     'total_courses': LONG_TYPE,
                     'is_learner': BOOL_TYPE,
+                    'enrollments': {
+                        'type': 'nested',
+                        'properties': {
+                            'course_title': KEYWORD_TYPE,
+                        }
+                    },
                     'course_runs': {
                         'type': 'nested',
                         'properties': {
@@ -180,6 +186,15 @@ PRIVATE_ENROLLMENT_MAPPING = {
                     'num_courses_passed': LONG_TYPE,
                     'total_courses': LONG_TYPE,
                     'is_learner': BOOL_TYPE,
+                    'enrollments': {
+                        'type': 'nested',
+                        'properties': {
+                            'final_grade': LONG_TYPE,
+                            'course_title': KEYWORD_TYPE,
+                            'status': KEYWORD_TYPE,
+                            'payment_status': KEYWORD_TYPE,
+                        }
+                    },
                     'course_runs': {
                         'type': 'nested',
                         'properties': {
@@ -300,8 +315,12 @@ def serialize_public_enrolled_user(serialized_enrolled_user):
     # filter out grades, courses passed, etc
     program = dict_with_keys(
         serialized_enrolled_user['program'],
-        ['id', 'courses', 'is_learner', 'total_courses', 'course_runs']
+        ['id', 'enrollments', 'courses', 'is_learner', 'total_courses', 'course_runs']
     )
+    program['enrollments'] = [
+        dict_with_keys(enrollment, ['course_title', ])
+        for enrollment in program['courses']
+    ]
     program['courses'] = [
         dict_with_keys(enrollment, ['course_title', ])
         for enrollment in program['courses']

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -581,6 +581,9 @@ class SerializerTests(ESTestCase):
             },
             'program': {
                 'id': program_enrollment.program.id,
+                'enrollments': [{
+                    'course_title': enrollment['course_title']
+                } for enrollment in serialized['program']['courses']],
                 'courses': [{
                     'course_title': enrollment['course_title']
                 } for enrollment in serialized['program']['courses']],


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #3963

#### What's this PR do?
This PR adds the 'enrollments' serialization to avoid conflicts with the percolate queries currently on RC.

#### How should this be manually tested?
The tests should pass.

