### PR TITLE
Set discussions JWT cookie max age

### DIFF
--- a/discussions/views.py
+++ b/discussions/views.py
@@ -34,6 +34,7 @@ def _set_jwt_cookie(response, token):
     response.set_cookie(
         settings.OPEN_DISCUSSIONS_COOKIE_NAME,
         token,
+        max_age=settings.OPEN_DISCUSSIONS_JWT_EXPIRES_DELTA,
         domain=settings.OPEN_DISCUSSIONS_COOKIE_DOMAIN,
         httponly=True
     )


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4154

#### What's this PR do?
Set max age for discussions JWT cookie.

#### How should this be manually tested?
Make sure the cookie expiry is set correctly.
