### PR TITLE
Status message for paid but not enrolled

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -266,7 +266,7 @@ def get_info_for_course(course, mmtrack):
                       datetime.datetime(datetime.MAXYEAR, 1, 1, tzinfo=pytz.utc), reverse=True)
     # pick the first `not enrolled` or the first
     for run_status in run_statuses:
-        if run_status.status not in [CourseRunStatus.NOT_ENROLLED, CourseRunStatus.PAID_BUT_NOT_ENROLLED]:
+        if run_status.status not in [CourseRunStatus.NOT_ENROLLED]:
             break
     else:
         run_status = run_statuses[0]
@@ -306,7 +306,12 @@ def get_info_for_course(course, mmtrack):
     elif run_status.status == CourseRunStatus.CAN_UPGRADE:
         _add_run(run_status.course_run, mmtrack, CourseStatus.CAN_UPGRADE)
     elif run_status.status == CourseRunStatus.PAID_BUT_NOT_ENROLLED:
-        _add_run(run_status.course_run, mmtrack, CourseStatus.PAID_BUT_NOT_ENROLLED)
+        if course.program.financial_aid_availability:
+            next_run = course.first_unexpired_run()
+            if next_run is not None:
+                _add_run(next_run, mmtrack, CourseStatus.PAID_BUT_NOT_ENROLLED)
+        else:
+            _add_run(run_status.course_run, mmtrack, CourseStatus.PAID_BUT_NOT_ENROLLED)
 
     # add all the other runs with status != NOT_ENROLLED
     # the first one (or two in some cases) has been added with the logic before

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -266,7 +266,7 @@ def get_info_for_course(course, mmtrack):
                       datetime.datetime(datetime.MAXYEAR, 1, 1, tzinfo=pytz.utc), reverse=True)
     # pick the first `not enrolled` or the first
     for run_status in run_statuses:
