### PR TITLE
Added unenroll program(s) feature

### DIFF
--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -1,6 +1,7 @@
 """
 Provides functionality for serializing a ProgramEnrollment for the ES index
 """
+from rest_framework import serializers
 from courses.utils import get_year_season_from_course_run
 from dashboard.utils import get_mmtrack
 from roles.api import is_learner
@@ -147,3 +148,13 @@ class UserProgramSearchSerializer:
             'num_courses_passed': mmtrack.count_courses_passed(),
             'total_courses': program.course_set.count()
         }
+
+
+class UnEnrollProgramsSerializer(serializers.Serializer):
+    """Serialize list of numbers"""
+    program_ids = serializers.ListField(child=serializers.IntegerField())
+
+    def get_program_ids(self):
+        """return list of program ids extracted from payload"""
+        self.is_valid(raise_exception=True)
+        return self.data['program_ids']

--- a/dashboard/serializers_test.py
+++ b/dashboard/serializers_test.py
@@ -21,7 +21,10 @@ from dashboard.factories import (
     CachedEnrollmentFactory,
 )
 from dashboard.models import ProgramEnrollment
-from dashboard.serializers import UserProgramSearchSerializer
+from dashboard.serializers import (
+    UserProgramSearchSerializer,
+    UnEnrollProgramsSerializer
+)
 from dashboard.utils import MMTrack
 from ecommerce.factories import (
     OrderFactory,
@@ -460,3 +463,31 @@ class UserProgramSerializerSemesterTests(MockedESTestCase):
         no_semester_serialized = UserProgramSearchSerializer.serialize_semester(no_semester_course_run)
         assert valid_semester_serialized == '2017 - Spring'
         assert no_semester_serialized is None
+
+
+class UserProgramSerializerTests(MockedESTestCase):
+    """
+    Test cases for the serialization of program list to be unenrolled
+    """
+    def test_serializer_payload(self):
+        """Test for list of programs ids serialization"""
+        array = [1, 2, 3]
+        payload = {
+            "program_ids": array
+        }
+        data = UnEnrollProgramsSerializer(payload).data
+        assert data == payload
+
+    def test_serializer_empty_list(self):
+        """Test for list of programs ids serialization"""
+        payload = {
+            "program_ids": []
+        }
+        data = UnEnrollProgramsSerializer(payload).data
+        assert data == payload
+
+    def test_serializer_invalid_payload(self):
+        """Test for invalid list of programs ids serialization"""
+        payload = {}
+        with self.assertRaises(KeyError):
+            __ = UnEnrollProgramsSerializer(payload).data

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -4,9 +4,11 @@ from django.conf.urls import url
 from dashboard.views import (
     UserCourseEnrollment,
     UserDashboard,
+    UnEnrollPrograms,
 )
 
 urlpatterns = [
     url(r'^api/v0/dashboard/(?P<username>[-\w.]+)/$', UserDashboard.as_view(), name='dashboard_api'),
     url(r'^api/v0/course_enrollments/$', UserCourseEnrollment.as_view(), name='user_course_enrollments'),
+    url(r'^api/v0/unenroll_programs/$', UnEnrollPrograms.as_view(), name='unenroll_programs'),
 ]

--- a/mail/utils_test.py
+++ b/mail/utils_test.py
@@ -42,13 +42,13 @@ class MailUtilsTests(MockedESTestCase):
         cls.tier_program = cls.financial_aid.tier_program
         cls.tier_program.program = course_run.course.program
         cls.tier_program.save()
-        cls.program_enrollment = ProgramEnrollment.objects.create(
-            user=cls.financial_aid.user,
-            program=cls.tier_program.program
-        )
 
     def setUp(self):
         self.financial_aid.refresh_from_db()
+        self.program_enrollment = ProgramEnrollment.objects.create(
+            user=self.financial_aid.user,
+            program=self.tier_program.program
+        )
 
     def test_generate_financial_aid_email_approved(self):
         """
@@ -68,6 +68,16 @@ class MailUtilsTests(MockedESTestCase):
             ),
             program_name=self.financial_aid.tier_program.program.title
         )
+
+    def test_generate_financial_aid_email_approved_after_unenroll(self):
+        """
+        Tests generate_financial_aid_email() with status APPROVED and user unenroll from
+        program.
+        """
+        self.financial_aid.status = FinancialAidStatus.APPROVED
+        self.financial_aid.save()
+        self.program_enrollment.delete()
+        self.assertRaises(ProgramEnrollment.DoesNotExist, generate_financial_aid_email, self.financial_aid)
 
     def test_generate_financial_aid_email_reset(self):
         """

--- a/static/js/actions/programs.js
+++ b/static/js/actions/programs.js
@@ -6,8 +6,11 @@ import { createAction } from "redux-actions"
 import { TOAST_SUCCESS, TOAST_FAILURE } from "../constants"
 import { fetchDashboard } from "./dashboard"
 import {
+  hideDialog,
   setToastMessage,
-  setEnrollProgramDialogVisibility
+  setEnrollProgramDialogVisibility,
+  setUnEnrollApiInFlightState,
+  setProgramsToUnEnroll
 } from "../actions/ui"
 import type { Dispatcher } from "../flow/reduxTypes"
 import type { AvailableProgram } from "../flow/enrollmentTypes"
@@ -100,5 +103,42 @@ export const addProgramEnrollment = (
   }
 }
 
