### PR TITLE
Show exam message even when has enrollable runs

### DIFF
--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -114,6 +114,7 @@ class DashboardStates:  # pylint: disable=too-many-locals
             course=course,
             exam_run=exam_run,
             passed=exam_passed,
+            percentage_grade=0.8 if exam_passed else 0.3
         )
         if new_offering:
             CourseRunFactory.create(course=course)
@@ -146,6 +147,7 @@ class DashboardStates:  # pylint: disable=too-many-locals
                 course=course,
                 exam_run=exam_run,
                 passed=False,
+                percentage_grade=0.3
             )
 
     def with_prev_passed_run(self):

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -277,7 +277,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
         }
         messages.push(messageBox)
 
-        if(S.isJust(futureEnrollableRun(course))){
+        if (S.isJust(futureEnrollableRun(course))) {
           messages.push({
             message: (
               <span>

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -281,7 +281,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
           messages.push({
             message: (
               <span>
-                {" If you want to re-take the course you can "}
+                {"If you want to re-take the course you can "}
                 <a onClick={() => setShowExpandedCourseStatus(course.id)}>
                   re-enroll.
                 </a>

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -275,24 +275,20 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
           messageBox["message"] =
             "The edX course is complete, but you need to pass the final exam."
         }
-        messages.push(
-          S.maybe(
-            messageBox,
-            () => ({
-              message: (
-                <span>
-                  The edX course is complete, but you need to pass the final
-                  exam.
-                  {" If you want to re-take the course you can "}
-                  <a onClick={() => setShowExpandedCourseStatus(course.id)}>
-                    re-enroll.
-                  </a>
-                </span>
-              )
-            }),
-            futureEnrollableRun(course)
-          )
-        )
+        messages.push(messageBox)
+
+        if(S.isJust(futureEnrollableRun(course))){
+          messages.push({
+            message: (
+              <span>
+                {" If you want to re-take the course you can "}
+                <a onClick={() => setShowExpandedCourseStatus(course.id)}>
+                  re-enroll.
+                </a>
+              </span>
+            )
+          })
+        }
       } else if (!course.certificate_url) {
         messages.push({
           message: "You passed this course."

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -393,20 +393,18 @@ describe("Course Status Messages", () => {
         course.can_schedule_exam = true
         course.has_to_pay = true
         const messages = calculateMessages(calculateMessagesProps).value
-        assert.deepEqual(messages[0],
-          {
-            message:
-              "You did not pass the exam. If you want to re-take the exam, you need to pay again.",
-            action: "course action was called"
-          }
-        )
-        const mounted = shallow(messages[1]['message'])
+        assert.deepEqual(messages[0], {
+          message:
+            "You did not pass the exam. If you want to re-take the exam, you need to pay again.",
+          action: "course action was called"
+        })
+        const mounted = shallow(messages[1]["message"])
         assert.equal(
           mounted.text().trim(),
           "If you want to re-take the course you can re-enroll."
         )
       })
-      
+
       it("should ask to pay and schedule another exam", () => {
         course.runs = [course.runs[0]]
         course.proctorate_exams_grades = [makeProctoredExamResult()]
@@ -483,8 +481,11 @@ describe("Course Status Messages", () => {
         // this component returns a react component as its message
         const messages = calculateMessages(calculateMessagesProps).value
         assert.equal(messages.length, 2)
-        assert.equal(messages[0]['message'], 'The edX course is complete, but you need to pass the final exam.')
-        const mounted = shallow(messages[1]['message'])
+        assert.equal(
+          messages[0]["message"],
+          "The edX course is complete, but you need to pass the final exam."
+        )
+        const mounted = shallow(messages[1]["message"])
         assert.equal(
           mounted.text().trim(),
           "If you want to re-take the course you can re-enroll."

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -387,6 +387,26 @@ describe("Course Status Messages", () => {
         ])
       })
 
+      it("should ask to pay and schedule another exam even when there is another run", () => {
+        course.proctorate_exams_grades = [makeProctoredExamResult()]
+        course.proctorate_exams_grades[0].passed = false
+        course.can_schedule_exam = true
+        course.has_to_pay = true
+        const messages = calculateMessages(calculateMessagesProps).value
+        assert.deepEqual(messages[0],
+          {
+            message:
+              "You did not pass the exam. If you want to re-take the exam, you need to pay again.",
+            action: "course action was called"
+          }
+        )
+        const mounted = shallow(messages[1]['message'])
+        assert.equal(
+          mounted.text().trim(),
+          "If you want to re-take the course you can re-enroll."
+        )
+      })
+      
       it("should ask to pay and schedule another exam", () => {
         course.runs = [course.runs[0]]
         course.proctorate_exams_grades = [makeProctoredExamResult()]
@@ -461,12 +481,13 @@ describe("Course Status Messages", () => {
 
       it("should show un-expanded message", () => {
         // this component returns a react component as its message
-        const [{ message }] = calculateMessages(calculateMessagesProps).value
-        const mounted = shallow(message)
+        const messages = calculateMessages(calculateMessagesProps).value
+        assert.equal(messages.length, 2)
+        assert.equal(messages[0]['message'], 'The edX course is complete, but you need to pass the final exam.')
+        const mounted = shallow(messages[1]['message'])
         assert.equal(
           mounted.text().trim(),
-          "The edX course is complete, but you need to pass the final exam. " +
-            "If you want to re-take the course you can re-enroll."
+          "If you want to re-take the course you can re-enroll."
         )
         mounted.find("a").simulate("click")
         assert(
@@ -479,8 +500,8 @@ describe("Course Status Messages", () => {
       it("should include an expanded message, if the expanded status set includes the course id", () => {
         calculateMessagesProps.expandedStatuses.add(course.id)
         const messages = calculateMessages(calculateMessagesProps).value
-        assert.equal(messages.length, 2)
-        assert.deepEqual(messages[1], {
+        assert.equal(messages.length, 3)
+        assert.deepEqual(messages[2], {
           message: `Next course starts ${formatDate(
             course.runs[1].course_start_date
           )}.`,


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4025

#### What's this PR do?
Displays both messages about enrolling in a future run, and about not passed exams, including the case where the user needs to pay for another attempt.

#### How should this be manually tested?
Run  `scripts/test/run_snapshot_dashboard_states.sh --match "exam"`. Take a look at snapshots with the name variations that include:
"is_offered": another run is offered, user can enroll,
"can_schedule": there is another exam run,
"has_to_pay": the user exceeded the number of attempts, has two failed exam grades.

![screen shot 2018-06-20 at 11 47 08 am](https://user-images.githubusercontent.com/7574259/41674913-311eac2a-748f-11e8-8168-025fc1504c80.png)

<img width="710" alt="screen shot 2018-06-20 at 1 45 01 pm" src="https://user-images.githubusercontent.com/7574259/41675186-0232b946-7490-11e8-8dc3-e0103b90d826.png">

