### PR TITLE
fix dashboard message for past end date course run

### DIFF
--- a/static/js/components/dashboard/courses/ProgressMessage_test.js
+++ b/static/js/components/dashboard/courses/ProgressMessage_test.js
@@ -12,7 +12,7 @@ import { makeCourse } from "../../../factories/dashboard"
 import {
   makeRunCurrent,
   makeRunEnrolled,
-  makeRunFuture,
+  makeRunFuture, makeRunMissedDeadline, makeRunPaid,
   makeRunPast
 } from "./test_util"
 import {
@@ -235,6 +235,18 @@ describe("Course ProgressMessage", () => {
       assert.equal(
         staffCourseInfo(course.runs[0], course),
         "Audited, missed payment deadline"
+      )
+    })
+
+    it("should return Paid when course is past, but still currently-enrolled", () => {
+      makeRunPast(course.runs[0])
+      makeRunEnrolled(course.runs[0])
+      makeRunPaid(course.runs[0])
+      makeRunMissedDeadline(course.runs[1])
+      makeRunPast(course.runs[1])
+      assert.equal(
+        staffCourseInfo(course.runs[0], course),
+        "Paid"
       )
     })
   })

--- a/static/js/components/dashboard/courses/ProgressMessage_test.js
+++ b/static/js/components/dashboard/courses/ProgressMessage_test.js
@@ -12,7 +12,9 @@ import { makeCourse } from "../../../factories/dashboard"
 import {
   makeRunCurrent,
   makeRunEnrolled,
-  makeRunFuture, makeRunMissedDeadline, makeRunPaid,
+  makeRunFuture,
+  makeRunMissedDeadline,
+  makeRunPaid,
   makeRunPast
 } from "./test_util"
 import {
@@ -244,10 +246,7 @@ describe("Course ProgressMessage", () => {
       makeRunPaid(course.runs[0])
       makeRunMissedDeadline(course.runs[1])
       makeRunPast(course.runs[1])
-      assert.equal(
-        staffCourseInfo(course.runs[0], course),
-        "Paid"
-      )
+      assert.equal(staffCourseInfo(course.runs[0], course), "Paid")
     })
   })
 })

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -33,7 +33,7 @@ import {
   makeRunCanUpgrade,
   makeRunMissedDeadline
 } from "./test_util"
-import {assertIsJust, assertIsNothing} from "../../../lib/test_utils"
+import { assertIsJust } from "../../../lib/test_utils"
 import {
   COURSE_ACTION_PAY,
   COURSE_ACTION_CALCULATE_PRICE,
@@ -49,7 +49,6 @@ import {
 } from "../../../constants"
 import * as libCoupon from "../../../lib/coupon"
 import { FINANCIAL_AID_PARTIAL_RESPONSE } from "../../../test_constants"
-import {courseUpcomingOrCurrent} from "./util";
 
 describe("Course Status Messages", () => {
   let message

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -33,7 +33,7 @@ import {
   makeRunCanUpgrade,
   makeRunMissedDeadline
 } from "./test_util"
-import { assertIsJust } from "../../../lib/test_utils"
+import {assertIsJust, assertIsNothing} from "../../../lib/test_utils"
 import {
   COURSE_ACTION_PAY,
   COURSE_ACTION_CALCULATE_PRICE,
@@ -49,6 +49,7 @@ import {
 } from "../../../constants"
 import * as libCoupon from "../../../lib/coupon"
 import { FINANCIAL_AID_PARTIAL_RESPONSE } from "../../../test_constants"
+import {courseUpcomingOrCurrent} from "./util";
 
 describe("Course Status Messages", () => {
   let message
@@ -956,6 +957,15 @@ describe("Course Status Messages", () => {
           message: "You did not pass the edX course."
         }
       ])
+    })
+
+    it("should not have a message if course is past but still not frozen", () => {
+      makeRunPast(course.runs[0])
+      makeRunEnrolled(course.runs[0])
+      makeRunPaid(course.runs[0])
+      makeRunMissedDeadline(course.runs[1])
+      makeRunPast(course.runs[1])
+      assertIsJust(calculateMessages(calculateMessagesProps), [])
     })
   })
 })

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -67,7 +67,8 @@ export const courseCurrentlyInProgress = (courseRun: CourseRun) => {
 
 export const courseUpcomingOrCurrent = (courseRun: CourseRun) =>
   courseRun.course_end_date
-    ? moment().isBefore(moment(courseRun.course_end_date)) || courseRun.status === STATUS_CURRENTLY_ENROLLED
+    ? moment().isBefore(moment(courseRun.course_end_date)) ||
+      courseRun.status === STATUS_CURRENTLY_ENROLLED
     : true
 
 export const hasPaidForAnyCourseRun = R.compose(

--- a/static/js/components/dashboard/courses/util.js
+++ b/static/js/components/dashboard/courses/util.js
@@ -67,7 +67,7 @@ export const courseCurrentlyInProgress = (courseRun: CourseRun) => {
 
 export const courseUpcomingOrCurrent = (courseRun: CourseRun) =>
   courseRun.course_end_date
-    ? moment().isBefore(moment(courseRun.course_end_date))
+    ? moment().isBefore(moment(courseRun.course_end_date)) || courseRun.status === STATUS_CURRENTLY_ENROLLED
     : true
 
 export const hasPaidForAnyCourseRun = R.compose(

--- a/static/js/components/dashboard/courses/util_test.js
+++ b/static/js/components/dashboard/courses/util_test.js
@@ -195,6 +195,14 @@ describe("dashboard course utilities", () => {
       run.course_end_date = ""
       assert.isTrue(courseUpcomingOrCurrent(run))
     })
+
+    it("should return true if course ended but status currently-enrolled", () => {
+      run.course_end_date = moment()
+        .subtract(5, "days")
+        .format()
+      run.status = STATUS_CURRENTLY_ENROLLED
+      assert.isTrue(courseUpcomingOrCurrent(run))
+    })
   })
 
   describe("hasPaidForAnyCourseRun", () => {


### PR DESCRIPTION
#### What are the relevant tickets?
https://odl.zendesk.com/agent/tickets/29299

#### What's this PR do?
Fix the status message when the course ended but has not been frozen yet, and status is 'currently-enrolled' in the learner dashboard as well as the instructor view of the learner's page.
 
#### How should this be manually tested?
Tests should pass.
The bug occurred when there are two course runs one is `missed-deadline`, and the other `currently-enrolled` with course_end_date in the past.

The dashboard api assigns a status of `currently-enrolled` to a course that already ended, but has no frozen grades. This was causing a bug in `StatusMessages.js`. The function `courseUpcomingOrCurrent` considered a course current only based on the end date. I changed the functionality to consider the status of the course run as well. 
