### PR TITLE
Added student id on learners page for staff only use

### DIFF
--- a/static/js/components/LearnerInfoCard.js
+++ b/static/js/components/LearnerInfoCard.js
@@ -22,6 +22,12 @@ const showLegalNameIfStaff = profile => {
   ) : null
 }
 
+const showIdIfStaff = profile => {
+  return hasAnyStaffRole(SETTINGS.roles) ? (
+    <div className="student-id">{`(Student Id: ${profile.student_id})`}</div>
+  ) : null
+}
+
 export default class LearnerInfoCard extends React.Component {
   props: {
     profile: Profile,
@@ -129,6 +135,7 @@ export default class LearnerInfoCard extends React.Component {
           <div className="col user-info">
             <div className="profile-title">{getPreferredName(profile)}</div>
             {showLegalNameIfStaff(profile)}
+            {showIdIfStaff(profile)}
             <div className="profile-company-name">
               {mstr(getEmployer(profile))}
             </div>

--- a/static/js/components/LearnerInfoCard_test.js
+++ b/static/js/components/LearnerInfoCard_test.js
@@ -122,6 +122,28 @@ describe("LearnerInfoCard", () => {
     assert.equal(wrapper.find(".legal-name").text(), "(Legal name: FIRST LAST)")
   })
 
+  it("should not show student id if the user is not staff", () => {
+    const wrapper = renderInfoCard()
+    assert.equal(wrapper.find(".student-id").length, 0)
+  })
+
+  it("should show student id if the user is staff", () => {
+    SETTINGS.user.username = "My user"
+    SETTINGS.roles = [
+      {
+        role:    "staff",
+        program: 1
+      }
+    ]
+    const wrapper = renderInfoCard({
+      profile: {
+        ...USER_PROFILE_RESPONSE,
+        student_id: 123
+      }
+    })
+    assert.equal(wrapper.find(".student-id").text(), "(Student Id: 123)")
+  })
+
   describe("email link", () => {
     const originalUsername = SETTINGS.user.username
 

--- a/static/scss/user-page.scss
+++ b/static/scss/user-page.scss
@@ -7,7 +7,7 @@
     font-weight: 400;
   }
 
-  .legal-name {
+  .legal-name, .student-id {
     font-size: 13px;
     color: $font-gray-light;
     margin-top: 15px;


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/4113

#### What's this PR do?
- Displays student id on learners profile page for staff only.

#### How should this be manually tested?
- Login as staff and view profile of learner
- Login as student and view profile

@pdpinch 

#### Screenshots (if appropriate)
<img width="997" alt="screen shot 2018-10-03 at 2 20 50 pm" src="https://user-images.githubusercontent.com/10431250/46402827-41187880-c71a-11e8-869c-43b9ae25ae36.png">

