### PR TITLE
Expose SESSION_COOKIE_NAME as env variable

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -156,6 +156,7 @@ AUTHENTICATION_BACKENDS = (
 )
 
 SESSION_ENGINE = get_string('SESSION_ENGINE', 'django.contrib.sessions.backends.signed_cookies')
+SESSION_COOKIE_NAME = get_string('SESSION_COOKIE_NAME', 'sessionid')
 
 EDXORG_BASE_URL = get_string('EDXORG_BASE_URL', 'https://courses.edx.org/')
 SOCIAL_AUTH_EDXORG_KEY = get_string('EDXORG_CLIENT_ID', '')


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4090

#### What's this PR do?
Lets set SESSION_COOKIE_NAME so that we can invalidate existing session cookies by changing the name.

#### How should this be manually tested?
Make sure nothing breaks.

