### PR TITLE
Skip exam authorization for inactive user

### DIFF
--- a/exams/api.py
+++ b/exams/api.py
@@ -76,13 +76,12 @@ def authorize_for_exam_run(mmtrack, course_run, exam_run):
         exam_run (exams.models.ExamRun): the ExamRun we're authorizing for
     """
     if not mmtrack.user.is_active:
-        log.info(
-            '[Exam authorization] Inactive user "%s" cannot be authorized for the exam for course id "%s"',
-            mmtrack.user.username,
-            course_run.edx_course_key
+        raise ExamAuthorizationException(
+            "Inactive user '{}' cannot be authorized for the exam for course id '{}'".format(
+                mmtrack.user.username,
+                course_run.course
+            )
         )
-        return
-
     if course_run.course != exam_run.course:
         raise ExamAuthorizationException(
             "Course '{}' on CourseRun doesn't match Course '{}' on ExamRun".format(course_run.course, exam_run.course)

--- a/exams/api.py
+++ b/exams/api.py
@@ -75,6 +75,14 @@ def authorize_for_exam_run(mmtrack, course_run, exam_run):
         course_run (courses.models.CourseRun): A CourseRun object.
         exam_run (exams.models.ExamRun): the ExamRun we're authorizing for
     """
+    if not mmtrack.user.is_active:
+        log.info(
+            '[Exam authorization] Inactive user "%s" cannot be authorized for the exam for course id "%s"',
+            mmtrack.user.username,
+            course_run.edx_course_key
+        )
+        return
+
     if course_run.course != exam_run.course:
         raise ExamAuthorizationException(
             "Course '{}' on CourseRun doesn't match Course '{}' on ExamRun".format(course_run.course, exam_run.course)

--- a/exams/api_test.py
+++ b/exams/api_test.py
@@ -141,7 +141,7 @@ class ExamAuthorizationApiTests(TestCase):
         with self.assertRaises(ExamAuthorizationException):
             authorize_for_exam_run(mmtrack, self.course_run, self.exam_run)
 
-        # Assert user has exam profile and authorization.
+        # Assert user doesn't have exam profile and authorization
         assert ExamProfile.objects.filter(profile=mmtrack.user.profile).exists() is False
         assert ExamAuthorization.objects.filter(
             user=mmtrack.user,

--- a/exams/api_test.py
+++ b/exams/api_test.py
@@ -106,6 +106,47 @@ class ExamAuthorizationApiTests(TestCase):
                 course_run_paid_on_edx=False,
             )
 
+    def test_exam_authorization_for_inactive_user(self):
+        """
+        test exam_authorization when inactive user passed and paid for course.
+        """
+        with mute_signals(post_save):
+            profile = ProfileFactory.create()
+
+        user = profile.user
+        user.is_active = False
+        user.save()
+        with mute_signals(post_save):
+            CachedEnrollmentFactory.create(user=user, course_run=self.course_run)
+
+        with mute_signals(post_save):
+            FinalGradeFactory.create(
+                user=user,
+                course_run=self.course_run,
+                passed=True,
+                course_run_paid_on_edx=False,
+            )
+        create_order(user, self.course_run)
+        mmtrack = get_mmtrack(user, self.program)
+        self.assertTrue(mmtrack.has_paid(self.course_run.edx_course_key))
+        self.assertTrue(mmtrack.has_passed_course(self.course_run.edx_course_key))
+
+        # Neither user has exam profile nor authorization.
+        assert ExamProfile.objects.filter(profile=mmtrack.user.profile).exists() is False
+        assert ExamAuthorization.objects.filter(
+            user=mmtrack.user,
+            course=self.course_run.course
+        ).exists() is False
+
+        authorize_for_exam_run(mmtrack, self.course_run, self.exam_run)
+
+        # Assert user has exam profile and authorization.
+        assert ExamProfile.objects.filter(profile=mmtrack.user.profile).exists() is False
+        assert ExamAuthorization.objects.filter(
+            user=mmtrack.user,
+            course=self.course_run.course
+        ).exists() is False
+
     def test_exam_authorization(self):
         """
         test exam_authorization when user passed and paid for course.

--- a/exams/api_test.py
+++ b/exams/api_test.py
@@ -138,7 +138,8 @@ class ExamAuthorizationApiTests(TestCase):
             course=self.course_run.course
         ).exists() is False
 
-        authorize_for_exam_run(mmtrack, self.course_run, self.exam_run)
+        with self.assertRaises(ExamAuthorizationException):
+            authorize_for_exam_run(mmtrack, self.course_run, self.exam_run)
 
         # Assert user has exam profile and authorization.
         assert ExamProfile.objects.filter(profile=mmtrack.user.profile).exists() is False


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3990

#### What's this PR do?
It skips authorization creation of inactive user

#### How should this be manually tested?
- create in active user,
- create exam run
- pay (full fill order) for user
- you will not see him authorize 

@pdpinch 
