### PR TITLE
Add exam states where course is in progress

### DIFF
--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -94,7 +94,9 @@ class DashboardStates:  # pylint: disable=too-many-locals
                 "alter_data", 'set_to_enrolled', '--username', 'staff',
                 '--course-run-key', course_run.edx_course_key
             )
-            FinalGradeFactory.create(user=self.user, course_run=course_run, grade=0.8 if edx_passed else 0.2, passed=True)
+            FinalGradeFactory.create(
+                user=self.user, course_run=course_run, grade=0.8 if edx_passed else 0.2, passed=True
+            )
         else:
             if edx_passed:
                 call_command(
@@ -400,9 +402,11 @@ class DashboardStates:  # pylint: disable=too-many-locals
 
             yield (
                 bind_args(
-                    self.create_exams, current, edx_passed, exam_passed, is_offered, can_schedule, future_exam, has_to_pay
+                    self.create_exams, current, edx_passed, exam_passed, is_offered,
+                    can_schedule, future_exam, has_to_pay
                 ),
-                'create_exams{current}_{edx_passed}_{exam_passed}{new_offering}{can_schedule}{future_exam}{has_to_pay}'.format(
+                'create_exams{current}_{edx_passed}_{exam_passed}{new_offering}'
+                '{can_schedule}{future_exam}{has_to_pay}'.format(
                     current='_current' if current else '',
                     edx_passed='edx_✔' if edx_passed else 'edx_✖',
                     exam_passed='exam_✔' if exam_passed else 'exam_✖',

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -34,7 +34,7 @@ from ecommerce.models import (
 from exams.factories import ExamRunFactory, ExamProfileFactory, ExamAuthorizationFactory
 from financialaid.factories import FinancialAidFactory
 from financialaid.models import FinancialAidStatus
-from grades.factories import ProctoredExamGradeFactory, MicromastersCourseCertificateFactory
+from grades.factories import ProctoredExamGradeFactory, MicromastersCourseCertificateFactory, FinalGradeFactory
 from grades.models import FinalGrade, CourseRunGradingStatus, MicromastersCourseCertificate
 from profiles.api import get_social_username
 from roles.models import Role, Staff
@@ -83,22 +83,31 @@ class DashboardStates:  # pylint: disable=too-many-locals
         """
         self.user = user
 
-    def create_exams(self, edx_passed, exam_passed, new_offering, can_schedule, future_exam, need_to_pay):
+    def create_exams(self, current, edx_passed, exam_passed, new_offering, can_schedule, future_exam, need_to_pay):
         """Create an exam and mark it and the related course as passed or not passed"""
         # pylint: disable-msg=too-many-arguments
         self.make_fa_program_enrollment(FinancialAidStatus.AUTO_APPROVED)
-        if edx_passed:
-            call_command(
-                "alter_data", 'set_to_passed', '--username', 'staff',
-                '--course-title', 'Digital Learning 200', '--grade', '75',
-            )
-        else:
-            call_command(
-                "alter_data", 'set_to_failed', '--username', 'staff',
-                '--course-title', 'Digital Learning 200', '--grade', '45',
-            )
         course = Course.objects.get(title='Digital Learning 200')
-        course_run = course.courserun_set.first()
+        if current:
+            course_run = CourseRunFactory(course=course)
+            call_command(
+                "alter_data", 'set_to_enrolled', '--username', 'staff',
+                '--course-run-key', course_run.edx_course_key
+            )
+            FinalGradeFactory.create(user=self.user, course_run=course_run, grade=0.8 if edx_passed else 0.2, passed=True)
+        else:
+            if edx_passed:
+                call_command(
+                    "alter_data", 'set_to_passed', '--username', 'staff',
+                    '--course-title', 'Digital Learning 200', '--grade', '75',
+                )
+            else:
+                call_command(
+                    "alter_data", 'set_to_failed', '--username', 'staff',
+                    '--course-title', 'Digital Learning 200', '--grade', '45',
+                )
+            course_run = course.courserun_set.first()
+
         ExamProfileFactory.create(status='success', profile=self.user.profile)
         exam_run = ExamRunFactory.create(course=course, eligibility_past=True, scheduling_past=True)
         ExamAuthorizationFactory.create(
@@ -386,14 +395,15 @@ class DashboardStates:  # pylint: disable=too-many-locals
         )
 
         # Add scenarios for every combination of passed/failed course and exam
-        for tup in itertools.product([True, False], repeat=6):
-            edx_passed, exam_passed, is_offered, can_schedule, future_exam, has_to_pay = tup
+        for tup in itertools.product([True, False], repeat=7):
+            current, edx_passed, exam_passed, is_offered, can_schedule, future_exam, has_to_pay = tup
 
             yield (
                 bind_args(
-                    self.create_exams, edx_passed, exam_passed, is_offered, can_schedule, future_exam, has_to_pay
+                    self.create_exams, current, edx_passed, exam_passed, is_offered, can_schedule, future_exam, has_to_pay
                 ),
-                'create_exams_{edx_passed}_{exam_passed}{new_offering}{can_schedule}{future_exam}{has_to_pay}'.format(
+                'create_exams{current}_{edx_passed}_{exam_passed}{new_offering}{can_schedule}{future_exam}{has_to_pay}'.format(
+                    current='_current' if current else '',
                     edx_passed='edx_✔' if edx_passed else 'edx_✖',
                     exam_passed='exam_✔' if exam_passed else 'exam_✖',
                     new_offering='_with_new_offering' if is_offered else '',


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #4026

#### What's this PR do?
Add exam states when course end date is in the future (course in-progress). 

#### How should this be manually tested?
Run `scripts/test/run_snapshot_dashboard_states.sh --match 'create_exams_current'`

#### Any background context you want to provide?
I decided to make this a separate PR so that it is easier to compare these new states on master branch.

There are states that have wrong messages that I will be fixing in PR #4032.

<img width="591" alt="screen shot 2018-06-25 at 1 51 28 pm" src="https://user-images.githubusercontent.com/7574259/41866740-0db5ae98-787f-11e8-9eee-ce66bf709e90.png">

<img width="639" alt="screen shot 2018-06-25 at 1 51 52 pm" src="https://user-images.githubusercontent.com/7574259/41866741-0dc913ca-787f-11e8-8d57-f6f979f2aefb.png">

<img width="682" alt="screen shot 2018-06-25 at 1 52 21 pm" src="https://user-images.githubusercontent.com/7574259/41866742-0dd88f1c-787f-11e8-8a98-3f9b2eee858d.png">


