### PR TITLE
add search and filter to coupon admin

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -103,6 +103,17 @@ class CouponInvoiceAuditAdmin(admin.ModelAdmin):
 class CouponAdmin(admin.ModelAdmin):
     """Admin for Coupon"""
     model = Coupon
+    search_fields = (
+        'coupon_code',
+        'invoice__invoice_number',
+        'invoice__description',
+    )
+    list_filter = [
+        'invoice',
+        'enabled',
+        'coupon_type',
+        'amount_type',
+    ]
 
     def save_model(self, request, obj, form, change):
         """


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

adds search and filter to the coupon admin. 

I wish I could add searching and filtering by course title, but that was going to require research that I didn't have time for. 

#### How should this be manually tested?

Make a couple of coupons. Take a look at /admin/ecommerce/coupon

#### Any background context you want to provide?

I'm adding this so that when the DEDP team gives me a list of coupon codes to disable, I can search for them easily. 

