### PR TITLE
Added html unescape to load raw html

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -3,6 +3,7 @@
 {% load i18n static %}
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
+{% load custom_tags %}
 
 {% block title %}{{ page.title }} MicroMasters{% endblock %}
 {% block description %}{% if page.program.description %}{{ page.program.description }}{% endif %}{% endblock %}
@@ -82,7 +83,7 @@
       <div class="mdl-cell mdl-cell--8-col">
       {% if active_tab == 'about' %}
         <div class="panel-content">
-          {{ page.description|richtext }}
+          {{ page.description|richtext_description }}
         </div>
       {% else %}
         <div class="panel-content">

--- a/cms/templatetags/custom_tags.py
+++ b/cms/templatetags/custom_tags.py
@@ -1,0 +1,26 @@
+"""
+cms custom filters
+"""
+from six.moves.html_parser import HTMLParser
+from django import template
+from django.utils.safestring import mark_safe
+
+from wagtail.core.rich_text import RichText, expand_db_html
+
+register = template.Library()
+
+
+@register.filter
+def richtext_description(value):
+    """
+    enables raw html on wagtail rich text
+    """
+    if isinstance(value, RichText):
+        # passing a RichText value through the |richtext filter should have no effect
+        return value
+    elif value is None:
+        html = ''
+    else:
+        html = expand_db_html(value)
+
+    return mark_safe('<div class="rich-text">' + HTMLParser().unescape(html) + '</div>')

--- a/cms/templatetags/custom_tags.py
+++ b/cms/templatetags/custom_tags.py
@@ -1,7 +1,7 @@
 """
 cms custom filters
 """
-from six.moves.html_parser import HTMLParser
+from html import unescape
 from django import template
 from django.utils.safestring import mark_safe
 
@@ -23,4 +23,4 @@ def richtext_description(value):
     else:
         html = expand_db_html(value)
 
-    return mark_safe('<div class="rich-text">' + HTMLParser().unescape(html) + '</div>')
+    return mark_safe('<div class="rich-text">' + unescape(html) + '</div>')


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/4119

#### What's this PR do?
- Allow raw html in rich text.

#### How should this be manually tested?
(Required)

@pdpinch 
#### Screenshots (if appropriate)
<img width="1160" alt="screen shot 2018-08-30 at 7 59 48 pm" src="https://user-images.githubusercontent.com/10431250/44860273-4acc3d80-ac8f-11e8-8877-4b3006c1cceb.png">

<img width="567" alt="screen shot 2018-08-30 at 7 59 53 pm" src="https://user-images.githubusercontent.com/10431250/44860274-4b64d400-ac8f-11e8-8728-b672a33a9b26.png">

