### PR TITLE
Revert "bump elasticsearch version (#4303)"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "6379"
 
   elastic:
-    image: elasticsearch:6.7.1
+    build: elastic
     command: elasticsearch -E network.host=0.0.0.0 -E http.cors.enabled=true -E http.cors.allow-origin=* -E rest.action.multi.allow_explicit_index=false
     ports:
       - "9100:9200"

--- a/elastic/Dockerfile
+++ b/elastic/Dockerfile
@@ -1,0 +1,5 @@
+FROM elasticsearch:5.6.6
+
+# Lower elasticsearch memory usage limit
+RUN sed -i 's/-Xms2g/-Xms512m/' /etc/elasticsearch/jvm.options
+RUN sed -i 's/-Xmx2g/-Xmx512m/' /etc/elasticsearch/jvm.options

--- a/requirements.in
+++ b/requirements.in
@@ -17,8 +17,8 @@ django-webpack-loader==0.5.0
 djangorestframework==3.7.7
 edx-api-client==0.6.1
 edx-opaque-keys==0.4
-elasticsearch-dsl==6.3.1
-elasticsearch==6.3.1
+elasticsearch-dsl==5.4.0
+elasticsearch==5.5.3
 factory_boy
 faker
 html5lib==0.999999999

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,8 +38,8 @@ djangorestframework==3.7.7
 draftjs-exporter==2.0.0   # via wagtail
 edx-api-client==0.6.1
 edx-opaque-keys==0.4
-elasticsearch-dsl==6.3.1
-elasticsearch==6.3.1
+elasticsearch-dsl==5.4.0
+elasticsearch==5.5.3
 factory-boy==2.8.1
 faker==0.9.1
 html5lib==0.999999999

--- a/search/api.py
+++ b/search/api.py
@@ -283,22 +283,11 @@ def _search_percolate_queries(program_enrollment):
     # We don't need this to search for percolator queries and
     # it causes a dynamic mapping failure so we need to remove it
     del doc['_id']
-
-    body = {
-        "query": {
-            "percolate": {
-                "field": "query",
-                "document": doc
-            }
-        }
-    }
-
-    result = conn.search(percolate_index, GLOBAL_DOC_TYPE, body=body)
+    result = conn.percolate(percolate_index, GLOBAL_DOC_TYPE, body={"doc": doc})
     failures = result.get('_shards', {}).get('failures', [])
     if len(failures) > 0:
         raise PercolateException("Failed to percolate: {}".format(failures))
-
-    return [int(row['_id']) for row in result['hits']['hits']]
+    return [int(row['_id']) for row in result['matches']]
 
 
 def adjust_search_for_percolator(search):
@@ -344,7 +333,7 @@ def document_needs_updating(enrollment):
 
     conn = get_conn()
     try:
-        document = conn.get(index=index, doc_type=GLOBAL_DOC_TYPE, id=enrollment.id)
+        document = conn.get(index=index, id=enrollment.id)
     except NotFoundError:
         return True
     serialized_enrollment = serialize_program_enrolled_user(enrollment)

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -398,7 +398,7 @@ class PercolateTests(ESTestCase):
             profile = ProfileFactory.create(filled_out=True)
         program_enrollment = ProgramEnrollmentFactory.create(user=profile.user)
         with self.assertRaises(PercolateException) as ex, patch(
-            'search.api.get_conn', return_value=Mock(search=Mock(return_value=failure_payload))
+            'search.api.get_conn', return_value=Mock(percolate=Mock(return_value=failure_payload))
         ):
             search_percolate_queries(program_enrollment.id, "doesnt_matter")
         assert ex.exception.args[0] == "Failed to percolate: {}".format(failures)
@@ -498,7 +498,7 @@ class PercolateTests(ESTestCase):
 
         with patch('search.api.get_conn') as es_mock:
             populate_query_memberships(query.id)
