### PR TITLE
Update user as moderator when staff role is added or removed

### DIFF
--- a/discussions/api.py
+++ b/discussions/api.py
@@ -203,6 +203,24 @@ def add_moderator_to_channel(channel_name, discussion_username):
         )) from ex
 
 
+def remove_moderator_from_channel(channel_name, discussion_username):
+    """
+    Remove user to channel as a moderator
+
+    Args:
+        channel_name (str): An open-discussions channel
+        discussion_username (str): The username used by open-discussions
+    """
+    admin_client = get_staff_client()
+    try:
+        admin_client.channels.remove_moderator(channel_name, discussion_username).raise_for_status()
+    except HTTPError as ex:
+        raise ModeratorSyncException("Error removing moderator {user} to channel {channel}".format(
+            user=discussion_username,
+            channel=channel_name,
+        )) from ex
+
+
 def add_subscriber_to_channel(channel_name, discussion_username):
     """
     Add a subscriber to channel
@@ -437,3 +455,28 @@ def add_moderators_to_channel(channel_name):
         discussion_user = create_or_update_discussion_user(mod_id)
         add_moderator_to_channel(channel_name, discussion_user.username)
         add_subscriber_to_channel(channel_name, discussion_user.username)
+
+
+def add_and_sub_moderator_to_channel(user_id, channel_name):
+    """
+    Add moderator to a channels
+
+    Args:
+        user_id (int): user id of the user to sync
+        channel_name (str): The name of the channel
+    """
+    discussion_user = create_or_update_discussion_user(user_id)
+    add_moderator_to_channel(channel_name, discussion_user.username)
+    add_subscriber_to_channel(channel_name, discussion_user.username)
+
+
+def remove_discussion_user_as_moderator_from_channel(user_id, channel_name):
+    """
+    Remove moderator to a channels
+
+    Args:
+        user_id (int): user id of the user to sync
+        channel_name (str): The name of the channel
+    """
+    discussion_user = create_or_update_discussion_user(user_id)
+    remove_moderator_from_channel(channel_name, discussion_user.username)

--- a/discussions/api.py
+++ b/discussions/api.py
@@ -433,8 +433,7 @@ def add_channel(
     # The creator is added in add_moderators_to_channel but do it here also to prevent a race condition
     # where the user is redirected to the channel page before they have permission to access it.
     discussion_user = create_or_update_discussion_user(creator_id)
-    add_moderator_to_channel(channel.name, discussion_user.username)
-    add_subscriber_to_channel(channel.name, discussion_user.username)
+    add_and_subscribe_moderator(discussion_user.username, channel.name)
 
     return channel
 
@@ -453,30 +452,16 @@ def add_moderators_to_channel(channel_name):
 
     for mod_id in mod_ids:
         discussion_user = create_or_update_discussion_user(mod_id)
-        add_moderator_to_channel(channel_name, discussion_user.username)
-        add_subscriber_to_channel(channel_name, discussion_user.username)
+        add_and_subscribe_moderator(discussion_user.username, channel_name)
 
 
-def add_and_sub_moderator_to_channel(user_id, channel_name):
+def add_and_subscribe_moderator(discussion_username, channel_name):
     """
-    Add moderator to a channels
+    Add and subscribe a moderator to a channels
 
     Args:
