### PR TITLE
Fix index error for field program.enrollments.semester

### DIFF
--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -30,6 +30,50 @@ class UserProgramSearchSerializer:
             # If any course run for this course was verified/paid, count it as verified
             if course_title not in serialized_enrollments_map or \
                     serialized_enrollments_map[course_title]['payment_status'] == cls.UNPAID_STATUS:
+                serialized_enrollments_map[course_title] = cls.serialize_enrollment_with_semester(mmtrack, course_run)
+        return list(serialized_enrollments_map.values())
+
+    @classmethod
+    def serialize_enrollment_with_semester(cls, mmtrack, course_run):
+        """
+        Serializes information about a user's enrollment in a course run
+
+        Args:
+            mmtrack (MMTrack): An MMTrack object
+            course_run (CourseRun): An enrolled CourseRun
+        Returns:
+            dict: Serialized course enrollment
+        """
+        course_title = course_run.course.title
+        has_paid = mmtrack.has_paid(course_run.edx_course_key)
+        payment_status = cls.PAID_STATUS if has_paid else cls.UNPAID_STATUS
+
+        final_grade = mmtrack.get_final_grades_for_course(course_run.course).first()
+        semester = cls.serialize_semester(course_run)
+        return {
+            'final_grade': final_grade.grade_percent if final_grade else None,
+            'semester': semester,
+            'course_title': course_title,
+            'payment_status': payment_status,
+        }
+
+    @classmethod
+    def serialize_course_enrollments(cls, mmtrack):
+        """
+        Serializes a user's enrollment data for search results in such a way that enrollments
+        in multiple runs of a single course will result in just one serialization.
+
+        Args:
+            mmtrack (MMTrack): An MMTrack object
+        Returns:
+            list: Serialized course enrollments
+        """
+        serialized_enrollments_map = {}
+        for course_run in mmtrack.get_all_enrolled_course_runs():
+            course_title = course_run.course.title
+            # If any course run for this course was verified/paid, count it as verified
+            if course_title not in serialized_enrollments_map or \
+                    serialized_enrollments_map[course_title]['payment_status'] == cls.UNPAID_STATUS:
                 serialized_enrollments_map[course_title] = cls.serialize_enrollment(mmtrack, course_run)
         return list(serialized_enrollments_map.values())
 
@@ -49,10 +93,8 @@ class UserProgramSearchSerializer:
         payment_status = cls.PAID_STATUS if has_paid else cls.UNPAID_STATUS
 
         final_grade = mmtrack.get_final_grades_for_course(course_run.course).first()
-        semester = cls.serialize_semester(course_run)
         return {
             'final_grade': final_grade.grade_percent if final_grade else None,
-            'semester': semester,
             'course_title': course_title,
             'payment_status': payment_status,
         }
@@ -98,7 +140,7 @@ class UserProgramSearchSerializer:
         return {
             'id': program.id,
             'enrollments': cls.serialize_enrollments(mmtrack),
-            'courses': cls.serialize_enrollments(mmtrack),
+            'courses': cls.serialize_course_enrollments(mmtrack),
             'course_runs': cls.serialize_course_runs_enrolled(mmtrack),
             'grade_average': mmtrack.calculate_final_grade_average(),
             'is_learner': is_learner(user, program),

--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -49,8 +49,10 @@ class UserProgramSearchSerializer:
         payment_status = cls.PAID_STATUS if has_paid else cls.UNPAID_STATUS
 
         final_grade = mmtrack.get_final_grades_for_course(course_run.course).first()
+        semester = cls.serialize_semester(course_run)
         return {
             'final_grade': final_grade.grade_percent if final_grade else None,
+            'semester': semester,
             'course_title': course_title,
             'payment_status': payment_status,
         }

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -116,6 +116,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         non_fa_cached_edx_data = CachedEdxUserData(cls.user, program=program)
         non_fa_mmtrack = MMTrack(cls.user, program, non_fa_cached_edx_data)
         cls.serialized_enrollments = UserProgramSearchSerializer.serialize_enrollments(non_fa_mmtrack)
+        cls.serialized_course_enrollments = UserProgramSearchSerializer.serialize_course_enrollments(non_fa_mmtrack)
         cls.semester_enrollments = UserProgramSearchSerializer.serialize_course_runs_enrolled(non_fa_mmtrack)
         cls.program_enrollment = ProgramEnrollment.objects.create(user=cls.user, program=program)
         # create a financial aid program
@@ -145,6 +146,9 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
             )
         fa_cached_edx_data = CachedEdxUserData(cls.user, program=cls.fa_program)
         fa_mmtrack = MMTrack(cls.user, cls.fa_program, fa_cached_edx_data)
