### PR TITLE
Update progress message for staff

### DIFF
--- a/static/js/components/dashboard/courses/ProgressMessage.js
+++ b/static/js/components/dashboard/courses/ProgressMessage.js
@@ -26,7 +26,9 @@ import {
   hasEnrolledInAnyRun,
   courseUpcomingOrCurrent,
   hasPaidForAnyCourseRun,
-  hasPassedCourseRun
+  hasPassedCourseRun,
+  hasCanUpgradeCourseRun,
+  hasMissedDeadlineCourseRun
 } from "./util"
 import { hasPassingExamGrade } from "../../../lib/grades"
 
@@ -81,6 +83,10 @@ export const staffCourseInfo = (courseRun: CourseRun, course: Course) => {
         return "Passed edX course, did not pass exam"
       }
       return "Passed"
+    } else if (hasCanUpgradeCourseRun(course)) {
+      return "Audited, passed, did not pay"
+    } else if (hasMissedDeadlineCourseRun(course)) {
+      return "Audited, passed, missed payment deadline"
     }
     if (courseRun.status === STATUS_NOT_PASSED) {
       if (hasPaidForAnyCourseRun(course)) {

--- a/static/js/components/dashboard/courses/ProgressMessage_test.js
+++ b/static/js/components/dashboard/courses/ProgressMessage_test.js
@@ -216,5 +216,26 @@ describe("Course ProgressMessage", () => {
         "Audited, did not pass"
       )
     })
+
+    it("should return Audited, passed, did not pay", () => {
+      makeRunPast(course.runs[0])
+      makeRunPast(course.runs[1])
+      course.runs[0].status = STATUS_NOT_PASSED
+      course.runs[1].status = STATUS_CAN_UPGRADE
+      assert.equal(
+        staffCourseInfo(course.runs[0], course),
+        "Audited, passed, did not pay"
+      )
+    })
+    it("should return Audited, passed, missed payment deadline", () => {
+      makeRunPast(course.runs[0])
+      makeRunPast(course.runs[1])
+      course.runs[0].status = STATUS_NOT_PASSED
+      course.runs[1].status = STATUS_MISSED_DEADLINE
+      assert.equal(
+        staffCourseInfo(course.runs[0], course),
+        "Audited, passed, missed payment deadline"
+      )
+    })
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #4116 
#### What's this PR do?
Updates the progress message to give appropriate message to auditing learners. When learner audited the course and passed it, the status of course run will never be `STATUS_PASSED`, the possible values can only be `STATUS_MISSED_DEADLINE` or `STATUS_CAN_UPGRADE`.

#### How should this be manually tested?
Create a passed audited course for user, and a failed audited course that is more recent. Similar to the selenium test in #4116. Look at the ProgressMessage from staff view. It should say that the user passed but did not pay for the course.