-        user_id (int): user id of the user to sync
+        discussion_username (str): discussion username
         channel_name (str): The name of the channel
     """
-    discussion_user = create_or_update_discussion_user(user_id)
-    add_moderator_to_channel(channel_name, discussion_user.username)
-    add_subscriber_to_channel(channel_name, discussion_user.username)
-
-
-def remove_discussion_user_as_moderator_from_channel(user_id, channel_name):
-    """
-    Remove moderator to a channels
-
-    Args:
-        user_id (int): user id of the user to sync
-        channel_name (str): The name of the channel
-    """
-    discussion_user = create_or_update_discussion_user(user_id)
-    remove_moderator_from_channel(channel_name, discussion_user.username)
+    add_moderator_to_channel(channel_name, discussion_username)
+    add_subscriber_to_channel(channel_name, discussion_username)

--- a/discussions/factories.py
+++ b/discussions/factories.py
@@ -1,8 +1,9 @@
 """Factories for discussions models"""
-from django.contrib.auth.models import User
+from datetime import timedelta
 from django.db.models.signals import post_save
 from factory import (
     Faker,
+    fuzzy,
     SubFactory,
 )
 from factory.django import (
@@ -16,6 +17,8 @@ from discussions.models import (
     ChannelProgram,
     DiscussionUser,
 )
+from micromasters.utils import now_in_utc
+from profiles.factories import UserFactory
 from search.factories import PercolateQueryFactory
 from search.models import PercolateQuery
 
@@ -40,9 +43,9 @@ class ChannelProgramFactory(DjangoModelFactory):
 
 class DiscussionUserFactory(DjangoModelFactory):
     """Factory for DiscussionUser"""
-    user = SubFactory(User)
+    user = SubFactory(UserFactory)
     username = Faker('user_name')
-    last_sync = Faker('date_time_this_month')
+    last_sync = fuzzy.FuzzyDateTime(now_in_utc() - timedelta(hours=12))
 
     @classmethod
     def create(cls, *args, **kwargs):

--- a/discussions/factories.py
+++ b/discussions/factories.py
@@ -1,9 +1,8 @@
 """Factories for discussions models"""
-from datetime import timedelta
+from pytz import UTC
 from django.db.models.signals import post_save
 from factory import (
     Faker,
-    fuzzy,
     SubFactory,
 )
 from factory.django import (
@@ -17,7 +16,6 @@ from discussions.models import (
     ChannelProgram,
     DiscussionUser,
 )
-from micromasters.utils import now_in_utc
 from profiles.factories import UserFactory
 from search.factories import PercolateQueryFactory
 from search.models import PercolateQuery
@@ -45,7 +43,7 @@ class DiscussionUserFactory(DjangoModelFactory):
     """Factory for DiscussionUser"""
     user = SubFactory(UserFactory)
     username = Faker('user_name')
-    last_sync = fuzzy.FuzzyDateTime(now_in_utc() - timedelta(hours=12))
+    last_sync = Faker('date_time_this_month', before_now=True, after_now=False, tzinfo=UTC)
 
     @classmethod
     def create(cls, *args, **kwargs):

--- a/discussions/signals.py
+++ b/discussions/signals.py
@@ -3,11 +3,13 @@ Signals for user profiles
 """
 from django.conf import settings
 from django.db import transaction
-from django.db.models.signals import post_save
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 from discussions import tasks
 from profiles.models import Profile
+from roles.models import Role
+from roles.roles import Permissions
 
 
 @receiver(post_save, sender=Profile, dispatch_uid="sync_user_profile")
@@ -18,3 +20,41 @@ def sync_user_profile(sender, instance, created, **kwargs):  # pylint: disable=u
     if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
         return
     transaction.on_commit(lambda: tasks.sync_discussion_user.delay(instance.user_id))
+
+
+@receiver(post_save, sender=Role, dispatch_uid="add_staff_as_moderator")
+def add_staff_as_moderator(sender, instance, created, **kwargs):  # pylint: disable=unused-argument
+    """
+    Signal handler add user as moderator when his staff role on program is added
+    """
+    if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
+        return
+
+    if instance.role not in Role.permission_to_roles[Permissions.CAN_CREATE_FORUMS]:
+        return
+
+    transaction.on_commit(
+        lambda: tasks.add_user_as_moderator_to_channel.delay(
+            instance.user_id,
+            instance.program_id,
+        )
+    )
+
+
+@receiver(post_delete, sender=Role, dispatch_uid="delete_staff_as_moderator")
+def delete_staff_as_moderator(sender, instance, **kwargs):  # pylint: disable=unused-argument
+    """
+    Signal handler removes user as moderator when his staff role on program is delete
+    """
+    if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
+        return
+
+    if instance.role not in Role.permission_to_roles[Permissions.CAN_CREATE_FORUMS]:
+        return
+
+    transaction.on_commit(
+        lambda: tasks.remove_user_as_moderator_from_channel.delay(
+            instance.user_id,
+            instance.program_id,
+        )
+    )

--- a/discussions/signals.py
+++ b/discussions/signals.py
@@ -44,7 +44,7 @@ def add_staff_as_moderator(sender, instance, created, **kwargs):  # pylint: disa
 @receiver(post_delete, sender=Role, dispatch_uid="delete_staff_as_moderator")
 def delete_staff_as_moderator(sender, instance, **kwargs):  # pylint: disable=unused-argument
     """
-    Signal handler removes user as moderator when his staff role on program is delete
+    Signal handler removes user as moderator when his staff role on program is deleted
     """
     if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
         return

