### PR TITLE
add search and filter to profile admin; use raw id instead of drop-down

### DIFF
--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -28,4 +28,4 @@ class ProfileAdmin(admin.ModelAdmin):
     ]
     raw_id_fields = ('user',)
 
-admin.site.register(Profile,ProfileAdmin)
+admin.site.register(Profile, ProfileAdmin)

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -6,4 +6,26 @@ from django.contrib import admin
 
 from .models import Profile
 
-admin.site.register(Profile)
+
+class ProfileAdmin(admin.ModelAdmin):
+    """Admin for Profile"""
+    model = Profile
+    list_display = [
+        'user',
+        'first_name',
+        'last_name',
+        'email_optin',
+    ]
+    search_fields = [
+        'user__username',
+        'user__email',
+        'first_name',
+        'last_name',
+    ]
+    list_filter = [
+        'email_optin',
+        'user__is_active',
+    ]
+    raw_id_fields = ('user',)
+
+admin.site.register(Profile,ProfileAdmin)


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

adds search and filter to the coupon admin. 

I wish I could add searching and filtering by course title, but that was going to require research that I didn't have time for. 

#### How should this be manually tested?

Take a look at /admin/profiles/profile/ -- it should:
- [x] have a search field, that supports searching by name, username or email
- [x] display first name, last name and email_optin status of each profile
- [x] open a profile; instead of a drop-down for the user foreign key, it should just display the id

#### Any background context you want to provide?

This will make it easier to find learner's profiles, particularly when they need to be manually opted out of email. 
