### PR TITLE
Fix fetch user profile

### DIFF
--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -107,14 +107,11 @@ class App extends React.Component {
     if (userProfile.getStatus === undefined) {
       dispatch(fetchUserProfile(username)).then(() => {
         if (PROFILE_REGEX.test(pathname)) {
-          dispatch(startProfileEdit(SETTINGS.user.username)).then(() => {
-            this.requireCompleteProfile()
-          })
+          dispatch(startProfileEdit(SETTINGS.user.username))
         }
       })
-    } else {
-      this.requireCompleteProfile()
     }
+    this.requireCompleteProfile()
   }
 
   requireCompleteProfile() {
@@ -126,7 +123,6 @@ class App extends React.Component {
     } = this.props
     const [complete, step] = validateProfileComplete(profile)
     const idealStep = currentOrFirstIncompleteStep(profileStep, step)
-
     if (
       userProfile.getStatus === FETCH_SUCCESS &&
       !PROFILE_REGEX.test(pathname) &&


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4304

#### What's this PR do?
Remove the `then` clause since `startProfileEdit` does not return a promise.
This change was originally introduced in https://github.com/mitodl/micromasters/pull/4294

#### How should this be manually tested?
Go to `/personal/profile` and try to submit the form.

