### PR TITLE
fix css issue on dashboard gradding popup

### DIFF
--- a/static/scss/dashboard/grade-detail-popup.scss
+++ b/static/scss/dashboard/grade-detail-popup.scss
@@ -17,7 +17,7 @@
     }
 
     .status {
-      display: inline;
+      display: inline-block;
     }
 
     .best-grade {


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/4158

#### What's this PR do?
Fix padding issue on grad popup

#### How should this be manually tested?
* Add couple of proctor exam grads
* Click on exam grads from dashboard

#### Screenshots (if appropriate)
<img width="944" alt="screen shot 2018-11-15 at 5 18 57 pm" src="https://user-images.githubusercontent.com/4245618/48552589-d94d7400-e8fa-11e8-8eed-43902034383c.png">

