### PR TITLE
Message about exam when course run in progress

### DIFF
--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -22,18 +22,19 @@ import {
   STATUS_CAN_UPGRADE,
   COURSE_ACTION_CALCULATE_PRICE,
   DASHBOARD_FORMAT,
-  COURSE_DEADLINE_FORMAT, STATUS_CURRENTLY_ENROLLED
+  COURSE_DEADLINE_FORMAT,
+  STATUS_CURRENTLY_ENROLLED
 } from "../../../constants"
 import { S } from "../../../lib/sanctuary"
 import {
-  hasPaidForAnyCourseRun,
   courseUpcomingOrCurrent,
   isPassedOrMissedDeadline,
   hasFailedCourseRun,
   futureEnrollableRun,
   isEnrollableRun,
   userIsEnrolled,
-  isOfferedInUncertainFuture, isPassedOrCurrentlyErolled, isPassedOrCurrentlyEnrolled
+  isOfferedInUncertainFuture,
+  isPassedOrCurrentlyEnrolled
 } from "./util"
 import {
   hasPassingExamGrade,
@@ -85,8 +86,6 @@ const messageForNotAttemptedExam = (course: Course) => {
   return message
 }
 
-
-
 // this calculates any status messages we'll need to show the user
 // we wrap the array of messages in a Maybe, so that we can indicate
 // the case where there are no messages cleanly
@@ -114,7 +113,6 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   )
 
   const messageForNoPassedExams = (course: Course) => {
-
     if (course.can_schedule_exam) {
       // if can schedule exam now
       if (course.has_to_pay) {
@@ -124,15 +122,19 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
           action: courseAction(firstRun, COURSE_ACTION_PAY)
         }
       } else {
-        return {"message":
-          "You did not pass the exam, but you can try again. " +
-          "Click above to reschedule an exam with Pearson."}
+        return {
+          message:
+            "You did not pass the exam, but you can try again. " +
+            "Click above to reschedule an exam with Pearson."
+        }
       }
     } else if (R.isEmpty(course.exams_schedulable_in_future)) {
       // no info about future exam runs
-      return {"message":
-        "You did not pass the exam. There are currently no exams " +
-        "available for scheduling. Please check back later."}
+      return {
+        message:
+          "You did not pass the exam. There are currently no exams " +
+          "available for scheduling. Please check back later."
+      }
     } else {
       // can not schedule now, but some time in the future
       if (course.has_to_pay) {
@@ -144,10 +146,12 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
           action: courseAction(firstRun, COURSE_ACTION_PAY)
         }
       } else {
-        return {"message":
-          "You did not pass the exam, but you can try again. " +
-          "You can sign up to re-take the exam starting on " +
-          `on ${formatDate(course.exams_schedulable_in_future[0])}.`}
+        return {
+          message:
+            "You did not pass the exam, but you can try again. " +
+            "You can sign up to re-take the exam starting on " +
+            `on ${formatDate(course.exams_schedulable_in_future[0])}.`
+        }
       }
     }
   }
@@ -217,7 +221,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     })
   }
   // course is passed and paid but no certificate yet
