### PR TITLE
add coupon message on dashboard

### DIFF
--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -196,6 +196,7 @@ export default class CourseRow extends React.Component {
             courseAction={this.courseAction}
             hasFinancialAid={hasFinancialAid}
             firstRun={run}
+            coupon={this.getCourseCoupon()}
           />
         ) : null}
       </div>

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -160,6 +160,8 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     R.defaultTo("", firstRun.course_upgrade_deadline)
   )
 
+  const messages = []
+
   //If first run is paid but user never enrolled, most likely there was
   //problem enrolling, and first_unexpired_run is returned, so no need to check for past enrollment
   if (firstRun.status === STATUS_PAID_BUT_NOT_ENROLLED) {
@@ -189,34 +191,34 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     ])
   }
 
+  if (
+    coupon &&
+    coupon.content_type === COUPON_CONTENT_TYPE_COURSE &&
+    coupon.object_id === course.id
+  ) {
+    messages.push({ message: makeCouponMessage(coupon) })
+  }
+
   // User never enrolled
   if (!R.any(userIsEnrolled, course.runs)) {
     if (isEnrollableRun(firstRun)) {
-      return S.Just([
-        {
-          message: `${courseStartMessage(firstRun)}`,
-          action:  courseAction(firstRun, COURSE_ACTION_ENROLL)
-        }
-      ])
+      messages.push({
+        message: `${courseStartMessage(firstRun)}`,
+        action:  courseAction(firstRun, COURSE_ACTION_ENROLL)
+      })
     } else if (
       firstRun.fuzzy_start_date &&
       isOfferedInUncertainFuture(firstRun)
     ) {
-      return S.Just([
-        {
-          message: `${courseStartMessage(firstRun)}`
-        }
-      ])
+      messages.push({
+        message: `${courseStartMessage(firstRun)}`
+      })
     } else {
-      return S.Just([
-        {
-          message: "There are no future course runs scheduled."
-        }
-      ])
+      messages.push({
+        message: "There are no future course runs scheduled."
+      })
     }
   }
-
-  const messages = []
 
   if (course.certificate_url) {
     messages.push({
@@ -263,14 +265,6 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     !exams
   ) {
     return S.Just(messages)
-  }
-
-  if (
-    coupon &&
-    coupon.content_type === COUPON_CONTENT_TYPE_COURSE &&
-    coupon.object_id === course.id
-  ) {
-    messages.push({ message: makeCouponMessage(coupon) })
   }
 
   // handle other 'in-progress' cases

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -1,6 +1,7 @@
 // @flow
 /* global SETTINGS: false */
 import _ from "lodash"
+import Decimal from "decimal.js-light"
 import React from "react"
 import { shallow } from "enzyme"
 import { assert } from "chai"
@@ -38,6 +39,7 @@ import {
   COURSE_ACTION_CALCULATE_PRICE,
   COURSE_ACTION_REENROLL,
   COUPON_CONTENT_TYPE_COURSE,
+  COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT,
   DASHBOARD_FORMAT,
   COURSE_DEADLINE_FORMAT,
   STATUS_PAID_BUT_NOT_ENROLLED,
@@ -174,6 +176,23 @@ describe("Course Status Messages", () => {
       ])
       assert.isTrue(makeAmountMessageStub.calledWith(coupon))
       assert.isTrue(makeCouponTargetMessageStub.calledWith(coupon))
+    })
+
+    it("should display 'You will receive 100% off' message", () => {
+      const program = makeProgram()
+      const coupon = makeCoupon(program)
+      coupon.content_type = COUPON_CONTENT_TYPE_COURSE
+      coupon.object_id = program.courses[0].id
+      coupon.amount_type = COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT
+      coupon.amount = Decimal("1")
+      calculateMessagesProps.course = program.courses[0]
+      calculateMessagesProps.coupon = coupon
+      const messages = calculateMessages(calculateMessagesProps).value
+
+      assert.equal(
+        messages[0]["message"],
+        "You will get 100% off the cost for this course."
+      )
     })
 
     it("should nag unpaid auditors to pay", () => {


### PR DESCRIPTION
#### What are the relevant tickets?
fixes [4177](https://github.com/mitodl/micromasters/issues/4177)

#### What's this PR do?
Add coupon message on dashboard.

#### How should this be manually tested?

- Create a coupon for a course in MM admin
- Apply coupon and you will see the message.
- For details about coupons please see https://github.com/mitodl/micromasters/pull/4181

#### Screenshots (if appropriate)
**Dashboard without message**
<img width="780" alt="48415780-553d9580-e71c-11e8-9128-b345182c57eb" src="https://user-images.githubusercontent.com/4245618/48693713-2e8bcd00-ebfc-11e8-941a-39af2e864616.png">

**Dashboard with message**
<img width="887" alt="screen shot 2018-11-19 at 12 54 03 pm" src="https://user-images.githubusercontent.com/4245618/48693656-fe442e80-ebfb-11e8-813e-fb458912f11e.png">
