### PR TITLE
show signup dialog on start

### DIFF
--- a/static/js/entry/public.js
+++ b/static/js/entry/public.js
@@ -83,6 +83,11 @@ const openDialog = () => store.dispatch(setDialogVisibility(true))
 
 const nodes = [...document.querySelectorAll(".open-signup-dialog")]
 
+const url = new URL(window.location.href)
+if (url.searchParams.get("next")) {
+  openDialog()
+}
+
 nodes.forEach(signUpButton => {
   signUpButton.onclick = openDialog
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #4248 

#### What's this PR do?
Show login dialog at the start, if user is not logged in.

#### How should this be manually tested?

- Logout from micromaster
- Hit any of the following URLs, you will see login/signup popup.
  - http://0.0.0.0:8079/dashboard
  - http://0.0.0.0:8079/learners
- Signup will not be shown on home page 
  - https://0.0.0.0:8079