### PR TITLE
Fix sentry error/exception logging

### DIFF
--- a/discussions/tasks.py
+++ b/discussions/tasks.py
@@ -1,8 +1,8 @@
 """Tasks for profiles"""
 from datetime import timedelta
 from itertools import takewhile
+import logging
 
-from celery.utils.log import get_task_logger
 from django.conf import settings
 
 from discussions import api
@@ -19,7 +19,7 @@ SYNC_MEMBERSHIPS_LOCK_NAME = 'discussions.tasks.sync_memberships_lock'
 # this is a trade off of letting it run longer vs. having a stale view
 SYNC_MEMBERSHIPS_LOCK_TTL_SECONDS = 60 * 2 - 5
 
-log = get_task_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 @app.task()

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -371,7 +371,7 @@ LOGGING = {
         'django': {
             'propagate': True,
             'level': DJANGO_LOG_LEVEL,
-            'handlers': ['console', 'syslog'],
+            'handlers': ['console', 'syslog', 'sentry'],
         },
         'django.request': {
             'handlers': ['mail_admins'],
@@ -397,7 +397,7 @@ LOGGING = {
         },
     },
     'root': {
-        'handlers': ['console', 'syslog'],
+        'handlers': ['console', 'syslog', 'sentry'],
         'level': LOG_LEVEL,
     },
 }
@@ -414,13 +414,6 @@ RAVEN_CONFIG = {
 # CORS
 CORS_ORIGIN_WHITELIST = get_list_of_str("MICROMASTERS_CORS_ORIGIN_WHITELIST", [])
 CORS_ALLOW_CREDENTIALS = True
-
-# to run the app locally on mac you need to bypass syslog
-if get_bool('MICROMASTERS_BYPASS_SYSLOG', False):
-    LOGGING['handlers'].pop('syslog')
-    LOGGING['loggers']['root']['handlers'] = ['console']
-    LOGGING['loggers']['ui']['handlers'] = ['console']
-    LOGGING['loggers']['django']['handlers'] = ['console']
 
 # server-status
 STATUS_TOKEN = get_string("STATUS_TOKEN", "")

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 Django==2.0.2
 Pillow==3.4.2
 boto==2.39.0
-celery==4.0.2
+celery==4.2.0
 certifi==2018.1.18
 dj-database-url==0.3.0
 dj-static==0.0.6
@@ -33,7 +33,7 @@ psycopg2==2.7.3.2
 pycountry==16.11.27.1
 pysftp==0.2.9
 python-dateutil
-raven==6.6.0
+raven==6.9.0
 redis==2.10.5
 requests
 social-auth-app-django==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ bcrypt==3.1.3             # via paramiko
 beautifulsoup4==4.6.0     # via wagtail
 billiard==3.5.0.3         # via celery
 boto==2.39.0
-celery==4.0.2
+celery==4.2.0
 certifi==2018.1.18
 cffi==1.10.0              # via bcrypt, cryptography, pynacl
 cryptography==2.0.2       # via paramiko
@@ -18,11 +18,11 @@ decorator==4.1.2          # via ipython, traitlets
 defusedxml==0.5.0         # via python3-openid, social-auth-core
 dj-database-url==0.3.0
 dj-static==0.0.6
-django-cors-headers==2.1.0
 django-compat==1.0.15
-django-hijack==2.1.7
-django-hijack-admin==2.1.7
+django-cors-headers==2.1.0
 django-discover-runner==1.0  # via django-role-permissions
+django-hijack-admin==2.1.7
+django-hijack==2.1.7
 django-modelcluster==4.1  # via wagtail
 django-redis==4.7.0
 django-role-permissions==2.2.0
@@ -49,7 +49,7 @@ jedi==0.10.2              # via ipython
 jsonfield==1.0.3
 jsonpatch==1.16
 jsonpointer==1.12         # via jsonpatch
-kombu==4.1.0              # via celery, django-server-status
+kombu==4.2.1              # via celery, django-server-status
 newrelic==2.88.1.73
 oauthlib==2.0.2           # via requests-oauthlib, social-auth-core
 open-discussions-client==0.4.0
@@ -74,13 +74,13 @@ pysftp==0.2.9
 python-dateutil==2.5.3
 python3-openid==3.1.0     # via social-auth-core
 pytz==2017.2              # via celery, django, django-modelcluster
-raven==6.6.0
+raven==6.9.0
 redis==2.10.5
 requests-oauthlib==0.8.0  # via social-auth-core
 requests==2.11.1
 robohash==1.0
 simplegeneric==0.8.1      # via ipython
-six==1.10.0               # via bcrypt, cryptography, django-role-permissions, django-server-status, edx-api-client, edx-opaque-keys, elasticsearch-dsl, faker, html5lib, prompt-toolkit, pynacl, python-dateutil, social-auth-app-django, social-auth-core, stevedore, traitlets
+six==1.10.0               # via bcrypt, cryptography, django-compat, django-role-permissions, django-server-status, edx-api-client, edx-opaque-keys, elasticsearch-dsl, faker, html5lib, prompt-toolkit, pynacl, python-dateutil, social-auth-app-django, social-auth-core, stevedore, traitlets
 social-auth-app-django==2.1.0
 social-auth-core==1.4.0   # via social-auth-app-django
 static3==0.5.1


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/cookiecutter-djangoapp/pull/131

#### What's this PR do?
Fixes error and exception sentry reporting. The sentry handler needs to be part of the logging in order to handle explicit error and exception logging (unhandled exceptions are taken care of in the middleware I think). More info: https://docs.sentry.io/clients/python/integrations/django/#integration-with-logging

Celery exception reporting also isn't working with `get_task_logger` for some reason. I replaced it with `logging.getLogger` like we do everywhere else.

There are also a few unrelated dependency upgrades.

#### How should this be manually tested?
Run a shell in the heroku PR build and type `logging.getLogger().error("testing")`. You should see a new sentry exception with that text.

To test the celery exception reporting shell into the heroku PR build and type `discussions.tasks.sync_discussion_user.delay(1)`. There is a user with id `1` which exists locally and the sync will fail with the exception being logged via `log.exception`