### PR TITLE
Audited passed, then audited failed course

### DIFF
--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -36,7 +36,9 @@ import {
   userIsEnrolled,
   isOfferedInUncertainFuture,
   isPassedOrCurrentlyEnrolled,
-  notNilorEmpty, hasCanUpgradeCourseRun, hasMissedDeadlineCourseRun
+  notNilorEmpty,
+  hasCanUpgradeCourseRun,
+  hasMissedDeadlineCourseRun
 } from "./util"
 import {
   hasPassingExamGrade,
@@ -274,7 +276,10 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   }
 
   // handle other 'in-progress' cases
-  if (firstRun.status === STATUS_CAN_UPGRADE && courseUpcomingOrCurrent(firstRun)) {
+  if (
+    firstRun.status === STATUS_CAN_UPGRADE &&
+    courseUpcomingOrCurrent(firstRun)
+  ) {
     let message =
       "You are auditing. To get credit, you need to pay for the course."
     if (course.certificate_url) {
@@ -352,33 +357,33 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
         S.maybe(
           null,
           run => ({
-            message: `Next course starts ${formatDate(
-              run.course_start_date
-            )}.`,
-            action: courseAction(run, COURSE_ACTION_REENROLL)
+            message: `Next course starts ${formatDate(run.course_start_date)}.`,
+            action:  courseAction(run, COURSE_ACTION_REENROLL)
           }),
           futureEnrollableRun(course)
         )
       )
     }
     return S.Just(messages)
-  } else if (hasCanUpgradeCourseRun(course)) { //the course finished but can still pay
+  } else if (hasCanUpgradeCourseRun(course)) {
+    //the course finished but can still pay
     const dueDate = paymentDueDate.isValid()
       ? ` (Payment due on ${paymentDueDate.format(DASHBOARD_FORMAT)})`
       : ""
     if (exams) {
       messages.push({
         message: `The edX course is complete, but you need to pass the exam.${dueDate}`,
-        action: courseAction(firstRun, COURSE_ACTION_PAY)
+        action:  courseAction(firstRun, COURSE_ACTION_PAY)
       })
     } else {
       messages.push({
         message: `The edX course is complete, but you need to pay to get credit.${dueDate}`,
-        action: courseAction(firstRun, COURSE_ACTION_PAY)
+        action:  courseAction(firstRun, COURSE_ACTION_PAY)
       })
     }
     return S.Just(messages)
-  } else if (hasMissedDeadlineCourseRun(course)) { //the course finished can't pay
+  } else if (hasMissedDeadlineCourseRun(course)) {
+    //the course finished can't pay
     const date = run => formatDate(run.course_start_date)
     const msg = run => {
       return `You missed the payment deadline, but you can re-enroll. Next course starts ${date(
@@ -389,12 +394,12 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
       S.maybe(
         {
           message:
-          "You missed the payment deadline and will not receive MicroMasters credit for this course. " +
-          "There are no future runs of this course scheduled at this time."
+            "You missed the payment deadline and will not receive MicroMasters credit for this course. " +
+            "There are no future runs of this course scheduled at this time."
         },
         run => ({
           message: msg(run),
-          action: courseAction(run, COURSE_ACTION_REENROLL)
+          action:  courseAction(run, COURSE_ACTION_REENROLL)
         }),
         futureEnrollableRun(course)
       )
@@ -404,7 +409,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   if (hasFailedCourseRun(course) && !hasPassedCourseRun(course)) {
     return S.Just(
       S.maybe(
-        messages.concat({message: "You did not pass the edX course."}),
+        messages.concat({ message: "You did not pass the edX course." }),
         run =>
           messages.concat({
             message: `You did not pass the edX course, but you can re-enroll. ${courseStartMessage(

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -274,7 +274,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   }
 
   // handle other 'in-progress' cases
-  if (firstRun.status === STATUS_CAN_UPGRADE) {
+  if (firstRun.status === STATUS_CAN_UPGRADE && courseUpcomingOrCurrent(firstRun)) {
     let message =
       "You are auditing. To get credit, you need to pay for the course."
     if (course.certificate_url) {

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -17,7 +17,6 @@ import {
   COURSE_ACTION_REENROLL,
   FA_PENDING_STATUSES,
   FA_TERMINAL_STATUSES,
-  STATUS_MISSED_DEADLINE,
   STATUS_PAID_BUT_NOT_ENROLLED,
   STATUS_CAN_UPGRADE,
   COURSE_ACTION_CALCULATE_PRICE,
@@ -29,7 +28,6 @@ import {
 import { S } from "../../../lib/sanctuary"
 import {
   courseUpcomingOrCurrent,
-  isPassedOrMissedDeadline,
   hasFailedCourseRun,
   futureEnrollableRun,
   isEnrollableRun,

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -29,7 +29,7 @@ import {
   makeRunOverdue,
   makeRunDueSoon,
   makeRunFailed,
-  makeRunCanUpgrade
+  makeRunCanUpgrade, makeRunMissedDeadline
 } from "./test_util"
 import { assertIsJust } from "../../../lib/test_utils"
 import {
@@ -42,7 +42,7 @@ import {
   STATUS_PAID_BUT_NOT_ENROLLED,
   FA_STATUS_PENDING_DOCS,
   STATUS_MISSED_DEADLINE,
-  COURSE_ACTION_ENROLL
+  COURSE_ACTION_ENROLL, STATUS_CAN_UPGRADE
 } from "../../../constants"
 import * as libCoupon from "../../../lib/coupon"
 import { FINANCIAL_AID_PARTIAL_RESPONSE } from "../../../test_constants"
@@ -626,7 +626,7 @@ describe("Course Status Messages", () => {
 
     it("should nag about missing the payment deadline", () => {
       makeRunPast(course.runs[0])
-      makeRunPassed(course.runs[0])
+      makeRunMissedDeadline(course.runs[0])
       makeRunOverdue(course.runs[0])
       makeRunFuture(course.runs[1])
       course.runs[1].enrollment_start_date = moment()
@@ -690,7 +690,7 @@ describe("Course Status Messages", () => {
     ]) {
       it(`should nag about missing the payment deadline when future re-enrollments and date is ${nextEnrollmentStart[0]}`, () => {
         makeRunPast(course.runs[0])
-        makeRunPassed(course.runs[0])
+        makeRunMissedDeadline(course.runs[0])
         makeRunOverdue(course.runs[0])
         makeRunFuture(course.runs[1])
         course.runs[1].enrollment_start_date = nextEnrollmentStart[0]
@@ -713,7 +713,7 @@ describe("Course Status Messages", () => {
     it("should have a message for missing the payment deadline with no future courses", () => {
       course.runs = [course.runs[0]]
       makeRunPast(course.runs[0])
-      makeRunPassed(course.runs[0])
+      makeRunMissedDeadline(course.runs[0])
       makeRunOverdue(course.runs[0])
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
@@ -726,7 +726,7 @@ describe("Course Status Messages", () => {
 
     it("should nag about paying after the edx course is complete", () => {
       makeRunPast(course.runs[0])
-      makeRunPassed(course.runs[0])
+      makeRunCanUpgrade(course.runs[0])
       makeRunDueSoon(course.runs[0])
       const date = moment(course.runs[0].course_upgrade_deadline).format(
         DASHBOARD_FORMAT
@@ -747,7 +747,7 @@ describe("Course Status Messages", () => {
 
     it("should nag about paying after the edx course is complete with no deadline", () => {
       makeRunPast(course.runs[0])
-      makeRunPassed(course.runs[0])
+      makeRunCanUpgrade(course.runs[0])
 
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
@@ -766,7 +766,7 @@ describe("Course Status Messages", () => {
 
     it("should nag slightly differently if the course has an exam", () => {
       makeRunPast(course.runs[0])
-      makeRunPassed(course.runs[0])
+      makeRunCanUpgrade(course.runs[0])
       makeRunDueSoon(course.runs[0])
       course.has_exam = true
       const date = moment(course.runs[0].course_upgrade_deadline).format(
@@ -788,7 +788,7 @@ describe("Course Status Messages", () => {
 
     it("should nag slightly differently if the course has an exam with no deadline", () => {
       makeRunPast(course.runs[0])
-      makeRunPassed(course.runs[0])
+      makeRunCanUpgrade(course.runs[0])
       course.has_exam = true
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -43,8 +43,7 @@ import {
   STATUS_PAID_BUT_NOT_ENROLLED,
   FA_STATUS_PENDING_DOCS,
   STATUS_MISSED_DEADLINE,
-  COURSE_ACTION_ENROLL,
-  STATUS_CAN_UPGRADE
+  COURSE_ACTION_ENROLL
 } from "../../../constants"
 import * as libCoupon from "../../../lib/coupon"
 import { FINANCIAL_AID_PARTIAL_RESPONSE } from "../../../test_constants"

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -29,7 +29,8 @@ import {
   makeRunOverdue,
   makeRunDueSoon,
   makeRunFailed,
-  makeRunCanUpgrade, makeRunMissedDeadline
+  makeRunCanUpgrade,
+  makeRunMissedDeadline
 } from "./test_util"
 import { assertIsJust } from "../../../lib/test_utils"
 import {
@@ -42,7 +43,8 @@ import {
   STATUS_PAID_BUT_NOT_ENROLLED,
   FA_STATUS_PENDING_DOCS,
   STATUS_MISSED_DEADLINE,
-  COURSE_ACTION_ENROLL, STATUS_CAN_UPGRADE
+  COURSE_ACTION_ENROLL,
+  STATUS_CAN_UPGRADE
 } from "../../../constants"
 import * as libCoupon from "../../../lib/coupon"
 import { FINANCIAL_AID_PARTIAL_RESPONSE } from "../../../test_constants"

--- a/static/js/components/dashboard/courses/test_util.js
+++ b/static/js/components/dashboard/courses/test_util.js
@@ -6,7 +6,7 @@ import {
   STATUS_CURRENTLY_ENROLLED,
   STATUS_CAN_UPGRADE,
   STATUS_PASSED,
-  STATUS_NOT_PASSED
+  STATUS_NOT_PASSED, STATUS_MISSED_DEADLINE
 } from "../../../constants"
 
 export const makeRunCurrent = (run: CourseRun) => {
@@ -65,6 +65,10 @@ export const makeRunPaid = (run: CourseRun) => {
 
 export const makeRunPassed = (run: CourseRun) => {
   run.status = STATUS_PASSED
+}
+
+export const makeRunMissedDeadline = (run: CourseRun) => {
+  run.status = STATUS_MISSED_DEADLINE
 }
 
 export const makeRunFailed = (run: CourseRun) => {

--- a/static/js/components/dashboard/courses/test_util.js
+++ b/static/js/components/dashboard/courses/test_util.js
@@ -6,7 +6,8 @@ import {
   STATUS_CURRENTLY_ENROLLED,
   STATUS_CAN_UPGRADE,
   STATUS_PASSED,
-  STATUS_NOT_PASSED, STATUS_MISSED_DEADLINE
+  STATUS_NOT_PASSED,
+  STATUS_MISSED_DEADLINE
 } from "../../../constants"
 
 export const makeRunCurrent = (run: CourseRun) => {

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -85,6 +85,16 @@ export const isPassedOrCurrentlyEnrolled = R.compose(
   R.prop("status")
 )
 
+export const hasCanUpgradeCourseRun = R.compose(
+  R.any(R.propEq("status", STATUS_CAN_UPGRADE)),
+  R.prop("runs")
+)
+
+export const hasMissedDeadlineCourseRun = R.compose(
+  R.any(R.propEq("status", STATUS_MISSED_DEADLINE)),
+  R.prop("runs")
+)
+
 export const hasFailedCourseRun = R.compose(
   R.any(R.propEq("status", STATUS_NOT_PASSED)),
   R.prop("runs")

--- a/static/js/components/dashboard/courses/util_test.js
+++ b/static/js/components/dashboard/courses/util_test.js
@@ -16,7 +16,9 @@ import {
   hasEnrolledInAnyRun,
   hasPassedCourseRun,
   isEnrollableRun,
-  isOfferedInUncertainFuture
+  isOfferedInUncertainFuture,
+  hasMissedDeadlineCourseRun,
+  hasCanUpgradeCourseRun
 } from "./util"
 import {
   STATUS_PASSED,
@@ -257,6 +259,52 @@ describe("dashboard course utilities", () => {
 
     it("should return false otherwise", () => {
       assert.isFalse(hasFailedCourseRun(course))
+    })
+  })
+
+  describe("hasMissedDeadlineCourseRun", () => {
+    let course
+
+    beforeEach(() => {
+      course = makeCourse(0)
+    })
+
+    it("should return true if there is a missed course run", () => {
+      course.runs[0].status = STATUS_MISSED_DEADLINE
+      assert.isTrue(hasMissedDeadlineCourseRun(course))
+    })
+
+    it("should return true if there is a missed and failed course runs", () => {
+      course.runs[0].status = STATUS_NOT_PASSED
+      course.runs[1].status = STATUS_MISSED_DEADLINE
+      assert.isTrue(hasMissedDeadlineCourseRun(course))
+    })
+
+    it("should return false otherwise", () => {
+      assert.isFalse(hasMissedDeadlineCourseRun(course))
+    })
+  })
+
+  describe("hasCanUpgradeCourseRun", () => {
+    let course
+
+    beforeEach(() => {
+      course = makeCourse(0)
+    })
+
+    it("should return true if there is a missed course run", () => {
+      course.runs[0].status = STATUS_CAN_UPGRADE
+      assert.isTrue(hasCanUpgradeCourseRun(course))
+    })
+
+    it("should return true if there is a missed and failed course runs", () => {
+      course.runs[0].status = STATUS_NOT_PASSED
+      course.runs[1].status = STATUS_CAN_UPGRADE
+      assert.isTrue(hasCanUpgradeCourseRun(course))
+    })
+
+    it("should return false otherwise", () => {
+      assert.isFalse(hasCanUpgradeCourseRun(course))
     })
   })
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fix https://odl.zendesk.com/agent/tickets/20106

fixes #4117

#### What's this PR do?
Two main fixes:

- In the situation where user has passed a course but did not pay, the course run status is `CAN_UPGADE` or `MISSED_DEADLINE`. The existing code would only check for PASSED status, which happens only when user has paid.
- If a user passed a course and then failed it, the most recent one will be returned first, and the status messages would be calculated incorrectly for the overall status of the course.

The changes are made on the assumption that the backend returns status PASSED only for paid courses, and for any course run that is/was audited the status would be CAN_UPGRADE, MISSED_DEADLINE, or NOT_PASSED.

#### How should this be manually tested?
Run `scripts/test/run_snapshot_dashboard_states.sh`

