### PR TITLE
remove passed from course progress for staff view

### DIFF
--- a/static/js/components/dashboard/courses/ProgressMessage.js
+++ b/static/js/components/dashboard/courses/ProgressMessage.js
@@ -86,7 +86,7 @@ export const staffCourseInfo = (courseRun: CourseRun, course: Course) => {
     } else if (hasCanUpgradeCourseRun(course)) {
       return "Audited, passed, did not pay"
     } else if (hasMissedDeadlineCourseRun(course)) {
-      return "Audited, passed, missed payment deadline"
+      return "Audited, missed payment deadline"
     }
     if (courseRun.status === STATUS_NOT_PASSED) {
       if (hasPaidForAnyCourseRun(course)) {

--- a/static/js/components/dashboard/courses/ProgressMessage_test.js
+++ b/static/js/components/dashboard/courses/ProgressMessage_test.js
@@ -227,14 +227,14 @@ describe("Course ProgressMessage", () => {
         "Audited, passed, did not pay"
       )
     })
-    it("should return Audited, passed, missed payment deadline", () => {
+    it("should return Audited, missed payment deadline", () => {
       makeRunPast(course.runs[0])
       makeRunPast(course.runs[1])
       course.runs[0].status = STATUS_NOT_PASSED
       course.runs[1].status = STATUS_MISSED_DEADLINE
       assert.equal(
         staffCourseInfo(course.runs[0], course),
-        "Audited, passed, missed payment deadline"
+        "Audited, missed payment deadline"
       )
     })
   })


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Remove passed from course progress for staff view

#### How should this be manually tested?
Create a user that audited a course run with a failing grade, and the user's page through a staff account.

