### PR TITLE
Fixed education and employment dialog titles

### DIFF
--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -447,12 +447,8 @@ class EducationForm extends ProfileFormFields {
     const inFlight = profilePatchStatus === FETCH_PROCESSING
     const keySet = (key): any => ["education", educationDialogIndex, key]
     const id = _.get(profile, keySet("id"))
-    const degreeName = _.get(
-      R.find(R.propEq("value", _.get(profile, keySet("degree_name"))))(
-        EDUCATION_LEVELS
-      ),
-      "label"
-    )
+    const degreeName =
+      EDUCATION_LEVEL_LABELS[_.get(profile, keySet("degree_name"))]
     const title =
       id !== undefined ? `Edit ${degreeName}` : `Add a ${degreeName}`
 

--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -209,7 +209,7 @@ class EducationForm extends ProfileFormFields {
               className="mm-minor-action add-education-button"
               onClick={() => this.openNewEducationForm(levelValue)}
             >
-              Add degree
+              Add a degree
             </button>
           </Cell>
         ),
@@ -319,8 +319,6 @@ class EducationForm extends ProfileFormFields {
 
     const keySet = (key): any => ["education", educationDialogIndex, key]
     const educationDegreeLevel = _.get(profile, keySet("degree_name"))
-    const id = _.get(profile, keySet("id"))
-    const title = id !== undefined ? "Edit Education" : "Add Education"
 
     const fieldOfStudy = () => {
       if (educationDegreeLevel !== HIGH_SCHOOL) {
@@ -354,9 +352,6 @@ class EducationForm extends ProfileFormFields {
 
     return (
       <Grid className="profile-tab-grid">
-        <Cell col={12} className="profile-form-title">
-          {title}
-        </Cell>
         {levelForm()}
         {fieldOfStudy()}
         <Cell col={12}>
@@ -440,11 +435,26 @@ class EducationForm extends ProfileFormFields {
 
   render() {
     const {
-      ui: { showEducationDeleteDialog, educationDialogVisibility },
-      profilePatchStatus
+      ui: {
+        educationDialogIndex,
+        showEducationDeleteDialog,
+        educationDialogVisibility
+      },
+      profilePatchStatus,
+      profile
     } = this.props
 
     const inFlight = profilePatchStatus === FETCH_PROCESSING
+    const keySet = (key): any => ["education", educationDialogIndex, key]
+    const id = _.get(profile, keySet("id"))
+    const degreeName = _.get(
+      R.find(R.propEq("value", _.get(profile, keySet("degree_name"))))(
+        EDUCATION_LEVELS
+      ),
+      "label"
+    )
+    const title =
+      id !== undefined ? `Edit ${degreeName}` : `Add a ${degreeName}`
 
     return (
       <div>
@@ -456,7 +466,7 @@ class EducationForm extends ProfileFormFields {
           inFlight={inFlight}
         />
         <Dialog
-          title="Education"
+          title={title}
           titleClassName="dialog-title"
           contentClassName="dialog education-dialog"
           className="education-dialog-wrapper"

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -119,16 +119,11 @@ class EmploymentForm extends ProfileFormFields {
   }
 
   editWorkHistoryForm(): React$Element<*> {
-    const { ui, profile } = this.props
+    const { ui } = this.props
     const keySet = (key): any => ["work_history", ui.workDialogIndex, key]
-    const id = _.get(profile, keySet("id"))
-    const title = id !== undefined ? "Edit Employment" : "Add Employment"
 
     return (
       <Grid className="profile-tab-grid">
-        <Cell col={12} className="profile-form-title">
-          {title}
-        </Cell>
         <Cell col={12}>
           {this.boundTextField(keySet("company_name"), "Name of Employer")}
         </Cell>
@@ -351,11 +346,16 @@ class EmploymentForm extends ProfileFormFields {
 
   render() {
     const {
-      ui: { workDialogVisibility, showWorkDeleteDialog },
-      profilePatchStatus
+      ui: { workDialogVisibility, showWorkDeleteDialog, workDialogIndex },
+      profilePatchStatus,
+      profile
     } = this.props
 
     const inFlight = profilePatchStatus === FETCH_PROCESSING
+    const keySet = (key): any => ["work_history", workDialogIndex, key]
+    const id = _.get(profile, keySet("id"))
+    const title = id !== undefined ? "Edit Employment" : "Add Employment"
+
     return (
       <div>
         <ConfirmDeletion
@@ -366,7 +366,7 @@ class EmploymentForm extends ProfileFormFields {
           inFlight={inFlight}
         />
         <Dialog
-          title="Employment"
+          title={title}
           titleClassName="dialog-title"
           contentClassName="dialog employment-dialog"
           className="employment-dialog-wrapper"

--- a/static/js/containers/LearnerPage_test.js
+++ b/static/js/containers/LearnerPage_test.js
@@ -574,8 +574,8 @@ describe("LearnerPage", function() {
               ReactTestUtils.Simulate.click(editButton)
 
               assert.equal(
-                document.querySelector(".profile-form-title").innerHTML,
-                "Edit Education"
+                document.querySelector(".dialog-title").innerHTML,
+                "Edit Doctorate"
               )
             }
           )
@@ -637,8 +637,8 @@ describe("LearnerPage", function() {
             ReactTestUtils.Simulate.click(addButton)
 
             assert.equal(
-              document.querySelector(".profile-form-title").innerHTML,
-              "Add Education"
+              document.querySelector(".dialog-title").innerHTML,
+              "Add a High school"
             )
 
             const dialog = document.querySelector(".education-dialog")
@@ -867,7 +867,7 @@ describe("LearnerPage", function() {
               ReactTestUtils.Simulate.click(editButton)
 
               assert.equal(
-                document.querySelector(".profile-form-title").innerHTML,
+                document.querySelector(".dialog-title").innerHTML,
                 "Edit Employment"
               )
             }
@@ -936,7 +936,7 @@ describe("LearnerPage", function() {
             ReactTestUtils.Simulate.click(addButton)
 
             assert.equal(
-              document.querySelector(".profile-form-title").innerHTML,
+              document.querySelector(".dialog-title").innerHTML,
               "Add Employment"
             )
             const dialog = document.querySelector(".employment-dialog")


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3118

#### What's this PR do?
This PR fixes makes:
- Each modal with a single title.
- The title will include the type of degree being added/edited. 

#### How should this be manually tested?
Go to profile page and add/edit degree and employment

@pdpinch 
#### Screenshots (if appropriate)
- <img width="749" alt="screen shot 2018-07-09 at 4 41 07 pm" src="https://user-images.githubusercontent.com/10431250/42448573-0074ce1c-8397-11e8-9721-8e064697c77f.png">
- <img width="777" alt="screen shot 2018-07-09 at 4 41 16 pm" src="https://user-images.githubusercontent.com/10431250/42448574-00a505b4-8397-11e8-9e52-f3f6ac08f238.png">
- <img width="803" alt="screen shot 2018-07-09 at 4 41 23 pm" src="https://user-images.githubusercontent.com/10431250/42448576-00d21b9e-8397-11e8-8e50-c853229a4ec8.png">
- <img width="801" alt="screen shot 2018-07-09 at 4 41 30 pm" src="https://user-images.githubusercontent.com/10431250/42448578-00ff08c0-8397-11e8-8ac1-f3355e5795ce.png">

