### PR TITLE
Absolute program page URL

### DIFF
--- a/courses/catalog_serializers.py
+++ b/courses/catalog_serializers.py
@@ -48,7 +48,7 @@ class CatalogProgramSerializer(serializers.ModelSerializer):
         """
         from cms.models import ProgramPage
         try:
-            return program.programpage.url
+            return program.programpage.get_full_url()
         except ProgramPage.DoesNotExist:
             return None
 

--- a/courses/catalog_serializers_test.py
+++ b/courses/catalog_serializers_test.py
@@ -35,7 +35,7 @@ def test_catalog_program_serializer(has_page, has_thumbnail):
     assert serialized == {
         "id": program.id,
         "title": program.title,
-        "programpage_url": page.url if has_page else None,
+        "programpage_url": page.get_full_url() if has_page else None,
         "thumbnail_url": (
             page.thumbnail_image.get_rendition('fill-300x186').url
             if has_page and has_thumbnail else None

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -25,7 +25,7 @@ class ProgramSerializer(serializers.ModelSerializer):
         """
         from cms.models import ProgramPage
         try:
-            return program.programpage.url
+            return program.programpage.get_full_url()
         except ProgramPage.DoesNotExist:
             return None
 

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -121,7 +121,7 @@ class ProgramSerializerTests(MockedESTestCase):
         assert data == {
             'id': self.program.id,
             'title': self.program.title,
-            'programpage_url': programpage.url,
+            'programpage_url': programpage.get_full_url(),
             'enrolled': False,
             'total_courses': 0,
         }


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #4410

#### What's this PR do?
Makes program URL absolute in API results

#### How should this be manually tested?
Check the following and make sure the "url" field is absolute and not relative:
- `/api/v0/catalog`
- `/api/v0/programs`

#### Where should the reviewer start?
Based on xPro PR https://github.com/mitodl/mitxpro/pull/1155
