### PR TITLE
improve certificates admin

### DIFF
--- a/grades/admin.py
+++ b/grades/admin.py
@@ -79,8 +79,13 @@ class ProctoredExamGradeAuditAdmin(admin.ModelAdmin):
 class MicromastersCourseCertificateAdmin(admin.ModelAdmin):
     """Admin for MicromastersCourseCertificate"""
     model = models.MicromastersCourseCertificate
-    list_display = ('id', 'user_username', 'course', 'hash')
+    list_display = ('id', 'user_username', 'course', 'hash', 'created_on')
     list_filter = ('course', )
+    raw_id_fields = ('user',)
+    search_fields = (
+        'user__username',
+        'user__email',
+    )
 
     def user_username(self, obj):  # pylint: disable=missing-docstring
         return obj.user.username


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

Adds an admin for MicromastersCourseCertificate

#### How should this be manually tested?

- create some course certificates
- checkout the admin at /admin/grades/micromasterscoursecertificate/
- the list view should include the username and creation date
- you should be able to filter on course name
- you should be able to search on email address or username