+export const UNENROLL_PROGRAM_DIALOG = "unenrollProgramDialog"
 export const CLEAR_ENROLLMENTS = "CLEAR_ENROLLMENTS"
 export const clearEnrollments = createAction(CLEAR_ENROLLMENTS)
+
+export const unEnrollProgramEnrollments = (
+  programIds: []
+): Dispatcher<?AvailableProgram> => {
+  return async (dispatch: Dispatch) => {
+    await dispatch(setUnEnrollApiInFlightState(true))
+    return api
+      .unEnrollProgramEnrollments(programIds)
+      .then(
+        programs => {
+          dispatch(setProgramsToUnEnroll([]))
+          dispatch(fetchProgramEnrollments())
+          const programTitles = programs.map(program => program["title"])
+          dispatch(
+            setToastMessage({
+              message: `You left the ${programTitles.join(", ")} program(s).`,
+              icon:    TOAST_SUCCESS
+            })
+          )
+        },
+        () => {
+          dispatch(
+            setToastMessage({
+              message: "There was an error during unenrollment",
+              icon:    TOAST_FAILURE
+            })
+          )
+          return Promise.reject()
+        }
+      )
+      .finally(() => {
+        dispatch(hideDialog(UNENROLL_PROGRAM_DIALOG))
+        dispatch(setUnEnrollApiInFlightState(false))
+      })
+  }
+}

--- a/static/js/actions/programs.js
+++ b/static/js/actions/programs.js
@@ -108,7 +108,7 @@ export const CLEAR_ENROLLMENTS = "CLEAR_ENROLLMENTS"
 export const clearEnrollments = createAction(CLEAR_ENROLLMENTS)
 
 export const unEnrollProgramEnrollments = (
-  programIds: []
+  programIds: Array<number>
 ): Dispatcher<?AvailableProgram> => {
   return async (dispatch: Dispatch) => {
     await dispatch(setUnEnrollApiInFlightState(true))

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -163,3 +163,11 @@ export const SET_SHOW_EXPANDED_COURSE_STATUS = "SET_SHOW_EXPANDED_COURSE_STATUS"
 export const setShowExpandedCourseStatus = createAction(
   SET_SHOW_EXPANDED_COURSE_STATUS
 )
+
+export const SET_PROGRAMS_TO_UNENROLL = "SET_PROGRAMS_TO_UNENROLL"
+export const setProgramsToUnEnroll = createAction(SET_PROGRAMS_TO_UNENROLL)
+
+export const SET_UNENROLL_API_INFLIGHT_STATE = "SET_UNENROLL_API_INFLIGHT_STATE"
+export const setUnEnrollApiInFlightState = createAction(
+  SET_UNENROLL_API_INFLIGHT_STATE
+)

--- a/static/js/actions/ui_test.js
+++ b/static/js/actions/ui_test.js
@@ -27,6 +27,8 @@ import {
   SET_NAV_DRAWER_OPEN,
   SHOW_ENROLL_PAY_LATER_SUCCESS,
   SET_SHOW_EXPANDED_COURSE_STATUS,
+  SET_PROGRAMS_TO_UNENROLL,
+  SET_UNENROLL_API_INFLIGHT_STATE,
   clearUI,
   setWorkDialogVisibility,
   setWorkDialogIndex,
@@ -54,7 +56,9 @@ import {
   setCouponNotificationVisibility,
   setNavDrawerOpen,
   showEnrollPayLaterSuccess,
-  setShowExpandedCourseStatus
+  setShowExpandedCourseStatus,
+  setProgramsToUnEnroll,
+  setUnEnrollApiInFlightState
 } from "../actions/ui"
 import { assertCreatedActionHelper } from "./test_util"
 
@@ -88,7 +92,9 @@ describe("generated UI action helpers", () => {
       [setWorkHistoryAnswer, SET_WORK_HISTORY_ANSWER],
       [setNavDrawerOpen, SET_NAV_DRAWER_OPEN],
       [showEnrollPayLaterSuccess, SHOW_ENROLL_PAY_LATER_SUCCESS],
-      [setShowExpandedCourseStatus, SET_SHOW_EXPANDED_COURSE_STATUS]
+      [setShowExpandedCourseStatus, SET_SHOW_EXPANDED_COURSE_STATUS],
+      [setProgramsToUnEnroll, SET_PROGRAMS_TO_UNENROLL],
+      [setUnEnrollApiInFlightState, SET_UNENROLL_API_INFLIGHT_STATE]
     ].forEach(assertCreatedActionHelper)
   })
 })

--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -158,7 +158,7 @@ describe("ErrorMessage", () => {
         })
       })
 