--- a/discussions/tasks.py
+++ b/discussions/tasks.py
@@ -6,6 +6,7 @@ import logging
 from django.conf import settings
 
 from discussions import api
+from discussions.models import ChannelProgram
 from discussions.exceptions import DiscussionUserSyncException
 from micromasters.celery import app
 from micromasters.locks import Lock
@@ -99,3 +100,31 @@ def sync_channel_memberships():
     with Lock(SYNC_MEMBERSHIPS_LOCK_NAME, expiration) as lock:
         membership_ids = takewhile(lock.is_still_locked, api.get_membership_ids_needing_sync())
         api.sync_channel_memberships(membership_ids)
+
+
+@app.task()
+def add_user_as_moderator_to_channel(user_id, program_id):
+    """
+    Add moderator to a open-discussions channels of given program
+    """
+    if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
+        log.debug('OPEN_DISCUSSIONS_USER_SYNC is set to False (so disabled) in the settings')
+        return
+
+    channel_program_filter = ChannelProgram.objects.filter(program_id=program_id)
+    for channel_program in channel_program_filter:
+        api.add_and_sub_moderator_to_channel(user_id, channel_program.channel.name)
+
+
+@app.task()
+def remove_user_as_moderator_from_channel(user_id, program_id):
+    """
+    Remove moderator to a open-discussions channels of given program
+    """
+    if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
+        log.debug('OPEN_DISCUSSIONS_USER_SYNC is set to False (so disabled) in the settings')
+        return
+
+    channel_program_filter = ChannelProgram.objects.filter(program_id=program_id)
+    for channel_program in channel_program_filter:
+        api.remove_discussion_user_as_moderator_from_channel(user_id, channel_program.channel.name)

--- a/discussions/tasks.py
+++ b/discussions/tasks.py
@@ -117,15 +117,16 @@ def add_user_as_moderator_to_channel(user_id, program_id):
 
     try:
         discussion_user = DiscussionUser.objects.get(user_id=user_id)
-        channel_programs = ChannelProgram.objects.filter(program_id=program_id)
-
-        for channel_program in channel_programs:
-            api.add_and_subscribe_moderator(
-                discussion_user.username,
-                channel_program.channel.name
-            )
     except DiscussionUser.DoesNotExist:
         log.exception('unable to add user with id: %d as moderator', user_id)
+        return
+
+    channel_programs = ChannelProgram.objects.filter(program_id=program_id)
+    for channel_program in channel_programs:
+        api.add_and_subscribe_moderator(
+            discussion_user.username,
+            channel_program.channel.name
+        )
 
 
 @app.task()
@@ -143,12 +144,13 @@ def remove_user_as_moderator_from_channel(user_id, program_id):
 
     try:
         discussion_user = DiscussionUser.objects.get(user_id=user_id)
-        channel_programs = ChannelProgram.objects.filter(program_id=program_id)
-
-        for channel_program in channel_programs:
-            api.remove_moderator_from_channel(
-                channel_program.channel.name,
-                discussion_user.username
-            )
     except DiscussionUser.DoesNotExist:
         log.exception('unable to remove user with id: %d as moderator', user_id)
+        return
+
+    channel_programs = ChannelProgram.objects.filter(program_id=program_id)
+    for channel_program in channel_programs:
+        api.remove_moderator_from_channel(
+            channel_program.channel.name,
+            discussion_user.username
+        )

--- a/discussions/tasks.py
+++ b/discussions/tasks.py
@@ -6,7 +6,7 @@ import logging
 from django.conf import settings
 
 from discussions import api
-from discussions.models import ChannelProgram
+from discussions.models import ChannelProgram, DiscussionUser
 from discussions.exceptions import DiscussionUserSyncException
 from micromasters.celery import app
 from micromasters.locks import Lock
@@ -106,25 +106,49 @@ def sync_channel_memberships():
 def add_user_as_moderator_to_channel(user_id, program_id):
     """
     Add moderator to a open-discussions channels of given program
+
+    Args:
+        user_id (int): user id
+        program_id(int): program id
     """
     if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
         log.debug('OPEN_DISCUSSIONS_USER_SYNC is set to False (so disabled) in the settings')
         return
 
