### PR TITLE
make the missed payment deadline message work for all learners

### DIFF
--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -391,7 +391,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
 
       messages.push({
         message:
-          "You passed the edX course but missed the payment deadline to take the proctored scheduled for " +
+          "You missed the payment deadline to take the proctored exam scheduled for " +
           `${course.past_exam_date}.${futureExamMessage}`,
         action: courseAction(firstRun, COURSE_ACTION_PAY)
       })

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -737,7 +737,7 @@ describe("Course Status Messages", () => {
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
           message:
-            "You missed the payment deadline to take the proctored exam scheduled for " +
+            "You missed the payment deadline to take the proctored exam " +
             `scheduled for ${course.past_exam_date}. There are no future exams scheduled at this ` +
             "time. Please check back later.",
           action: "course action was called"
@@ -767,7 +767,7 @@ describe("Course Status Messages", () => {
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
           message:
-            "You missed the payment deadline to take the proctored exam scheduled for " +
+            "You missed the payment deadline to take the proctored exam " +
             `scheduled for ${course.past_exam_date}. You can pay now to take the next exam, scheduled for ` +
             `${formatDate(course.exams_schedulable_in_future[0])}.`,
           action: "course action was called"

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -737,7 +737,7 @@ describe("Course Status Messages", () => {
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
           message:
-            "You passed the edX course but missed the payment deadline to take the proctored " +
+            "You missed the payment deadline to take the proctored exam scheduled for " +
             `scheduled for ${course.past_exam_date}. There are no future exams scheduled at this ` +
             "time. Please check back later.",
           action: "course action was called"
@@ -767,7 +767,7 @@ describe("Course Status Messages", () => {
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
           message:
-            "You passed the edX course but missed the payment deadline to take the proctored " +
+            "You missed the payment deadline to take the proctored exam scheduled for " +
             `scheduled for ${course.past_exam_date}. You can pay now to take the next exam, scheduled for ` +
             `${formatDate(course.exams_schedulable_in_future[0])}.`,
           action: "course action was called"


### PR DESCRIPTION
#### What are the relevant tickets?

none yet

#### What's this PR do?

- adds a word that was missing from the dashboard message
- makes the message work for all learners, whether or not they've passed the course

#### How should this be manually tested?

- waiting on a new dashboard test state from @annagav 

#### Screenshots (if appropriate)

- Needs a screenshot

