### PR TITLE
Handle users who are inactive or have no profiles during populate_query_memberships

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -278,16 +278,17 @@ def _search_percolate_queries(program_enrollment):
     conn = get_conn()
     percolate_index = get_default_alias(PERCOLATE_INDEX_TYPE)
     doc = serialize_program_enrolled_user(program_enrollment)
-    if doc:
-        # We don't need this to search for percolator queries and
-        # it causes a dynamic mapping failure so we need to remove it
-        del doc['_id']
-        result = conn.percolate(percolate_index, GLOBAL_DOC_TYPE, body={"doc": doc})
-        failures = result.get('_shards', {}).get('failures', [])
-        if len(failures) > 0:
-            raise PercolateException("Failed to percolate: {}".format(failures))
-        return [int(row['_id']) for row in result['matches']]
-    return []
+    if not doc:
+        return []
+    # We don't need this to search for percolator queries and
+    # it causes a dynamic mapping failure so we need to remove it
+    del doc['_id']
+    result = conn.percolate(percolate_index, GLOBAL_DOC_TYPE, body={"doc": doc})
+    failures = result.get('_shards', {}).get('failures', [])
+    if len(failures) > 0:
+        raise PercolateException("Failed to percolate: {}".format(failures))
+    return [int(row['_id']) for row in result['matches']]
+
 
 
 def adjust_search_for_percolator(search):

--- a/search/api.py
+++ b/search/api.py
@@ -290,7 +290,6 @@ def _search_percolate_queries(program_enrollment):
     return [int(row['_id']) for row in result['matches']]
 
 
-
 def adjust_search_for_percolator(search):
     """
     Returns an updated Search which can be used with percolator.

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -14,6 +14,7 @@ from django.db.models.signals import post_save
 from courses.factories import ProgramFactory
 from dashboard.models import ProgramEnrollment
 from dashboard.factories import ProgramEnrollmentFactory
+from micromasters.factories import UserFactory
 from profiles.factories import ProfileFactory
 from roles.models import Role
 from roles.roles import Staff
@@ -476,3 +477,27 @@ class PercolateTests(ESTestCase):
             membership = PercolateQueryMembership.objects.get(user=profile.user, query=query)
             assert membership.is_member is query_matches
             assert membership.needs_update is True
+
+    @ddt.data(*product(
+        [True, False],
+        [True, False]
+    ))
+    @ddt.unpack
+    def test_populate_query_inactive_memberships(self, is_active, has_profile, mock_on_commit):
+        """
+        Tests that memberships are handled correctly for users who are inactive or have no profiles
+        """
+        with mute_signals(post_save):
+            query = PercolateQueryFactory.create(source_type=PercolateQuery.DISCUSSION_CHANNEL_TYPE)
+            user = UserFactory.create(is_active=is_active)
+            if has_profile:
+                ProfileFactory.create(user=user, filled_out=True)
+            ProgramEnrollmentFactory.create(user=user)
+
+        with patch('search.api.get_conn') as es_mock:
+            populate_query_memberships(query.id)
+            assert es_mock.return_value.percolate.call_count == (1 if has_profile and is_active else 0)
+
+        assert PercolateQueryMembership.objects.filter(user=user, query=query).count() == (
+            1 if is_active else 0
+        )

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -478,10 +478,12 @@ class PercolateTests(ESTestCase):
             assert membership.is_member is query_matches
             assert membership.needs_update is True
 
-    @ddt.data(*product(
+    @ddt.data(
         [True, False],
-        [True, False]
-    ))
+        [True, True],
+        [False, True],
+        [False, False]
+    )
     @ddt.unpack
     def test_populate_query_inactive_memberships(self, is_active, has_profile, mock_on_commit):
         """

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -473,6 +473,7 @@ def serialize_program_enrolled_user(program_enrollment):
     try:
         serialized['profile'] = filter_current_work(ProfileSerializer(user.profile).data)
     except Profile.DoesNotExist:
+        log.exception('User %s has no profile', user.username)
         return None
 
     serialized['program'] = UserProgramSearchSerializer.serialize(program_enrollment)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #4188 

#### What's this PR do?
Modifies `search.api.populate_query_memberships` to skip inactive users.
Modifies `search.api._search_percolate_queries` to gracefully handle users with missing profiles
Modifies `search.indexing_api.serialize_program_enrolled_user` to log an exception if a user has no profile.

#### How should this be manually tested?
For a given program, inactivate a user and add a user without a profile or delete the profile of an existing user in the program.
Create a new channel for the program.  The channel should be created successfully, with all contributors and moderators added (minus inactive user and user without profile).
You can also run the `populate_query_memberships` manually for the channel's `PercolateQuery` and make sure it finishes successfully.