### PR TITLE
Offer to pay again for exam when already passed

### DIFF
--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -110,7 +110,7 @@ const messageForAttemptedExams = (course: Course, passedExam: boolean) => {
       "You can sign up to re-take the exam starting " +
       `on ${formatDate(course.exams_schedulable_in_future[0])}.`
   }
-  return { message: `${whenFailed}${payAgain}${whenToSchedule}` }
+  return `${whenFailed}${payAgain}${whenToSchedule}`
 }
 
 const courseStartMessage = (run: CourseRun) => {
@@ -309,21 +309,22 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
 
   //Exam messages only
   if (isPassedOrCurrentlyEnrolled(firstRun) && exams && paid) {
-    let messageBox = {}
+    let message
     if (!passedExam) {
-      if (failedExam) {
-        messageBox = messageForAttemptedExams(course, passedExam)
-      } else {
-        // no past exam attempts
-        messageBox["message"] = messageForNotAttemptedExam(course)
-      }
+      message = failedExam
+        ? messageForAttemptedExams(course, passedExam)
+        : messageForNotAttemptedExam(course)
     } else {
-      messageBox = messageForAttemptedExams(course, passedExam)
+      message = messageForAttemptedExams(course, passedExam)
     }
     if (course.can_schedule_exam && course.has_to_pay) {
-      messageBox["action"] = courseAction(firstRun, COURSE_ACTION_PAY)
+      messages.push({
+        message: message,
+        action:  courseAction(firstRun, COURSE_ACTION_PAY)
+      })
+    } else {
+      messages.push({ message: message })
     }
-    messages.push(messageBox)
 
     if (
       firstRun["status"] !== STATUS_CURRENTLY_ENROLLED &&

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -89,25 +89,29 @@ const messageForNotAttemptedExam = (course: Course) => {
 }
 
 const messageForAttemptedExams = (course: Course, passedExam: boolean) => {
-    const whenFailed = passedExam ? "" : "You did not pass the exam. "
-    const payAgain = course.has_to_pay ? "If you want to re-take the exam, you need to pay again." : ""
-    let whenToSchedule = ""
-    if (course.can_schedule_exam) {
-      // if can schedule exam now
-      if (!course.has_to_pay){
-        whenToSchedule = "Click above to reschedule an exam with Pearson."
-      }
-    } else if (R.isEmpty(course.exams_schedulable_in_future)) {
-      // no info about future exam runs
-       whenToSchedule = `There are currently no exams ` +
-       "available for scheduling. Please check back later."
-    } else {
-      // can not schedule now, but some time in the future
-      whenToSchedule = "You can sign up to re-take the exam starting " +
-        `on ${formatDate(course.exams_schedulable_in_future[0])}`
+  const whenFailed = passedExam ? "" : "You did not pass the exam. "
+  const payAgain = course.has_to_pay
+    ? "If you want to re-take the exam, you need to pay again. "
+    : ""
+  let whenToSchedule = ""
+  if (course.can_schedule_exam) {
+    // if can schedule exam now
+    if (!course.has_to_pay) {
+      whenToSchedule = "Click above to reschedule an exam with Pearson."
     }
-    return { message : `${whenFailed}${payAgain}${whenToSchedule}`}
+  } else if (R.isEmpty(course.exams_schedulable_in_future)) {
+    // no info about future exam runs
+    whenToSchedule =
+      `There are currently no exams ` +
+      "available for scheduling. Please check back later."
+  } else {
+    // can not schedule now, but some time in the future
+    whenToSchedule =
+      "You can sign up to re-take the exam starting " +
+      `on ${formatDate(course.exams_schedulable_in_future[0])}.`
   }
+  return { message: `${whenFailed}${payAgain}${whenToSchedule}` }
+}
 
 const courseStartMessage = (run: CourseRun) => {
   const startDate = notNilorEmpty(run.course_start_date)
@@ -316,26 +320,26 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     } else {
       messageBox = messageForAttemptedExams(course, passedExam)
     }
-    if (course.can_schedule_exam && course.has_to_pay){
-      messageBox['action'] = courseAction(firstRun, COURSE_ACTION_PAY)
+    if (course.can_schedule_exam && course.has_to_pay) {
+      messageBox["action"] = courseAction(firstRun, COURSE_ACTION_PAY)
     }
     messages.push(messageBox)
 
     if (
-        firstRun["status"] !== STATUS_CURRENTLY_ENROLLED &&
-        S.isJust(futureEnrollableRun(course))
-      ) {
-        messages.push({
-          message: (
-            <span>
-              {"If you want to re-take the course you can "}
-              <a onClick={() => setShowExpandedCourseStatus(course.id)}>
-                re-enroll.
-              </a>
-            </span>
-          )
-        })
-      }
+      firstRun["status"] !== STATUS_CURRENTLY_ENROLLED &&
+      S.isJust(futureEnrollableRun(course))
+    ) {
+      messages.push({
+        message: (
+          <span>
+            {"If you want to re-take the course you can "}
+            <a onClick={() => setShowExpandedCourseStatus(course.id)}>
+              re-enroll.
+            </a>
+          </span>
+        )
+      })
+    }
   }
 
   // all cases where courseRun is not currently in progress

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -378,17 +378,22 @@ describe("Course Status Messages", () => {
         )
       })
 
-      it("should not prompt to schedule exam if already passed exam", () => {
+      it("should prompt about future exams if already passed exam", () => {
         course.has_exam = true
         course.can_schedule_exam = true
         course.proctorate_exams_grades = [makeProctoredExamResult()]
         course.proctorate_exams_grades[0].passed = true
-
-        assertIsJust(calculateMessages(calculateMessagesProps), [
-          {
-            message: "You passed this course."
-          }
-        ])
+        const messages = calculateMessages(calculateMessagesProps).value
+        assert.equal(messages[0]["message"], "You passed this course.")
+        assert.equal(
+          messages[1]["message"],
+          "Click above to reschedule an exam with Pearson."
+        )
+        const mounted = shallow(messages[2]["message"])
+        assert.equal(
+          mounted.text().trim(),
+          "If you want to re-take the course you can re-enroll."
+        )
       })
 
       it("should prompt when passed the course and exam", () => {
@@ -397,11 +402,17 @@ describe("Course Status Messages", () => {
         course.proctorate_exams_grades = [makeProctoredExamResult()]
         course.proctorate_exams_grades[0].passed = true
 
-        assertIsJust(calculateMessages(calculateMessagesProps), [
-          {
-            message: "You passed this course."
-          }
-        ])
+        const messages = calculateMessages(calculateMessagesProps).value
+        assert.equal(messages[0]["message"], "You passed this course.")
+        assert.equal(
+          messages[1]["message"],
+          "Click above to reschedule an exam with Pearson."
+        )
+        const mounted = shallow(messages[2]["message"])
+        assert.equal(
+          mounted.text().trim(),
+          "If you want to re-take the course you can re-enroll."
+        )
       })
     })
 
@@ -432,8 +443,7 @@ describe("Course Status Messages", () => {
         assertIsJust(calculateMessages(calculateMessagesProps), [
           {
             message:
-              "You did not pass the exam, but you can try again." +
-              " Click above to reschedule an exam with Pearson."
+              "You did not pass the exam. Click above to reschedule an exam with Pearson."
           }
         ])
       })
@@ -446,7 +456,7 @@ describe("Course Status Messages", () => {
         const messages = calculateMessages(calculateMessagesProps).value
         assert.deepEqual(messages[0], {
           message:
-            "You did not pass the exam. If you want to re-take the exam, you need to pay again.",
+            "You did not pass the exam. If you want to re-take the exam, you need to pay again. ",
           action: "course action was called"
         })
         const mounted = shallow(messages[1]["message"])
@@ -465,7 +475,7 @@ describe("Course Status Messages", () => {
         assertIsJust(calculateMessages(calculateMessagesProps), [
           {
             message:
-              "You did not pass the exam. If you want to re-take the exam, you need to pay again.",
+              "You did not pass the exam. If you want to re-take the exam, you need to pay again. ",
             action: "course action was called"
           }
         ])
@@ -485,8 +495,7 @@ describe("Course Status Messages", () => {
         assertIsJust(calculateMessages(calculateMessagesProps), [
           {
             message:
-              "You did not pass the exam, but you can try again. " +
-              "You can sign up to re-take the exam starting on " +
+              "You did not pass the exam. You can sign up to re-take the exam starting " +
               `on ${formatDate(course.exams_schedulable_in_future[0])}.`
           }
         ])
@@ -508,8 +517,7 @@ describe("Course Status Messages", () => {
             message:
               "You did not pass the exam. If you want to re-take the exam, you need to pay again. " +
               "You can sign up to re-take the exam starting on " +
-              `${formatDate(course.exams_schedulable_in_future[0])}`,
-            action: "course action was called"
+              `${formatDate(course.exams_schedulable_in_future[0])}.`
           }
         ])
       })
@@ -580,14 +588,22 @@ describe("Course Status Messages", () => {
       course.has_exam = true
       course.proctorate_exams_grades = [makeProctoredExamResult()]
       course.proctorate_exams_grades[0].passed = true
-      assertIsJust(calculateMessages(calculateMessagesProps), [
-        {
-          message: "You passed this course."
-        }
-      ])
+      const messages = calculateMessages(calculateMessagesProps).value
+      assert.equal(messages.length, 3)
+      assert.equal(messages[0]["message"], "You passed this course.")
+      assert.equal(
+        messages[1]["message"],
+        "There are currently no exams available for scheduling. Please check back later."
+      )
+      let mounted = shallow(messages[2]["message"])
+      assert.equal(
+        mounted.text().trim(),
+        "If you want to re-take the course you can re-enroll."
+      )
+
       course.certificate_url = "certificate_url"
       const [{ message }] = calculateMessages(calculateMessagesProps).value
-      const mounted = shallow(message)
+      mounted = shallow(message)
       assert.equal(
         mounted.text(),
         "You passed this course! View Certificate | Re-enroll"


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4025

#### What's this PR do?
Show message about exams even when user has passed exam.

#### How should this be manually tested?
(Required)
Run `./scripts/test/run_snapshot_dashboard_states.sh  --match exams`

<img width="662" alt="screen shot 2018-07-16 at 1 38 48 pm" src="https://user-images.githubusercontent.com/7574259/42774283-50e6d9b8-88ff-11e8-8891-99a52b88127d.png">
<img width="557" alt="screen shot 2018-07-16 at 1 52 15 pm" src="https://user-images.githubusercontent.com/7574259/42774341-73ea0eee-88ff-11e8-9eac-1e842de72952.png">
<img width="585" alt="screen shot 2018-07-16 at 1 52 44 pm" src="https://user-images.githubusercontent.com/7574259/42774366-86e71168-88ff-11e8-9d33-d938ff3fb71d.png">


