### PR TITLE
Added mmfin redirect

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -55,6 +55,12 @@ http {
     }
 
     server {
+        listen <%= ENV["PORT"] %>;
+        server_name mmfin.mit.edu;
+        return 301 https://micromasters.mit.edu/fin;
+    }
+
+    server {
         listen <%= ENV["PORT"] %> default_server;
         server_name _;
         root /app;


### PR DESCRIPTION
#### What are the relevant tickets?
Related to a ServiceNow Ticket # INC0336006 

#### What's this PR do?
Adds a redirect from `mmfin.mit.edu` to `micormasters.mit.edu/fin`. We already got and applied a new cert for mm that includes the mmfin as a SAN.
