### PR TITLE
Fixed missing run issue on production

### DIFF
--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1013,6 +1013,7 @@ class InfoCourseTest(CourseTests):
     def test_info_not_enrolled_offered(
             self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with with an offered run"""
+        self.mmtrack.configure_mock(**{'is_enrolled_mmtrack.return_value': True})
         with patch(
             'dashboard.api.get_status_for_courserun',
             autospec=True,
@@ -1036,6 +1037,7 @@ class InfoCourseTest(CourseTests):
     def test_info_not_enrolled_but_paid(
             self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with with a paid but not enrolled run"""
+        self.mmtrack.configure_mock(**{'is_enrolled_mmtrack.return_value': True})
         with patch(
             'dashboard.api.get_status_for_courserun',
             autospec=True,
@@ -1064,6 +1066,7 @@ class InfoCourseTest(CourseTests):
     def test_info_not_passed_offered(
             self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with a run not passed and another offered"""
+        self.mmtrack.configure_mock(**{'is_enrolled_mmtrack.return_value': True})
         with patch(
             'dashboard.api.get_status_for_courserun',
             autospec=True,
@@ -1089,7 +1092,10 @@ class InfoCourseTest(CourseTests):
     def test_info_not_enrolled_not_passed_not_offered(
             self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with run not passed and nothing offered"""
-        self.mmtrack.configure_mock(**{'has_passed_course.return_value': False})
+        self.mmtrack.configure_mock(**{
+            'has_passed_course.return_value': False,
+            'is_enrolled_mmtrack.return_value': True
+        })
         with patch(
             'dashboard.api.get_status_for_courserun',
             autospec=True,
@@ -1112,7 +1118,10 @@ class InfoCourseTest(CourseTests):
     def test_info_grade(
             self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with a course current and another not passed"""
-        self.mmtrack.configure_mock(**{'has_passed_course.return_value': False})
+        self.mmtrack.configure_mock(**{
+            'has_passed_course.return_value': False,
+            'is_enrolled_mmtrack.return_value': True
+        })
         with patch(
             'dashboard.api.get_status_for_courserun',
             autospec=True,
@@ -1137,7 +1146,10 @@ class InfoCourseTest(CourseTests):
         """
         test for get_info_for_course in case a check if the course has been passed is required
         """
-        self.mmtrack.configure_mock(**{'has_passed_course.return_value': False})
+        self.mmtrack.configure_mock(**{
+            'has_passed_course.return_value': False,
+            'is_enrolled_mmtrack.return_value': True
+        })
         with patch(
             'dashboard.api.get_status_for_courserun',
             autospec=True,
@@ -1162,6 +1174,9 @@ class InfoCourseTest(CourseTests):
         """
         test for get_info_for_course with a missed upgrade deadline
         """
+        self.mmtrack.configure_mock(**{
+            'is_enrolled_mmtrack.return_value': True
+        })
         with patch(
             'dashboard.api.get_status_for_courserun',
             autospec=True,
@@ -1213,7 +1228,10 @@ class InfoCourseTest(CourseTests):
         test for get_info_for_course in case a check if the course has been passed
         is required for the course and the course has been passed
         """
-        self.mmtrack.configure_mock(**{'has_passed_course.return_value': True})
+        self.mmtrack.configure_mock(**{
+            'has_passed_course.return_value': True,
+            'is_enrolled_mmtrack.return_value': True
+        })
         with patch(
             'dashboard.api.get_status_for_courserun',
             autospec=True,
@@ -1235,6 +1253,9 @@ class InfoCourseTest(CourseTests):
     def test_info_will_attend(
             self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with enrolled run that will happen in the future"""
+        self.mmtrack.configure_mock(**{
+            'is_enrolled_mmtrack.return_value': True
+        })
         with patch(
             'dashboard.api.get_status_for_courserun',
             autospec=True,
@@ -1256,6 +1277,7 @@ class InfoCourseTest(CourseTests):
     def test_info_upgrade(
             self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay):
         """test for get_info_for_course for course with a run that needs to be upgraded"""
+        self.mmtrack.configure_mock(**{'is_enrolled_mmtrack.return_value': True})
         with patch(
             'dashboard.api.get_status_for_courserun',
             autospec=True,
@@ -1280,6 +1302,7 @@ class InfoCourseTest(CourseTests):
         test for get_info_for_course for course with a run
         that needs to be upgraded but before a current enrolled one
         """
+        self.mmtrack.configure_mock(**{'is_enrolled_mmtrack.return_value': True})
         with patch(
             'dashboard.api.get_status_for_courserun',
             autospec=True,
@@ -1349,7 +1372,10 @@ class InfoCourseTest(CourseTests):
         """
         test for get_info_for_course in case the less recent course is flagged to be checked if passed
         """
-        self.mmtrack.configure_mock(**{'has_passed_course.return_value': True})
+        self.mmtrack.configure_mock(**{
+            'has_passed_course.return_value': True,
+            'is_enrolled_mmtrack.return_value': True
+        })
         with patch(
             'dashboard.api.get_status_for_courserun',
             autospec=True,
@@ -1386,7 +1412,10 @@ class InfoCourseTest(CourseTests):
                 course_run=run
             )
 
-        self.mmtrack.configure_mock(**{'user': self.user})
+        self.mmtrack.configure_mock(**{
+            'user': self.user,
+            'is_enrolled_mmtrack.return_value': True
+        })
 
         run1 = CourseRunFactory.create(
             start_date=now_in_utc(),

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -388,6 +388,23 @@ class DashboardStates:  # pylint: disable=too-many-locals
             '--missed-deadline'
         )
 
+    def create_paid_enrolled_currently_with_future_run(self):
+        """Make paid and enrolled with offered currently and a future run """
+        self.make_fa_program_enrollment(FinancialAidStatus.AUTO_APPROVED)
+        course = Course.objects.get(title='Digital Learning 200')
+        course_run_current = CourseRunFactory(course=course)
+        call_command(
+            "alter_data", 'set_to_enrolled', '--username', 'staff',
+            '--course-run-key', course_run_current.edx_course_key
+        )
+
+        course_run_future = CourseRunFactory(course=course)
+        call_command(
+            "alter_data", 'set_to_enrolled', '--username', 'staff',
+            '--course-run-key', course_run_future.edx_course_key,
+            '--in-future'
+        )
+
     def __iter__(self):
         """
         Iterator over all dashboard states supported by this command.
@@ -489,6 +506,7 @@ class DashboardStates:  # pylint: disable=too-many-locals
         yield (self.contact_course, 'contact_course')
         yield (self.missed_payment_can_reenroll, 'missed_payment_can_reenroll')
         yield (self.failed_run_missed_payment_can_reenroll, 'failed_run_missed_payment_can_reenroll')
+        yield (self.create_paid_enrolled_currently_with_future_run, 'create_paid_enrolled_currently_with_future_run')
 
         # Financial aid statuses
         for status in FinancialAidStatus.ALL_STATUSES:


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://odl.zendesk.com/agent/tickets/19315
fixes #4064

#### What's this PR do?
- There was two runs sorted reverse/decending. 
  - First run is future and some how enrolled and paid and status of second run is [CourseStatus.WILL_ATTEND](https://github.com/mitodl/micromasters/blob/master/dashboard/api.py#L388)
  - Second run is currently enrolled and paid 
- Because of this current run was skipped.

#### How should this be manually tested?
**Run command:** `./scripts/test/run_snapshot_dashboard_states.sh --match create_paid_enrolled_currently_with_future_run` on my changes and on master

##### Before 
```
                    "runs": [
                        {
                            "id": 20,
                            "course_id": "course:/v1/iure-animi-eveniet",
                            "title": "CourseRun Minus eveniet qui saepe voluptatum.",
                            "status": "will-attend",
                            "has_paid": true,
                            "position": 1,
                            "course_start_date": "2018-08-05T17:16:03.273534Z",
                            "course_end_date": "2018-09-04T17:16:03.273534Z",
                            "fuzzy_start_date": "Starting Repudiandae nostrum quas delectus animi doloremque.",
                            "enrollment_url": "https://smith-brown.info/",
                            "current_grade": null
                        }
                    ]
```

##### After 
```
                    "runs": [
                        {
                            "id": 19,
                            "course_id": "course:/v0/non-facilis-ratione",
                            "title": "CourseRun Fugit recusandae nostrum dolorem minima cupiditate.",
                            "status": "currently-enrolled",
                            "has_paid": true,
                            "position": 2,
                            "course_start_date": "2018-07-12T11:47:22.554646Z",
                            "course_end_date": "2018-08-11T11:47:22.554646Z",
                            "fuzzy_start_date": "Starting Quia neque reprehenderit quae doloremque.",
                            "enrollment_url": "https://johnson-dixon.biz/",
                            "current_grade": null
                        },
                        {
                            "id": 20,
                            "course_id": "course:/v1/iure-animi-eveniet",
                            "title": "CourseRun Minus eveniet qui saepe voluptatum.",
                            "status": "will-attend",
                            "has_paid": true,
                            "position": 1,
                            "course_start_date": "2018-08-06T11:47:22.686236Z",
                            "course_end_date": "2018-09-05T11:47:22.686236Z",
                            "fuzzy_start_date": "Starting Repudiandae nostrum quas delectus animi doloremque.",
                            "enrollment_url": "https://smith-brown.info/",
                            "current_grade": null
                        }
 ]
```
@pdpinch 
#### Screenshots (if appropriate)
![dashboard_state_175_create_paid_enrolled_currently_with_future_run](https://user-images.githubusercontent.com/10431250/42815625-53e91760-89e1-11e8-8063-8cf6120a855b.png)

