### PR TITLE
Learner dashboard: elective courses

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -16,7 +16,7 @@ from edx_api.client import EdxApi
 
 from backends.exceptions import InvalidCredentialStored
 from backends import utils
-from courses.models import Program
+from courses.models import Program, ElectiveCourse, ElectivesSet
 from courses.utils import format_season_year_for_course_run
 from dashboard.api_edx_cache import CachedEdxDataApi
 from dashboard.utils import get_mmtrack
@@ -196,6 +196,8 @@ def get_info_for_program(mmtrack):
         "pearson_exam_status": mmtrack.get_pearson_exam_status(),
         "grade_average": mmtrack.calculate_final_grade_average(),
         "certificate": mmtrack.get_program_certificate_url(),
+        "number_courses_required": mmtrack.program.num_required_courses
+        if mmtrack.program.electivesset_set.exists() else mmtrack.program.course_set.count()
     }
     if mmtrack.financial_aid_available:
         data["financial_aid_user_info"] = FinancialAidDashboardSerializer.serialize(mmtrack.user, mmtrack.program)
@@ -240,6 +242,7 @@ def get_info_for_course(course, mmtrack):
         "proctorate_exams_grades": ProctoredExamGradeSerializer(
             mmtrack.get_course_proctorate_exam_results(course), many=True
         ).data,
+        "is_elective": ElectiveCourse.objects.filter(course=course).exists(),
         "has_exam": course.has_exam,
         "certificate_url": get_certificate_url(mmtrack, course),
         "overall_grade": mmtrack.get_overall_final_grade_for_course(course)

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -16,7 +16,7 @@ from edx_api.client import EdxApi
 
 from backends.exceptions import InvalidCredentialStored
 from backends import utils
-from courses.models import Program, ElectiveCourse, ElectivesSet
+from courses.models import Program, ElectiveCourse
 from courses.utils import format_season_year_for_course_run
 from dashboard.api_edx_cache import CachedEdxDataApi
 from dashboard.utils import get_mmtrack
@@ -196,8 +196,11 @@ def get_info_for_program(mmtrack):
         "pearson_exam_status": mmtrack.get_pearson_exam_status(),
         "grade_average": mmtrack.calculate_final_grade_average(),
         "certificate": mmtrack.get_program_certificate_url(),
-        "number_courses_required": mmtrack.program.num_required_courses
-        if mmtrack.program.electivesset_set.exists() else mmtrack.program.course_set.count()
+        "number_courses_required": (
+            mmtrack.program.num_required_courses
+            if mmtrack.program.electivesset_set.exists()
+            else mmtrack.program.course_set.count()
+        )
     }
     if mmtrack.financial_aid_available:
         data["financial_aid_user_info"] = FinancialAidDashboardSerializer.serialize(mmtrack.user, mmtrack.program)

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -74,6 +74,7 @@ const COURSE: Course = {
   has_to_pay:                  false,
   has_exam:                    false,
   proctorate_exams_grades:     [],
+  is_elective:                 false,
   certificate_url:             "",
   overall_grade:               ""
 }

