### PR TITLE
Fixed regression on semester facet front end side

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -271,7 +271,7 @@ export default class LearnerSearch extends SearchkitComponent {
           title="Course"
           filterName="courses"
           stayVisibleIfFilterApplied="final-grade"
-          disabled={this.isFilterSelected("program.enrollments.semester")}
+          disabled={this.isFilterSelected("program.course_runs.semester")}
         >
           <NestedAggregatingMenuFilter
             field="program.courses.course_title"
@@ -321,7 +321,7 @@ export default class LearnerSearch extends SearchkitComponent {
           {...this.props}
           filterName="semester"
           title="Enrolled Semester"
-          disabled={this.isFilterSelected("program.enrollments.course_title")}
+          disabled={this.isFilterSelected("program.courses.course_title")}
         >
           <RefinementListFilter
             id="semester"


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
- It fixes a regression where semester facet is not disabling when courses are select and vise versa

#### How should this be manually tested?
- Go to learner search as staff
- Select one or all semesters then see course faces must be disable 
- Select a course then see semester facet must be disbale

@pdpinch @annagav 

#### Screenshots (if appropriate)
<img width="660" alt="screen shot 2018-06-01 at 6 29 25 pm" src="https://user-images.githubusercontent.com/10431250/40843243-c4da5812-65c9-11e8-8c2d-06935c55ed38.png">

<img width="786" alt="screen shot 2018-06-01 at 6 29 32 pm" src="https://user-images.githubusercontent.com/10431250/40843244-c50a599a-65c9-11e8-8a5d-48edce9833b6.png">

