### PR TITLE
Added mailgun unsub user support

### DIFF
--- a/mail/urls.py
+++ b/mail/urls.py
@@ -9,6 +9,7 @@ from mail.views import (
     CourseTeamMailView,
     AutomaticEmailView,
     MailWebhookView,
+    UnSubWebhookView,
 )
 
 router = routers.DefaultRouter()
@@ -21,5 +22,6 @@ urlpatterns = [
     url(r'^api/v0/mail/course/(?P<course_id>[\d]+)/$', CourseTeamMailView.as_view(), name='course_team_mail_api'),
     url(r'^api/v0/mail/learner/(?P<student_id>[\d]+)/$', LearnerMailView.as_view(), name='learner_mail_api'),
     url(r'^api/v0/mail/webhook/$', MailWebhookView.as_view(), name='mailgun_webhook'),
+    url(r'^api/v0/mail/unsub_webhook/$', UnSubWebhookView.as_view(), name='mailgun_unsub_webhook'),
     url(r'^api/v0/mail/', include(router.urls)),
 ]

--- a/mail/utils.py
+++ b/mail/utils.py
@@ -118,7 +118,7 @@ def get_email_footer(url):
     text = ("You are receiving this e-mail because you signed up for MITx"
             " MicroMasters.<br/> If you don't want to receive these emails in the"
             " future, you can<br/> <a href='{0}'>edit your settings</a>"
-            " or <a href='{0}'>unsubscribe</a>.").format(url)
+            " or <a href='%unsubscribe_url%'>unsubscribe</a>.").format(url)
     return ("<div style='margin-top:80px; text-align: center; color: #757575;'>"
             "<div style='margin:auto; max-width:50%;'><p>{0}</p>"
             "<p>MIT Office of Digital Learning<br/>"

--- a/mail/views.py
+++ b/mail/views.py
@@ -270,3 +270,34 @@ class MailWebhookView(APIView):
             log.debug(error_msg)
 
         return Response(status=status.HTTP_200_OK)
+
+
+class UnSubWebhookView(APIView):
+    """
+    View class that handles Mailgun unsubscribed webhooks
+    """
+    permission_classes = (MailGunWebHookPermission, )
+
+    def post(self, request, *args, **kargs):  # pylint: disable=unused-argument
+        """
+        POST method handler
+        """
+        event = request.POST.get("event", None)
+        recipient = request.POST.get("recipient", None)
+
+        if recipient and event == "unsubscribed":
+            profile = Profile.objects.get(user__email=recipient)
+            profile.email_optin = False
+            profile.save()
+
+            message_headers = request.POST.get("message", None)
+            debug_msg = (
+                "Webhook event {event} received by Mailgun for recipient {to}:{header}".format(
+                    to=recipient,
+                    event=event,
+                    header=message_headers
+                )
+            )
+            log.debug(debug_msg)
+
+        return Response(status=status.HTTP_200_OK)

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -32,7 +32,8 @@ from mail.factories import AutomaticEmailFactory
 from mail.models import SentAutomaticEmail, AutomaticEmail
 from mail.serializers import AutomaticEmailSerializer
 from mail.utils import get_email_footer
-from mail.views import MailWebhookView
+from mail.views import MailWebhookView, UnSubWebhookView
+from profiles.models import Profile
 from profiles.factories import (
     ProfileFactory,
     UserFactory,
@@ -718,3 +719,52 @@ class EmailBouncedViewTests(APITestCase, MockedESTestCase):
 
         # assert that error message is logged
         getattr(mock_logger, logger).assert_called_with(error_msg)
+
+
+@ddt.ddt
+class UnSubWebhookViewTests(APITestCase):
+    """Test email unsub webhook view web hook"""
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.url = reverse('mailgun_unsub_webhook')
+
+    def test_unsub(self):
+        """Tests that api unsub user"""
+        with mute_signals(post_save):
+            recipient = ProfileFactory.create(
+                email_optin=True,
+                user__username="foo"
+            )
+
+        data = {
+            "event": "unsubscribed",
+            "recipient": recipient.user.email,
+            "message": {
+                "headers": {
+                    "message-id": "20130822232216.13966.79700@samples.mailgun.org"
+                }
+            }
+        }
+        factory = RequestFactory()
+        request = factory.post(self.url, data=data)
+        UnSubWebhookView().post(request)
+        recipient.refresh_from_db()
+        assert recipient.email_optin is False
+
+    def test_unsub_invalid_email(self):
+        """Tests when invalid email comes from webhook"""
+        data = {
+            "event": "unsubscribed",
+            "recipient": "foo@example.com",
+            "message": {
+                "headers": {
+                    "message-id": "20130822232216.13966.79700@samples.mailgun.org"
+                }
+            }
+        }
+        factory = RequestFactory()
+        request = factory.post(self.url, data=data)
+
+        with self.assertRaises(Profile.DoesNotExist):
+            UnSubWebhookView().post(request)

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -307,7 +307,8 @@ class ProfilePATCHTests(ProfileBaseTests):
     """
     client_class = APIClient
 
-    def test_patch_own_profile(self):
+    @patch('profiles.views.ProfileViewSet.mailgun_action', return_value=True)
+    def test_patch_own_profile(self, mailgun_action):
         """
         A user PATCHes their own profile
         """
@@ -326,6 +327,7 @@ class ProfilePATCHTests(ProfileBaseTests):
 
         resp = self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
         assert resp.status_code == 200
+        assert mailgun_action.called
 
         old_profile = Profile.objects.get(user__username=self.user1.username)
         for key, value in patch_data.items():
@@ -339,7 +341,36 @@ class ProfilePATCHTests(ProfileBaseTests):
             else:
                 assert getattr(old_profile, key) == value
 
-    def test_serializer(self):
+    @patch('profiles.views.ProfileViewSet.mailgun_action', return_value=False)
+    def test_when_mailgun_fail(self, mailgun_action):
+        """
+        When user updates email optin but mailgun fail to response.
+        """
+        with mute_signals(post_save):
+            ProfileFactory.create(
+                user=self.user1,
+                filled_out=False,
+                agreed_to_terms_of_service=False,
+                email_optin=False
+
+            )
+        self.client.force_login(self.user1)
+
+        with mute_signals(post_save):
+            new_profile = ProfileFactory.create(filled_out=False, email_optin=True)
+        new_profile.user.social_auth.create(
+            provider=EdxOrgOAuth2.name,
+            uid="{}_edx".format(new_profile.user.username)
+        )
+        patch_data = ProfileSerializer(new_profile).data
+        del patch_data['image']
+
+        resp = self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
+        assert resp.status_code == 304
+        assert mailgun_action.called
+
+    @patch('profiles.views.ProfileViewSet.mailgun_action', return_value=True)
+    def test_serializer(self, mailgun_action):
         """
         Get a user's own profile, ensure that we used ProfileSerializer and not ProfileFilledOutSerializer
         """
@@ -361,8 +392,10 @@ class ProfilePATCHTests(ProfileBaseTests):
             self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
         assert mocked.called
         assert not mocked_filled_out.called
+        assert mailgun_action.called
 
-    def test_filled_out_serializer(self):
+    @patch('profiles.views.ProfileViewSet.mailgun_action', return_value=True)
+    def test_filled_out_serializer(self, mailgun_action):
         """
         Get a user's own profile, ensure that we used ProfileFilledOutSerializer
         """
@@ -379,6 +412,7 @@ class ProfilePATCHTests(ProfileBaseTests):
         ) as mocked:
             self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
         assert mocked.called
+        assert mailgun_action.called
 
     def test_forbidden_methods(self):
         """
@@ -410,11 +444,12 @@ class ProfilePATCHTests(ProfileBaseTests):
         assert profile.education.count() == 1
         assert profile.work_history.count() == 1
 
+    @patch('profiles.views.ProfileViewSet.mailgun_action', return_value=True)
     @ddt.data(
         *itertools.product([True, False], [True, False])
     )
     @ddt.unpack
-    def test_no_thumbnail_change_if_image_upload(self, image_already_exists, thumb_already_exists):
+    def test_no_thumbnail_change_if_image_upload(self, image_already_exists, thumb_already_exists, mailgun_action):
         """
         A patch without an image upload should not touch the image or the thumbnail
         """
@@ -435,6 +470,7 @@ class ProfilePATCHTests(ProfileBaseTests):
 
         resp = self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
         assert resp.status_code == 200
+        assert mailgun_action.called
 
         profile.refresh_from_db()
         assert bool(profile.image) == image_already_exists


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3917

#### What's this PR do?
- If email-optin is updated to False then it adds user to mailgun unsub list.
  - User  will not receive any email from MM mailgun address.
  - **Question:** Is discussion uses MM mailgun address? Should it be block?
-  If email-optin is updated to True then it removes user from mailgun unsub list.


#### How should this be manually tested?
**To enable/disable unsubscribes:**
- Enable unsubscription feature for your domain.
- Remove text in the html and text footer templates so they won’t be appended automatically.
- Insert a variable in the html and text bodies of your email when you need unsubscribe links.
- This variable will be replaced by the corresponding unsubscribe link.

https://documentation.mailgun.com/en/latest/user_manual.html#tracking-unsubscribes

**Also set the webhook:**
- `api/v0/mail/unsub_webhook/`

@pdpinch 

#### Screenshoot:
<img width="1231" alt="screen shot 2018-07-04 at 7 41 54 pm" src="https://user-images.githubusercontent.com/10431250/42283262-5c53106e-7fc2-11e8-8848-31a713c7e79e.png">

<img width="677" alt="screen shot 2018-07-04 at 7 42 34 pm" src="https://user-images.githubusercontent.com/10431250/42283277-6bae8a48-7fc2-11e8-9114-8bbfb4b6317e.png">

