### PR TITLE
remove "0 courses" from home page

### DIFF
--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -152,13 +152,17 @@
                       {{ programpage.title }}
                     {% endif %}
                   </h4>
-                  <div class="program-num-courses">
-                    {% blocktrans count counter=program.course_set.count %}
-                      {{ counter }} course
-                    {% plural %}
-                      {{ counter }} courses
-                    {% endblocktrans %}
-                  </div>
+                  {% with program.course_set.count as course_count %}
+                    {% if course_count %}
+                      <div class="program-num-courses">
+                        {% blocktrans count counter=course_count %}
+                          {{ counter }} course
+                        {% plural %}
+                          {{ counter }} courses
+                        {% endblocktrans %}
+                      </div>
+                    {% endif %}
+                  {% endwith %}
                 </div>
                 {% if programpage and programpage.thumbnail_image %}
                   {% image programpage.thumbnail_image fill-690x530 as thumbnail_image %}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #4299 

#### What's this PR do?
Remove text "0 courses" from home page.

#### Screenshots (if appropriate)

**OLD:**
<img width="675" alt="Screen Shot 2019-04-18 at 4 32 54 PM" src="https://user-images.githubusercontent.com/4245618/56359031-e21fda00-61f9-11e9-95d2-d8efc32e25e6.png">

**NEW**
<img width="672" alt="Screen Shot 2019-04-18 at 4 49 48 PM" src="https://user-images.githubusercontent.com/4245618/56359083-04195c80-61fa-11e9-982c-0b43e46fe742.png">