-    channel_program_filter = ChannelProgram.objects.filter(program_id=program_id)
-    for channel_program in channel_program_filter:
-        api.add_and_sub_moderator_to_channel(user_id, channel_program.channel.name)
+    try:
+        discussion_user = DiscussionUser.objects.get(user_id=user_id)
+        channel_programs = ChannelProgram.objects.filter(program_id=program_id)
+
+        for channel_program in channel_programs:
+            api.add_and_subscribe_moderator(
+                discussion_user.username,
+                channel_program.channel.name
+            )
+    except DiscussionUser.DoesNotExist:
+        log.exception('unable to add user with id: %d as moderator', user_id)
 
 
 @app.task()
 def remove_user_as_moderator_from_channel(user_id, program_id):
     """
     Remove moderator to a open-discussions channels of given program
+
+    Args:
+        user_id (int): user id
+        program_id(int): program id
     """
     if not settings.FEATURES.get('OPEN_DISCUSSIONS_USER_SYNC', False):
         log.debug('OPEN_DISCUSSIONS_USER_SYNC is set to False (so disabled) in the settings')
         return
 
-    channel_program_filter = ChannelProgram.objects.filter(program_id=program_id)
-    for channel_program in channel_program_filter:
-        api.remove_discussion_user_as_moderator_from_channel(user_id, channel_program.channel.name)
+    try:
+        discussion_user = DiscussionUser.objects.get(user_id=user_id)
+        channel_programs = ChannelProgram.objects.filter(program_id=program_id)
+
+        for channel_program in channel_programs:
+            api.remove_moderator_from_channel(
+                channel_program.channel.name,
+                discussion_user.username
+            )
+    except DiscussionUser.DoesNotExist:
+        log.exception('unable to remove user with id: %d as moderator', user_id)

--- a/discussions/tasks_test.py
+++ b/discussions/tasks_test.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import pytest
 
 from discussions import tasks
+from discussions.factories import ChannelProgramFactory
 from discussions.exceptions import DiscussionUserSyncException
 from profiles.factories import UserFactory
 from micromasters.utils import (
@@ -273,3 +274,37 @@ def test_sync_channel_memberships_no_feature_flag(settings, mocker):
     api_stub = mocker.patch('discussions.api.sync_channel_memberships', autospec=True)
     tasks.sync_channel_memberships.delay()
     assert api_stub.call_count == 0
+
+
+def test_add_moderator_to_channel(mocker):
+    """add_moderator_to_channels should forward all arguments to the api function"""
+    stub = mocker.patch('discussions.api.add_and_sub_moderator_to_channel', autospec=True)
+    program = ChannelProgramFactory.create().program
+    tasks.add_user_as_moderator_to_channel.delay(1, program.id)
+    assert stub.called is True
+
+
+def test_add_moderator_to_channel_no_feature_flag(settings, mocker):
+    """add_moderator_to_channels should not call the api function if the feature flag is disabled"""
+    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = False
+    stub = mocker.patch('discussions.api.add_and_sub_moderator_to_channel', autospec=True)
+    program = ChannelProgramFactory.create().program
+    tasks.add_user_as_moderator_to_channel.delay(1, program.id)
+    assert stub.called is False
+
+
+def test_remove_moderator_to_channel(mocker):
+    """add_moderator_to_channels should forward all arguments to the api function"""
+    stub = mocker.patch('discussions.api.remove_discussion_user_as_moderator_from_channel', autospec=True)
+    program = ChannelProgramFactory.create().program
+    tasks.remove_user_as_moderator_from_channel.delay(1, program.id)
+    assert stub.called is True
+
+
+def test_remove_moderator_to_channel_no_feature_flag(settings, mocker):
+    """add_moderator_to_channels should not call the api function if the feature flag is disabled"""
+    settings.FEATURES['OPEN_DISCUSSIONS_USER_SYNC'] = False
+    stub = mocker.patch('discussions.api.remove_discussion_user_as_moderator_from_channel', autospec=True)
+    program = ChannelProgramFactory.create().program
+    tasks.remove_user_as_moderator_from_channel.delay(1, program.id)
+    assert stub.called is False


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3613

#### What's this PR do?
- Adds user as moderator when staff role is added
- Remove user as moderator when staff role is delete

#### How should this be manually tested?
Try to add and remove user an see state op OD

@pdpinch 