### PR TITLE
Updated odc and switched to passing user.username

### DIFF
--- a/discussions/api.py
+++ b/discussions/api.py
@@ -97,6 +97,7 @@ def create_discussion_user(discussion_user):
 
     api = get_staff_client()
     result = api.users.create(
+        profile.user.username,
         email=profile.user.email,
         profile=dict(
             name=profile.full_name,
@@ -152,6 +153,7 @@ def update_discussion_user(discussion_user, allow_email_optin=False):
 
     result = api.users.update(
         discussion_user.username,
+        uid=profile.user.username,
         email=profile.user.email,
         profile=profile_dict
     )

--- a/discussions/api_test.py
+++ b/discussions/api_test.py
@@ -120,6 +120,7 @@ def test_create_discussion_user(mock_staff_client):
     api.create_discussion_user(discussion_user)
     assert discussion_user.username == 'username'
     mock_staff_client.users.create.assert_called_once_with(
+        profile.user.username,
         email=profile.user.email,
         profile=dict(
             name=profile.full_name,
@@ -156,6 +157,7 @@ def test_update_discussion_user(mock_staff_client):
     api.update_discussion_user(discussion_user)
     mock_staff_client.users.update.assert_called_once_with(
         discussion_user.username,
+        uid=discussion_user.user.username,
         email=profile.user.email,
         profile=dict(
             name=profile.full_name,
@@ -179,6 +181,7 @@ def test_update_discussion_user_with_email_optin(mock_staff_client):
     api.update_discussion_user(discussion_user, allow_email_optin=True)
     mock_staff_client.users.update.assert_called_once_with(
         discussion_user.username,
+        uid=discussion_user.user.username,
         email=profile.user.email,
         profile=dict(
             name=profile.full_name,

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ ipython
 jsonfield==1.0.3
 jsonpatch==1.16
 newrelic
-open-discussions-client==0.4.0
+open-discussions-client==0.5.0
 phonenumbers==8.3.2
 psycopg2==2.7.3.2
 pycountry==16.11.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ jsonpointer==1.12         # via jsonpatch
 kombu==4.2.1              # via celery, django-server-status
 newrelic==2.88.1.73
 oauthlib==2.0.2           # via requests-oauthlib, social-auth-core
-open-discussions-client==0.4.0
+open-discussions-client==0.5.0
 paramiko==2.2.1           # via pysftp
 pbr==3.1.1                # via stevedore
 pexpect==4.2.1            # via ipython


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #4074 

#### What's this PR do?
This updates our APIs to start sending the username to discussions so we can send this in the JWT

#### How should this be manually tested?
Be sure to `docker-compose build web`

Verify you can create and update users and you get the correct `UserSocialAuth` records in discussions (uid == MM username)