### PR TITLE
fix background img on benefits page

### DIFF
--- a/cms/templates/cms/benefits_page.html
+++ b/cms/templates/cms/benefits_page.html
@@ -29,7 +29,7 @@
 {% block content %}
 {% include "header.html" %}
 <main class="page-content benefits-page">
-  {% image page.background_image fill-1310x613 as background_image %}
+  {% image page.background_image original as background_image %}
   <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
     <div class="hero-image" style="background-image: url({{ background_image.url }})">
       <!-- big image, and sign-up links, etc -->


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fixes #4451 

#### What's this PR do?
fix background image on benefits page

#### How should this be manually tested?
the image on the benefits page should load correctly.

#### Screenshots (if appropriate)
<img width="1278" alt="Screenshot 2019-11-07 at 1 25 35 PM" src="https://user-images.githubusercontent.com/4245618/68372452-b39c2900-0162-11ea-8eb6-2814a2358d5c.png">