-      it("shows nothing if there are no programs", () => {
+      it("shows enrollment card if there are no programs", () => {
         helper.dashboardStub.returns(Promise.resolve([]))
         const expectedActions = DASHBOARD_SUCCESS_NO_LEARNERS_ACTIONS.filter(
           actionType =>
@@ -170,11 +170,14 @@ describe("ErrorMessage", () => {
           expectedActions
         ).then(([wrapper]) => {
           const message = wrapper.find(".page-content").text()
-          assert.equal(message, "")
+          assert.equal(
+            message,
+            "You are not currently enrolled in any programsEnroll in a MicroMasters Program"
+          )
         })
       })
 
-      it("shows nothing if there is no matching current program enrollment", () => {
+      it("shows enrollment card if there is no matching current program enrollment", () => {
         helper.programsGetStub.returns(Promise.resolve([]))
         const expectedActions = DASHBOARD_SUCCESS_NO_LEARNERS_ACTIONS.filter(
           actionType =>
@@ -186,7 +189,10 @@ describe("ErrorMessage", () => {
           expectedActions
         ).then(([wrapper]) => {
           const message = wrapper.find(".page-content").text()
-          assert.equal(message, "")
+          assert.equal(
+            message,
+            "You are not currently enrolled in any programsEnroll in a MicroMasters Program"
+          )
         })
       })
     })

--- a/static/js/components/LeaveProgramWizard.js
+++ b/static/js/components/LeaveProgramWizard.js
@@ -1,0 +1,171 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+import type { Dispatch } from "redux"
+import { Card } from "react-mdl/lib/Card"
+import Dialog from "material-ui/Dialog"
+import SelectField from "material-ui/SelectField"
+import MenuItem from "material-ui/MenuItem"
+import R from "ramda"
+import { dialogActions } from "./inputs/util"
+import _ from "lodash"
+
+import ProfileFormFields from "../util/ProfileFormFields"
+import { showDialog, hideDialog, setProgramsToUnEnroll } from "../actions/ui"
+import {
+  unEnrollProgramEnrollments,
+  UNENROLL_PROGRAM_DIALOG
+} from "../actions/programs"
+import type { Profile } from "../flow/profileTypes"
+import type {
+  AvailableProgramsState,
+  AvailableProgram
+} from "../flow/enrollmentTypes"
+import type { UIState } from "../reducers/ui"
+
+const selectStyle = {
+  backgroundColor: "#ffff",
+  border:          "1px solid #c3c1c1",
+  padding:         "0 10px",
+  borderRadius:    "3px",
+  height:          "40px",
+  marginTop:       "7px"
+}
+const underlineStyle = {
+  borderBottom: "0",
+  bottom:       "0"
+}
+const hintStyle = {
+  color:  "#a2a2a2",
+  bottom: "5px"
+}
+const isVisible = R.propOr(false, UNENROLL_PROGRAM_DIALOG)
+const enrolledInPrograms = (programs: AvailableProgramsState) =>
+  R.filter((program: AvailableProgram) => program.enrolled, programs)
+
+class LeaveProgramWizard extends ProfileFormFields {
+  props: {
+    dispatch: Dispatch,
+    profile: Profile,
+    programs: AvailableProgramsState,
+    ui: UIState
+  }
+
+  onProgramUnEnrollChange = (
+    event: Event,
+    index: ?number,
+    values: Array<number>
+  ) => {
+    const { dispatch } = this.props
+    dispatch(setProgramsToUnEnroll(_.uniq(values)))
+  }
+
+  unEnrollUserTask = () => {
+    const { dispatch, ui: { programsToUnEnroll } } = this.props
+    if (!_.isEmpty(programsToUnEnroll)) {
+      dispatch(unEnrollProgramEnrollments(programsToUnEnroll))
+    }
+  }
+
+  menuItems = (programs: Array<AvailableProgram>) => {
+    const { ui: { programsToUnEnroll = [] } } = this.props
+    return programs.map((program: AvailableProgram) => (
+      <MenuItem
+        key={program.id}
+        insetChildren={true}
+        checked={R.and(
+          R.not(R.isEmpty(programsToUnEnroll)),
+          R.not(_.isUndefined(programsToUnEnroll.find(id => id === program.id)))
+        )}
+        value={program.id}
+        primaryText={program.title}
+      />
+    ))
+  }
+
+  renderUnenrollUI = () => {
+    const { ui: { programsToUnEnroll = [] }, programs } = this.props
+    const enrolledPrograms = enrolledInPrograms(programs)
+    return (
+      <SelectField
+        multiple={true}
+        hintText="Select"
+        value={programsToUnEnroll}
+        onChange={this.onProgramUnEnrollChange}
+        style={selectStyle}
+        underlineStyle={underlineStyle}
+        hintStyle={hintStyle}
+      >
+        {this.menuItems(enrolledPrograms)}
+      </SelectField>
+    )
+  }
+
+  closeDialog = () => {
+    const { dispatch } = this.props
+    dispatch(hideDialog(UNENROLL_PROGRAM_DIALOG))
+  }
+
+  renderDialog = () => {
+    const {
+      ui: {
+        dialogVisibility,
+        programsToUnEnrollInFlight,
+        programsToUnEnroll = []
+      }
+    } = this.props
+    return (
+      <Dialog
+        title="Leave a MicroMasters Program(s)"
+        titleClassName="dialog-title"
+        contentClassName="dialog unenroll-dialog"
+        className="unenroll-dialog-wrapper"
+        open={isVisible(dialogVisibility)}
+        onRequestClose={() => this.closeDialog()}
+        autoScrollBodyContent={true}
+        maxWidth="xs"
+        actions={dialogActions(
+          this.closeDialog,
+          this.unEnrollUserTask,
+          programsToUnEnrollInFlight,
+          "LEAVE SELECTED PROGRAM(S)",
+          "",
+          programsToUnEnroll.length === 0
+        )}
+      >
+        <div className="unenroll-settings">
+          <p>
+            When you leave a MicroMasters program, you will no longer be able to
+            participate in discussions or receive any email about that program.
+          </p>
+          <Card className="unenroll-settings-card">
+            <div className="remind">Which program do you want to leave?</div>
+            {this.renderUnenrollUI()}
+          </Card>
+        </div>
+      </Dialog>
+    )
+  }
+
+  render() {
+    const { dispatch } = this.props
+    return (
+      <div>
+        <Card shadow={1} className="other-settings">
+          <h4 className="heading">Other Settings</h4>
+          <div className="other-settings-row">
+            <button
+              className="mm-minor-action unenroll-wizard-button"
+              onClick={() => dispatch(showDialog(UNENROLL_PROGRAM_DIALOG))}
+            >
+              Leave a MicroMasters Program
+            </button>
+          </div>
+        </Card>
+        {this.renderDialog()}
+      </div>
+    )
+  }
+}
+
+export default LeaveProgramWizard

--- a/static/js/components/LeaveProgramWizard_test.js
+++ b/static/js/components/LeaveProgramWizard_test.js
@@ -1,0 +1,80 @@
+/* global SETTINGS: false */
+import PropTypes from "prop-types"
+import { assert } from "chai"
+import { mount } from "enzyme"
+import sinon from "sinon"
+import React from "react"
+import MuiThemeProvider from "material-ui/styles/MuiThemeProvider"
+import getMuiTheme from "material-ui/styles/getMuiTheme"
+
+import LeaveProgramWizard from "./LeaveProgramWizard"
+import { USER_PROFILE_RESPONSE, PROGRAMS } from "../test_constants"
+import { UNENROLL_PROGRAM_DIALOG } from "../actions/programs"
+
+describe("LeaveProgramWizard", () => {
+  let sandbox
+  const props = {
+    profile:  USER_PROFILE_RESPONSE,
+    programs: PROGRAMS,
+    ui:       {
+      programsToUnEnroll:         [],
+      programsToUnEnrollInFlight: false,
+      dialogVisibility:           {
+        unenrollProgramDialog: false
+      }
+    }
+  }
+
+  const getEl = (selector: string): HTMLElement => {
+    return (document.querySelector(selector): HTMLElement)
+  }
+
+  const renderLeaveProgramWizard = () =>
+    mount(
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <LeaveProgramWizard {...props} />
+      </MuiThemeProvider>,
+      {
+        context:           { router: { push: sandbox.stub() } },
+        childContextTypes: {
+          router: PropTypes.object.isRequired
+        }
+      }
+    )
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+    props["dispatch"] = sandbox.stub()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("assert other settings text", () => {
+    const wrapper = renderLeaveProgramWizard()
+    assert.equal(wrapper.find(".heading").text(), "Other Settings")
+    assert.equal(
+      wrapper.find(".unenroll-wizard-button").text(),
+      "Leave a MicroMasters Program"
+    )
+  })
+
+  it("assert dialog text", () => {
+    props["ui"]["dialogVisibility"][UNENROLL_PROGRAM_DIALOG] = true
+    renderLeaveProgramWizard(props)
+    assert.include(
+      getEl(".unenroll-settings").textContent,
+      "When you leave a MicroMasters program, you will no longer be able " +
+        "to participate in discussions or receive any email about that program."
+    )
+    assert.equal(
+      getEl(".remind").textContent,
+      "Which program do you want to leave?"
+    )
+    assert.equal(
+      getEl(".dialog-title").textContent,
+      "Leave a MicroMasters Program(s)"
+    )
+  })
+})

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -36,8 +36,12 @@ import {
   SET_ENROLL_COURSE_DIALOG_VISIBILITY,
   SET_ENROLL_SELECTED_COURSE_RUN,
   SET_CONFIRM_SKIP_DIALOG_VISIBILITY,
+  SET_ENROLL_PROGRAM_DIALOG_VISIBILITY,
+  SET_ENROLL_SELECTED_PROGRAM,
+  SET_ENROLL_PROGRAM_DIALOG_ERROR,
   setToastMessage,
-  showDialog
+  showDialog,
+  setEnrollSelectedProgram
 } from "../actions/ui"
 import {
   INITIATE_SEND_EMAIL,
@@ -48,7 +52,11 @@ import {
 } from "../actions/email"
 import { SET_TIMEOUT_ACTIVE, setInitialTime } from "../actions/order_receipt"
 import { CLEAR_PROFILE } from "../actions/profile"
-import { CLEAR_ENROLLMENTS } from "../actions/programs"
+import {
+  CLEAR_ENROLLMENTS,
+  REQUEST_ADD_PROGRAM_ENROLLMENT,
+  RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS
+} from "../actions/programs"
 import { EMAIL_COMPOSITION_DIALOG } from "../components/email/constants"
 import {
   REQUEST_SKIP_FINANCIAL_AID,
@@ -87,7 +95,8 @@ import { findCourse, modifyTextField } from "../util/test_utils"
 import {
   DASHBOARD_SUCCESS_ACTIONS,
   DASHBOARD_SUCCESS_NO_FRONTPAGE_ACTIONS,
-  DASHBOARD_ERROR_ACTIONS
+  DASHBOARD_ERROR_ACTIONS,
+  DASHBOARD_SUCCESS_NO_LEARNERS_ACTIONS
 } from "./test_util"
 import { actions } from "../lib/redux_rest"
 import EmailCompositionDialog from "../components/email/EmailCompositionDialog"
@@ -98,16 +107,19 @@ import Grades, {
 import { EDX_GRADE } from "./DashboardPage"
 import DiscussionCard from "../components/DiscussionCard"
 import { makeFrontPageList } from "../factories/posts"
+import * as api from "../lib/api"
 import { postURL } from "../lib/discussions"
 import FinancialAidCard from "../components/dashboard/FinancialAidCard"
 
 describe("DashboardPage", () => {
-  let renderComponent, helper, listenForActions
+  let renderComponent, helper, listenForActions, addProgramEnrollmentStub
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
     renderComponent = helper.renderComponent.bind(helper)
     listenForActions = helper.listenForActions.bind(helper)
+    addProgramEnrollmentStub = helper.sandbox.stub(api, "addProgramEnrollment")
+    addProgramEnrollmentStub.returns(Promise.resolve())
   })
 
   afterEach(() => {
@@ -206,6 +218,83 @@ describe("DashboardPage", () => {
       DASHBOARD_SUCCESS_ACTIONS
     ).then(([wrapper]) => {
       assert.lengthOf(wrapper.find(".learners-card"), 0)
+    })
+  })
+
+  it("should show no program enrolled view", () => {
+    helper.dashboardStub.returns(Promise.resolve({ programs: [] }))
+
+    const actionsNoFrontpage = R.filter(
+      R.compose(
+        R.not,
+        R.contains(R.__, [actions.discussionsFrontpage.get.successType])
+      ),
+      DASHBOARD_SUCCESS_NO_LEARNERS_ACTIONS
+    )
+
+    return renderComponent(
+      "/dashboard",
+      actionsNoFrontpage
+    ).then(([wrapper]) => {
+      const text = wrapper.find(".no-program-card").text()
+      assert.equal(
+        text,
+        "You are not currently enrolled in any programsEnroll in a MicroMasters Program"
+      )
+    })
+  })
+
+  it("should enroll user in program", () => {
+    const dashboard = makeDashboard()
+    helper.dashboardStub.returns(Promise.resolve({ programs: [] }))
+    const availablePrograms = makeAvailablePrograms(dashboard, false)
+    helper.programsGetStub.returns(Promise.resolve(availablePrograms))
+    addProgramEnrollmentStub.returns(Promise.resolve(availablePrograms[0]))
+    const actionsNoFrontpage = R.filter(
+      R.compose(
+        R.not,
+        R.contains(R.__, [actions.discussionsFrontpage.get.successType])
+      ),
+      DASHBOARD_SUCCESS_NO_LEARNERS_ACTIONS
+    )
+
+    return renderComponent(
+      "/dashboard",
+      actionsNoFrontpage
+    ).then(([wrapper]) => {
+      const link = wrapper.find(".enroll-wizard-button")
+      assert.equal(link.text(), "Enroll in a MicroMasters Program")
+      return helper
+        .listenForActions([SET_ENROLL_PROGRAM_DIALOG_VISIBILITY], () => {
+          link.simulate("click")
+        })
+        .then(() => {
+          assert.isFalse(addProgramEnrollmentStub.called)
+          const enrollBtn = document.querySelector(".enroll-button")
+          return helper
+            .listenForActions([SET_ENROLL_PROGRAM_DIALOG_ERROR], () => {
+              enrollBtn.click()
+            })
+            .then(() => {
+              return helper
+                .listenForActions(
+                  [
+                    REQUEST_ADD_PROGRAM_ENROLLMENT,
+                    RECEIVE_ADD_PROGRAM_ENROLLMENT_SUCCESS,
+                    SET_ENROLL_SELECTED_PROGRAM
+                  ],
+                  () => {
+                    helper.store.dispatch(
+                      setEnrollSelectedProgram(availablePrograms[0].id)
+                    )
+                    enrollBtn.click()
+                  }
+                )
+                .then(() => {
+                  assert.isTrue(addProgramEnrollmentStub.called)
+                })
+            })
+        })
     })
   })
 

--- a/static/js/containers/DashboardPage_test.js
+++ b/static/js/containers/DashboardPage_test.js
@@ -7,6 +7,7 @@ import Decimal from "decimal.js-light"
 import R from "ramda"
 import Dialog from "material-ui/Dialog"
 
+import ProgramEnrollmentDialog from "../components/ProgramEnrollmentDialog"
 import {
   makeAvailablePrograms,
   makeCoupon,
@@ -40,8 +41,7 @@ import {
   SET_ENROLL_SELECTED_PROGRAM,
   SET_ENROLL_PROGRAM_DIALOG_ERROR,
   setToastMessage,
-  showDialog,
-  setEnrollSelectedProgram
+  showDialog
 } from "../actions/ui"
 import {
   INITIATE_SEND_EMAIL,
@@ -284,9 +284,11 @@ describe("DashboardPage", () => {
                     SET_ENROLL_SELECTED_PROGRAM
                   ],
                   () => {
-                    helper.store.dispatch(
-                      setEnrollSelectedProgram(availablePrograms[0].id)
-                    )
+                    const props = wrapper
+                      .find(ProgramEnrollmentDialog)
+                      .at(2)
+                      .props()
+                    props.setSelectedProgram(availablePrograms[0].id)
                     enrollBtn.click()
                   }
                 )

--- a/static/js/containers/SettingsPage.js
+++ b/static/js/containers/SettingsPage.js
@@ -11,6 +11,7 @@ import {
   profileFormContainer,
   mapStateToProfileProps
 } from "./ProfileFormContainer"
+import LeaveProgramWizard from "../components/LeaveProgramWizard"
 import PrivacyForm from "../components/PrivacyForm"
 import ProfileProgressControls from "../components/ProfileProgressControls"
 import { privacyValidation } from "../lib/validation/profile"
@@ -42,6 +43,7 @@ class SettingsPage extends React.Component<*, ProfileContainerProps, *> {
         <div className="single-column privacy-form">
           <h4 className="privacy-form-heading">Settings</h4>
           <PrivacyForm {...props} validator={privacyValidation} />
+          <LeaveProgramWizard {...props} />
           <ProfileProgressControls
             {...props}
             nextBtnLabel="Save"

--- a/static/js/containers/SettingsPage_test.js
+++ b/static/js/containers/SettingsPage_test.js
@@ -10,7 +10,8 @@ import {
 } from "../actions/profile"
 import {
   REQUEST_GET_PROGRAM_ENROLLMENTS,
-  RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS
+  RECEIVE_GET_PROGRAM_ENROLLMENTS_SUCCESS,
+  UNENROLL_PROGRAM_DIALOG
 } from "../actions/programs"
 import {
   START_PROFILE_EDIT,
@@ -21,6 +22,7 @@ import {
   UPDATE_VALIDATION_VISIBILITY,
   receiveGetUserProfileSuccess
 } from "../actions/profile"
+import { SHOW_DIALOG } from "../actions/ui"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import * as api from "../lib/api"
 import { USER_PROFILE_RESPONSE } from "../test_constants"
@@ -95,6 +97,9 @@ describe("SettingsPage", function() {
         "privacy-form-heading"
       )[2]
       assert.equal(emailPrefHeading.textContent, "Email Preferences")
+
+      const otherSettingsHeading = div.getElementsByClassName("heading")[0]
+      assert.equal(otherSettingsHeading.textContent, "Other Settings")
     })
   })
 
@@ -137,5 +142,20 @@ describe("SettingsPage", function() {
         })
       })
     }
+
+    it("when unenroll program button click", () => {
+      return renderComponent("/settings", userActions).then(([, div]) => {
+        const unEnrollBtn = div.getElementsByClassName(
+          "unenroll-wizard-button"
+        )[0]
+        assert.equal(unEnrollBtn.textContent, "Leave a MicroMasters Program")
+
+        return listenForActions([SHOW_DIALOG], () => {
+          unEnrollBtn.click()
+        }).then(state => {
+          assert.isTrue(state.ui.dialogVisibility[UNENROLL_PROGRAM_DIALOG])
+        })
+      })
+    })
   })
 })

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -54,10 +54,11 @@ export const makeDashboard = (): Dashboard => {
 }
 
 export const makeAvailablePrograms = (
-  dashboard: Dashboard
+  dashboard: Dashboard,
+  enrolled: boolean = true
 ): AvailablePrograms => {
   return dashboard.programs.map(program => ({
-    enrolled:        true,
+    enrolled:        enrolled,
     id:              program.id,
     programpage_url: `/page/${program.id}`,
     title:           `AvailableProgram for ${program.id}`,

--- a/static/js/flow/enrollmentTypes.js
+++ b/static/js/flow/enrollmentTypes.js
@@ -22,3 +22,9 @@ export type AvailableProgramsState = {
 export type CourseEnrollmentsState = {
   courseEnrollAddStatus?: string,
 }
+
+
+export type UnEnrollPrograms = {
+  program_id: number,
+  title: string,
+}

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -236,7 +236,7 @@ export function attachCoupon(
   }).then(response => R.evolve({ coupon: { amount: Decimal } }, response))
 }
 
-export function unEnrollProgramEnrollments(programIds: []) {
+export function unEnrollProgramEnrollments(programIds: Array<number>) {
   return fetchJSONWithCSRF("/api/v0/unenroll_programs/", {
     method: "POST",
     body:   JSON.stringify({

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -235,3 +235,12 @@ export function attachCoupon(
     })
   }).then(response => R.evolve({ coupon: { amount: Decimal } }, response))
 }
+
+export function unEnrollProgramEnrollments(programIds: []) {
+  return fetchJSONWithCSRF("/api/v0/unenroll_programs/", {
+    method: "POST",
+    body:   JSON.stringify({
+      program_ids: programIds
+    })
+  })
+}

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -22,7 +22,8 @@ import {
   addCourseEnrollment,
   getCoupons,
   attachCoupon,
-  getPearsonSSO
+  getPearsonSSO,
+  unEnrollProgramEnrollments
 } from "./api"
 import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
 import {
@@ -644,6 +645,44 @@ describe("api", function() {
 
           return assert.isRejected(getPearsonSSO()).then(() => {
             assert(fetchJSONStub.calledWith("/api/v0/pearson/sso/"))
+          })
+        })
+      })
+    })
+
+    describe("UnEnroll API functions", () => {
+      describe("unEnrollProgramEnrollments", () => {
+        it("post list of programs to unenroll", () => {
+          const programIds = [1, 2]
+          const response = [
+            {
+              program_id: 1,
+              title:      "foo"
+            },
+            {
+              program_id: 2,
+              title:      "bar"
+            }
+          ]
+          fetchJSONStub.returns(Promise.resolve(response))
+          return unEnrollProgramEnrollments([1, 2]).then(data => {
+            assert.ok(
+              fetchJSONStub.calledWith("/api/v0/unenroll_programs/", {
+                method: "POST",
+                body:   JSON.stringify({
+                  program_ids: programIds
+                })
+              })
+            )
+            assert.deepEqual(data, response)
+          })
+        })
+
+        it("fails to post list of programs to unenroll", () => {
+          fetchJSONStub.returns(Promise.reject())
+
+          return assert.isRejected(unEnrollProgramEnrollments()).then(() => {
+            assert(fetchJSONStub.calledWith("/api/v0/unenroll_programs/"))
           })
         })
       })

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -34,7 +34,9 @@ import {
   SET_NAV_DRAWER_OPEN,
   SET_PROGRAM,
   SHOW_ENROLL_PAY_LATER_SUCCESS,
-  SET_SHOW_EXPANDED_COURSE_STATUS
+  SET_SHOW_EXPANDED_COURSE_STATUS,
+  SET_PROGRAMS_TO_UNENROLL,
+  SET_UNENROLL_API_INFLIGHT_STATE
 } from "../actions/ui"
 import { EMAIL_COMPOSITION_DIALOG } from "../components/email/constants"
 import { CHANNEL_CREATE_DIALOG } from "../constants"
@@ -92,7 +94,9 @@ export type UIState = {
   navDrawerOpen: boolean,
   dialogVisibility: DialogVisibilityState,
   showEnrollPayLaterSuccess: ?string,
-  expandedCourseStatuses: Set<number>
+  expandedCourseStatuses: Set<number>,
+  programsToUnEnroll: [],
+  programsToUnEnrollInFlight: boolean
 }
 
 export const INITIAL_UI_STATE: UIState = {
@@ -131,7 +135,9 @@ export const INITIAL_UI_STATE: UIState = {
   navDrawerOpen:                      false,
   dialogVisibility:                   INITIAL_DIALOG_VISIBILITY_STATE,
   showEnrollPayLaterSuccess:          null,
-  expandedCourseStatuses:             new Set()
+  expandedCourseStatuses:             new Set(),
+  programsToUnEnroll:                 [],
+  programsToUnEnrollInFlight:         false
 }
 
 export const ui = (
@@ -318,6 +324,16 @@ export const ui = (
       expandedCourseStatuses: new Set(state.expandedCourseStatuses).add(
         action.payload
       )
+    }
+  case SET_PROGRAMS_TO_UNENROLL:
+    return {
+      ...state,
+      programsToUnEnroll: action.payload
+    }
+  case SET_UNENROLL_API_INFLIGHT_STATE:
+    return {
+      ...state,
+      programsToUnEnrollInFlight: action.payload
     }
   default:
     return state

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -95,7 +95,7 @@ export type UIState = {
   dialogVisibility: DialogVisibilityState,
   showEnrollPayLaterSuccess: ?string,
   expandedCourseStatuses: Set<number>,
-  programsToUnEnroll: [],
+  programsToUnEnroll: Array<number>,
   programsToUnEnrollInFlight: boolean
 }
 

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -29,6 +29,8 @@ import {
   setNavDrawerOpen,
   showEnrollPayLaterSuccess,
   setShowExpandedCourseStatus,
+  setProgramsToUnEnroll,
+  setUnEnrollApiInFlightState,
   SHOW_ENROLL_PAY_LATER_SUCCESS
 } from "../actions/ui"
 import { INITIAL_UI_STATE } from "../reducers/ui"
@@ -303,6 +305,32 @@ describe("ui reducers", () => {
       assert.isTrue(store.getState().ui.expandedCourseStatuses.has(1))
       store.dispatch(setShowExpandedCourseStatus(1))
       assert.isTrue(store.getState().ui.expandedCourseStatuses.has(1))
+    })
+  })
+
+  describe("list of programs to unenroll", () => {
+    it("is empty on start", () => {
+      assert.lengthOf(store.getState().ui.programsToUnEnroll, 0)
+    })
+
+    it("is populated", () => {
+      store.dispatch(setProgramsToUnEnroll([1]))
+      assert.deepEqual(store.getState().ui.programsToUnEnroll, [1])
+      store.dispatch(setProgramsToUnEnroll([1, 2]))
+      assert.deepEqual(store.getState().ui.programsToUnEnroll, [1, 2])
+    })
+  })
+
+  describe("unenroll dialog flight state", () => {
+    it("false on start", () => {
+      assert.isFalse(store.getState().ui.programsToUnEnrollInFlight)
+    })
+
+    it("set and unset", () => {
+      store.dispatch(setUnEnrollApiInFlightState(true))
+      assert.isTrue(store.getState().ui.programsToUnEnrollInFlight)
+      store.dispatch(setUnEnrollApiInFlightState(false))
+      assert.isFalse(store.getState().ui.programsToUnEnrollInFlight)
     })
   })
 })

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -60,6 +60,7 @@ $program_selector_border: rgba(255,255,255,.2);
 $header_font_color: white;
 $text-highlight: #fbf9db;
 $email-composition-type: #e3eef8;
+$lightest-blue: #e9f2f9;
 
 // other
 $block-padding: 20px;

--- a/static/scss/navbar.scss
+++ b/static/scss/navbar.scss
@@ -313,3 +313,20 @@
 .mdl-layout-title > a:hover, .mdl-layout-title > a:focus {
   color: white;
 }
+
+.no-program-card {
+  width: 500px !important;
+  top: 30px;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  text-align: center;
+  min-height: 100px !important;
+
+  > div {
+    font-weight: bold;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 0;
+    margin-top: 10px;
+  }
+}

--- a/static/scss/profile.scss
+++ b/static/scss/profile.scss
@@ -2,6 +2,43 @@
   text-align: center;
 }
 
+.other-settings {
+  min-height: 0 !important;
+  font-weight: 400 !important;
+
+  .heading {
+    font-size: 20px;
+    font-weight: 500;
+    margin-top: 0;
+  }
+
+  .other-settings-row {
+    margin: 10px 0;
+
+    > button {
+      font-size: 15px;
+    }
+  }
+}
+
+.unenroll-settings {
+  padding: 10px 0 0 0;
+
+  .unenroll-settings-card {
+    background-color: $lightest-blue;
+  }
+
+  .remind {
+    font-weight: bold;
+    font-size: 14px;
+    padding: 2px 0;
+  }
+}
+
+.unenroll-dialog {
+  max-width: 570px !important;
+}
+
 .profile-form {
   min-height: 0 !important;
   font-weight: 400 !important;


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/4056

#### What's this PR do?
It adds a wizard to unenroll from one or many programs. And update UI on unenroll.

- [x] Added api
- [x] Add unenroll card on settings
- [x] Add unenroll programs wizard
  - [x] display enrolled programs
  - [x] Add multi select programs widget
  - [x] api call
  - [x] show spinner on api call
- [x] dashboard card when no program selected
- [x] Unit tests for front end
- [x] Unit tests for backend
 
#### How should this be manually tested?
- Enroll programs one or many
- Go to settings and click unenroll link
- then select program(s)
- check dashboard
- when no program left i.e you unenroll all, check new card on dashboard with enroll link

@pdpinch 
#### Screenshots (if appropriate)
-  <img width="825" alt="screen shot 2018-08-03 at 5 25 22 pm" src="https://user-images.githubusercontent.com/10431250/43642760-41d601f0-9742-11e8-9523-8b3a85c3403f.png">
- ![screen shot 2018-08-02 at 3 07 14 pm](https://user-images.githubusercontent.com/10431250/43577621-c7687772-9665-11e8-99d4-3a315c292401.png)
-  <img width="650" alt="screen shot 2018-08-02 at 3 02 58 pm" src="https://user-images.githubusercontent.com/10431250/43577405-2faddd0a-9665-11e8-8aba-5a0fd26512c8.png">
-  <img width="550" alt="screen shot 2018-08-02 at 3 08 47 pm" src="https://user-images.githubusercontent.com/10431250/43577707-01999624-9666-11e8-8365-f9abf1a75220.png">
- ![screen shot 2018-08-03 at 4 30 50 pm](https://user-images.githubusercontent.com/10431250/43640777-a0d51964-973a-11e8-8ce9-c8fde7ded8f1.png)



