### PR TITLE
Fix fonts and spacing on program pages

### DIFF
--- a/static/scss/general-styles.scss
+++ b/static/scss/general-styles.scss
@@ -46,6 +46,7 @@ p {
 
 a {
   color: $link-text;
+  font-weight: inherit;
 }
 
 a:focus, a:hover {

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -236,9 +236,38 @@
       }
     }
 
+    h2, h3, h4 {
+      line-height: 1.3;
+
+      &:first-child {
+        margin-top: 0;
+      }
+    }
+
+    h2 {
+      color: $font-black;
+      font-size: 23px;
+      font-weight: 500;
+      margin: 35px 0 26px;
+    }
+
+    h3 {
+      color: $font-black;
+      font-size: 20px;
+      font-weight: 500;
+      margin: 35px 0 23px;
+    }
+
+    h4 {
+      color: $font-black;
+      font-weight: 500;
+      font-size: 17px;
+      margin: 33px 0 15px 0;;
+    }
+
     p {
       font-size: 16px;
-      color: rgba(0,0,0,.87);
+      color: $font-black;
       margin-bottom: 24px;
       line-height: 1.4em;
     }
@@ -246,20 +275,14 @@
     li {
       font-size: 16px;
       line-height: 1.4em;
-      margin-bottom: 20px;
-      color: rgba(0,0,0,.7);
-    }
-
-    h4 {
-      margin-top: 44px;
-      margin-bottom: 36px;
-    }
-
-    h3 {
+      margin-bottom: 11px;
       color: $font-black;
-      font-size: 20px;
-      font-weight: 500;
     }
+
+    ul {
+      margin-bottom: 33px;
+    }
+
   }
 
   .faqs {

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -279,7 +279,7 @@
       color: $font-black;
     }
 
-    ul {
+    ul, ol {
       margin-bottom: 33px;
     }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #4014

#### What's this PR do?
This PR sets sensible header sizes and margins for the program pages. There are now H2, H3, and H4 header sizes with appropriate margins. Top margins are set to zero for the first child element so that headers at the top of the page will be correctly aligned. This also decreases the margins for list items, and sets a bigger bottom margin for the ul element. 

#### How should this be manually tested?
Create a program page with different size headers, and paragraphs, and lists.See that the headers on the page match the screenshot below.

![image](https://user-images.githubusercontent.com/20047260/41174658-c7d46512-6b28-11e8-8142-45f14a428559.png)