--- a/static/js/components/ProgressWidget.js
+++ b/static/js/components/ProgressWidget.js
@@ -20,7 +20,8 @@ export const circularProgressWidget = (
   const viewBox = `0 0 ${width} ${height}`
   const dashArray = radiusForMeasures * Math.PI * 2
   const dashOffset =
-    dashArray - (dashArray * R.min(totalPassedCourses, totalCourses)) / (totalCourses || 1)
+    dashArray -
+    (dashArray * R.min(totalPassedCourses, totalCourses)) / (totalCourses || 1)
 
   return (
     <div className="circular-progress-widget">
@@ -135,7 +136,12 @@ export default class ProgressWidget extends React.Component {
     return (
       <Card className="progress-widget" shadow={0}>
         <CardTitle className="progress-title">Progress</CardTitle>
-        {circularProgressWidget(60, 6, totalPassedCourses, program.number_courses_required)}
+        {circularProgressWidget(
+          60,
+          6,
+          totalPassedCourses,
+          program.number_courses_required
+        )}
         {SETTINGS.FEATURES.PROGRAM_RECORD_LINK &&
           program.financial_aid_availability &&
           gradeRecordsLink(program.grade_records_url)}

--- a/static/js/components/ProgressWidget.js
+++ b/static/js/components/ProgressWidget.js
@@ -129,12 +129,12 @@ export default class ProgressWidget extends React.Component {
 
   renderProgressIndicator() {
     const { program } = this.props
-    const { totalPassedCourses, totalCourses } = programCourseInfo(program)
+    const totalPassedCourses = programCourseInfo(program)
 
     return (
       <Card className="progress-widget" shadow={0}>
         <CardTitle className="progress-title">Progress</CardTitle>
-        {circularProgressWidget(60, 6, totalPassedCourses, totalCourses)}
+        {circularProgressWidget(60, 6, totalPassedCourses, program.number_courses_required)}
         {SETTINGS.FEATURES.PROGRAM_RECORD_LINK &&
           program.financial_aid_availability &&
           gradeRecordsLink(program.grade_records_url)}

--- a/static/js/components/ProgressWidget.js
+++ b/static/js/components/ProgressWidget.js
@@ -3,6 +3,7 @@
 import React from "react"
 import { Card, CardTitle } from "react-mdl/lib/Card"
 import Button from "react-mdl/lib/Button"
+import R from "ramda"
 
 import type { Program } from "../flow/programTypes"
 import { programCourseInfo } from "../util/util"
@@ -19,7 +20,7 @@ export const circularProgressWidget = (
   const viewBox = `0 0 ${width} ${height}`
   const dashArray = radiusForMeasures * Math.PI * 2
   const dashOffset =
-    dashArray - (dashArray * totalPassedCourses) / (totalCourses || 1)
+    dashArray - (dashArray * R.min(totalPassedCourses, totalCourses)) / (totalCourses || 1)
 
   return (
     <div className="circular-progress-widget">

--- a/static/js/components/ProgressWidget_test.js
+++ b/static/js/components/ProgressWidget_test.js
@@ -144,7 +144,12 @@ describe("ProgressWidget", () => {
     assert.equal(wrapper.find(".circular-progress-widget-txt").text(), "3/5")
 
     program.number_courses_required = 3
-    assert.equal(shallow(<ProgressWidget program={program} />).find(".circular-progress-widget-txt").text(), "3/3")
+    assert.equal(
+      shallow(<ProgressWidget program={program} />)
+        .find(".circular-progress-widget-txt")
+        .text(),
+      "3/3"
+    )
   })
   it("should display program certificate when a certificate link exists", () => {
     program["certificate"] = "certificate_url"

--- a/static/js/components/ProgressWidget_test.js
+++ b/static/js/components/ProgressWidget_test.js
@@ -11,6 +11,7 @@ export const program = {
   financial_aid_user_info:    null,
   description:                "Not passed program",
   title:                      "Not passed program",
+  num_required_courses:       5,
   courses:                    [
     {
       prerequisites: "",

--- a/static/js/components/ProgressWidget_test.js
+++ b/static/js/components/ProgressWidget_test.js
@@ -142,6 +142,9 @@ describe("ProgressWidget", () => {
       "Courses complete"
     )
     assert.equal(wrapper.find(".circular-progress-widget-txt").text(), "3/5")
+
+    program.number_courses_required = 3
+    assert.equal(shallow(<ProgressWidget program={program} />).find(".circular-progress-widget-txt").text(), "3/3")
   })
   it("should display program certificate when a certificate link exists", () => {
     program["certificate"] = "certificate_url"

--- a/static/js/components/ProgressWidget_test.js
+++ b/static/js/components/ProgressWidget_test.js
@@ -11,7 +11,7 @@ export const program = {
   financial_aid_user_info:    null,
   description:                "Not passed program",
   title:                      "Not passed program",
-  num_required_courses:       5,
+  number_courses_required:    5,
   courses:                    [
     {
       prerequisites: "",

--- a/static/js/components/StaffLearnerInfoCard.js
+++ b/static/js/components/StaffLearnerInfoCard.js
@@ -44,7 +44,12 @@ const StaffLearnerInfoCard = (props: StaffLearnerCardProps) => {
       <div className="program-info">
         <div className="row">
           <div className="progress-widget">
-            {circularProgressWidget(63, 7, totalPassedCourses, program.num_required_courses)}
+            {circularProgressWidget(
+              63,
+              7,
+              totalPassedCourses,
+              program.number_courses_required
+            )}
           </div>
           {programInfoBadge(
             "Average program grade",

--- a/static/js/components/StaffLearnerInfoCard.js
+++ b/static/js/components/StaffLearnerInfoCard.js
@@ -36,7 +36,7 @@ const formatCourseGrade = R.compose(
 
 const StaffLearnerInfoCard = (props: StaffLearnerCardProps) => {
   const { program } = props
-  const { totalPassedCourses, totalCourses } = programCourseInfo(program)
+  const totalPassedCourses = programCourseInfo(program)
 
   return (
     <Card shadow={1} className="staff-learner-info-card course-list">
@@ -44,7 +44,7 @@ const StaffLearnerInfoCard = (props: StaffLearnerCardProps) => {
       <div className="program-info">
         <div className="row">
           <div className="progress-widget">
-            {circularProgressWidget(63, 7, totalPassedCourses, totalCourses)}
+            {circularProgressWidget(63, 7, totalPassedCourses, program.num_required_courses)}
           </div>
           {programInfoBadge(
             "Average program grade",

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -167,7 +167,7 @@ export default class CourseListCard extends React.Component {
       showStaffView
     } = this.props
     const now = this.props.now || moment()
-
+    const has_electives = program.number_courses_required < program.courses.length
     const sortedCourses = R.sortBy(
       R.prop("position_in_program"),
       program.courses
@@ -181,6 +181,7 @@ export default class CourseListCard extends React.Component {
         openFinancialAidCalculator={openFinancialAidCalculator}
         couponPrices={couponPrices}
         now={now}
+        program_has_electives={has_electives}
         addCourseEnrollment={addCourseEnrollment}
         openCourseContactDialog={openCourseContactDialog}
         setEnrollSelectedCourseRun={setEnrollSelectedCourseRun}

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -167,7 +167,8 @@ export default class CourseListCard extends React.Component {
       showStaffView
     } = this.props
     const now = this.props.now || moment()
-    const has_electives = program.number_courses_required < program.courses.length
+    const hasElectives =
+      program.number_courses_required < program.courses.length
     const sortedCourses = R.sortBy(
       R.prop("position_in_program"),
       program.courses
@@ -181,7 +182,7 @@ export default class CourseListCard extends React.Component {
         openFinancialAidCalculator={openFinancialAidCalculator}
         couponPrices={couponPrices}
         now={now}
-        program_has_electives={has_electives}
+        programHasElectives={hasElectives}
         addCourseEnrollment={addCourseEnrollment}
         openCourseContactDialog={openCourseContactDialog}
         setEnrollSelectedCourseRun={setEnrollSelectedCourseRun}

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -35,7 +35,7 @@ export default class CourseRow extends React.Component {
     couponPrices: CouponPrices,
     financialAid: FinancialAidUserInfo,
     hasFinancialAid: boolean,
-    program_has_electives: boolean,
+    programHasElectives: boolean,
     openFinancialAidCalculator: () => void,
     addCourseEnrollment: (courseId: string) => Promise<*>,
     openCourseContactDialog: (
@@ -206,17 +206,21 @@ export default class CourseRow extends React.Component {
   }
   getCourseTag = (): React$Element<*> => {
     const { course } = this.props
-    return <div className="elective-tag">{course.is_elective? "Elective": "Core"}</div>
+    return (
+      <div className="elective-tag">
+        {course.is_elective ? "Elective" : "Core"}
+      </div>
+    )
   }
 
   renderCourseInfo = (run: CourseRun) => {
-    const { course, program_has_electives } = this.props
+    const { course, programHasElectives } = this.props
 
     return (
       <div className="course-info">
         <div className="course-title">
           {course.title}
-          { program_has_electives? this.getCourseTag() : null}
+          {programHasElectives ? this.getCourseTag() : null}
         </div>
         {R.any(userIsEnrolled, course.runs)
           ? this.renderInProgressCourseInfo(run)

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -209,11 +209,12 @@ export default class CourseRow extends React.Component {
 
     return (
       <div className="course-info">
-        <div className="course-title">{course.title}
+        <div className="course-title">
+          {course.title}
           {course.is_elective ? (
             <div className="elective-tag">Elective</div>
-          ): null}
-          </div>
+          ) : null}
+        </div>
         {R.any(userIsEnrolled, course.runs)
           ? this.renderInProgressCourseInfo(run)
           : this.renderEnrollableCourseInfo(run)}

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -35,6 +35,7 @@ export default class CourseRow extends React.Component {
     couponPrices: CouponPrices,
     financialAid: FinancialAidUserInfo,
     hasFinancialAid: boolean,
+    program_has_electives: boolean,
     openFinancialAidCalculator: () => void,
     addCourseEnrollment: (courseId: string) => Promise<*>,
     openCourseContactDialog: (
@@ -203,17 +204,19 @@ export default class CourseRow extends React.Component {
       </div>
     )
   }
+  getCourseTag = (): React$Element<*> => {
+    const { course } = this.props
+    return <div className="elective-tag">{course.is_elective? "Elective": "Core"}</div>
+  }
 
   renderCourseInfo = (run: CourseRun) => {
-    const { course } = this.props
+    const { course, program_has_electives } = this.props
 
     return (
       <div className="course-info">
         <div className="course-title">
           {course.title}
-          {course.is_elective ? (
-            <div className="elective-tag">Elective</div>
-          ) : null}
+          { program_has_electives? this.getCourseTag() : null}
         </div>
         {R.any(userIsEnrolled, course.runs)
           ? this.renderInProgressCourseInfo(run)

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -209,7 +209,11 @@ export default class CourseRow extends React.Component {
 
     return (
       <div className="course-info">
-        <div className="course-title">{course.title}</div>
+        <div className="course-title">{course.title}
+          {course.is_elective ? (
+            <div className="elective-tag">Elective</div>
+          ): null}
+          </div>
         {R.any(userIsEnrolled, course.runs)
           ? this.renderInProgressCourseInfo(run)
           : this.renderEnrollableCourseInfo(run)}

--- a/static/js/components/dashboard/CourseRow_test.js
+++ b/static/js/components/dashboard/CourseRow_test.js
@@ -80,6 +80,22 @@ describe("CourseRow", () => {
     assert.deepEqual(statusProps.firstRun, course.runs[0])
 
     assert.deepEqual(wrapper.find(".course-title").text(), course.title)
+    assert.equal(wrapper.find(".elective-tag").exists(), false)
+  })
+
+  it("displays relevant things for elective course", () => {
+    const { programs } = makeDashboard()
+    let course = programs[0].courses[0]
+    makeRunCurrent(course.runs[0])
+    course.is_elective = true
+    const wrapper = renderRow(
+      {
+        course: course,
+        program_has_electives: true
+      },
+      true
+    )
+    assert.deepEqual(wrapper.find(".elective-tag").text(), "Elective")
   })
 
   it("displays a CourseAction if the showStaffView prop is not set", () => {

--- a/static/js/components/dashboard/CourseRow_test.js
+++ b/static/js/components/dashboard/CourseRow_test.js
@@ -90,7 +90,7 @@ describe("CourseRow", () => {
     course.is_elective = true
     const wrapper = renderRow(
       {
-        course:                course,
+        course:              course,
         programHasElectives: true
       },
       true

--- a/static/js/components/dashboard/CourseRow_test.js
+++ b/static/js/components/dashboard/CourseRow_test.js
@@ -91,7 +91,7 @@ describe("CourseRow", () => {
     const wrapper = renderRow(
       {
         course:                course,
-        program_has_electives: true
+        programHasElectives: true
       },
       true
     )

--- a/static/js/components/dashboard/CourseRow_test.js
+++ b/static/js/components/dashboard/CourseRow_test.js
@@ -85,12 +85,12 @@ describe("CourseRow", () => {
 
   it("displays relevant things for elective course", () => {
     const { programs } = makeDashboard()
-    let course = programs[0].courses[0]
+    const course = programs[0].courses[0]
     makeRunCurrent(course.runs[0])
     course.is_elective = true
     const wrapper = renderRow(
       {
-        course: course,
+        course:                course,
         program_has_electives: true
       },
       true

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -130,10 +130,10 @@ export const makeProgram = (): Program => {
     },
     pearson_exam_status:
       PEARSON_STATUSES[Math.floor(Math.random() * PEARSON_STATUSES.length)],
-    grade_average:      Math.floor(Math.random() * 100),
-    certificate:        "",
-    grade_records_url:  "",
-    program_letter_url: "",
+    grade_average:           Math.floor(Math.random() * 100),
+    certificate:             "",
+    grade_records_url:       "",
+    program_letter_url:      "",
     number_courses_required: courses.length
   }
 }

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -96,6 +96,7 @@ export const makeCourse = (positionInProgram: number): Course => {
     past_exam_date:              "",
     has_to_pay:                  false,
     has_exam:                    false,
+    is_elective:                 false,
     proctorate_exams_grades:     [],
     certificate_url:             "",
     overall_grade:               ""
@@ -132,7 +133,8 @@ export const makeProgram = (): Program => {
     grade_average:      Math.floor(Math.random() * 100),
     certificate:        "",
     grade_records_url:  "",
-    program_letter_url: ""
+    program_letter_url: "",
+    number_courses_required: courses.length
   }
 }
 

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -39,6 +39,7 @@ export type Program = {
   certificate:                string,
   grade_records_url:          string,
   program_letter_url:         string,
+  number_courses_required:    number,
 }
 
 export type ProctoredExamResult = {
@@ -62,6 +63,7 @@ export type Course = {
   past_exam_date:               string,
   has_to_pay:                   boolean,
   proctorate_exams_grades:      Array<ProctoredExamResult>,
+  is_elective:                  boolean,
   has_exam:                     boolean,
   certificate_url:              string,
   overall_grade:                string,

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -915,10 +915,10 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
   is_edx_data_fresh: true,
   programs:          [
     {
-      description: "Not passed program",
-      title:       "Not passed program",
-      num_required_courses: 4,
-      courses:     [
+      description:             "Not passed program",
+      title:                   "Not passed program",
+      number_courses_required: 4,
+      courses:                 [
         {
           prerequisites: "",
           runs:          [

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -917,6 +917,7 @@ export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
     {
       description: "Not passed program",
       title:       "Not passed program",
+      num_required_courses: 4,
       courses:     [
         {
           prerequisites: "",

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -425,14 +425,12 @@ export function formatPrice(price: ?string | number | Decimal): string {
 }
 
 /**
- * Returns total courses and passed courses in program.
+ * Returns number of passed courses in program.
  */
 export function programCourseInfo(program: Program): Object {
-  let totalCourses = 0
   let totalPassedCourses = 0
 
   if (program.courses) {
-    totalCourses = program.courses.length
     const passedCourses = program.courses.filter(
       // returns true if any course run has a `status` property set to STATUS_PASSED.
       // $FlowFixMe: Flow thinks second arg is not a valid predicate
@@ -440,11 +438,7 @@ export function programCourseInfo(program: Program): Object {
     )
     totalPassedCourses = passedCourses.length
   }
-
-  return {
-    totalPassedCourses: totalPassedCourses,
-    totalCourses:       totalCourses
-  }
+  return totalPassedCourses
 }
 
 export function findCourseRun(

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -427,7 +427,7 @@ export function formatPrice(price: ?string | number | Decimal): string {
 /**
  * Returns number of passed courses in program.
  */
-export function programCourseInfo(program: Program): Object {
+export function programCourseInfo(program: Program): number {
   let totalPassedCourses = 0
 
   if (program.courses) {

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -548,6 +548,7 @@ describe("utility functions", () => {
       const programInfoActual = programCourseInfo(program)
 
       assert.deepEqual(programInfoActual, 3)
+    })
   })
 
   describe("findCourseRun", () => {

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -547,11 +547,7 @@ describe("utility functions", () => {
     it("assert program info", () => {
       const programInfoActual = programCourseInfo(program)
 
-      assert.deepEqual(programInfoActual, {
-        totalPassedCourses: 3,
-        totalCourses:       5
-      })
-    })
+      assert.deepEqual(programInfoActual, 3)
   })
 
   describe("findCourseRun", () => {

--- a/static/scss/dashboard/course-row.scss
+++ b/static/scss/dashboard/course-row.scss
@@ -8,7 +8,7 @@
       margin-bottom: 4px;
 
       .elective-tag {
-        display:inline-flex;
+        display: inline-flex;
         border: 1px solid $lightgray;
         color: $font-gray;
         margin-left: 14px;

--- a/static/scss/dashboard/course-row.scss
+++ b/static/scss/dashboard/course-row.scss
@@ -6,6 +6,17 @@
       font-weight: 500;
       font-size: 16px;
       margin-bottom: 4px;
+
+      .elective-tag {
+        display:inline-flex;
+        border: 1px solid $lightgray;
+        color: $font-gray;
+        margin-left: 14px;
+        padding: 5px;
+        font-size: 12px;
+        background: $lightest-blue;
+        font-weight: 300;
+      }
     }
   }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #4251

#### What's this PR do?
Adding elective courses to the learner dashboard.

#### How should this be manually tested?
Create a passing grade for a course and pay for it to see the progress widget circle fill up:
```
final_grade = FinalGradeFactory.create(user=user, course_run=course_run, passed=True, status='complete', grade=0.8)
CourseRunGradingStatus.objects.create(course_run=course_run, status='complete')
set_course_run_to_paid(user, course_run)
```
![Screen Shot 2019-07-19 at 4 50 24 PM](https://user-images.githubusercontent.com/7574259/61638299-1bd40700-ac67-11e9-8813-670c85b3be81.png)
![Screen Shot 2019-07-22 at 9 41 39 AM](https://user-images.githubusercontent.com/7574259/61638300-1bd40700-ac67-11e9-92e6-e1dfe10382a2.png)
![Screen Shot 2019-07-22 at 9 51 08 AM](https://user-images.githubusercontent.com/7574259/61638301-1bd40700-ac67-11e9-9e90-edb7533f356b.png)
