### PR TITLE
Fix Non-Error exception issue

### DIFF
--- a/static/js/components/ProfileProgressControls.js
+++ b/static/js/components/ProfileProgressControls.js
@@ -40,16 +40,21 @@ export default class ProfileProgressControls extends React.Component {
       addProgramEnrollment
     } = this.props
 
-    saveProfileStep.call(this, validator, isLastTab).then(() => {
-      if (programIdForEnrollment && addProgramEnrollment) {
-        addProgramEnrollment(programIdForEnrollment)
-      }
+    saveProfileStep
+      .call(this, validator, isLastTab)
+      .then(() => {
+        if (programIdForEnrollment && addProgramEnrollment) {
+          addProgramEnrollment(programIdForEnrollment)
+        }
 
-      if (isLastTab) {
-        sendGAEvent("profile-form", "completed", SETTINGS.user.username)
-      }
-      this.context.router.push(nextUrl)
-    })
+        if (isLastTab) {
+          sendGAEvent("profile-form", "completed", SETTINGS.user.username)
+        }
+        this.context.router.push(nextUrl)
+      })
+      .catch(() => {
+        /* Promise rejected due to validation error or API error */
+      })
   }
 
   render() {

--- a/static/js/containers/ProfileFormContainer.js
+++ b/static/js/containers/ProfileFormContainer.js
@@ -163,7 +163,7 @@ export const profileFormContainer = (WrappedComponent: ReactClass<*>) => {
         })
       } else {
         this.scrollToError()
-        return Promise.reject(errors)
+        return Promise.reject("Invalid profile value(s)")
       }
     }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #4356

#### What's this PR do?
Fixes the rejection of a promise to reject with a string reason instead of an errors object.

The `Promise.reject()` API takes a string, not an object, which is why we're getting this error: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject

#### How should this be manually tested?
- On master, start to register with a new user. On the first page, click "Next" without filling out any fields, note that you get an error logged to the console.
- In this branch, do the same, you should no longer see the error and you should still be able to complete registration
