### PR TITLE
Skip payment when user has paid via coupon

### DIFF
--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -64,8 +64,8 @@ export default class CourseAction extends React.Component {
   }
 
   redirectToOrderSummary(run: CourseRun): void {
-    const { hasFinancialAid, checkout } = this.props
-    if (hasFinancialAid) {
+    const { hasFinancialAid, checkout, coupon } = this.props
+    if (hasFinancialAid && !(coupon && isFreeCoupon(coupon))) {
       const url = `/order_summary/?course_key=${encodeURIComponent(
         run.course_id
       )}`


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/4160

#### What's this PR do?
(Required)

#### How should this be manually tested?
- Create current course
- Enroll/audit course
- Click pay now button. it should apply coupon.

#### Screenshots (if appropriate)
<img width="799" alt="screen shot 2018-11-07 at 5 28 48 pm" src="https://user-images.githubusercontent.com/10431250/48131695-c7445380-e2b2-11e8-878f-809449e92b4f.png">
