### PR TITLE
fix `next` parameter issue for /discussions

### DIFF
--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -45,9 +45,10 @@ def update_profile_from_edx(backend, user, response, is_new, *args, **kwargs):
     else:
         next_relative_url = "/dashboard"
 
-    next_url = backend.strategy.session.get('next')
+    next_url = backend.strategy.session.load().get('next') or backend.strategy.session.get('next')
     if not next_url:
         next_url = next_relative_url
+
     backend.strategy.session_set('next', next_url)
 
     user_profile_edx = kwargs.get('edx_profile')

--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -45,7 +45,7 @@ def update_profile_from_edx(backend, user, response, is_new, *args, **kwargs):
     else:
         next_relative_url = "/dashboard"
 
-    next_url = backend.strategy.session.load().get('next')
+    next_url = backend.strategy.session.get('next')
     if not next_url:
         next_url = next_relative_url
     backend.strategy.session_set('next', next_url)

--- a/backends/pipeline_api_test.py
+++ b/backends/pipeline_api_test.py
@@ -265,6 +265,7 @@ class EdxPipelineApiTest(MockedESTestCase):
         student = UserFactory.create()
         mock_strategy = mock.Mock()
         mock_strategy.session.load.return_value = {}
+        mock_strategy.session.get.return_value = {}
         backend = edxorg.EdxOrgOAuth2(strategy=mock_strategy)
         pipeline_api.update_profile_from_edx(backend, student, {}, False, **{'edx_profile': self.mocked_edx_profile})
         mock_strategy.session_set.assert_called_with('next', '/dashboard')
@@ -278,6 +279,7 @@ class EdxPipelineApiTest(MockedESTestCase):
             Role.objects.create(user=user, role=role, program=ProgramFactory.create())
             mock_strategy = mock.Mock()
             mock_strategy.session.load.return_value = {}
+            mock_strategy.session.get.return_value = {}
             backend = edxorg.EdxOrgOAuth2(strategy=mock_strategy)
             pipeline_api.update_profile_from_edx(backend, user, {}, False, **{'edx_profile': self.mocked_edx_profile})
             mock_strategy.session_set.assert_called_with('next', '/learners')
@@ -290,6 +292,20 @@ class EdxPipelineApiTest(MockedESTestCase):
         next_url = "/x/y?a=bc"
         mock_strategy = mock.Mock()
         mock_strategy.session.load.return_value = {"next": next_url}
+        mock_strategy.session.get.return_value = {}
+        backend = edxorg.EdxOrgOAuth2(strategy=mock_strategy)
+        pipeline_api.update_profile_from_edx(backend, student, {}, False, **{'edx_profile': self.mocked_edx_profile})
+        mock_strategy.session_set.assert_called_with('next', next_url)
+
+    def test_login_redirect_next_for_user_already_logged_in(self):
+        """
+        A student should be directed to what's in the next query parameter if user is already logged in to MM.
+        """
+        student = UserFactory.create()
+        next_url = "/discussion"
+        mock_strategy = mock.Mock()
+        mock_strategy.session.load.return_value = {}
+        mock_strategy.session.get.return_value = next_url
         backend = edxorg.EdxOrgOAuth2(strategy=mock_strategy)
         pipeline_api.update_profile_from_edx(backend, student, {}, False, **{'edx_profile': self.mocked_edx_profile})
         mock_strategy.session_set.assert_called_with('next', next_url)

--- a/backends/views.py
+++ b/backends/views.py
@@ -18,12 +18,14 @@ def complete(request, *args, **kwargs):
     # social_core can get confused on which User should get the SocialAuth object.
     if request.user.is_authenticated:
         key = "{}_state".format(request.backend.name)
+        redirect_url = request.session.get("next")
         backend_state = request.session.get(key)
         logout(request)
         # logout will clear the session, this preserves the backend session state. We need to do
         # this so that this workflow will validate correctly (EdxOrgOAuth2.validate_state).
         # key is the same one used in EdxOrgAuth2.get_session_state().
         request.session[key] = backend_state
+        request.session["next"] = redirect_url
 
     # Continue with social_core pipeline
     social_complete_rtn = social_complete(request, *args, **kwargs)

--- a/discussions/views.py
+++ b/discussions/views.py
@@ -58,7 +58,7 @@ def discussions_token(request):
     return response
 
 
-@login_required(login_url="/login/edxorg/")
+@login_required
 def discussions_redirect(request):
     """
     View for setting discussions JWT token and redirecting to discussions

--- a/discussions/views.py
+++ b/discussions/views.py
@@ -58,7 +58,7 @@ def discussions_token(request):
     return response
 
 
-@login_required
+@login_required(login_url="/login/edxorg/")
 def discussions_redirect(request):
     """
     View for setting discussions JWT token and redirecting to discussions


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #4190 

#### What's this PR do?
User will redirect to correct `next` url even if they are already logged in to MM.

#### How should this be manually tested?
* Log out of discussions, micromasters, and edx
* navigate to `/login/edxorg/?next=/discussions/` in micromasters
* entering credentials in edx
  you should be redirected to discussions (via micromasters)
* Now, with active logged-in sessions, navigate _again_ to  `/login/edxorg/?next=/discussions/` in micromasters, again you should redirected to `/discussion`

