### PR TITLE
Show payment button when user has to pay

### DIFF
--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -317,7 +317,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     } else {
       message = messageForAttemptedExams(course, passedExam)
     }
-    if (course.can_schedule_exam && course.has_to_pay) {
+    if (course.has_to_pay) {
       messages.push({
         message: message,
         action:  courseAction(firstRun, COURSE_ACTION_PAY)

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -514,6 +514,7 @@ describe("Course Status Messages", () => {
         course.has_to_pay = true
         assertIsJust(calculateMessages(calculateMessagesProps), [
           {
+            action:  "course action was called",
             message:
               "You did not pass the exam. If you want to re-take the exam, you need to pay again. " +
               "You can sign up to re-take the exam starting on " +


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/4025

#### What's this PR do?
adds payment button to has_to_pay courses

#### How should this be manually tested?
run `./scripts/test/run_snapshot_dashboard_states.sh --match=create_exams_current_edx_✔_exam_✔`

@pdpinch 
#### Screenshots (if appropriate)
![dashboard_state_018_create_exams_current_edx_ _exam_ _with_new_offering_more_exams_failed_one_exam](https://user-images.githubusercontent.com/10431250/43327699-87da9cc8-91d5-11e8-8e57-ca48805eacec.png)

