### PR TITLE
Add dashboard state: failed and pending price

### DIFF
--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -340,6 +340,14 @@ class DashboardStates:  # pylint: disable=too-many-locals
         set_course_run_current(course_run, upgradeable=True, save=True)
         CachedEnrollmentHandler(self.user).set_or_create(course_run, verified=False)
 
+    def create_failed_course_price_pending(self):
+        """Make failed course and still pending personal course price"""
+        self.make_fa_program_enrollment(FinancialAidStatus.PENDING_MANUAL_APPROVAL)
+        call_command(
+            "alter_data", 'set_past_run_to_failed', '--username', 'staff',
+            '--course-title', 'Digital Learning 200', '--grade', '10', '--audit'
+        )
+
     def create_passed_and_upgrade_deadline_past(self):
         """Make course passed in past and fail new next attempts"""
         self.make_fa_program_enrollment(FinancialAidStatus.AUTO_APPROVED)
@@ -413,6 +421,7 @@ class DashboardStates:  # pylint: disable=too-many-locals
 
         yield (self.create_passed_enrolled_again, 'passed_and_taking_again')
         yield (self.create_passed_and_upgrade_deadline_past, 'passed_and_missed_deadline_and_fail_in_next')
+        yield (self.create_failed_course_price_pending, 'failed_and_pending_price')
 
         # Add scenarios for paid and course run offered [now, in future, fuzzy future]
         for tup in itertools.product([True, False], repeat=2):


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #4004

#### What's this PR do?
Add a dashboard state where user has failed a course, and wants to enroll again but personal course price still pending.

#### How should this be manually tested?
Run scripts/test/run_snapshot_dashboard_states.sh --match "failed_and_pending"

<img width="613" alt="screen shot 2018-06-04 at 9 41 53 am" src="https://user-images.githubusercontent.com/7574259/40920751-75f48f10-67db-11e8-9453-f997e592c3ef.png">


