### PR TITLE
Pinned Dockerfile to python:3.6.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6.4
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Pins dockerfile to pytohn 3.6.4 since 3.6.5 has broken apt packages

#### How should this be manually tested?
`docker-compose build --no-cache web` should succeed