### PR TITLE
use the raw id for user in admin instead of drop-down

### DIFF
--- a/roles/admin.py
+++ b/roles/admin.py
@@ -9,7 +9,7 @@ from roles.models import Role
 
 class RoleAdmin(admin.ModelAdmin):
     """ModelAdmin for Roles"""
-    list_display = ('program', 'role', )
+    list_display = ('user', 'program', 'role', )
     raw_id_fields = ('user', )
 
 admin.site.register(Role, RoleAdmin)

--- a/roles/admin.py
+++ b/roles/admin.py
@@ -9,6 +9,7 @@ from roles.models import Role
 
 class RoleAdmin(admin.ModelAdmin):
     """ModelAdmin for Roles"""
-    list_display = ('user', 'program', 'role', )
+    list_display = ('program', 'role', )
+    raw_id_fields = ('user', )
 
 admin.site.register(Role, RoleAdmin)


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #4087 

#### What's this PR do?

Changes the user field in the roles admin from a drop-down to a raw id. 

Now the page won't try to load a list of 30k+ usernames. 

#### How should this be manually tested?

Go to /admin/roles/role/add and confirm that User is a input field now instead of a drop-down. 

#### Screenshots (if appropriate)

![screenshot 2018-08-02 14 05 26](https://user-images.githubusercontent.com/430126/43602151-217387c4-965d-11e8-8890-38a1faccc762.png)

#### What GIF best describes this PR or how it makes you feel?

![screenshot 2018-08-02 14 06 53](https://user-images.githubusercontent.com/430126/43602220-56dc693a-965d-11e8-9f47-0a8e11c1dbb6.png)

