### PR TITLE
Add instructors, price, start_date, end_date, and enrollment_start to catalog API

### DIFF
--- a/courses/catalog_serializers.py
+++ b/courses/catalog_serializers.py
@@ -3,6 +3,7 @@ Serializers for courses
 """
 from rest_framework import serializers
 
+from cms.models import ProgramPage
 from courses.models import Course, Program, CourseRun
 from courses.serializers import TopicSerializer
 
@@ -34,6 +35,7 @@ class CatalogProgramSerializer(serializers.ModelSerializer):
     """Serializer for Program objects"""
     programpage_url = serializers.SerializerMethodField()
     thumbnail_url = serializers.SerializerMethodField()
+    instructors = serializers.SerializerMethodField()
 
     courses = CatalogCourseSerializer(source="course_set", many=True)
     topics = TopicSerializer(many=True)
@@ -73,6 +75,15 @@ class CatalogProgramSerializer(serializers.ModelSerializer):
         except ProgramPage.DoesNotExist:
             return None
 
+    def get_instructors(self, program):
+        """Get the list of instructors from the program page"""
+        try:
+            page = program.programpage
+        except ProgramPage.DoesNotExist:
+            return []
+
+        return list(page.faculty_members.values("name"))
+
     class Meta:
         model = Program
         fields = (
@@ -80,6 +91,7 @@ class CatalogProgramSerializer(serializers.ModelSerializer):
             'title',
             'programpage_url',
             'thumbnail_url',
+            'instructors',
             'courses',
             'topics',
         )

--- a/courses/catalog_serializers.py
+++ b/courses/catalog_serializers.py
@@ -99,9 +99,7 @@ class CatalogProgramSerializer(serializers.ModelSerializer):
         first_unexpired = first_matching_item(
             course.courserun_set.all().order_by("start_date"), lambda run: run.is_unexpired
         )
-        if not first_unexpired:
-            return None
-        return first_unexpired.start_date.isoformat() if first_unexpired.start_date else None
+        return first_unexpired.start_date if first_unexpired else None
 
     def get_end_date(self, program):
         """Get the ending date of the last course of the program"""
@@ -111,9 +109,7 @@ class CatalogProgramSerializer(serializers.ModelSerializer):
         last_unexpired = first_matching_item(
             course.courserun_set.all().order_by("-start_date"), lambda run: run.is_unexpired
         )
-        if not last_unexpired:
-            return None
-        return last_unexpired.end_date.isoformat() if last_unexpired.end_date else None
+        return last_unexpired.end_date if last_unexpired else None
 
     def get_enrollment_start(self, program):
         """Get the start date for enrollment of the first course in the program"""
@@ -123,9 +119,7 @@ class CatalogProgramSerializer(serializers.ModelSerializer):
         first_unexpired = first_matching_item(
             course.courserun_set.all().order_by("start_date"), lambda run: run.is_unexpired
         )
-        if not first_unexpired:
-            return None
-        return first_unexpired.enrollment_start.isoformat() if first_unexpired.enrollment_start else None
+        return first_unexpired.enrollment_start if first_unexpired else None
 
     class Meta:
         model = Program

--- a/courses/catalog_serializers_test.py
+++ b/courses/catalog_serializers_test.py
@@ -58,8 +58,8 @@ def test_catalog_program_serializer(has_page, has_thumbnail):
         } for course in courses],
         'topics': [{'name': topic.name} for topic in program.topics.iterator()],
         "instructors": [{"name": faculty_name}] if has_page else [],
-        "start_date": courses[0].first_unexpired_run().start_date.isoformat(),
-        "enrollment_start": courses[0].first_unexpired_run().enrollment_start.isoformat(),
-        "end_date": courses[-1].courserun_set.last().end_date.isoformat(),
+        "start_date": courses[0].first_unexpired_run().start_date,
+        "enrollment_start": courses[0].first_unexpired_run().enrollment_start,
+        "end_date": courses[-1].courserun_set.last().end_date,
         "total_price": str(program.price * program.num_required_courses),
     }

--- a/courses/catalog_serializers_test.py
+++ b/courses/catalog_serializers_test.py
@@ -1,6 +1,7 @@
 """Tests for the catalog serializers"""
 import pytest
 
+from cms.models import ProgramFaculty
 from cms.factories import ProgramPageFactory
 from courses.catalog_serializers import CatalogProgramSerializer
 from courses.factories import (
@@ -21,6 +22,12 @@ def test_catalog_program_serializer(has_page, has_thumbnail):
     courses = CourseFactory.create_batch(3, program=program)
     for course in courses:
         CourseRunFactory.create_batch(2, course=course)
+    faculty_name = "faculty"
+    if has_page:
+        ProgramFaculty.objects.create(
+            program_page=page,
+            name=faculty_name,
+        )
     serialized = CatalogProgramSerializer(program).data
     # coerce OrderedDict objects to dict
     serialized = {
@@ -49,5 +56,6 @@ def test_catalog_program_serializer(has_page, has_thumbnail):
                 "edx_course_key": course_run.edx_course_key,
             } for course_run in course.courserun_set.all()]
         } for course in courses],
-        'topics': [{'name': topic.name} for topic in program.topics.iterator()]
+        'topics': [{'name': topic.name} for topic in program.topics.iterator()],
+        "instructors": [{"name": faculty_name}] if has_page else [],
     }

--- a/courses/catalog_serializers_test.py
+++ b/courses/catalog_serializers_test.py
@@ -58,4 +58,8 @@ def test_catalog_program_serializer(has_page, has_thumbnail):
         } for course in courses],
         'topics': [{'name': topic.name} for topic in program.topics.iterator()],
         "instructors": [{"name": faculty_name}] if has_page else [],
+        "start_date": courses[0].first_unexpired_run().start_date.isoformat(),
+        "enrollment_start": courses[0].first_unexpired_run().enrollment_start.isoformat(),
+        "end_date": courses[-1].courserun_set.last().end_date.isoformat(),
+        "total_price": str(program.price * program.num_required_courses),
     }

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -12,6 +12,7 @@ from courses.serializers import ProgramSerializer, CourseRunSerializer
 from dashboard.factories import ProgramEnrollmentFactory
 from dashboard.models import ProgramEnrollment
 from micromasters.factories import UserFactory
+from micromasters.test_utils import assert_drf_json_equal
 from profiles.models import Profile
 from search.base import MockedESTestCase
 
@@ -249,4 +250,5 @@ class CatalogTests(MockedESTestCase, APITestCase):
 
         assert len(resp.json()) == 1
         data = CatalogProgramSerializer(program).data
-        assert [data] == resp.json()
+
+        assert_drf_json_equal([data], resp.json())

--- a/micromasters/test_utils.py
+++ b/micromasters/test_utils.py
@@ -1,0 +1,19 @@
+"""Testing utils"""
+import json
+
+from rest_framework.renderers import JSONRenderer
+
+
+def assert_drf_json_equal(obj1, obj2):
+    """
+    Asserts that two objects are equal after a round trip through JSON serialization/deserialization.
+    Particularly helpful when testing DRF serializers where you may get back OrderedDict and other such objects.
+
+    Args:
+        obj1 (object): the first object
+        obj2 (object): the second object
+    """
+    json_renderer = JSONRenderer()
+    converted1 = json.loads(json_renderer.render(obj1))
+    converted2 = json.loads(json_renderer.render(obj2))
+    assert converted1 == converted2

--- a/micromasters/test_utils_test.py
+++ b/micromasters/test_utils_test.py
@@ -1,0 +1,9 @@
+"""Tests for test utils"""
+from micromasters.test_utils import assert_drf_json_equal
+
+
+def test_assert_drf_json_equal():
+    """Asserts that objects are equal in JSON"""
+    assert_drf_json_equal({"a": 1}, {"a": 1})
+    assert_drf_json_equal(2, 2)
+    assert_drf_json_equal([2], [2])


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #4406 
Fixes #4418 

#### What's this PR do?
Calculates instructors, total price, some date fields and renders them in the catalog API

#### How should this be manually tested?
Go to `/api/v0/catalog/` and verify that everything looks right. The `total_price` field should be a string representing a cost value with the number of courses times the price per course. The dates should be ISO-8601 formatted strings, or None if the date is null or if no course runs are unexpired.
