### PR TITLE
Only try to enroll learner if learner isn't already enrolled

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -309,13 +309,15 @@ def enroll_user_on_success(order):
     """
     user_social = get_social_auth(order.user)
     enrollments_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL).enrollments
+    existing_enrollments = enrollments_client.get_student_enrollments()
 
     exceptions = []
     enrollments = []
     for line in order.line_set.all():
         course_key = line.course_key
         try:
-            enrollments.append(enrollments_client.create_audit_student_enrollment(course_key))
+            if not existing_enrollments.is_enrolled_in(course_key):
+                enrollments.append(enrollments_client.create_audit_student_enrollment(course_key))
         except Exception as ex:  # pylint: disable=broad-except
             log.exception(
                 "Error creating audit enrollment for course key %s for user %s",

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -17,7 +17,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.http.response import Http404
 from django.test import override_settings
 from rest_framework.exceptions import ValidationError
-from edx_api.enrollments import Enrollment
+from edx_api.enrollments import Enrollment, Enrollments
 
 from backends.pipeline_api import EdxOrgOAuth2
 from courses.factories import (
@@ -494,12 +494,21 @@ class EnrollUserTests(MockedESTestCase):
             """Helper function to create a fake enrollment"""
             return Enrollment({"course_details": {"course_id": course_key}})
 
+        def get_student_enrollments():
+            """List of existing enrollments"""
+            return Enrollments([])
+
         create_audit_mock = MagicMock(side_effect=create_audit)
-        enrollments_mock = MagicMock(create_audit_student_enrollment=create_audit_mock)
+        get_enrollments_mock = MagicMock(side_effect=get_student_enrollments)
+        enrollments_mock = MagicMock(
+            create_audit_student_enrollment=create_audit_mock,
+            get_student_enrollments=get_enrollments_mock
+        )
         edx_api_mock = MagicMock(enrollments=enrollments_mock)
         with patch('ecommerce.api.EdxApi', return_value=edx_api_mock):
             enroll_user_on_success(self.order)
 
+        assert get_enrollments_mock.called is True
         assert len(create_audit_mock.call_args_list) == self.order.line_set.count()
         for i, line in enumerate(self.order.line_set.all()):
             assert create_audit_mock.call_args_list[i][0] == (line.course_key, )
@@ -511,6 +520,31 @@ class EnrollUserTests(MockedESTestCase):
                 course_run__edx_course_key=line.course_key,
             )
             assert enrollment.data == create_audit(line.course_key).json
+
+    def test_if_already_enroll(self):
+        """
+        Test that enrollment api is skipped of user is already enroll is course.
+        """
+        def create_audit(course_key):
+            """Helper function to create a fake enrollment"""
+            return Enrollment({"course_details": {"course_id": course_key}})
+
+        def get_student_enrollments():
+            """List of existing enrollments"""
+            return Enrollments([create_audit(self.line1.course_key).json])
+
+        create_audit_mock = MagicMock(side_effect=create_audit)
+        get_enrollments_mock = MagicMock(side_effect=get_student_enrollments)
+        enrollments_mock = MagicMock(
+            create_audit_student_enrollment=create_audit_mock,
+            get_student_enrollments=get_enrollments_mock
+        )
+        edx_api_mock = MagicMock(enrollments=enrollments_mock)
+        with patch('ecommerce.api.EdxApi', return_value=edx_api_mock):
+            enroll_user_on_success(self.order)
+
+        assert get_enrollments_mock.called is True
+        assert not create_audit_mock.called
 
     def test_failed(self):
         """

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -531,10 +531,16 @@ class EnrollUserTests(MockedESTestCase):
 
         def get_student_enrollments():
             """List of existing enrollments"""
-            return Enrollments([create_audit(self.line1.course_key).json])
+            return Enrollments([
+                {"course_details": {"course_id": self.line1.course_key}},
+                {"course_details": {"course_id": self.line2.course_key}}
+            ])
 
         create_audit_mock = MagicMock(side_effect=create_audit)
-        get_enrollments_mock = MagicMock(side_effect=get_student_enrollments)
+        get_enrollments_mock = MagicMock(
+            side_effect=get_student_enrollments,
+            is_enrolled_in=True
+        )
         enrollments_mock = MagicMock(
             create_audit_student_enrollment=create_audit_mock,
             get_student_enrollments=get_enrollments_mock
@@ -556,8 +562,16 @@ class EnrollUserTests(MockedESTestCase):
                 raise Exception("fatal error {}".format(course_key))
             return Enrollment({"course_details": {"course_id": course_key}})
 
+        def get_student_enrollments():
+            """List of existing enrollments"""
+            return Enrollments([])
+
         create_audit_mock = MagicMock(side_effect=create_audit)
-        enrollments_mock = MagicMock(create_audit_student_enrollment=create_audit_mock)
+        get_enrollments_mock = MagicMock(side_effect=get_student_enrollments)
+        enrollments_mock = MagicMock(
+            create_audit_student_enrollment=create_audit_mock,
+            get_student_enrollments=get_enrollments_mock
+        )
         edx_api_mock = MagicMock(enrollments=enrollments_mock)
         with patch('ecommerce.api.EdxApi', return_value=edx_api_mock):
             with self.assertRaises(EcommerceEdxApiException) as ex:


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/4029

#### What's this PR do?
When user is already enroll in course do not try to call enroll api. Because it was casing exception. see trace in issue

#### How should this be manually tested?
- enroll user
- pay for course
- it should not trow exception

@pdpinch 
