### PR TITLE
add line break in title

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -52,7 +52,8 @@
       <div class="hero-image" style="background-image: url({{ background_image.url }})">
         <!-- big image, and sign-up links, etc -->
         <h1 class="title">
-          MicroMasters Program in {{ page.title }}
+          MicroMasters Program in <br />
+          {{ page.title }}
         </h1>
         <div class="description">
           {{ page.title_over_image|richtext }}


### PR DESCRIPTION
#### What are the relevant tickets?

one way to fix #4042 

#### What's this PR do?

Adds a `<br />` tag to the h1 on the program page after "MicroMasters program in"

#### Screenshots 

<img width="1330" alt="screenshot 2018-06-26 22 11 09" src="https://user-images.githubusercontent.com/430126/41949097-fc9e325a-798d-11e8-8167-70026422cac4.png">
<img width="1330" alt="screenshot 2018-06-26 22 11 06" src="https://user-images.githubusercontent.com/430126/41949098-fcb78836-798d-11e8-9858-49d81b7326d0.png">
<img width="1330" alt="screenshot 2018-06-26 22 11 02" src="https://user-images.githubusercontent.com/430126/41949099-fccd1caa-798d-11e8-937f-b7282f039cc1.png">
<img width="1330" alt="screenshot 2018-06-26 22 10 59" src="https://user-images.githubusercontent.com/430126/41949100-fceac160-798d-11e8-97cc-adf668f8023a.png">

