### PR TITLE
Revert "Added mailgun unsub feature (#4051)"

### DIFF
--- a/mail/urls.py
+++ b/mail/urls.py
@@ -9,7 +9,6 @@ from mail.views import (
     CourseTeamMailView,
     AutomaticEmailView,
     MailWebhookView,
-    UnSubWebhookView,
 )
 
 router = routers.DefaultRouter()
@@ -22,6 +21,5 @@ urlpatterns = [
     url(r'^api/v0/mail/course/(?P<course_id>[\d]+)/$', CourseTeamMailView.as_view(), name='course_team_mail_api'),
     url(r'^api/v0/mail/learner/(?P<student_id>[\d]+)/$', LearnerMailView.as_view(), name='learner_mail_api'),
     url(r'^api/v0/mail/webhook/$', MailWebhookView.as_view(), name='mailgun_webhook'),
-    url(r'^api/v0/mail/unsub_webhook/$', UnSubWebhookView.as_view(), name='mailgun_unsub_webhook'),
     url(r'^api/v0/mail/', include(router.urls)),
 ]

--- a/mail/utils.py
+++ b/mail/utils.py
@@ -118,7 +118,7 @@ def get_email_footer(url):
     text = ("You are receiving this e-mail because you signed up for MITx"
             " MicroMasters.<br/> If you don't want to receive these emails in the"
             " future, you can<br/> <a href='{0}'>edit your settings</a>"
-            " or <a href='%unsubscribe_url%'>unsubscribe</a>.").format(url)
+            " or <a href='{0}'>unsubscribe</a>.").format(url)
     return ("<div style='margin-top:80px; text-align: center; color: #757575;'>"
             "<div style='margin:auto; max-width:50%;'><p>{0}</p>"
             "<p>MIT Office of Digital Learning<br/>"

--- a/mail/views.py
+++ b/mail/views.py
@@ -270,34 +270,3 @@ class MailWebhookView(APIView):
             log.debug(error_msg)
 
         return Response(status=status.HTTP_200_OK)
-
-
-class UnSubWebhookView(APIView):
-    """
-    View class that handles Mailgun unsubscribed webhooks
-    """
-    permission_classes = (MailGunWebHookPermission, )
-
-    def post(self, request, *args, **kargs):  # pylint: disable=unused-argument
-        """
-        POST method handler
-        """
-        event = request.POST.get("event", None)
-        recipient = request.POST.get("recipient", None)
-
-        if recipient and event == "unsubscribed":
-            profile = Profile.objects.get(user__email=recipient)
-            profile.email_optin = False
-            profile.save()
-
-            message_headers = request.POST.get("message", None)
-            debug_msg = (
-                "Webhook event {event} received by Mailgun for recipient {to}:{header}".format(
-                    to=recipient,
-                    event=event,
-                    header=message_headers
-                )
-            )
-            log.debug(debug_msg)
-
-        return Response(status=status.HTTP_200_OK)

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -1,10 +1,4 @@
 """Views for courses"""
-import logging
-import requests
-from django.conf import settings
-from django.http import HttpResponse
-
-from rest_framework import status as statuses
 from rest_framework.mixins import (
     RetrieveModelMixin,
     UpdateModelMixin,
@@ -27,9 +21,6 @@ from profiles.permissions import (
 )
 
 
-log = logging.getLogger(__name__)
-
-
 class ProfileViewSet(RetrieveModelMixin, UpdateModelMixin, GenericViewSet):
     """API for the Program collection"""
     # pylint: disable=too-many-return-statements
@@ -45,101 +36,6 @@ class ProfileViewSet(RetrieveModelMixin, UpdateModelMixin, GenericViewSet):
     serializer_class_owner = ProfileSerializer
     serializer_class_filled_out = ProfileFilledOutSerializer
     serializer_class_limited = ProfileLimitedSerializer
-
-    @staticmethod
-    def add_email_to_unsub_list(url, email):
-        """
-        It adds user email to mailgun unsub list.
-
-        Args:
-            url (str): mailgun api url:
-            email (str): user email
-        """
-        try:
-            response = requests.post(
-                url,
-                auth=('api', settings.MAILGUN_KEY),
-                data={
-                    'address': email,
-                    'tag': '*'
-                }
-            )
-            if response.status_code == statuses.HTTP_200_OK:
-                log.debug(
-                    "Added user's email: %s to mailgun unsubscribes list. Message received: %s",
-                    email,
-                    response.json()
-                )
-                return True
-        except requests.exceptions.RequestException:
-            log.exception(
-                "Unable to add email: %s to mailgun unsubscribes list.", email
-            )
-        return False
-
-    @staticmethod
-    def remove_email_from_unsub_list(url, email):
-        """
-        It removes user email from mailgun unsub list.
-
-        Args:
-            url (str): mailgun api url:
-            email (str): user email
-        """
-        try:
-            response = requests.delete(url, auth=('api', settings.MAILGUN_KEY))
-            if response.status_code == statuses.HTTP_200_OK:
-                log.debug(
-                    "Removed user's email: %s from mailgun unsubscribes list. Message received: %s",
-                    email,
-                    response.json()
-                )
-                return True
-        except requests.exceptions.RequestException:
-            log.exception(
-                "Unable to remove email: %s from mailgun unsubscribes list.", email
-            )
-        return False
-
-    @staticmethod
-    def mailgun_action(email_optin, email):
-        """
-        it removes user from mailgun unsubscribes list.
-        https://documentation.mailgun.com/en/latest/api-suppressions.html#delete-a-single-unsubscribe
-
-        Args:
-            email_optin (bool): email optin flag
-            email (str): user email
-        """
-        url = "{base}/unsubscribes".format(base=settings.MAILGUN_URL)
-        if email_optin:
-            url = '{base}/{email}'.format(base=url, email=email)
-            return ProfileViewSet.remove_email_from_unsub_list(url, email)
-        else:
-            return ProfileViewSet.add_email_to_unsub_list(url, email)
-
-    @staticmethod
-    def simple_response(status):
-        """
-        returns status response.
-
-        Args:
-            status (int): Http status
-        """
-        return HttpResponse(status=status)
-
-    def update(self, request, *args, **kwargs):
-        """
-        updates user profile.
-        """
-        if 'email_optin' in request.data and 'email' in request.data:
-            # perform mailgun action if email optin is set then remove user from mailgun unsubscription
-            # list otherwise add user to mailgun unsubscription.
-            if ProfileViewSet.mailgun_action(request.data['email_optin'], request.data['email']):
-                return super().update(request, *args, **kwargs)
-            else:
-                return ProfileViewSet.simple_response(statuses.HTTP_304_NOT_MODIFIED)
-        return super().update(request, *args, **kwargs)
 
     def get_serializer_class(self):
         """


### PR DESCRIPTION
This reverts commit f6580833d8bfe3addba9f76558fa15241ef6f29e.

#### What are the relevant tickets?
Fixes #4091 

#### What's this PR do?
Fixes a breakage of the profile api

#### How should this be manually tested?
1. Confirm you can register a new user and complete the profile
2. Confirm you can update an existing users profile and the changes stick without error