### PR TITLE
Added mailgun unsub user support 

### DIFF
--- a/mail/api.py
+++ b/mail/api.py
@@ -286,14 +286,14 @@ class MailgunClient:
         return response
 
     @staticmethod
-    def add_email_to_unsub_list(url, email):
+    def add_email_to_unsub_list(email):
         """
         It adds user email to mailgun unsub list.
 
         Args:
-            url (str): mailgun api url:
             email (str): user email
         """
+        url = "{base}/unsubscribes".format(base=settings.MAILGUN_URL)
         try:
             response = requests.post(
                 url,
@@ -316,14 +316,14 @@ class MailgunClient:
             )
 
     @staticmethod
-    def remove_email_from_unsub_list(url, email):
+    def remove_email_from_unsub_list(email):
         """
         It removes user email from mailgun unsub list.
 
         Args:
-            url (str): mailgun api url:
             email (str): user email
         """
+        url = "{base}/unsubscribes/{email}".format(base=settings.MAILGUN_URL, email=email)
         try:
             response = requests.delete(url, auth=('api', settings.MAILGUN_KEY))
         except requests.exceptions.RequestException:
@@ -337,23 +337,6 @@ class MailgunClient:
                 email,
                 response.json()
             )
-
-    @staticmethod
-    def toggle_mailing_list_subscription(email_optin, email):
-        """
-        it removes user from mailgun unsubscribes list.
-        https://documentation.mailgun.com/en/latest/api-suppressions.html#delete-a-single-unsubscribe
-
-        Args:
-            email_optin (bool): email optin flag
-            email (str): user email
-        """
-        url = "{base}/unsubscribes".format(base=settings.MAILGUN_URL)
-        if email_optin:
-            url = '{base}/{email}'.format(base=url, email=email)
-            MailgunClient.remove_email_from_unsub_list(url, email)
-        else:
-            MailgunClient.add_email_to_unsub_list(url, email)
 
 
 def send_automatic_emails(program_enrollment):

--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -713,8 +713,7 @@ class ToggleMailingListSubscriptionTests(MockedESTestCase):
         """
         Test add user to Mailgun unsubscribe list
         """
