### PR TITLE
Re-remove course run api permissions

### DIFF
--- a/courses/views.py
+++ b/courses/views.py
@@ -124,13 +124,6 @@ class ProgramEnrollmentListView(CreateAPIView):
 
 class CourseRunViewSet(viewsets.ReadOnlyModelViewSet):
     """API for the CourseRun model"""
-    authentication_classes = (
-        SessionAuthentication,
-        TokenAuthentication,
-    )
-    permission_classes = (
-        IsAuthenticated,
-    )
     serializer_class = CourseRunSerializer
     queryset = CourseRun.objects.all()
 


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Makes the courserun api public again

#### How should this be manually tested?
- ensure you're logged out
- ensure http://mm.odl.local:8079/api/v0/courseruns/ doesn't issue a 4xx error
