### PR TITLE
Fix semester user count bug

### DIFF
--- a/static/js/components/LearnerSearch.js
+++ b/static/js/components/LearnerSearch.js
@@ -48,6 +48,7 @@ import {
   canMessageLearnersProgram,
   hasStaffForProgram
 } from "../lib/roles"
+import CustomRefinementListFilter from "./search/CustomRefinementListFilter"
 
 export const makeTranslations: () => Object = () => {
   const translations = {}
@@ -323,7 +324,7 @@ export default class LearnerSearch extends SearchkitComponent {
           title="Enrolled Semester"
           disabled={this.isFilterSelected("program.courses.course_title")}
         >
-          <RefinementListFilter
+          <CustomRefinementListFilter
             id="semester"
             title=""
             fieldOptions={{

--- a/static/js/components/search/CustomRefinementListFilter.js
+++ b/static/js/components/search/CustomRefinementListFilter.js
@@ -1,0 +1,35 @@
+import { RefinementListFilter } from "searchkit"
+import {
+  NestedAggregatingFacetAccessor,
+  REVERSE_NESTED_AGG_KEY
+} from "./NestedAggregatingMenuFilter"
+
+export default class CustomRefinementListFilter extends RefinementListFilter {
+  /**
+   * Overrides defineAccessor in RefinementListFilter
+   * Sets a custom Accessor for this Filter type. This is otherwise identical to the original implementation.
+   */
+  defineAccessor() {
+    return new NestedAggregatingFacetAccessor(
+      this.props.field,
+      this.getAccessorOptions()
+    )
+  }
+
+  /**
+   * Overrides getItems in RefinementListFilter
+   * Before the aggregation results are rendered, set the doc_count of each item to be the
+   * "reverse nested" doc_count. This effectively means that we will show how many unique users
+   * match the query against a set of nested elements, as opposed to the total count of nested
+   * elements that match (which could be greater than the number of users).
+   */
+  getItems() {
+    const items = super.getItems()
+    return items.map(item => ({
+      ...item,
+      doc_count: item[REVERSE_NESTED_AGG_KEY]
+        ? item[REVERSE_NESTED_AGG_KEY].doc_count
+        : item.doc_count
+    }))
+  }
+}

--- a/static/js/components/search/FilterVisibilityToggle.js
+++ b/static/js/components/search/FilterVisibilityToggle.js
@@ -8,7 +8,8 @@ import { getAppliedFilterValue, matchFieldName } from "./util"
 
 export const FILTER_ID_ADJUST = {
   courses:        "program.courses.course_title",
-  payment_status: "program.courses.payment_status"
+  payment_status: "program.courses.payment_status",
+  semester:       "program.course_runs.semester"
 }
 
 export default class FilterVisibilityToggle extends SearchkitComponent {

--- a/static/js/components/search/NestedAggregatingMenuFilter.js
+++ b/static/js/components/search/NestedAggregatingMenuFilter.js
@@ -10,7 +10,7 @@ import {
 import _ from "lodash"
 import { NestedAccessorMixin } from "./util"
 
-const REVERSE_NESTED_AGG_KEY = "top_level_doc_count"
+export const REVERSE_NESTED_AGG_KEY = "top_level_doc_count"
 const INNER_TERMS_AGG_KEY = "nested_terms"
 
 /**
@@ -34,7 +34,7 @@ function ReverseNestedTermsBucket(key, field, options) {
   return TermsBucket(key, field, options, reverseNestedAgg)
 }
 
-class NestedAggregatingFacetAccessor extends NestedAccessorMixin(
+export class NestedAggregatingFacetAccessor extends NestedAccessorMixin(
   FacetAccessor
 ) {
   /**


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4009

#### What's this PR do?
make RefinementListFilter use reverse nested aggregation to count users for semester enrollment.

#### How should this be manually tested?
Make a user enrolled in two different course runs in the same semester.

![screen shot 2018-06-29 at 1 04 58 pm](https://user-images.githubusercontent.com/7574259/42105086-177dca7a-7b9d-11e8-8464-36aba74e0e6d.png)
