### PR TITLE
add search, filter and fields to order admin list view

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -37,8 +37,18 @@ class LineAdmin(admin.ModelAdmin):
 class OrderAdmin(admin.ModelAdmin):
     """Admin for Order"""
     model = Order
+    list_filter = ('status',) # 'get_course_key')
+    list_display =('id','user','status','created_at','course_key',)
+    search_fields = (
+        'user__username',
+        'user__email',
+    )
 
     readonly_fields = [name for name in get_field_names(Order) if name != 'status']
+
+    def course_key(self, obj):
+        line = obj.line_set.first()
+        return line.course_key
 
     def has_add_permission(self, request):
         return False

--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -37,8 +37,8 @@ class LineAdmin(admin.ModelAdmin):
 class OrderAdmin(admin.ModelAdmin):
     """Admin for Order"""
     model = Order
-    list_filter = ('status',) # 'get_course_key')
-    list_display =('id','user','status','created_at','course_key',)
+    list_filter = ('status',)
+    list_display = ('id', 'user', 'status', 'created_at', 'course_key',)
     search_fields = (
         'user__username',
         'user__email',

--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -47,6 +47,9 @@ class OrderAdmin(admin.ModelAdmin):
     readonly_fields = [name for name in get_field_names(Order) if name != 'status']
 
     def course_key(self, obj):
+        """
+        returns first course key associated with order
+        """
         line = obj.line_set.first()
         return line.course_key
 


### PR DESCRIPTION
#### What are the relevant tickets?

None

#### What's this PR do?

on the order admin you can now:
- search by username and email
- filter by status
- view creation date, course key 

#### How should this be manually tested?

go to /admin/ecommerce/order and search on a username or email. 

