### PR TITLE
Add instructors to catalog API

### DIFF
--- a/courses/catalog_serializers.py
+++ b/courses/catalog_serializers.py
@@ -33,6 +33,7 @@ class CatalogProgramSerializer(serializers.ModelSerializer):
     """Serializer for Program objects"""
     programpage_url = serializers.SerializerMethodField()
     thumbnail_url = serializers.SerializerMethodField()
+    instructors = serializers.SerializerMethodField()
 
     courses = CatalogCourseSerializer(source="course_set", many=True)
 
@@ -71,6 +72,16 @@ class CatalogProgramSerializer(serializers.ModelSerializer):
         except ProgramPage.DoesNotExist:
             return None
 
+    def get_instructors(self, program):
+        """Get the list of instructors from the program page"""
+        from cms.models import ProgramPage
+        try:
+            page = program.programpage
+        except ProgramPage.DoesNotExist:
+            return []
+
+        return list(page.faculty_members.values("name"))
+
     class Meta:
         model = Program
         fields = (
@@ -78,5 +89,6 @@ class CatalogProgramSerializer(serializers.ModelSerializer):
             'title',
             'programpage_url',
             'thumbnail_url',
+            'instructors',
             'courses',
         )

--- a/courses/catalog_serializers_test.py
+++ b/courses/catalog_serializers_test.py
@@ -1,6 +1,7 @@
 """Tests for the catalog serializers"""
 import pytest
 
+from cms.models import ProgramFaculty
 from cms.factories import ProgramPageFactory
 from courses.catalog_serializers import CatalogProgramSerializer
 from courses.factories import (
@@ -21,6 +22,12 @@ def test_catalog_program_serializer(has_page, has_thumbnail):
     courses = CourseFactory.create_batch(3, program=program)
     for course in courses:
         CourseRunFactory.create_batch(2, course=course)
+    faculty_name = "faculty"
+    if has_page:
+        ProgramFaculty.objects.create(
+            program_page=page,
+            name=faculty_name,
+        )
     serialized = CatalogProgramSerializer(program).data
     # coerce OrderedDict objects to dict
     serialized = {
@@ -48,5 +55,6 @@ def test_catalog_program_serializer(has_page, has_thumbnail):
                 "id": course_run.id,
                 "edx_course_key": course_run.edx_course_key,
             } for course_run in course.courserun_set.all()]
-        } for course in courses]
+        } for course in courses],
+        "instructors": [{"name": faculty_name}] if has_page else [],
     }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #4411 

#### What's this PR do?
Reads the related `FacultyMember` instances and renders the `name` in the catalog API

#### How should this be manually tested?
Go to `/api/v0/catalog/` and check that instructors are listed like they are in the issue.
