### PR TITLE
Loading session engine from env var

### DIFF
--- a/app.json
+++ b/app.json
@@ -241,6 +241,10 @@
     "SENTRY_DSN": {
       "description": "The connection settings for Sentry"
     },
+    "SESSION_ENGINE": {
+      "description": "Django session engine",
+      "required": true
+    },
     "STATUS_TOKEN": {
       "description": "Token to access the status API.",
       "required": true

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -155,7 +155,7 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
 
-SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
+SESSION_ENGINE = get_string('SESSION_ENGINE', 'django.contrib.sessions.backends.signed_cookies')
 
 EDXORG_BASE_URL = get_string('EDXORG_BASE_URL', 'https://courses.edx.org/')
 SOCIAL_AUTH_EDXORG_KEY = get_string('EDXORG_CLIENT_ID', '')


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/4007
fixes https://github.com/mitodl/micromasters/issues/3453
fixes https://github.com/mitodl/micromasters/issues/3982

#### What's this PR do?
It suggest to set `SESSION_ENGINE='django.contrib.sessions.backends.cache'`

#### How should this be manually tested?
login to wagtail and pre page with big tests

@pdpinch 