-            assert es_mock.return_value.search.call_count == (1 if has_profile and is_active else 0)
+            assert es_mock.return_value.percolate.call_count == (1 if has_profile and is_active else 0)
 
         assert PercolateQueryMembership.objects.filter(user=user, query=query).count() == (
             1 if is_active else 0

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -3,7 +3,6 @@ Functions for ES indexing
 """
 import logging
 
-from django.conf import settings
 from elasticsearch.helpers import bulk
 from elasticsearch.exceptions import NotFoundError
 
@@ -230,8 +229,6 @@ PERCOLATE_MAPPING = {
         }
     }
 }
-
-INDEX_WILDCARD = '{index_name}_*'.format(index_name=settings.ELASTICSEARCH_INDEX)
 
 
 def _index_chunk(chunk, *, index):
@@ -565,7 +562,7 @@ def delete_indices():
         aliases = get_aliases(index_type)
         for alias in aliases:
             if conn.indices.exists(alias):
-                conn.indices.delete_alias(index=INDEX_WILDCARD, name=alias)
+                conn.indices.delete(alias)
 
 
 # pylint: disable=too-many-locals
@@ -590,7 +587,7 @@ def recreate_index():
         temp_alias = make_alias_name(index_type, is_reindexing=True)
         if conn.indices.exists_alias(name=temp_alias):
             # Deletes both alias and backing indexes
-            conn.indices.delete_alias(index=INDEX_WILDCARD, name=temp_alias)
+            conn.indices.delete(temp_alias)
 
         # Point temp_alias toward new backing index
         conn.indices.put_alias(index=backing_index, name=temp_alias)

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -91,7 +91,7 @@ class ESTestActions:
     def get_percolate_query(self, _id):
         """Get percolate query"""
         index = get_default_alias(PERCOLATE_INDEX_TYPE)
-        return self.conn.get(id=_id, doc_type=GLOBAL_DOC_TYPE, index=index)
+        return self.conn.get(id=_id, index=index)
 
     def get_mappings(self, index_type):
         """Gets mapping data"""
@@ -788,8 +788,6 @@ class PercolateQueryTests(ESTestCase):
             '_id': str(percolate_query_id),
             '_index': es.get_default_backing_index(PERCOLATE_INDEX_TYPE),
             '_source': query,
-            '_seq_no': 0,
-            '_primary_term': 1,
             '_type': GLOBAL_DOC_TYPE,
             '_version': 1,
             'found': True,
@@ -804,8 +802,6 @@ class PercolateQueryTests(ESTestCase):
                 '_id': str(percolate_query.id),
                 '_index': es.get_default_backing_index(PERCOLATE_INDEX_TYPE),
                 '_source': query,
-                '_seq_no': 0,
-                '_primary_term': 1,
                 '_type': GLOBAL_DOC_TYPE,
                 '_version': 1,
                 'found': True,

--- a/travis/Dockerfile-travis-watch
+++ b/travis/Dockerfile-travis-watch
@@ -1,4 +1,4 @@
-FROM mitodl/micromasters_watch_travis_960cf1
+FROM mitodl/micromasters_watch_travis_ba4c35
 
 WORKDIR /src
 

--- a/travis/Dockerfile-travis-web
+++ b/travis/Dockerfile-travis-web
@@ -1,4 +1,4 @@
-FROM mitodl/micromasters_web_travis_960cf1
+FROM mitodl/micromasters_web_travis_ba4c35
 
 WORKDIR /tmp
 


### PR DESCRIPTION
This reverts commit e890c10a1025fd5cdb450d48aa82a3d69314d318, reversing
changes made to 307ad527bd0857c9c23c10bd45858693aea37a78.

Output of the command `git revert -m 1 e890c10`

#### What are the relevant tickets?
Fixes #4318 

#### What's this PR do?
Reverts the ES upgrade until we can plan/test the upgrade path.

#### How should this be manually tested?
You should be able to reindex and the app should still work