-        if run_status.status not in [CourseRunStatus.NOT_ENROLLED]:
+        if run_status.status not in [CourseRunStatus.NOT_ENROLLED, CourseRunStatus.PAID_BUT_NOT_ENROLLED]:
             break
     else:
         run_status = run_statuses[0]

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -19,7 +19,7 @@ import type { GradeType } from "../../containers/DashboardPage"
 import type { CouponPrices, Coupon } from "../../flow/couponTypes"
 import {
   STATUS_PENDING_ENROLLMENT,
-  COURSE_ACTION_ENROLL, STATUS_PAID_BUT_NOT_ENROLLED
+  COURSE_ACTION_ENROLL
 } from "../../constants"
 import {
   courseStartDateMessage,
@@ -195,7 +195,8 @@ export default class CourseRow extends React.Component {
             course={course}
             courseAction={this.courseAction}
             hasFinancialAid={hasFinancialAid}
-            firstRun={run} />
+            firstRun={run}
+          />
         ) : null}
       </div>
     )

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -19,7 +19,7 @@ import type { GradeType } from "../../containers/DashboardPage"
 import type { CouponPrices, Coupon } from "../../flow/couponTypes"
 import {
   STATUS_PENDING_ENROLLMENT,
-  COURSE_ACTION_ENROLL
+  COURSE_ACTION_ENROLL, STATUS_PAID_BUT_NOT_ENROLLED
 } from "../../constants"
 import {
   courseStartDateMessage,
@@ -175,7 +175,7 @@ export default class CourseRow extends React.Component {
   }
 
   renderEnrollableCourseInfo = (run: CourseRun) => {
-    const { course, showStaffView } = this.props
+    const { course, hasFinancialAid, showStaffView } = this.props
 
     return (
       <div className="enrollable-course-info">
@@ -186,14 +186,16 @@ export default class CourseRow extends React.Component {
           <div className="second-col">
             {run.status === STATUS_PENDING_ENROLLMENT ? (
               <Spinner singleColor />
-            ) : (
-              this.courseAction(run, COURSE_ACTION_ENROLL)
-            )}
+            ) : null}
             {run.status === STATUS_PENDING_ENROLLMENT ? "Processing..." : null}
           </div>
         </div>
-        {!isEnrollableRun(run) && !showStaffView ? (
-          <StatusMessages course={course} firstRun={run} />
+        {!showStaffView ? (
+          <StatusMessages
+            course={course}
+            courseAction={this.courseAction}
+            hasFinancialAid={hasFinancialAid}
+            firstRun={run} />
         ) : null}
       </div>
     )

--- a/static/js/components/dashboard/CourseRow_test.js
+++ b/static/js/components/dashboard/CourseRow_test.js
@@ -74,14 +74,11 @@ describe("CourseRow", () => {
       },
       true
     )
-    const courseRowProps = wrapper.props()
-    const keys = Object.keys(courseRowProps).filter(
-      key => key !== "children" && key !== "className"
-    )
-    const actionProps = wrapper.find(CourseAction).props()
-    for (const key of keys) {
-      assert.deepEqual(actionProps[key], courseRowProps[key])
-    }
+    const statusProps = wrapper.find(StatusMessages).props()
+    assert.deepEqual(statusProps.course, course)
+    assert.deepEqual(statusProps.hasFinancialAid, true)
+    assert.deepEqual(statusProps.firstRun, course.runs[0])
+
     assert.deepEqual(wrapper.find(".course-title").text(), course.title)
   })
 

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -88,9 +88,10 @@ const messageForNotAttemptedExam = (course: Course) => {
   return message
 }
 
-
 const courseStartMessage = (run: CourseRun) => {
-  const startDate = notNilorEmpty(run.course_start_date) ? formatDate(run.course_start_date) : run.fuzzy_start_date
+  const startDate = notNilorEmpty(run.course_start_date)
+    ? formatDate(run.course_start_date)
+    : run.fuzzy_start_date
   if (startDate) {
     return `Next course starts ${startDate}.`
   }
@@ -98,8 +99,9 @@ const courseStartMessage = (run: CourseRun) => {
 }
 
 const enrollmentDateMessage = (run: CourseRun) => {
-  const enrollmentDate = notNilorEmpty(run.enrollment_start_date) ?
-    formatDate(run.enrollment_start_date) : run.fuzzy_enrollment_start_date
+  const enrollmentDate = notNilorEmpty(run.enrollment_start_date)
+    ? formatDate(run.enrollment_start_date)
+    : run.fuzzy_enrollment_start_date
   if (enrollmentDate) {
     const startText = isEnrollableRun(run) ? "started" : "starts"
     return ` Enrollment ${startText} ${enrollmentDate}.`

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -179,13 +179,26 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     }
   }
 
+  //If first run is paid but user never enrolled, most likely there was
+  //problem enrolling, and first_unexpired_run is returned, so no need to check for past enrollment
   if (firstRun.status === STATUS_PAID_BUT_NOT_ENROLLED) {
     const contactHref = `mailto:${SETTINGS.support_email}`
+    let date = ""
+    if (isEnrollableRun(firstRun)) {
+      date = `now`
+    } else if (notNilorEmpty(firstRun.enrollment_start_date)) {
+      date = formatDate(firstRun.enrollment_start_date)
+    } else if (
+      firstRun.fuzzy_start_date &&
+      isOfferedInUncertainFuture(firstRun)
+    ) {
+      date = `in ${firstRun.fuzzy_start_date}`
+    }
     return S.Just([
       {
         message: (
           <div>
-            {"You paid for this course but are not enrolled. You can enroll now, or if" +
+            {`You paid for this course but are not enrolled. You can enroll ${date}, or if` +
               " you think there is a problem, "}
             <a href={contactHref}>contact us for help.</a>
           </div>

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -109,47 +109,35 @@ describe("Course Status Messages", () => {
       sandbox.restore()
     })
 
-    it("should have a message for STATUS_PAID_BUT_NOT_ENROLLED", () => {
-      course.runs[0].status = STATUS_PAID_BUT_NOT_ENROLLED
-      course.runs[0].has_paid = true
-      const [{ message }] = calculateMessages(calculateMessagesProps).value
-      const mounted = shallow(message)
-      assert.equal(
-        mounted.text(),
-        "Something went wrong. You paid for this course but are not enrolled. Contact us for help."
-      )
-      assert.equal(
-        mounted.find("a").props().href,
-        `mailto:${SETTINGS.support_email}`
-      )
-    })
     it("should have a message for STATUS_PAID_BUT_NOT_ENROLLED for FA", () => {
-      course.runs[0].status = STATUS_PAID_BUT_NOT_ENROLLED
-      course.runs[0].has_paid = true
-      calculateMessagesProps["hasFinancialAid"] = true
-      course.runs[1].has_paid = true
-      makeRunCurrent(course.runs[0])
-      makeRunFuture(course.runs[1])
-      const [{ message, action }] = calculateMessages(
-        calculateMessagesProps
-      ).value
-      const mounted = shallow(message)
-      assert.equal(
-        mounted.text(),
-        "You paid for this course but are not enrolled. You can enroll now, or if you" +
-          " think there is a problem, contact us for help."
-      )
-      assert.equal(
-        mounted.find("a").props().href,
-        `mailto:${SETTINGS.support_email}`
-      )
-      assert.equal(action, "course action was called")
-      assert(
-        calculateMessagesProps.courseAction.calledWith(
-          course.runs[0],
-          COURSE_ACTION_ENROLL
+      [true, false].forEach(finAid => {
+        course.runs[0].status = STATUS_PAID_BUT_NOT_ENROLLED
+        course.runs[0].has_paid = true
+        calculateMessagesProps["hasFinancialAid"] = finAid
+        course.runs[1].has_paid = true
+        makeRunCurrent(course.runs[0])
+        makeRunFuture(course.runs[1])
+        const [{ message, action }] = calculateMessages(
+          calculateMessagesProps
+        ).value
+        const mounted = shallow(message)
+        assert.equal(
+          mounted.text(),
+          "You paid for this course but are not enrolled. You can enroll now, or if you" +
+            " think there is a problem, contact us for help."
         )
-      )
+        assert.equal(
+          mounted.find("a").props().href,
+          `mailto:${SETTINGS.support_email}`
+        )
+        assert.equal(action, "course action was called")
+        assert(
+          calculateMessagesProps.courseAction.calledWith(
+            course.runs[0],
+            COURSE_ACTION_ENROLL
+          )
+        )
+      })
     })
 
     it("should show next promised course", () => {

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -606,7 +606,8 @@ describe("Course Status Messages", () => {
       const date = formatDate(course.runs[1].course_start_date)
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
-          message: `You missed the payment deadline, but you can re-enroll. Next course starts ${date}.`,
+          message: `You missed the payment deadline, but you can re-enroll. Next course starts ${date}.`+
+            ` Enrollment started ${formatDate(course.runs[1].enrollment_start_date)}`,
           action:  "course action was called"
         }
       ])

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -34,7 +34,8 @@ export const courseStartDateMessage = (courseRun: CourseRun) => {
   }
 }
 
-export const notNilorEmpty = (date : string) => R.not(R.isNil(date) || R.isEmpty(date))
+export const notNilorEmpty = (date: ?string) =>
+  R.not(R.isNil(date) || R.isEmpty(date))
 
 export const hasPearsonExam = R.propEq("has_exam", true)
 

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -118,4 +118,4 @@ export const isEnrollableRun = (run: CourseRun): boolean =>
 export const isOfferedInUncertainFuture = (run: CourseRun): boolean =>
   R.isNil(run.course_start_date) &&
   notNilorEmpty(run.fuzzy_start_date) &&
-  run.status === STATUS_OFFERED
+  (run.status === STATUS_OFFERED || run.status === STATUS_PAID_BUT_NOT_ENROLLED)

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -34,6 +34,8 @@ export const courseStartDateMessage = (courseRun: CourseRun) => {
   }
 }
 
+export const notNilorEmpty = (date : string) => R.not(R.isNil(date) || R.isEmpty(date))
+
 export const hasPearsonExam = R.propEq("has_exam", true)
 
 export const userIsEnrolled = R.compose(
@@ -108,13 +110,11 @@ export const futureEnrollableRun = R.compose(
 // checks if a run is enrollable
 export const isEnrollableRun = (run: CourseRun): boolean =>
   !R.isEmpty(run.course_id) &&
-  !R.isNil(run.enrollment_start_date) &&
-  !R.isEmpty(run.enrollment_start_date) &&
+  notNilorEmpty(run.enrollment_start_date) &&
   moment(run.enrollment_start_date).isSameOrBefore(moment(), "day") &&
   (run.status === STATUS_OFFERED || run.status === STATUS_PAID_BUT_NOT_ENROLLED)
 
 export const isOfferedInUncertainFuture = (run: CourseRun): boolean =>
   R.isNil(run.course_start_date) &&
-  !R.isNil(run.fuzzy_start_date) &&
-  !R.isEmpty(run.fuzzy_start_date) &&
+  notNilorEmpty(run.fuzzy_start_date) &&
   run.status === STATUS_OFFERED

--- a/static/js/components/dashboard/courses/util_test.js
+++ b/static/js/components/dashboard/courses/util_test.js
@@ -387,7 +387,8 @@ describe("dashboard course utilities", () => {
         [STATUS_OFFERED, "Fuzzy date", null, true],
         [STATUS_WILL_ATTEND, "Fuzzy date", null, false],
         [STATUS_OFFERED, "Fuzzy date", moment(), false],
-        [STATUS_OFFERED, "", null, false]
+        [STATUS_OFFERED, "", null, false],
+        [STATUS_PAID_BUT_NOT_ENROLLED, "Fuzzy date", null, true]
       ].forEach(([status, fuzzyDate, startDate, result]) => {
         course.runs[0].status = status
         course.runs[0].fuzzy_start_date = fuzzyDate


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4034

#### What's this PR do?
Change the message for FA course when user has paid but has not been enrolled in any course run.

#### How should this be manually tested?

Run `scripts/test/run_snapshot_dashboard_states.sh` make sure that `paid_but_not_enrolled` states make sense, and other states haven't changed.

<img width="592" alt="screen shot 2018-07-05 at 9 16 10 am" src="https://user-images.githubusercontent.com/7574259/42328343-ff28afd2-803b-11e8-95b1-6dc8894551f3.png">
