### PR TITLE
Use flag to determine if discussions user should be updated

### DIFF
--- a/discussions/api.py
+++ b/discussions/api.py
@@ -78,8 +78,8 @@ def create_or_update_discussion_user(user_id, allow_email_optin=False):
         if discussion_user.username is None:
             create_discussion_user(discussion_user)
         else:
-            update_discussion_user(discussion_user, allow_email_optin=allow_email_optin)
-
+            if settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', True):
+                update_discussion_user(discussion_user, allow_email_optin=allow_email_optin)
         return discussion_user
 
 

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -91,8 +91,10 @@ def test_create_or_update_discussion_user_no_username(mocker):
     assert DiscussionUser.objects.count() == 1
 
 
-def test_create_or_update_discussion_user_has_username(mocker):
+@pytest.mark.parametrize('enable_update', [True, False])
+def test_create_or_update_discussion_user_has_username(mocker, enable_update, settings):
     """Test that create_or_update_discussion_user updates if we have a username"""
+    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = enable_update
     create_mock = mocker.patch('discussions.api.create_discussion_user')
     update_mock = mocker.patch('discussions.api.update_discussion_user')
     with mute_signals(post_save):
@@ -100,7 +102,7 @@ def test_create_or_update_discussion_user_has_username(mocker):
     DiscussionUser.objects.create(user=profile.user, username='username')
     api.create_or_update_discussion_user(profile.user_id)
     assert create_mock.call_count == 0
-    assert update_mock.call_count == 1
+    assert update_mock.call_count == (1 if enable_update else 0)
     assert DiscussionUser.objects.count() == 1
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/783 (3rd checkbox)

#### What's this PR do?
If `FEATURE_OPEN_DISCUSSIONS_USER_SYNC` is `True` or `None`, update the discussions profile when the Micromasters profile is updated.  If set to `False`, do not update.

#### How should this be manually tested?
- Set `FEATURE_OPEN_DISCUSSIONS_USER_SYNC=False` in your `.env` file
- Log in as a new user in Micromasters, fill in the required blanks, then go to 'View Discussions' link from the dashboard.
- In a discussions shell:
  ```python
  from profiles.models import Profile
  Profile.objects.first().name
  ```
  - The full name should be the same as the first + last name in Micromasters
- In Micromasters, edit your profile and change your first or last name.
- In a discussions shell:
  ```python
  Profile.objects.first().name
  ```
  - The profile name should be unchanged (original first + last name).
- Set `FEATURE_OPEN_DISCUSSIONS_USER_SYNC=True` in your `.env` file, or remove it altogether.
- Restart Micromasters
- Change your micromasters profile first or last name
- In a discussions shell:
  ```python
  Profile.objects.first().name
  ```
  - The profile name should be changed to match the micromasters profile.
