### PR TITLE
Fix exam messages when user has failed and passed course runs

### DIFF
--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -75,7 +75,7 @@ def bind_args(func, *args, **kwargs):
     return lambda: func(*args, **kwargs)
 
 
-class DashboardStates:  # pylint: disable=too-many-locals
+class DashboardStates:  # pylint: disable=too-many-locals, too-many-public-methods
     """Runs through each dashboard state taking a snapshot"""
     def __init__(self, user=None):
         """

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -722,8 +722,6 @@ def test_dashboard_states(browser, override_allowed_hosts, seeded_database_loade
                     Role.objects.create(role=Staff.ROLE_ID, user=dashboard_states.user, program=program)
             filename = make_filename(num, name, output_directory=output_directory, use_mobile=use_mobile)
             new_url = run_scenario()
-            # import pdb
-            # pdb.set_trace()
             if new_url is None:
                 if use_learner_page:
                     new_url = '/learner'

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -33,10 +33,10 @@ import {
   isEnrollableRun,
   userIsEnrolled,
   isOfferedInUncertainFuture,
-  isPassedOrCurrentlyEnrolled,
   notNilorEmpty,
   hasCanUpgradeCourseRun,
-  hasMissedDeadlineCourseRun
+  hasMissedDeadlineCourseRun,
+  hasCurrentlyEnrolledCourseRun
 } from "./util"
 import {
   hasPassingExamGrade,
@@ -305,7 +305,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   }
 
   //Exam messages only
-  if (isPassedOrCurrentlyEnrolled(firstRun) && exams && paid) {
+  if ((hasPassedCourseRun(course) || hasCurrentlyEnrolledCourseRun(course)) && exams && paid) {
     let message
     if (!passedExam) {
       message = failedExam

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -305,7 +305,11 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   }
 
   //Exam messages only
-  if ((hasPassedCourseRun(course) || hasCurrentlyEnrolledCourseRun(course)) && exams && paid) {
+  if (
+    (hasPassedCourseRun(course) || hasCurrentlyEnrolledCourseRun(course)) &&
+    exams &&
+    paid
+  ) {
     let message
     if (!passedExam) {
       message = failedExam

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -80,9 +80,9 @@ export const isPassedOrMissedDeadline = R.compose(
   R.prop("status")
 )
 
-export const isPassedOrCurrentlyEnrolled = R.compose(
-  R.contains(R.__, [STATUS_PASSED, STATUS_CURRENTLY_ENROLLED]),
-  R.prop("status")
+export const hasCurrentlyEnrolledCourseRun = R.compose(
+  R.any(R.propEq("status", STATUS_CURRENTLY_ENROLLED)),
+  R.prop("runs")
 )
 
 export const hasCanUpgradeCourseRun = R.compose(


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4192

#### What's this PR do?
In the first ticket of the issue the user had a passed and failed course runs, where the failed course run appears first in the api response. `StatusMessages` logic was based on the first course run to provide appropriate messages.
This PR changes the logic to be checking for any passing course runs to offer information about exams.
#### How should this be manually tested?
Run the test
```scripts/test/run_snapshot_dashboard_states.sh --match "two_no_show_exam_attempts"```
Before:
<img width="684" alt="screen shot 2019-01-18 at 1 30 14 pm" src="https://user-images.githubusercontent.com/7574259/51406858-5201c400-1b28-11e9-8e71-916507b59472.png">
After:
<img width="638" alt="screen shot 2019-01-18 at 1 29 48 pm" src="https://user-images.githubusercontent.com/7574259/51406878-5c23c280-1b28-11e9-8755-0e00ecdca3f9.png">