+        cls.fa_serialized_course_enrollments = (
+            UserProgramSearchSerializer.serialize_course_enrollments(fa_mmtrack)
+        )
         cls.fa_serialized_enrollments = (
             UserProgramSearchSerializer.serialize_enrollments(fa_mmtrack)
         )
@@ -158,7 +162,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         expected_values = {
             'id': program.id,
             'enrollments': self.serialized_enrollments,
-            'courses': self.serialized_enrollments,
+            'courses': self.serialized_course_enrollments,
             'course_runs': self.semester_enrollments,
             'grade_average': 75,
             'is_learner': True,
@@ -179,7 +183,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         expected_result = {
             'id': self.fa_program.id,
             'enrollments': self.fa_serialized_enrollments,
-            'courses': self.fa_serialized_enrollments,
+            'courses': self.fa_serialized_course_enrollments,
             'course_runs': self.semester_enrollments,
             'grade_average': 95,
             'is_learner': True,
@@ -203,7 +207,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
         expected_result = {
             'id': program.id,
             'enrollments': self.serialized_enrollments,
-            'courses': self.serialized_enrollments,
+            'courses': self.serialized_course_enrollments,
             'course_runs': self.semester_enrollments,
             'grade_average': 75,
             'is_learner': False,
@@ -224,7 +228,7 @@ class UserProgramSearchSerializerTests(MockedESTestCase):
             expected_result = {
                 'id': program.id,
                 'enrollments': self.serialized_enrollments,
-                'courses': self.serialized_enrollments,
+                'courses': self.serialized_course_enrollments,
                 'course_runs': self.semester_enrollments,
                 'grade_average': 75,
                 'is_learner': True,
@@ -443,7 +447,8 @@ class UserProgramSerializerSemesterTests(MockedESTestCase):
             semester_enrollment['semester'] == '2017 - Spring'
             for semester_enrollment in serialized_program_user['course_runs']
         )
-        assert get_year_season_patch.call_count == num_courses
+        # multiply by two while serialize_enrollments has semester
+        assert get_year_season_patch.call_count == num_courses*2
 
     def test_serialized_semester_value(self):
         """

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -321,7 +321,7 @@ def serialize_public_enrolled_user(serialized_enrolled_user):
     )
     program['enrollments'] = [
         dict_with_keys(enrollment, ['course_title', 'semester'])
-        for enrollment in program['courses']
+        for enrollment in program['enrollments']
     ]
     program['courses'] = [
         dict_with_keys(enrollment, ['course_title', ])

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -95,6 +95,7 @@ PUBLIC_ENROLLMENT_MAPPING = {
                     'enrollments': {
                         'type': 'nested',
                         'properties': {
+                            'semester': KEYWORD_TYPE,
                             'course_title': KEYWORD_TYPE,
                         }
                     },
@@ -190,6 +191,7 @@ PRIVATE_ENROLLMENT_MAPPING = {
                         'type': 'nested',
                         'properties': {
                             'final_grade': LONG_TYPE,
+                            'semester': KEYWORD_TYPE,
                             'course_title': KEYWORD_TYPE,
                             'status': KEYWORD_TYPE,
                             'payment_status': KEYWORD_TYPE,
@@ -318,7 +320,7 @@ def serialize_public_enrolled_user(serialized_enrolled_user):
         ['id', 'enrollments', 'courses', 'is_learner', 'total_courses', 'course_runs']
     )
     program['enrollments'] = [
-        dict_with_keys(enrollment, ['course_title', ])
+        dict_with_keys(enrollment, ['course_title', 'semester'])
         for enrollment in program['courses']
     ]
     program['courses'] = [

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -582,7 +582,8 @@ class SerializerTests(ESTestCase):
             'program': {
                 'id': program_enrollment.program.id,
                 'enrollments': [{
-                    'course_title': enrollment['course_title']
+                    'course_title': enrollment['course_title'],
+                    'semester': enrollment['semester']
                 } for enrollment in serialized['program']['courses']],
                 'courses': [{
                     'course_title': enrollment['course_title']

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -584,7 +584,7 @@ class SerializerTests(ESTestCase):
                 'enrollments': [{
                     'course_title': enrollment['course_title'],
                     'semester': enrollment['semester']
-                } for enrollment in serialized['program']['courses']],
+                } for enrollment in serialized['program']['enrollments']],
                 'courses': [{
                     'course_title': enrollment['course_title']
                 } for enrollment in serialized['program']['courses']],


### PR DESCRIPTION
#### What are the relevant tickets?
Fix https://sentry.io/mit-office-of-digital-learning/micromasters/issues/564282932/

#### What's this PR do?
Some percolate queries use filter on the semester. This PR adds the semester field to enrollments.

#### How should this be manually tested?
Tests should pass. 

