### PR TITLE
New Elective tags for program page

### DIFF
--- a/selenium_tests/basic_test.py
+++ b/selenium_tests/basic_test.py
@@ -133,7 +133,7 @@ def test_program_page(browser, base_test_data, logged_in_student):
     assert len(info_links) == len(info_elements)
     semester_elements = browser.driver.find_elements_by_css_selector(".semester-date")
     assert len(semester_dates) == len(semester_elements)
-    program_course_elements = browser.driver.find_elements_by_css_selector(".program-course .title")
+    program_course_elements = browser.driver.find_elements_by_css_selector(".program-course .course-row")
     assert len(program_courses) == len(program_course_elements)
 
 

--- a/static/js/components/CourseListItemWithPopover.js
+++ b/static/js/components/CourseListItemWithPopover.js
@@ -69,11 +69,13 @@ export default class CourseListItemWithPopover extends React.Component {
     // sure that the popover gets off our lawn.
     return (
       <li className="program-course">
-        <h4 className="title" onClick={this.handleClick}>
-          {title}
+        <h4 className="course-row" onClick={this.handleClick}>
           {electiveTag ? (
-            <div className="elective-tag">{electiveTag}</div>
+            <div className="elective-tag-wrapper">
+              <div className={`elective-tag ${electiveTag}`}>{electiveTag}</div>
+            </div>
           ) : null}
+          {title}
         </h4>
 
         <Popover
@@ -93,7 +95,9 @@ export default class CourseListItemWithPopover extends React.Component {
           />
           {popoverLink(url)}
         </Popover>
-        <div className="description enrollment-dates">{enrollmentText}</div>
+        <div className="description enrollment-dates label-padding">
+          {enrollmentText}
+          </div>
       </li>
     )
   }

--- a/static/js/components/CourseListItemWithPopover.js
+++ b/static/js/components/CourseListItemWithPopover.js
@@ -97,7 +97,7 @@ export default class CourseListItemWithPopover extends React.Component {
         </Popover>
         <div className="description enrollment-dates label-padding">
           {enrollmentText}
-          </div>
+        </div>
       </li>
     )
   }

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -61,6 +61,7 @@ $header_font_color: white;
 $text-highlight: #fbf9db;
 $email-composition-type: #e3eef8;
 $lightest-blue: #e9f2f9;
+$elective-bg-color: #386082;
 
 // other
 $block-padding: 20px;

--- a/static/scss/dashboard/course-row.scss
+++ b/static/scss/dashboard/course-row.scss
@@ -8,16 +8,6 @@
   margin-left: 36px;
 }
 
-.course-row {
-  color: #0070da;
-  font-weight: 500;
-  font-size: 15px;
-  margin: 0 0 6px 0;
-  cursor: pointer;
-  line-height: 1.4em;
-  display: flex;
-}
-
 .elective-tag {
   display: inline-flex;
   color: $lightgray;
@@ -38,6 +28,14 @@
 }
 
 .course-row {
+  color: #0070da;
+  font-weight: 500;
+  font-size: 15px;
+  margin: 0 0 6px 0;
+  cursor: pointer;
+  line-height: 1.4em;
+  display: flex;
+
   .course-info {
     margin: 29px 22px 35px 28px;
 

--- a/static/scss/dashboard/course-row.scss
+++ b/static/scss/dashboard/course-row.scss
@@ -24,7 +24,7 @@
 }
 
 .elective-tag.Elective {
-  background: $darkgray;
+  background: $elective-bg-color;
 }
 
 .course-row {

--- a/static/scss/dashboard/course-row.scss
+++ b/static/scss/dashboard/course-row.scss
@@ -1,12 +1,40 @@
+.elective-tag-wrapper {
+  min-width: 60px;
+  margin-left: -25px;
+  height: min-content;
+}
+
+.label-padding {
+  margin-left: 36px;
+}
+
+.course-row {
+  color: #0070da;
+  font-weight: 500;
+  font-size: 15px;
+  margin: 0 0 6px 0;
+  cursor: pointer;
+  line-height: 1.4em;
+  display: flex;
+}
+
 .elective-tag {
   display: inline-flex;
-  border: 1px solid $lightgray;
-  color: $font-gray;
-  margin-left: 14px;
-  padding: 5px;
+  color: $lightgray;
+  padding: 1px 4px;
   font-size: 12px;
-  background: $lightest-blue;
   font-weight: 300;
+  float: right;
+  border-radius: 4px;
+  margin: 1px 5px;
+}
+
+.elective-tag.Core {
+  background: $mm-brand-bg-dark;
+}
+
+.elective-tag.Elective {
+  background: $darkgray;
 }
 
 .course-row {

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -269,7 +269,7 @@
       color: $font-black;
       font-weight: 500;
       font-size: 16px;
-      margin: 33px 0 13px 0;
+      margin: 33px 0 0px 0;
     }
 
     p {


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4427

#### What's this PR do?
Redesign of elective tags for courses.

#### How should this be manually tested?
Set up the program page to have electives. Check the program page in the course widget for new electives labels.

<img width="351" alt="Screenshot 2019-10-28 at 5 32 15 PM" src="https://user-images.githubusercontent.com/4245618/67678649-ff074800-f9a8-11e9-9cf2-d2ca8cd4f9f6.png">