-  if (firstRun['status'] === 'passed' && paid && !course.certificate_url) {
+  if (firstRun["status"] === "passed" && paid && !course.certificate_url) {
     if (!exams || (exams && passedExam)) {
       messages.push({
         message: "You passed this course."
@@ -225,7 +229,12 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     }
   }
   // Course is running, user has already paid,
-  if (courseUpcomingOrCurrent(firstRun) && paid && userIsEnrolled(firstRun) && !exams) {
+  if (
+    courseUpcomingOrCurrent(firstRun) &&
+    paid &&
+    userIsEnrolled(firstRun) &&
+    !exams
+  ) {
     return S.Just(messages)
   }
 
@@ -283,16 +292,19 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
       }
       messages.push(messageBox)
 
-      if (firstRun['status'] !== STATUS_CURRENTLY_ENROLLED && S.isJust(futureEnrollableRun(course))) {
-      messages.push({
-        message: (
-          <span>
-            {"If you want to re-take the course you can "}
-            <a onClick={() => setShowExpandedCourseStatus(course.id)}>
-              re-enroll.
-            </a>
-          </span>
-        )
+      if (
+        firstRun["status"] !== STATUS_CURRENTLY_ENROLLED &&
+        S.isJust(futureEnrollableRun(course))
+      ) {
+        messages.push({
+          message: (
+            <span>
+              {"If you want to re-take the course you can "}
+              <a onClick={() => setShowExpandedCourseStatus(course.id)}>
+                re-enroll.
+              </a>
+            </span>
+          )
         })
       }
     } // If passed exam don't show message about exams

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -22,7 +22,7 @@ import {
   STATUS_CAN_UPGRADE,
   COURSE_ACTION_CALCULATE_PRICE,
   DASHBOARD_FORMAT,
-  COURSE_DEADLINE_FORMAT
+  COURSE_DEADLINE_FORMAT, STATUS_CURRENTLY_ENROLLED
 } from "../../../constants"
 import { S } from "../../../lib/sanctuary"
 import {
@@ -33,7 +33,7 @@ import {
   futureEnrollableRun,
   isEnrollableRun,
   userIsEnrolled,
-  isOfferedInUncertainFuture
+  isOfferedInUncertainFuture, isPassedOrCurrentlyErolled, isPassedOrCurrentlyEnrolled
 } from "./util"
 import {
   hasPassingExamGrade,
@@ -85,6 +85,8 @@ const messageForNotAttemptedExam = (course: Course) => {
   return message
 }
 
+
+
 // this calculates any status messages we'll need to show the user
 // we wrap the array of messages in a Maybe, so that we can indicate
 // the case where there are no messages cleanly
@@ -110,6 +112,46 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   const paymentDueDate = moment(
     R.defaultTo("", firstRun.course_upgrade_deadline)
   )
+
+  const messageForNoPassedExams = (course: Course) => {
+
+    if (course.can_schedule_exam) {
+      // if can schedule exam now
+      if (course.has_to_pay) {
+        return {
+          message:
+            "You did not pass the exam. If you want to re-take the exam, you need to pay again.",
+          action: courseAction(firstRun, COURSE_ACTION_PAY)
+        }
+      } else {
+        return {"message":
+          "You did not pass the exam, but you can try again. " +
+          "Click above to reschedule an exam with Pearson."}
+      }
+    } else if (R.isEmpty(course.exams_schedulable_in_future)) {
+      // no info about future exam runs
+      return {"message":
+        "You did not pass the exam. There are currently no exams " +
+        "available for scheduling. Please check back later."}
+    } else {
+      // can not schedule now, but some time in the future
+      if (course.has_to_pay) {
+        return {
+          message:
+            "You did not pass the exam. If you want to re-take the exam, you need " +
+            "to pay again. You can sign up to re-take the exam starting " +
+            `on ${formatDate(course.exams_schedulable_in_future[0])}`,
+          action: courseAction(firstRun, COURSE_ACTION_PAY)
+        }
+      } else {
+        return {"message":
+          "You did not pass the exam, but you can try again. " +
+          "You can sign up to re-take the exam starting on " +
+          `on ${formatDate(course.exams_schedulable_in_future[0])}.`}
+      }
+    }
+  }
+
   if (firstRun.status === STATUS_PAID_BUT_NOT_ENROLLED && !hasFinancialAid) {
     const contactHref = `mailto:${SETTINGS.support_email}`
     return S.Just([
@@ -174,13 +216,16 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
       )
     })
   }
-  // Course is running, user has already paid,
-  if (courseUpcomingOrCurrent(firstRun) && paid && userIsEnrolled(firstRun)) {
-    if (exams) {
+  // course is passed and paid but no certificate yet
+  if (firstRun['status'] === 'passed' && paid && !course.certificate_url) {
+    if (!exams || (exams && passedExam)) {
       messages.push({
-        message: messageForNotAttemptedExam(course)
+        message: "You passed this course."
       })
     }
+  }
+  // Course is running, user has already paid,
+  if (courseUpcomingOrCurrent(firstRun) && paid && userIsEnrolled(firstRun) && !exams) {
     return S.Just(messages)
   }
 
@@ -226,75 +271,38 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     return S.Just(messages)
   }
 
+  //Exam messages only
+  if (isPassedOrCurrentlyEnrolled(firstRun) && exams && paid) {
+    if (!passedExam) {
+      let messageBox = {}
+      if (failedExam) {
+        messageBox = messageForNoPassedExams(course)
+      } else {
+        // no past exam attempts
+        messageBox["message"] = messageForNotAttemptedExam(course)
+      }
+      messages.push(messageBox)
+
+      if (firstRun['status'] !== STATUS_CURRENTLY_ENROLLED && S.isJust(futureEnrollableRun(course))) {
+      messages.push({
+        message: (
+          <span>
+            {"If you want to re-take the course you can "}
+            <a onClick={() => setShowExpandedCourseStatus(course.id)}>
+              re-enroll.
+            </a>
+          </span>
+        )
+        })
+      }
+    } // If passed exam don't show message about exams
+  }
+
   // all cases where courseRun is not currently in progress
   // first, all cases where the user has already passed the course
   if (isPassedOrMissedDeadline(firstRun)) {
     // paid statuses
-    if (hasPaidForAnyCourseRun(course)) {
-      // exam is required, user has not yet passed it
-      if (exams && !passedExam) {
-        let messageBox = {}
-        if (failedExam) {
-          if (course.can_schedule_exam) {
-            // if can schedule exam now
-            if (course.has_to_pay) {
-              messageBox = {
-                message:
-                  "You did not pass the exam. If you want to re-take the exam, you need to pay again.",
-                action: courseAction(firstRun, COURSE_ACTION_PAY)
-              }
-            } else {
-              messageBox["message"] =
-                "You did not pass the exam, but you can try again. " +
-                "Click above to reschedule an exam with Pearson."
-            }
-          } else if (R.isEmpty(course.exams_schedulable_in_future)) {
-            // no info about future exam runs
-            messageBox["message"] =
-              "You did not pass the exam. There are currently no exams " +
-              "available for scheduling. Please check back later."
-          } else {
-            // can not schedule now, but some time in the future
-            if (course.has_to_pay) {
-              messageBox = {
-                message:
-                  "You did not pass the exam. If you want to re-take the exam, you need " +
-                  "to pay again. You can sign up to re-take the exam starting " +
-                  `on ${formatDate(course.exams_schedulable_in_future[0])}`,
-                action: courseAction(firstRun, COURSE_ACTION_PAY)
-              }
-            } else {
-              messageBox["message"] =
-                "You did not pass the exam, but you can try again. " +
-                "You can sign up to re-take the exam starting on " +
-                `on ${formatDate(course.exams_schedulable_in_future[0])}.`
-            }
-          }
-        } else {
-          // no past exam attempts
-          messageBox["message"] =
-            "The edX course is complete, but you need to pass the final exam."
-        }
-        messages.push(messageBox)
-
-        if (S.isJust(futureEnrollableRun(course))) {
-          messages.push({
-            message: (
-              <span>
-                {"If you want to re-take the course you can "}
-                <a onClick={() => setShowExpandedCourseStatus(course.id)}>
-                  re-enroll.
-                </a>
-              </span>
-            )
-          })
-        }
-      } else if (!course.certificate_url) {
-        messages.push({
-          message: "You passed this course."
-        })
-      }
-
+    if (paid) {
       // this is the expanded message, which we should show if the user
       // has clicked one of the 're-enroll' links
       if (expandedStatuses.has(course.id)) {

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -368,7 +368,7 @@ describe("Course Status Messages", () => {
         assertIsJust(calculateMessages(calculateMessagesProps), [
           {
             message:
-              "The edX course is complete, but you need to pass the final exam."
+              "There are currently no exams available for scheduling. Please check back later."
           }
         ])
       })
@@ -483,7 +483,7 @@ describe("Course Status Messages", () => {
         assert.equal(messages.length, 2)
         assert.equal(
           messages[0]["message"],
-          "The edX course is complete, but you need to pass the final exam."
+          "There are currently no exams available for scheduling. Please check back later."
         )
         const mounted = shallow(messages[1]["message"])
         assert.equal(

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -311,17 +311,6 @@ describe("Course Status Messages", () => {
         makeRunEnrolled(course.runs[0])
       })
 
-      it("should prompt to schedule exam", () => {
-        course.has_exam = true
-        course.can_schedule_exam = true
-
-        assertIsJust(calculateMessages(calculateMessagesProps), [
-          {
-            message: "Click above to schedule an exam with Pearson."
-          }
-        ])
-      })
-
       it("should prompt to sign up for future", () => {
         course.has_exam = true
         course.can_schedule_exam = false
@@ -349,6 +338,56 @@ describe("Course Status Messages", () => {
           {
             message:
               "There are currently no exams available for scheduling. Please check back later."
+          }
+        ])
+      })
+    })
+    describe("should prompt users who are paid and passed but course is in progress, if applicable", () => {
+      beforeEach(() => {
+        makeRunCurrent(course.runs[0])
+        makeRunPaid(course.runs[0])
+        makeRunPassed(course.runs[0])
+      })
+
+      it("should prompt to schedule exam", () => {
+        course.has_exam = true
+        course.can_schedule_exam = true
+
+        const messages = calculateMessages(calculateMessagesProps).value
+        assert.equal(messages.length, 2)
+        assert.equal(
+          messages[0]["message"],
+          "Click above to schedule an exam with Pearson."
+        )
+        const mounted = shallow(messages[1]["message"])
+        assert.equal(
+          mounted.text().trim(),
+          "If you want to re-take the course you can re-enroll."
+        )
+      })
+
+      it("should not prompt to schedule exam if already passed exam", () => {
+        course.has_exam = true
+        course.can_schedule_exam = true
+        course.proctorate_exams_grades = [makeProctoredExamResult()]
+        course.proctorate_exams_grades[0].passed = true
+
+        assertIsJust(calculateMessages(calculateMessagesProps), [
+          {
+            message: "You passed this course."
+          }
+        ])
+      })
+
+      it("should prompt when passed the course and exam", () => {
+        course.has_exam = true
+        course.can_schedule_exam = true
+        course.proctorate_exams_grades = [makeProctoredExamResult()]
+        course.proctorate_exams_grades[0].passed = true
+
+        assertIsJust(calculateMessages(calculateMessagesProps), [
+          {
+            message: "You passed this course."
           }
         ])
       })

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -77,6 +77,12 @@ export const isPassedOrMissedDeadline = R.compose(
   R.prop("status")
 )
 
+export const isPassedOrCurrentlyEnrolled = R.compose(
+  R.contains(R.__, [STATUS_PASSED, STATUS_CURRENTLY_ENROLLED]),
+  R.prop("status")
+)
+
+
 export const hasFailedCourseRun = R.compose(
   R.any(R.propEq("status", STATUS_NOT_PASSED)),
   R.prop("runs")

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -82,7 +82,6 @@ export const isPassedOrCurrentlyEnrolled = R.compose(
   R.prop("status")
 )
 
-
 export const hasFailedCourseRun = R.compose(
   R.any(R.propEq("status", STATUS_NOT_PASSED)),
   R.prop("runs")


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4025

#### What's this PR do?
Changes the logic of messages for course that is still in progress.
Because the way the logic tree was constructed I had to refactor many of the exam messages out, and as part of that change some other messages got changed.

Main changes include:
- States for courses with end date in the future with exams (they were not handled correctly almost all of them are now changed)

- In non-FA program if the user passed the course, but didn't get the certificate yet, there was a message "You passed the course.". I extended this message to be shown for FA course with exams, when user passed the course and passed the exam, but did not get a certificate yet.

- Removed "The edX course is complete, but you need to pass the final exam." It did not contain any information about upcoming exams. Now this state is handled by `messageForNotAttemptedExam(course)` .

#### How should this be manually tested?
Added new dashboard state. Run `scripts/test/run_snapshot_dashboard_states.sh --match "current_paid_course_run"`

Make sure other states were not changed.