-        MailgunClient.toggle_mailing_list_subscription(
-            False,
+        MailgunClient.add_email_to_unsub_list(
             "foo@example.com"
         )
         mock_logger.debug.assert_called_with(
@@ -733,8 +732,7 @@ class ToggleMailingListSubscriptionTests(MockedESTestCase):
         """
         Test remove user from Mailgun unsubscribe list
         """
-        MailgunClient.toggle_mailing_list_subscription(
-            True,
+        MailgunClient.remove_email_from_unsub_list(
             "foo@example.com"
         )
         mock_logger.debug.assert_called_with(

--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -698,3 +698,47 @@ class RecipientVariablesTests(MockedESTestCase):
         profile.delete()
 
         assert list(get_mail_vars([user.email])) == []
+
+
+class ToggleMailingListSubscriptionTests(MockedESTestCase):
+    """Tests regarding toggle_mailing_list_subscription emails"""
+
+    @patch('requests.post', autospec=True, return_value=Mock(
+        spec=Response,
+        status_code=HTTP_200_OK,
+        json=mocked_json()
+    ))
+    @patch('mail.api.log')
+    def test_add_to_unsubscribe_list(self, mock_logger, mock_post):
+        """
+        Test add user to Mailgun unsubscribe list
+        """
+        MailgunClient.toggle_mailing_list_subscription(
+            False,
+            "foo@example.com"
+        )
+        mock_logger.debug.assert_called_with(
+            "Added user's email: %s to mailgun unsubscribes list. Message received: %s",
+            "foo@example.com",
+            mock_post.return_value.json()
+        )
+
+    @patch('requests.delete', autospec=True, return_value=Mock(
+        spec=Response,
+        status_code=HTTP_200_OK,
+        json=mocked_json()
+    ))
+    @patch('mail.api.log')
+    def test_remove_from_unsubscribe_list(self, mock_logger, mock_delete):
+        """
+        Test remove user from Mailgun unsubscribe list
+        """
+        MailgunClient.toggle_mailing_list_subscription(
+            True,
+            "foo@example.com"
+        )
+        mock_logger.debug.assert_called_with(
+            "Removed user's email: %s from mailgun unsubscribes list. Message received: %s",
+            "foo@example.com",
+            mock_delete.return_value.json()
+        )

--- a/mail/urls.py
+++ b/mail/urls.py
@@ -9,6 +9,7 @@ from mail.views import (
     CourseTeamMailView,
     AutomaticEmailView,
     MailWebhookView,
+    UnSubWebhookView,
 )
 
 router = routers.DefaultRouter()
@@ -21,5 +22,6 @@ urlpatterns = [
     url(r'^api/v0/mail/course/(?P<course_id>[\d]+)/$', CourseTeamMailView.as_view(), name='course_team_mail_api'),
     url(r'^api/v0/mail/learner/(?P<student_id>[\d]+)/$', LearnerMailView.as_view(), name='learner_mail_api'),
     url(r'^api/v0/mail/webhook/$', MailWebhookView.as_view(), name='mailgun_webhook'),
+    url(r'^api/v0/mail/unsub_webhook/$', UnSubWebhookView.as_view(), name='mailgun_unsub_webhook'),
     url(r'^api/v0/mail/', include(router.urls)),
 ]

--- a/mail/utils.py
+++ b/mail/utils.py
@@ -118,7 +118,7 @@ def get_email_footer(url):
     text = ("You are receiving this e-mail because you signed up for MITx"
             " MicroMasters.<br/> If you don't want to receive these emails in the"
             " future, you can<br/> <a href='{0}'>edit your settings</a>"
-            " or <a href='{0}'>unsubscribe</a>.").format(url)
+            " or <a href='%unsubscribe_url%'>unsubscribe</a>.").format(url)
     return ("<div style='margin-top:80px; text-align: center; color: #757575;'>"
             "<div style='margin:auto; max-width:50%;'><p>{0}</p>"
             "<p>MIT Office of Digital Learning<br/>"

--- a/mail/views.py
+++ b/mail/views.py
@@ -270,3 +270,30 @@ class MailWebhookView(APIView):
             log.debug(error_msg)
 
         return Response(status=status.HTTP_200_OK)
+
+
+class UnSubWebhookView(APIView):
+    """
+    View class that handles Mailgun unsubscribed webhooks
+    """
+    permission_classes = (MailGunWebHookPermission, )
+
+    def post(self, request, *args, **kargs):  # pylint: disable=unused-argument
+        """
+        POST method handler
+        """
+        event = request.POST.get("event", None)
+        recipient = request.POST.get("recipient", None)
+
+        if recipient and event == "unsubscribed":
+            profiles_updated = Profile.objects.filter(user__email=recipient).update(email_optin=False)
+            if profiles_updated > 0:
+                log.debug(
+                    "Webhook event: '%s' received by Mailgun for recipient: %s:", event, recipient
+                )
+            else:
+                log.error(
+                    "Webhook event: Unable to update profile of user: "
+                    "%s for event: '%s', received from Mailgun", recipient, event
+                )
+        return Response(status=status.HTTP_200_OK)

--- a/mail/views.py
+++ b/mail/views.py
@@ -293,7 +293,6 @@ class UnSubWebhookView(APIView):
                 )
             else:
                 log.error(
-                    "Webhook event: Unable to update profile of user: "
-                    "%s for event: '%s', received from Mailgun", recipient, event
+                    "Webhook event: '%s' failed. No profile exists for a user with email '%s'", event, recipient
                 )
         return Response(status=status.HTTP_200_OK)

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -753,6 +753,6 @@ class UnSubWebhookViewTests(APITestCase):
         request = factory.post(self.url, data=data)
         UnSubWebhookView().post(request)
         mock_logger.error.assert_called_with(
-            "Webhook event: Unable to update profile of user: "
-            "%s for event: '%s', received from Mailgun", "foo@example.com", "unsubscribed"
+            "Webhook event: '%s' failed. No profile exists for "
+            "a user with email '%s'", "unsubscribed", "foo@example.com"
         )

--- a/mail/views_test.py
+++ b/mail/views_test.py
@@ -32,7 +32,7 @@ from mail.factories import AutomaticEmailFactory
 from mail.models import SentAutomaticEmail, AutomaticEmail
 from mail.serializers import AutomaticEmailSerializer
 from mail.utils import get_email_footer
-from mail.views import MailWebhookView
+from mail.views import MailWebhookView, UnSubWebhookView
 from profiles.factories import (
     ProfileFactory,
     UserFactory,
@@ -718,3 +718,41 @@ class EmailBouncedViewTests(APITestCase, MockedESTestCase):
 
         # assert that error message is logged
         getattr(mock_logger, logger).assert_called_with(error_msg)
+
+
+class UnSubWebhookViewTests(APITestCase):
+    """Test email unsub webhook view web hook"""
+    url = reverse('mailgun_unsub_webhook')
+
+    def test_unsub(self):
+        """Tests that api unsub user"""
+        with mute_signals(post_save):
+            recipient = ProfileFactory.create(
+                email_optin=True,
+                user__username="foo"
+            )
+
+        data = {
+            "event": "unsubscribed",
+            "recipient": recipient.user.email
+        }
+        factory = RequestFactory()
+        request = factory.post(self.url, data=data)
+        UnSubWebhookView().post(request)
+        recipient.refresh_from_db()
+        assert recipient.email_optin is False
+
+    @patch('mail.views.log')
+    def test_unsub_invalid_email(self, mock_logger):
+        """Tests when invalid email comes from webhook"""
+        data = {
+            "event": "unsubscribed",
+            "recipient": "foo@example.com"
+        }
+        factory = RequestFactory()
+        request = factory.post(self.url, data=data)
+        UnSubWebhookView().post(request)
+        mock_logger.error.assert_called_with(
+            "Webhook event: Unable to update profile of user: "
+            "%s for event: '%s', received from Mailgun", "foo@example.com", "unsubscribed"
+        )

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -47,12 +47,10 @@ class ProfileViewSet(RetrieveModelMixin, UpdateModelMixin, GenericViewSet):
         """Updates object"""
         profile = serializer.save()
         if 'email_optin' in serializer.validated_data:
-            # perform mailgun action if email optin is set then remove user from mailgun unsubscription
-            # list otherwise add user to mailgun unsubscription.
-            MailgunClient.toggle_mailing_list_subscription(
-                serializer.validated_data['email_optin'],
-                profile.email
-            )
+            if serializer.validated_data['email_optin']:
+                MailgunClient.remove_email_from_unsub_list(profile.email)
+            else:
+                MailgunClient.add_email_to_unsub_list(profile.email)
 
     def get_serializer_class(self):
         """

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -308,8 +308,9 @@ class ProfilePATCHTests(ProfileBaseTests):
     """
     client_class = APIClient
 
-    @patch('mail.api.MailgunClient.toggle_mailing_list_subscription')
-    def test_patch_own_profile(self, mailgun_action):
+    @patch('mail.api.MailgunClient.remove_email_from_unsub_list')
+    @patch('mail.api.MailgunClient.add_email_to_unsub_list')
+    def test_patch_own_profile(self, add_mailgun_action, del_mailgun_action):
         """
         A user PATCHes their own profile
         """
@@ -318,7 +319,10 @@ class ProfilePATCHTests(ProfileBaseTests):
         self.client.force_login(self.user1)
 
         with mute_signals(post_save):
-            new_profile = ProfileFactory.create(filled_out=False)
+            new_profile = ProfileFactory.create(
+                filled_out=False,
+                email_optin=True
+            )
         new_profile.user.social_auth.create(
             provider=EdxOrgOAuth2.name,
             uid="{}_edx".format(new_profile.user.username)
@@ -328,7 +332,8 @@ class ProfilePATCHTests(ProfileBaseTests):
 
         resp = self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
         assert resp.status_code == HTTP_200_OK
-        assert mailgun_action.called
+        assert del_mailgun_action.called
+        assert add_mailgun_action.called is False
 
         old_profile = Profile.objects.get(user__username=self.user1.username)
         for key, value in patch_data.items():
@@ -342,8 +347,9 @@ class ProfilePATCHTests(ProfileBaseTests):
             else:
                 assert getattr(old_profile, key) == value
 
-    @patch('mail.api.MailgunClient.toggle_mailing_list_subscription')
-    def test_when_mailgun_fail(self, mailgun_action):
+    @patch('mail.api.MailgunClient.remove_email_from_unsub_list')
+    @patch('mail.api.MailgunClient.add_email_to_unsub_list')
+    def test_when_mailgun_fail(self, add_mailgun_action, del_mailgun_action):
         """
         When user updates email optin but mailgun fail to response.
         """
@@ -368,10 +374,12 @@ class ProfilePATCHTests(ProfileBaseTests):
 
         resp = self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
         assert resp.status_code == HTTP_200_OK
-        assert mailgun_action.called
+        assert add_mailgun_action.called is False
+        assert del_mailgun_action.called is True
 
-    @patch('mail.api.MailgunClient.toggle_mailing_list_subscription')
-    def test_serializer(self, mailgun_action):
+    @patch('mail.api.MailgunClient.remove_email_from_unsub_list')
+    @patch('mail.api.MailgunClient.add_email_to_unsub_list')
+    def test_serializer(self, add_mailgun_action, del_mailgun_action):
         """
         Get a user's own profile, ensure that we used ProfileSerializer and not ProfileFilledOutSerializer
         """
@@ -393,10 +401,12 @@ class ProfilePATCHTests(ProfileBaseTests):
             self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
         assert mocked.called
         assert not mocked_filled_out.called
-        assert mailgun_action.called is False
+        assert add_mailgun_action.called is False
+        assert del_mailgun_action.called is False
 
-    @patch('mail.api.MailgunClient.toggle_mailing_list_subscription')
-    def test_filled_out_serializer(self, mailgun_action):
+    @patch('mail.api.MailgunClient.remove_email_from_unsub_list')
+    @patch('mail.api.MailgunClient.add_email_to_unsub_list')
+    def test_filled_out_serializer(self, add_mailgun_action, del_mailgun_action):
         """
         Get a user's own profile, ensure that we used ProfileFilledOutSerializer
         """
@@ -413,7 +423,8 @@ class ProfilePATCHTests(ProfileBaseTests):
         ) as mocked:
             self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
         assert mocked.called
-        assert mailgun_action.called is False
+        assert add_mailgun_action.called is False
+        assert del_mailgun_action.called is False
 
     def test_forbidden_methods(self):
         """
@@ -445,17 +456,25 @@ class ProfilePATCHTests(ProfileBaseTests):
         assert profile.education.count() == 1
         assert profile.work_history.count() == 1
 
-    @patch('mail.api.MailgunClient.toggle_mailing_list_subscription')
+    @patch('mail.api.MailgunClient.remove_email_from_unsub_list')
+    @patch('mail.api.MailgunClient.add_email_to_unsub_list')
     @ddt.data(
         *itertools.product([True, False], [True, False])
     )
     @ddt.unpack
-    def test_no_thumbnail_change_if_image_upload(self, image_already_exists, thumb_already_exists, mailgun_action):
+    def test_no_thumbnail_change_if_image_upload(
+            self, image_already_exists, thumb_already_exists, add_mailgun_action, del_mailgun_action
+    ):
         """
         A patch without an image upload should not touch the image or the thumbnail
         """
         with mute_signals(post_save):
-            profile = ProfileFactory.create(user=self.user1, filled_out=False, agreed_to_terms_of_service=False)
+            profile = ProfileFactory.create(
+                user=self.user1,
+                filled_out=False,
+                agreed_to_terms_of_service=False,
+                email_optin=False
+            )
             if image_already_exists is False:
                 profile.image = None
             if thumb_already_exists is False:
@@ -471,7 +490,8 @@ class ProfilePATCHTests(ProfileBaseTests):
 
         resp = self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
         assert resp.status_code == 200
-        assert mailgun_action.called
+        assert add_mailgun_action.called is True
+        assert del_mailgun_action.called is False
 
         profile.refresh_from_db()
         assert bool(profile.image) == image_already_exists

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -17,8 +17,9 @@ from rest_framework.fields import (
 )
 from rest_framework.serializers import ListSerializer
 from rest_framework.status import (
+    HTTP_200_OK,
     HTTP_405_METHOD_NOT_ALLOWED,
-    HTTP_404_NOT_FOUND
+    HTTP_404_NOT_FOUND,
 )
 from rest_framework.test import (
     APIClient,
@@ -307,7 +308,8 @@ class ProfilePATCHTests(ProfileBaseTests):
     """
     client_class = APIClient
 
-    def test_patch_own_profile(self):
+    @patch('mail.api.MailgunClient.toggle_mailing_list_subscription')
+    def test_patch_own_profile(self, mailgun_action):
         """
         A user PATCHes their own profile
         """
@@ -325,7 +327,8 @@ class ProfilePATCHTests(ProfileBaseTests):
         del patch_data['image']
 
         resp = self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
-        assert resp.status_code == 200
+        assert resp.status_code == HTTP_200_OK
+        assert mailgun_action.called
 
         old_profile = Profile.objects.get(user__username=self.user1.username)
         for key, value in patch_data.items():
@@ -339,7 +342,36 @@ class ProfilePATCHTests(ProfileBaseTests):
             else:
                 assert getattr(old_profile, key) == value
 
-    def test_serializer(self):
+    @patch('mail.api.MailgunClient.toggle_mailing_list_subscription')
+    def test_when_mailgun_fail(self, mailgun_action):
+        """
+        When user updates email optin but mailgun fail to response.
+        """
+        with mute_signals(post_save):
+            ProfileFactory.create(
+                user=self.user1,
+                filled_out=False,
+                agreed_to_terms_of_service=False,
+                email_optin=False
+
+            )
+        self.client.force_login(self.user1)
+
+        with mute_signals(post_save):
+            new_profile = ProfileFactory.create(filled_out=False, email_optin=True)
+        new_profile.user.social_auth.create(
+            provider=EdxOrgOAuth2.name,
+            uid="{}_edx".format(new_profile.user.username)
+        )
+        patch_data = ProfileSerializer(new_profile).data
+        del patch_data['image']
+
+        resp = self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
+        assert resp.status_code == HTTP_200_OK
+        assert mailgun_action.called
+
+    @patch('mail.api.MailgunClient.toggle_mailing_list_subscription')
+    def test_serializer(self, mailgun_action):
         """
         Get a user's own profile, ensure that we used ProfileSerializer and not ProfileFilledOutSerializer
         """
@@ -361,8 +393,10 @@ class ProfilePATCHTests(ProfileBaseTests):
             self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
         assert mocked.called
         assert not mocked_filled_out.called
+        assert mailgun_action.called is False
 
-    def test_filled_out_serializer(self):
+    @patch('mail.api.MailgunClient.toggle_mailing_list_subscription')
+    def test_filled_out_serializer(self, mailgun_action):
         """
         Get a user's own profile, ensure that we used ProfileFilledOutSerializer
         """
@@ -379,6 +413,7 @@ class ProfilePATCHTests(ProfileBaseTests):
         ) as mocked:
             self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
         assert mocked.called
+        assert mailgun_action.called is False
 
     def test_forbidden_methods(self):
         """
@@ -410,11 +445,12 @@ class ProfilePATCHTests(ProfileBaseTests):
         assert profile.education.count() == 1
         assert profile.work_history.count() == 1
 
+    @patch('mail.api.MailgunClient.toggle_mailing_list_subscription')
     @ddt.data(
         *itertools.product([True, False], [True, False])
     )
     @ddt.unpack
-    def test_no_thumbnail_change_if_image_upload(self, image_already_exists, thumb_already_exists):
+    def test_no_thumbnail_change_if_image_upload(self, image_already_exists, thumb_already_exists, mailgun_action):
         """
         A patch without an image upload should not touch the image or the thumbnail
         """
@@ -435,6 +471,7 @@ class ProfilePATCHTests(ProfileBaseTests):
 
         resp = self.client.patch(self.url1, content_type="application/json", data=json.dumps(patch_data))
         assert resp.status_code == 200
+        assert mailgun_action.called
 
         profile.refresh_from_db()
         assert bool(profile.image) == image_already_exists


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3917

#### What's this PR do?
- If email-optin is updated to False then it adds user to mailgun unsub list.
  - User  will not receive any email from MM mailgun address.
  - **Question:** Is discussion uses MM mailgun address? Should it be block?
-  If email-optin is updated to True then it removes user from mailgun unsub list.


#### How should this be manually tested?
**To enable/disable unsubscribes:**
- Enable unsubscription feature for your domain.
- Remove text in the html and text footer templates so they won’t be appended automatically.
- Insert a variable in the html and text bodies of your email when you need unsubscribe links.
- This variable will be replaced by the corresponding unsubscribe link.

https://documentation.mailgun.com/en/latest/user_manual.html#tracking-unsubscribes

**Also set the webhook:**
- `api/v0/mail/unsub_webhook/`

@pdpinch 

#### Screenshoot:
<img width="1231" alt="screen shot 2018-07-04 at 7 41 54 pm" src="https://user-images.githubusercontent.com/10431250/42283262-5c53106e-7fc2-11e8-8848-31a713c7e79e.png">

<img width="677" alt="screen shot 2018-07-04 at 7 42 34 pm" src="https://user-images.githubusercontent.com/10431250/42283277-6bae8a48-7fc2-11e8-9114-8bbfb4b6317e.png">
