### PR TITLE
Show Created Date in Grade Records

### DIFF
--- a/certificates/views.py
+++ b/certificates/views.py
@@ -150,7 +150,7 @@ class GradeRecordView(TemplateView):
                 "attempts": mmtrack.get_course_proctorate_exam_results(course).count(),
                 "letter_grade": convert_to_letter(combined_grade.grade) if combined_grade else "",
                 "status": "Earned" if get_certificate_url(mmtrack, course) else "Not Earned",
-                "date_earned": combined_grade.updated_on if combined_grade else "",
+                "date_earned": combined_grade.created_on if combined_grade else "",
                 "overall_grade": mmtrack.get_overall_final_grade_for_course(course)
             })
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4260

#### What's this PR do?
Change the `Date Earned` date in the learner record to be the created date.

#### How should this be manually tested?

![screen shot 2019-01-25 at 9 40 17 am](https://user-images.githubusercontent.com/7574259/53425658-6ea8db80-39b3-11e9-9d08-e4a10070286e.png)
