### PR TITLE
Adds viewset for courseruns API, required serializer, and related tests

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -3,7 +3,7 @@ Serializers for courses
 """
 from rest_framework import serializers
 
-from courses.models import Course, Program
+from courses.models import Course, Program, CourseRun
 from dashboard.models import ProgramEnrollment
 
 
@@ -72,3 +72,12 @@ class CourseSerializer(serializers.ModelSerializer):
             'url',
             'enrollment_text',
         )
+
+
+class CourseRunSerializer(serializers.ModelSerializer):
+    """Serializer for Course Run Objects"""
+    program_title = serializers.CharField(source='course.program.title')
+
+    class Meta:
+        model = CourseRun
+        fields = ('edx_course_key', 'program_title')

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -14,7 +14,7 @@ from courses.factories import (
 from courses.serializers import (
     CourseSerializer,
     ProgramSerializer,
-)
+    CourseRunSerializer)
 from dashboard.models import ProgramEnrollment
 from profiles.factories import UserFactory
 from search.base import MockedESTestCase
@@ -49,6 +49,24 @@ class CourseSerializerTests(MockedESTestCase):
         data = CourseSerializer(course).data
         assert data['url'] == course_run.enrollment_url
         assert data['enrollment_text'] == course.enrollment_text
+
+
+class CourseRunSerializerTests(MockedESTestCase):
+    """
+    Tests for CourseRunSerializer
+    """
+
+    def test_course_run(self):
+        """
+        Make sure course run serializer correctly
+        """
+        course_run = CourseRunFactory.create()
+        data = CourseRunSerializer(course_run).data
+        expected = {
+            'edx_course_key': course_run.edx_course_key,
+            'program_title': course_run.course.program.title,
+        }
+        assert data == expected
 
 
 class ProgramSerializerTests(MockedESTestCase):

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -6,11 +6,12 @@ from rest_framework import routers
 from courses.views import (
     ProgramEnrollmentListView,
     ProgramViewSet,
-    ProgramLearnersView
-)
+    ProgramLearnersView,
+    CourseRunViewSet)
 
 router = routers.DefaultRouter()
 router.register(r'programs', ProgramViewSet)
+router.register(r'courseruns', CourseRunViewSet)
 
 urlpatterns = [
     url(r'^api/v0/', include(router.urls)),

--- a/courses/views.py
+++ b/courses/views.py
@@ -15,8 +15,8 @@ from rest_framework.generics import CreateAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from courses.models import Program
-from courses.serializers import ProgramSerializer
+from courses.models import Program, CourseRun
+from courses.serializers import ProgramSerializer, CourseRunSerializer
 from dashboard.models import ProgramEnrollment
 from profiles.models import Profile
 from profiles.serializers import ProfileImageSerializer
@@ -118,3 +118,16 @@ class ProgramEnrollmentListView(CreateAPIView):
             status=status_code,
             data=serializer(program, context={'request': request}).data
         )
+
+
+class CourseRunViewSet(viewsets.ReadOnlyModelViewSet):
+    """API for the CourseRun model"""
+    authentication_classes = (
+        SessionAuthentication,
+        TokenAuthentication,
+    )
+    permission_classes = (
+        IsAuthenticated,
+    )
+    serializer_class = CourseRunSerializer
+    queryset = CourseRun.objects.all()

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -6,8 +6,8 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from courses.factories import ProgramFactory
-from courses.serializers import ProgramSerializer
+from courses.factories import ProgramFactory, CourseRunFactory
+from courses.serializers import ProgramSerializer, CourseRunSerializer
 from dashboard.factories import ProgramEnrollmentFactory
 from dashboard.models import ProgramEnrollment
 from micromasters.factories import UserFactory
@@ -210,3 +210,26 @@ class ProgramEnrollmentTests(MockedESTestCase, APITestCase):
         self.assert_program_enrollments_count(count_before+1)
         assert resp.status_code == status.HTTP_201_CREATED
         assert resp.data.get('id') == self.program3.pk
+
+
+class CourseRunTests(MockedESTestCase, APITestCase):
+    """Tests for CourseRun API"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = UserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_login(self.user)
+
+    def test_lists_course_runs(self):
+        """Course Runs should show up"""
+        course_run = CourseRunFactory.create()
+        resp = self.client.get(reverse('courserun-list'))
+
+        assert len(resp.json()) == 1
+        context = {"request": Mock(user=self.user)}
+        data = CourseRunSerializer(course_run, context=context).data
+        assert [data] == resp.json()


### PR DESCRIPTION
#### What are the relevant tickets?
#4311 

#### What's this PR do?
This PR adds a course_run api endpoint, a new serializer, and associated tests to the courses app.

#### How should this be manually tested?
The new endpoint can be hit manually (`api/v0/courseruns/`).
