### PR TITLE
Oauth maintenance page on login

### DIFF
--- a/app.json
+++ b/app.json
@@ -187,7 +187,8 @@
     },
     "OAUTH_MAINTENANCE_MODE": {
       "description": "If true, on login redirects to a static page with message",
-      "value": "false"
+      "value": "False",
+      "required": false
     },
     "OPEN_DISCUSSIONS_API_USERNAME": {
       "description": "The username to use for authentication Open Discussions",

--- a/app.json
+++ b/app.json
@@ -185,6 +185,10 @@
       "description": "If false, disables the node_modules cache to fix yarn install",
       "value": "false"
     },
+    "OAUTH_MAINTENANCE_MODE": {
+      "description": "If true, on login redirects to a static page with message",
+      "value": "false"
+    },
     "OPEN_DISCUSSIONS_API_USERNAME": {
       "description": "The username to use for authentication Open Discussions",
       "required": false

--- a/backends/urls.py
+++ b/backends/urls.py
@@ -23,7 +23,7 @@ urlpatterns = [
     # authentication / association
 
     url(r'^login/(?P<backend>[^/]+){0}$'.format(extra),
-        RedirectView.as_view(url='/oauth_maintenance') if settings.OAUTH_MAINTENANCE_MODE else views.auth,
+        RedirectView.as_view(pattern_name='oauth_maintenance') if settings.OAUTH_MAINTENANCE_MODE else views.auth,
         name='begin'),
     # disconnection
     url(r'^disconnect/(?P<backend>[^/]+){0}$'.format(extra), views.disconnect,

--- a/backends/urls.py
+++ b/backends/urls.py
@@ -1,5 +1,6 @@
 """URLs module"""
 from django.conf.urls import url
+from django.conf import settings
 
 from social_django import views
 from social_django.urls import (  # pylint: disable=unused-import
@@ -8,6 +9,7 @@ from social_django.urls import (  # pylint: disable=unused-import
 )
 
 from backends.views import complete
+from ui.views import aouth_maintenance
 
 
 # These four endpoints were originally copied from social_django.urls. 'complete' is a modified view which
@@ -19,7 +21,9 @@ urlpatterns = [
 
     # These three go to views in social_core
     # authentication / association
-    url(r'^login/(?P<backend>[^/]+){0}$'.format(extra), views.auth,
+
+    url(r'^login/(?P<backend>[^/]+){0}$'.format(extra),
+        aouth_maintenance if settings.OAUTH_MAINTENANCE_MODE else views.auth,
         name='begin'),
     # disconnection
     url(r'^disconnect/(?P<backend>[^/]+){0}$'.format(extra), views.disconnect,

--- a/backends/urls.py
+++ b/backends/urls.py
@@ -1,6 +1,7 @@
 """URLs module"""
 from django.conf.urls import url
 from django.conf import settings
+from django.views.generic import RedirectView
 
 from social_django import views
 from social_django.urls import (  # pylint: disable=unused-import
@@ -9,7 +10,6 @@ from social_django.urls import (  # pylint: disable=unused-import
 )
 
 from backends.views import complete
-from ui.views import aouth_maintenance
 
 
 # These four endpoints were originally copied from social_django.urls. 'complete' is a modified view which
@@ -23,7 +23,7 @@ urlpatterns = [
     # authentication / association
 
     url(r'^login/(?P<backend>[^/]+){0}$'.format(extra),
-        aouth_maintenance if settings.OAUTH_MAINTENANCE_MODE else views.auth,
+        RedirectView.as_view(url='/oauth_maintenance') if settings.OAUTH_MAINTENANCE_MODE else views.auth,
         name='begin'),
     # disconnection
     url(r'^disconnect/(?P<backend>[^/]+){0}$'.format(extra), views.disconnect,

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -186,6 +186,8 @@ LOGIN_REDIRECT_URL = '/dashboard'
 LOGIN_URL = '/'
 LOGIN_ERROR_URL = '/'
 
+OAUTH_MAINTENANCE_MODE = get_bool('OAUTH_MAINTENANCE_MODE', False)
+
 ROOT_URLCONF = 'micromasters.urls'
 
 TEMPLATES = [

--- a/ui/templates/oauth_maintenance.html
+++ b/ui/templates/oauth_maintenance.html
@@ -1,0 +1,14 @@
+{% extends "base_error.html" %}
+{% load i18n static %}
+
+{% block title %}{% trans "MITx MicroMasters" %}{% endblock %}
+
+{% block error_header %}
+CURRENTLY UNAVAILABLE
+{% endblock %}
+
+{% block error_content %}
+<div id="page-not-found">
+	<p>MicroMasters login is unavailable now. Please try again later today.</p>
+</div>
+{% endblock %}

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -16,7 +16,7 @@ from ui.views import (
     page_500,
     BackgroundImagesCSSView,
     need_verified_email,
-)
+    oauth_maintenance)
 from certificates.views import CourseCertificateView, ProgramCertificateView
 
 dashboard_urlpatterns = [
@@ -29,6 +29,7 @@ urlpatterns = [
     url(r'^404/$', page_404, name='ui-404'),
     url(r'^500/$', page_500, name='ui-500'),
     url(r'^verify-email/$', need_verified_email, name='verify-email'),
+    url(r'^oauth_maintenance/$', oauth_maintenance, name='oauth_maintenance'),
     url(r'^learner/(?P<user>[-\w.]+)?/?', UsersView.as_view(), name='ui-users'),
     url(r'^certificate/course/(?P<certificate_hash>[-\w.]+)?/?', CourseCertificateView.as_view(), name='certificate'),
     url(r'^certificate/program/(?P<certificate_hash>[-\w.]+)?/?', ProgramCertificateView.as_view(),

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
     url(r'^404/$', page_404, name='ui-404'),
     url(r'^500/$', page_500, name='ui-500'),
     url(r'^verify-email/$', need_verified_email, name='verify-email'),
-    url(r'^oauth_maintenance/$', oauth_maintenance, name='oauth_maintenance'),
+    url(r'^oauth_maintenance/(?P<backend>[^/]+)/$', oauth_maintenance, name='oauth_maintenance'),
     url(r'^learner/(?P<user>[-\w.]+)?/?', UsersView.as_view(), name='ui-users'),
     url(r'^certificate/course/(?P<certificate_hash>[-\w.]+)?/?', CourseCertificateView.as_view(), name='certificate'),
     url(r'^certificate/program/(?P<certificate_hash>[-\w.]+)?/?', ProgramCertificateView.as_view(),

--- a/ui/views.py
+++ b/ui/views.py
@@ -188,6 +188,13 @@ def need_verified_email(request, *args, **kwargs):  # pylint: disable=unused-arg
     return standard_error_page(request, 401, "verify_email.html")
 
 
+def aouth_maintenance(request, *args, **kwargs):
+    """
+    Returns maintenance page during oauth downtime
+    """
+    return standard_error_page(request, 503, "oauth_maintenance.html")
+
+
 class BackgroundImagesCSSView(TemplateView):
     """
     Pass a CSS file through Django's template system, so that we can make

--- a/ui/views.py
+++ b/ui/views.py
@@ -188,11 +188,11 @@ def need_verified_email(request, *args, **kwargs):  # pylint: disable=unused-arg
     return standard_error_page(request, 401, "verify_email.html")
 
 
-def aouth_maintenance(request, *args, **kwargs):  # pylint: disable=unused-argument
+def oauth_maintenance(request, *args, **kwargs):  # pylint: disable=unused-argument
     """
     Returns maintenance page during oauth downtime
     """
-    return standard_error_page(request, 503, "oauth_maintenance.html")
+    return standard_error_page(request, 200, "oauth_maintenance.html")
 
 
 class BackgroundImagesCSSView(TemplateView):

--- a/ui/views.py
+++ b/ui/views.py
@@ -188,7 +188,7 @@ def need_verified_email(request, *args, **kwargs):  # pylint: disable=unused-arg
     return standard_error_page(request, 401, "verify_email.html")
 
 
-def aouth_maintenance(request, *args, **kwargs):
+def aouth_maintenance(request, *args, **kwargs):  # pylint: disable=unused-argument
     """
     Returns maintenance page during oauth downtime
     """


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4131

#### What's this PR do?
If the flag `OAUTH_MAINTENANCE_MODE ` is on redirect to a page with the message.

#### How should this be manually tested?
Set env var `OAUTH_MAINTENANCE_MODE` and try to login.

![screen shot 2018-09-11 at 2 38 41 pm](https://user-images.githubusercontent.com/7574259/45380526-e97e6580-b5d0-11e8-9da2-b515ec7dea34.png)
