### PR TITLE
Remove call to ready()

### DIFF
--- a/grades/tasks.py
+++ b/grades/tasks.py
@@ -147,9 +147,7 @@ def freeze_course_run_final_grades(course_run_id):
         # extract the results from the id
         results = GroupResult.restore(group_results_id, app=app)
         # if the subtasks are not done, revoke them
-        if not results.ready():
-            log.error('freezing of users for course %s took more than one iteration', course_run.edx_course_key)
-            results.revoke()
+        results.revoke()
         # delete the results anyway
         results.delete()
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4063

#### What's this PR do?
Removes call to ready() to avoid `Never call result.get() within a task!`.
#### How should this be manually tested?
Pick a course run you are going to test with and set the freeze grades deadline to now. Enroll your user in the course run.
Create cached info:
```
from dashboard.factories import *
CachedEnrollmentFactory.create(user=user, course_run=course_run, verified=True)
CachedCurrentGradeFactory.create(user=user, course_run=course_run)
```
To check that your user is ready to be frozen run:
```
from grades.tasks import *
api.get_users_without_frozen_final_grade(course_run).values_list('id', flat=True)
```
Call the task:
```
freeze_course_run_final_grades.delay(course_run.id)
```
Check on the freezing status:
```
./manage.py check_final_grade_freeze_status <edx_course_key>
```
Make sure you can reproduce this error on master first. The error occurs on the second invocation of the task whenever `group_results_id is not None`.

To try this again don't forget to delete this:
```
CourseRunGradingStatus.objects.filter(course_run=course_run).delete()
```