### PR TITLE
update Readme to reference edX docker devstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ need to use Django admin for the next step anyway.
 - **In Django admin**
 
     Run the server (discussed in step 2) and navigate to Django admin
-### change this URL
-    (eg: http://192.168.33.10:8000/admin). In the **Authentication and Authorization**
+    (eg: http://localhost:18000/admin/). In the **Authentication and Authorization**
     section, select a **User**, or add one then select it. In the **Permissions**
     section, check the **Superuser status** box and save.
 
@@ -77,20 +76,15 @@ need to use Django admin for the next step anyway.
 
 Open Django admin (see "In Django admin" in the previous step),
 login as the user you chose in the previous step,
-### check/change this URL
-navigate to the Django OAuth Toolkit section (/admin/oauth2_provider/),
+navigate to the Django OAuth Toolkit section (http://localhost:18000/admin/oauth2_provider/),
 and add a new Application. Fill in the values as follows:
 
 - **User**: Use the lookup (magnifying glass) to find your superuser from the previous step.
-- **Redirect uris**: The URL where MicroMaster’s will be running, followed by "/complete/edxorg/".
-### check/change these URLs
- **Linux users:** the MicroMaster’s URL will be `http://localhost:8079`. **OSX users:** The MicroMaster's
- IP can be found by running ``docker-machine ip <machine_name>`` from the host machine. MicroMaster’s runs on port
- ``8079`` by default, so the full URL should be something like
- ``http://192.168.99.100:8079/complete/edxorg/``
+- **Redirect uris**: `http://localhost:8079` should work for Linux and MacOS users
 - **Client type**: Set to '_Confidential_'.
 - **Authorization grant type**: Set to '_Authorization Code_'.
 - **Name**: Anything you want. Something like 'mm-local' would do fine here.
+- **Skip authorization**: Check this box to mimic the UX in production.
 
 #### 5) Copy relevant values to use in the MicroMasters .env file
 
@@ -99,10 +93,11 @@ a template to create your ``.env`` file. For MicroMasters to work, it needs 4 va
 
 - ``EDXORG_BASE_URL``
 
-### check/change these URLs
-    The base URL where the LMS server is running on your machine. When running in Vagrant, this 
-    _should_ be ``http://192.168.33.10:8000``. The Vagrant VM IP is hard-coded in the Vagrantfile, and 
-    it's unlikely that edX will change that. The LMS server runs on port ``8000`` by default.
+    The base URL where the LMS server is running on your machine. 
+    **Linux Users** use ``http://localhost:18000``, 
+    **MacOS Users** The MicroMasters container won't be able to reach the LMS container without a name. Use 
+    ``http://edx.devstack.lms:18000`` and make sure `edx.devstack.lms` is configured to point to 127.0.0.1 in your
+   `/etc/hosts` file.  The LMS server runs on port ``18000`` by default.
     
 - ``EDXORG_CLIENT_ID`` and ``EDXORG_CLIENT_SECRET``
 

--- a/README.md
+++ b/README.md
@@ -26,40 +26,28 @@ likely need to run it locally for other projects in the future.
 
 #### 1) Install edX
 
-Download the edX Vagrant box according to
-[these instructions provided by edX](https://edx-installing-configuring-and-running.readthedocs.io/en/latest/installation/devstack/install_devstack.html#installing-devstack-with-a-direct-vagrant-box-download)
-
-*NOTE: edX now maintains a [Docker-based solution](https://github.com/edx/devstack) for running Open edX, and they have stopped supporting the Vagrant solution. We have not yet done the work necessary to properly
-integrate MicroMasters with Open edX running on Docker in a development context, so Vagrant is still recommended here*
+Download and install the edX Docker containers according to [these instructions provided by 
+edX](https://edx-installing-configuring-and-running.readthedocs.io/en/latest/installation/install_devstack.html)
 
 #### 2) Connect to the VM and run the LMS server
 
 edX has [instructions for this as well](https://edx-installing-configuring-and-running.readthedocs.io/en/latest/installation/devstack/start_devstack.html#connect-to-devstack-vm).
 More concisely, these are the commands you should run to connect to the VM and run the LMS server:
 
-    # In your local edx_devstack/ directory, start the VM
-    vagrant up
-    # Once that's done, ssh into the running VM
-    vagrant ssh
-    # Switch to the edxapp account within SSH session
-    sudo su edxapp
-    # Run the LMS server
-    paver devstack lms
-    # To run the server without updating requirements and compiling assets, add the '--fast' parameter
-    # eg: paver devstack --fast lms
-
-A few notes:
-
-- Switching to the edxapp account sources the edxapp environment and sets the
- current working directory to the edx-platform repository.
-- "LMS" stands for "Learning Management System". The Open edX platform has
- [several different components](http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/architecture.html#overview);
- MicroMaster's only depends on LMS.
+    # In your local edx_devstack/ directory, checkout the master branch of devstack
+    git checkout master
+    # assuming you want to run the master branch of edX, check it out
+    make dev.checkout
+    # update devstack, just in case:
+    make down
+    make pull
+    make dev.up
 
 #### 3) Configure a user with superuser permissions
 
-edX devstack ships with [several test users](https://openedx.atlassian.net/wiki/spaces/OXA/pages/157751033/What+are+the+default+accounts+and+passwords) (there
-is also an `edx` user not listed in this wiki, already configured as a superuser). To keep things
+edX devstack ships with [several test 
+users](https://openedx.atlassian.net/wiki/spaces/OXA/pages/157751033/What+are+the+default+accounts+and+passwords) 
+(there is also an `edx` user not listed in this wiki, already configured as a superuser). To keep things
 simple, it is **highly** recommended that for your main MicroMasters login you use (a) the `edx` superuser, or (b) 
 one of the other test users and manually set superuser permissions. Setting superuser permissions can be done
 in Django admin or in a shell. It's preferable to do it in Django admin as you'll
@@ -68,6 +56,7 @@ need to use Django admin for the next step anyway.
 - **In Django admin**
 
     Run the server (discussed in step 2) and navigate to Django admin
+### change this URL
     (eg: http://192.168.33.10:8000/admin). In the **Authentication and Authorization**
     section, select a **User**, or add one then select it. In the **Permissions**
     section, check the **Superuser status** box and save.
@@ -88,11 +77,13 @@ need to use Django admin for the next step anyway.
 
 Open Django admin (see "In Django admin" in the previous step),
 login as the user you chose in the previous step,
+### check/change this URL
 navigate to the Django OAuth Toolkit section (/admin/oauth2_provider/),
 and add a new Application. Fill in the values as follows:
 
 - **User**: Use the lookup (magnifying glass) to find your superuser from the previous step.
 - **Redirect uris**: The URL where MicroMaster’s will be running, followed by "/complete/edxorg/".
+### check/change these URLs
  **Linux users:** the MicroMaster’s URL will be `http://localhost:8079`. **OSX users:** The MicroMaster's
  IP can be found by running ``docker-machine ip <machine_name>`` from the host machine. MicroMaster’s runs on port
  ``8079`` by default, so the full URL should be something like
@@ -108,6 +99,7 @@ a template to create your ``.env`` file. For MicroMasters to work, it needs 4 va
 
 - ``EDXORG_BASE_URL``
 
+### check/change these URLs
     The base URL where the LMS server is running on your machine. When running in Vagrant, this 
     _should_ be ``http://192.168.33.10:8000``. The Vagrant VM IP is hard-coded in the Vagrantfile, and 
     it's unlikely that edX will change that. The LMS server runs on port ``8000`` by default.
@@ -121,7 +113,7 @@ a template to create your ``.env`` file. For MicroMasters to work, it needs 4 va
 
 #### General edX devstack debugging notes
 
-- To update your devstack with important changes from edX, run `vagrant provision` in
+- To update your devstack with important changes from edX, run `make dev.provision` in
 your edx_devstack directory. This will pull down the latest release and run migrations, among
 other things.
 - If you get an error related to Mongo locking while ssh'ed into the Vagrant VM, run the following

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ navigate to the Django OAuth Toolkit section (http://localhost:18000/admin/oauth
 and add a new Application. Fill in the values as follows:
 
 - **User**: Use the lookup (magnifying glass) to find your superuser from the previous step.
-- **Redirect uris**: `http://localhost:8079` should work for Linux and MacOS users
+- **Redirect uris**: The URL where MicroMaster’s will be running, followed by "/complete/edxorg/". 
+  `http://localhost:8079/complete/edxorg/` should work for Linux and MacOS users
 - **Client type**: Set to '_Confidential_'.
 - **Authorization grant type**: Set to '_Authorization Code_'.
 - **Name**: Anything you want. Something like 'mm-local' would do fine here.

--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ a template to create your ``.env`` file. For MicroMasters to work, it needs 4 va
 - To update your devstack with important changes from edX, run `make dev.provision` in
 your edx_devstack directory. This will pull down the latest release and run migrations, among
 other things.
-- If you get an error related to Mongo locking while ssh'ed into the Vagrant VM, run the following
- **as the default 'vagrant' user, NOT as the 'edxapp' user**:
+- If you get an error related to Mongo locking, run the following in the lms container
 
        function mongo_unlock {
            sudo rm /edx/var/mongo/mongodb/mongod.lock

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ and add a new Application. Fill in the values as follows:
 
 - **User**: Use the lookup (magnifying glass) to find your superuser from the previous step.
 - **Redirect uris**: The URL where MicroMaster’s will be running, followed by "/complete/edxorg/". 
-  `http://localhost:8079/complete/edxorg/` should work for Linux and MacOS users
+  `http://localhost:8079/complete/edxorg/` should work for Linux and OSX users
 - **Client type**: Set to '_Confidential_'.
 - **Authorization grant type**: Set to '_Authorization Code_'.
 - **Name**: Anything you want. Something like 'mm-local' would do fine here.
@@ -96,7 +96,7 @@ a template to create your ``.env`` file. For MicroMasters to work, it needs 4 va
 
     The base URL where the LMS server is running on your machine. 
     **Linux Users** use ``http://localhost:18000``, 
-    **MacOS Users** The MicroMasters container won't be able to reach the LMS container without a name. Use 
+    **OSX Users** The MicroMasters container won't be able to reach the LMS container without a name. Use 
     ``http://edx.devstack.lms:18000`` and make sure `edx.devstack.lms` is configured to point to 127.0.0.1 in your
    `/etc/hosts` file.  The LMS server runs on port ``18000`` by default.
     
@@ -106,6 +106,17 @@ a template to create your ``.env`` file. For MicroMasters to work, it needs 4 va
     **Client id:** and **Client secret:** values should be auto-generated for
     that new Application. Use those values for the corresponding ``EDXORG_``
     variables in the ``.env`` file.
+
+#### 6) [OSX] Connect the MicroMasters web container to the edX devstack network
+
+MicroMasters containers and edX docker devstack containers run on separate networks. We need MicroMasters to be able
+to connect to the lms application to complete oauth authentication. Run the following command to add the MM web
+container to the devstack network:
+
+- ``docker network connect devstack_default micromasters_web_1``
+
+Unless we can find a way to add this to docker-compose.yml, you'll have to run this command every time you 
+start the MicroMasters containers. 
 
 #### General edX devstack debugging notes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,8 +100,3 @@ services:
     ports:
         - "2022:22"
     command: odl:123:1001:1001:results,results/topvue
-
-networks:
-  default:
-    external:
-      name: devstack_default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,3 +100,8 @@ services:
     ports:
         - "2022:22"
     command: odl:123:1001:1001:results,results/topvue
+
+networks:
+  default:
+    external:
+      name: devstack_default


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #4178 

#### What's this PR do?

Updates the ReadMe to reference edX docker devstack instead of Vagrant devstack. 

I wasn't able to find a wholly satisfying solution to bridging the MicroMasters docker network to the edX devstack docker network. 

Also, I believe the instructions now will work for Linux and for OSX. They might be simplified even further if we can find a setting for `EDX_BASE_URL` that works for both. 

#### How should this be manually tested?

Follow the instructions. I tested this on MacOS. They should probably be tested by someone using MacOS and someone using Linux. If it's possible to standardize on one set of instructions that works for both, that would be desirable.