### PR TITLE
add course_number & allow filtering by program in course admin list view

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -30,8 +30,8 @@ class ProgramAdmin(admin.ModelAdmin):
 
 class CourseAdmin(admin.ModelAdmin):
     """ModelAdmin for Courses"""
-    list_display = ('title', 'program_title', 'position_in_program',)
-    list_filter = ('program__live',)
+    list_display = ('title', 'course_number', 'program_title', 'position_in_program',)
+    list_filter = ('program__live', 'program',)
     inlines = [CourseRunInline]
     ordering = ('program__title', 'position_in_program',)
 


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #4057

#### What's this PR do?

in the course admin list view:

1. add course_number
2. allow filtering by program 

#### How should this be manually tested?

Got to /admin/courses/course and confirm that you can filter by program and see a column of course numbers. Note that the `seed_data` script doesn't create course numbers. If you haven't created your own, they will all display `-`

#### Any background context you want to provide?

We're up to 4 programs now, with 24 courses. This will help me find things more quickly. 
