### PR TITLE
SESSION_ENGINE is not a required setting

### DIFF
--- a/app.json
+++ b/app.json
@@ -56,9 +56,6 @@
     "CYBERSOURCE_SECURITY_KEY": {
       "description": "CyberSource API key"
     },
-    "CYBERSOURCE_TRANSACTION_KEY": {
-      "description": "CyberSource transaction key"
-    },
     "EDXORG_BASE_URL": {
       "description": "The base URL of the edX instance to use for logging in.",
       "required": true

--- a/app.json
+++ b/app.json
@@ -56,6 +56,9 @@
     "CYBERSOURCE_SECURITY_KEY": {
       "description": "CyberSource API key"
     },
+    "CYBERSOURCE_TRANSACTION_KEY": {
+      "description": "CyberSource transaction key"
+    },
     "EDXORG_BASE_URL": {
       "description": "The base URL of the edX instance to use for logging in.",
       "required": true
@@ -240,6 +243,7 @@
     },
     "SESSION_ENGINE": {
       "description": "Django session engine",
+      "required": false
     },
     "STATUS_TOKEN": {
       "description": "Token to access the status API.",

--- a/app.json
+++ b/app.json
@@ -240,7 +240,6 @@
     },
     "SESSION_ENGINE": {
       "description": "Django session engine",
-      "required": true
     },
     "STATUS_TOKEN": {
       "description": "Token to access the status API.",


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

stops required SESSION_ENGINE for new apps

#### How should this be manually tested?

Does the review application for this PR build? Or, at least, does it fail somewhere else than on a missing value for SESSION_ENGINE?

