### PR TITLE
Offer to pay after missed deadline

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -229,6 +229,7 @@ def get_info_for_course(course, mmtrack):
         "has_contact_email": bool(course.contact_email),
         "can_schedule_exam": is_exam_schedulable(mmtrack.user, course),
         "exams_schedulable_in_future": get_future_exam_runs(course),
+        "past_exam_date": get_past_recent_exam_run(course),
         "has_to_pay": has_to_pay_for_exam(mmtrack, course),
         "runs": [],
         "proctorate_exams_grades": ProctoredExamGradeSerializer(
@@ -508,6 +509,23 @@ def get_future_exam_runs(course):
 
     return (ExamRun.get_schedulable_in_future(course).
             order_by('date_first_schedulable').values_list('date_first_schedulable', flat=True))
+
+
+def get_past_recent_exam_run(course):
+    """
+    Return scheduling dates for a recent exam, example: 'Mar 7 - Mar 17, 2018'
+
+    Args:
+        course (courses.models.Course): A course
+
+    Returns:
+        str: a string representation of scheduling window for recent exam run
+    """
+    exam = ExamRun.get_schedulable_in_past(course).order_by('-date_last_schedulable').first()
+
+    return '{} - {}'.format(
+        exam.date_first_schedulable.strftime('%b %-d'), exam.date_last_schedulable.strftime('%b %-d, %Y')
+    ) if exam else ''
 
 
 def has_to_pay_for_exam(mmtrack, course):

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -905,6 +905,7 @@ class InfoCourseTest(CourseTests):
             "has_contact_email": bool(course.contact_email),
             "can_schedule_exam": can_schedule_exam,
             "exams_schedulable_in_future": exams_schedulable_in_future,
+            "past_exam_date": '',
             "has_to_pay": has_to_pay,
             "proctorate_exams_grades": proct_exams,
             "has_exam": has_exam,
@@ -1855,6 +1856,23 @@ class FutureExamRunsTests(MockedESTestCase):
         exam_run = ExamRunFactory.create(scheduling_past=is_past, scheduling_future=is_future)
 
         assert len(api.get_future_exam_runs(exam_run.course)) == result
+
+
+@ddt.ddt
+class PastExamRunTests(MockedESTestCase):
+    """Test for past schedulable exam run"""
+
+    @ddt.data(
+        (False, False, False),
+        (True, False, True),
+        (False, True, False),
+    )
+    @ddt.unpack
+    def test_get_past_exam_run(self, is_past, is_future, result):
+        """test get_past_recent_exam_run"""
+        exam_run = ExamRunFactory.create(scheduling_past=is_past, scheduling_future=is_future)
+
+        self.assertEqual(len(api.get_past_recent_exam_run(exam_run.course)) > 0, result)
 
 
 @ddt.ddt

--- a/exams/models.py
+++ b/exams/models.py
@@ -64,6 +64,23 @@ class ExamRun(TimestampedModel):
             self.exam_series_code
         )
 
