### PR TITLE
Fixed logic for program commendation letter creation

### DIFF
--- a/grades/api.py
+++ b/grades/api.py
@@ -257,7 +257,6 @@ def generate_program_letter(user, program):
         user (User): a Django user.
         program (programs.models.Program): program where the user is enrolled.
     """
-
     if program.financial_aid_availability:
         log.error('Congratulation letter is only available for non-financial aid programs.')
         return
@@ -266,14 +265,11 @@ def generate_program_letter(user, program):
         log.info('User [%s] already has a letter for program [%s]', user, program)
         return
 
-    program_course_ids = set(program.course_set.all().values_list('id', flat=True))
+    mmtrack = get_mmtrack(user, program)
+    courses_passed = mmtrack.count_courses_passed()
+    program_course_count = program.course_set.count()
 
-    num_courses_with_cert = MicromastersCourseCertificate.objects.filter(
-        user=user,
-        course_id__in=program_course_ids
-    ).values_list('course__id', flat=True).distinct().count()
-
-    if len(program_course_ids) > num_courses_with_cert:
+    if courses_passed < program_course_count:
         return
 
     MicromastersProgramCommendation.objects.create(user=user, program=program)

--- a/grades/management/commands/generate_program_letter.py
+++ b/grades/management/commands/generate_program_letter.py
@@ -1,5 +1,5 @@
 """
-Find all users those have completed the non-FA program and create letters
+Finds users that have passed all courses in non-FA programs and generates commendation letters for them
 """
 from django.core.management import BaseCommand
 
@@ -10,9 +10,9 @@ from grades.api import generate_program_letter
 
 class Command(BaseCommand):
     """
-    Finds all users, those have completed non-FA programs and generate letter for them
+    Finds users that have passed all courses in non-FA programs and generates commendation letters for them.
     """
-    help = "Finds all users those have completed the non-FA program and generate letter for them."
+    help = "Finds users that have passed all courses in non-FA programs and generates commendation letters for them."
 
     def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
         programs = Program.objects.filter(live=True, financial_aid_availability=False)

--- a/grades/signals.py
+++ b/grades/signals.py
@@ -20,18 +20,6 @@ def handle_create_coursecertificate(sender, instance, created, **kwargs):  # pyl
         transaction.on_commit(lambda: generate_program_certificate(user, program))
 
 
-@receiver(post_save, sender=MicromastersCourseCertificate, dispatch_uid="coursecertificate_post_save_for_letters")
-def handle_for_createprogram_letters(sender, instance, created, **kwargs):  # pylint: disable=unused-argument
-    """
-    When a MicromastersCourseCertificate model is created
-    """
-    if created:
-        user = instance.user
-        program = instance.course.program
-        if not program.financial_aid_availability:
-            transaction.on_commit(lambda: generate_program_letter(user, program))
-
-
 @receiver(post_save, sender=ProctoredExamGrade, dispatch_uid="examgrade_post_save")
 def handle_create_exam_grade(sender, instance, created, **kwargs):  # pylint: disable=unused-argument
     """
@@ -45,4 +33,12 @@ def handle_create_final_grade(sender, instance, created, **kwargs):  # pylint: d
     """
     When a FinalGrade model is created or updated
     """
-    transaction.on_commit(lambda: update_or_create_combined_final_grade(instance.user, instance.course_run.course))
+    def _on_transaction_commit():
+        """If either are applicable, update/create combined final grade and generate program letter"""
+        user = instance.user
+        course = instance.course_run.course
+        update_or_create_combined_final_grade(user, course)
+        if created and not course.program.financial_aid_availability:
+            generate_program_letter(instance.user, course.program)
+
+    transaction.on_commit(_on_transaction_commit)

--- a/grades/signals_test.py
+++ b/grades/signals_test.py
@@ -6,10 +6,11 @@ from unittest.mock import patch
 from django.db.models.signals import post_save
 from factory.django import mute_signals
 
-from courses.factories import CourseFactory
+from courses.factories import CourseFactory, CourseRunFactory
 from grades.factories import (
     MicromastersCourseCertificateFactory,
     ProctoredExamGradeFactory,
+    FinalGradeFactory,
 )
 from profiles.factories import ProfileFactory
 from search.base import MockedESTestCase
@@ -41,18 +42,6 @@ class CourseCertificateTests(MockedESTestCase):
         cert.save()
         generate_program_cert_mock.assert_called_once_with(self.user, course.program)
 
-    @patch('grades.signals.generate_program_letter', autospec=True)
-    def test_create_program_letter(self, generate_program_letter_mock, mock_on_commit):
-        """
-        Test that generate_program_letter is called when a course
-        certificate is created
-        """
-        course = CourseFactory.create()
-        cert = MicromastersCourseCertificateFactory.create(user=self.user, course=course)
-        generate_program_letter_mock.assert_called_once_with(self.user, course.program)
-        cert.save()
-        generate_program_letter_mock.assert_called_once_with(self.user, course.program)
-
 
 # pylint: disable=unused-argument
 @patch('search.signals.transaction.on_commit', side_effect=lambda callback: callback())
@@ -82,3 +71,39 @@ class ProctoredExamGradesTests(MockedESTestCase):
         # create another exam grade for a different exam run
         ProctoredExamGradeFactory.create(user=self.user, course=self.course)
         assert update_grade_mock.call_count == 3
+
+
+# pylint: disable=unused-argument
+@patch('search.signals.transaction.on_commit', side_effect=lambda callback: callback())
+@patch('grades.signals.update_or_create_combined_final_grade', autospec=True)
+@patch('grades.signals.generate_program_letter', autospec=True)
+class FinalGradeTests(MockedESTestCase):
+    """
+    Test signals for final grade creation
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        with mute_signals(post_save):
+            cls.user = ProfileFactory.create().user
+
+    def test_create_final_grade_fa(self, generate_letter_mock, update_grade_mock, mock_on_commit):
+        """
+        Test that final grades created for non-FA courses will try to update combined final grades.
+        """
+        fa_course_run = CourseRunFactory.create(course__program__financial_aid_availability=True)
+        FinalGradeFactory.create(user=self.user, course_run=fa_course_run, grade=0.9)
+        update_grade_mock.assert_called_once_with(self.user, fa_course_run.course)
+        generate_letter_mock.assert_not_called()
+
+    def test_create_final_grade_non_fa(self, generate_letter_mock, update_grade_mock, mock_on_commit):
+        """
+        Test that final grades created for non-FA courses will try to update combined final grades and
+        generate a program commendation letter.
+        """
+        non_fa_course_run = CourseRunFactory.create(course__program__financial_aid_availability=False)
+        FinalGradeFactory.create(user=self.user, course_run=non_fa_course_run, grade=0.9)
+        update_grade_mock.assert_called_once_with(self.user, non_fa_course_run.course)
+        generate_letter_mock.assert_called_once_with(self.user, non_fa_course_run.course.program)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #4285

#### What's this PR do?
Fixes logic for program commendation letter creation. Previously it would only create letters for FA programs

#### How should this be manually tested?
- Add passing FinalGrades for a CourseRuns for your user in a Program (in addition to all the setup steps outlined in the previous commendation letter PR). The signal should generate the letter
- Delete that letter object, then run the management command. The letter should be generated again