+    @classmethod
+    def get_schedulable_in_past(cls, course):
+        """
+        Get a QuerySet with recently expired scheduling time
+
+        Args:
+            course (courses.models.Course): the course to find exam runs for
+
+        Returns:
+            django.db.models.query.QuerySet: A Queryset filtered to past exam runs
+        """
+        now = now_in_utc()
+        return cls.objects.filter(
+            course=course,
+            date_last_schedulable__lt=now
+        )
+
     @property
     def is_schedulable(self):
         """

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -420,6 +420,32 @@ class DashboardStates:  # pylint: disable=too-many-locals
             '--missed-deadline'
         )
 
+    def create_passed_missed_payment_for_exam(self, enrollable, future_exam):
+        """Passed course but missed deadline to pay to take exam"""
+        self.make_fa_program_enrollment(FinancialAidStatus.AUTO_APPROVED)
+        call_command(
+            "alter_data", 'set_past_run_to_passed', '--username', 'staff',
+            '--course-title', 'Digital Learning 200', '--grade', '87', '--audit',
+            '--missed-deadline'
+        )
+        course = Course.objects.get(title='Digital Learning 200')
+        ExamProfileFactory.create(status='success', profile=self.user.profile)
+        ExamRunFactory.create(course=course, eligibility_past=True, scheduling_past=True)
+
+        if enrollable:
+            course_run = CourseRunFactory.create(course=course, edx_course_key='course-enrollable')
+            call_command(
+                "alter_data", 'set_to_offered', '--username', 'staff',
+                '--course-run-key', course_run.edx_course_key
+            )
+        if future_exam:
+            ExamRunFactory.create(
+                scheduling_past=False,
+                scheduling_future=True,
+                authorized=True,
+                course=course
+            )
+
     def create_paid_enrolled_currently_with_future_run(self):
         """Make paid and enrolled with offered currently and a future run """
         self.make_fa_program_enrollment(FinancialAidStatus.AUTO_APPROVED)
@@ -497,6 +523,19 @@ class DashboardStates:  # pylint: disable=too-many-locals
         yield (self.create_passed_and_upgrade_deadline_past, 'passed_and_missed_deadline_and_fail_in_next')
         yield (self.create_failed_course_price_pending, 'failed_and_pending_price')
         yield (self.create_audited_passed_enrolled_again_failed, 'create_audited_passed_enrolled_again_failed')
+
+        for tup in itertools.product([True, False], repeat=2):
+            enrollable, future_exam = tup
+
+            yield (bind_args(
+                self.create_passed_missed_payment_for_exam,
+                enrollable=enrollable,
+                future_exam=future_exam
+            ),
+                   'create_passed_missed_payment_for_exam{enrollable}{future_exam}'.format(
+                       enrollable='_enrollable_run' if enrollable else '',
+                       future_exam='_future_exam' if future_exam else ''
+                   ))
 
         # Add scenarios for paid and course run offered [now, in future, fuzzy future]
         for tup in itertools.product([True, False], repeat=3):

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -70,6 +70,7 @@ const COURSE: Course = {
   runs:                        [],
   can_schedule_exam:           false,
   exams_schedulable_in_future: [],
+  past_exam_date:              "",
   has_to_pay:                  false,
   has_exam:                    false,
   proctorate_exams_grades:     [],

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -383,9 +383,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   } else if (hasMissedDeadlineCourseRun(course)) {
     //the course finished can't pay
     if (exams && course.past_exam_date) {
-      const futureExamMessage = R.isEmpty(
-        course.exams_schedulable_in_future
-      )
+      const futureExamMessage = R.isEmpty(course.exams_schedulable_in_future)
         ? " There are no future exams scheduled at this time. Please check back later."
         : ` You can pay now to take the next exam, scheduled for ${formatDate(
           course.exams_schedulable_in_future[0]

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -382,27 +382,43 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     return S.Just(messages)
   } else if (hasMissedDeadlineCourseRun(course)) {
     //the course finished can't pay
-    const date = run => formatDate(run.course_start_date)
-    const msg = run => {
-      return `You missed the payment deadline, but you can re-enroll. Next course starts ${date(
-        run
-      )}.${enrollmentDateMessage(run)}`
-    }
-    messages.push(
-      S.maybe(
-        {
-          message:
-            "You missed the payment deadline and will not receive MicroMasters credit for this course. " +
-            "There are no future runs of this course scheduled at this time."
-        },
-        run => ({
-          message: msg(run),
-          action:  courseAction(run, COURSE_ACTION_REENROLL)
-        }),
-        futureEnrollableRun(course)
+    if (exams && course.past_exam_date) {
+      const futureExamMessage = R.isEmpty(
+        course.exams_schedulable_in_future
       )
-    )
-    return S.Just(messages)
+        ? " There are no future exams scheduled at this time. Please check back later."
+        : ` You can pay now to take the next exam, scheduled for ${formatDate(
+          course.exams_schedulable_in_future[0]
+        )}.`
+
+      messages.push({
+        message:
+          "You passed the edX course but missed the payment deadline to take the proctored scheduled for " +
+          `${course.past_exam_date}.${futureExamMessage}`,
+        action: courseAction(firstRun, COURSE_ACTION_PAY)
+      })
+    } else {
+      const date = run => formatDate(run.course_start_date)
+      const msg = run => {
+        return `You missed the payment deadline, but you can re-enroll. Next course starts ${date(
+          run
+        )}.${enrollmentDateMessage(run)}`
+      }
+      messages.push(
+        S.maybe(
+          {
+            message:
+              "You missed the payment deadline and will not receive MicroMasters credit for this course. " +
+              "There are no future runs of this course scheduled at this time."
+          },
+          run => ({
+            message: msg(run),
+            action:  courseAction(run, COURSE_ACTION_REENROLL)
+          }),
+          futureEnrollableRun(course)
+        )
+      )
+    }
   }
   if (hasFailedCourseRun(course) && !hasPassedCourseRun(course)) {
     return S.Just(

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -725,6 +725,56 @@ describe("Course Status Messages", () => {
       ])
     })
 
+    it("should have a message for missing the payment deadline to take an exam", () => {
+      course.runs = [course.runs[0]]
+      makeRunPast(course.runs[0])
+      makeRunPassed(course.runs[0])
+      makeRunOverdue(course.runs[0])
+
+      course.has_exam = true
+      course.past_exam_date = "Mar 12 - Mar 22, 2018"
+
+      assertIsJust(calculateMessages(calculateMessagesProps), [
+        {
+          message:
+            "You passed the edX course but missed the payment deadline to take the proctored " +
+            `scheduled for ${course.past_exam_date}. There are no future exams scheduled at this ` +
+            "time. Please check back later.",
+          action: "course action was called"
+        }
+      ])
+      assert(
+        calculateMessagesProps.courseAction.calledWith(
+          course.runs[0],
+          COURSE_ACTION_PAY
+        )
+      )
+    })
+
+    it("should have a message for missing the payment deadline has future exam", () => {
+      course.runs = [course.runs[0]]
+      makeRunPast(course.runs[0])
+      makeRunPassed(course.runs[0])
+      makeRunOverdue(course.runs[0])
+
+      course.has_exam = true
+      course.past_exam_date = "Mar 12 - Mar 22, 2018"
+      course.exams_schedulable_in_future = [
+        moment()
+          .add(2, "day")
+          .format()
+      ]
+      assertIsJust(calculateMessages(calculateMessagesProps), [
+        {
+          message:
+            "You passed the edX course but missed the payment deadline to take the proctored " +
+            `scheduled for ${course.past_exam_date}. You can pay now to take the next exam, scheduled for ` +
+            `${formatDate(course.exams_schedulable_in_future[0])}.`,
+          action: "course action was called"
+        }
+      ])
+    })
+
     it("should nag about paying after the edx course is complete", () => {
       makeRunPast(course.runs[0])
       makeRunCanUpgrade(course.runs[0])

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -728,7 +728,7 @@ describe("Course Status Messages", () => {
     it("should have a message for missing the payment deadline to take an exam", () => {
       course.runs = [course.runs[0]]
       makeRunPast(course.runs[0])
-      makeRunPassed(course.runs[0])
+      makeRunMissedDeadline(course.runs[0])
       makeRunOverdue(course.runs[0])
 
       course.has_exam = true
@@ -754,7 +754,7 @@ describe("Course Status Messages", () => {
     it("should have a message for missing the payment deadline has future exam", () => {
       course.runs = [course.runs[0]]
       makeRunPast(course.runs[0])
-      makeRunPassed(course.runs[0])
+      makeRunMissedDeadline(course.runs[0])
       makeRunOverdue(course.runs[0])
 
       course.has_exam = true

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -92,6 +92,7 @@ export const makeCourse = (positionInProgram: number): Course => {
     title:                       `Title for course ${courseId}`,
     can_schedule_exam:           false,
     exams_schedulable_in_future: [],
+    past_exam_date:              "",
     has_to_pay:                  false,
     has_exam:                    false,
     proctorate_exams_grades:     [],

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -57,6 +57,7 @@ export type Course = {
   position_in_program:          number,
   can_schedule_exam:            boolean,
   exams_schedulable_in_future:  Array<string>,
+  past_exam_date:               string,
   has_to_pay:                   boolean,
   proctorate_exams_grades:      Array<ProctoredExamResult>,
   has_exam:                     boolean,


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #3680

#### What's this PR do?
Add new states for `missed-deadline` status if exams are present.

#### How should this be manually tested?
Run 
`scripts/test/run_snapshot_dashboard_states.sh --match "create_passed_missed_payment_for_exam"`
