### PR TITLE
Fix styling of the Courses on program page

### DIFF
--- a/static/js/components/CourseListItemWithPopover.js
+++ b/static/js/components/CourseListItemWithPopover.js
@@ -95,7 +95,11 @@ export default class CourseListItemWithPopover extends React.Component {
           />
           {popoverLink(url)}
         </Popover>
-        <div className={`description enrollment-dates ${electiveTag? 'label-padding': ''}`}>
+        <div
+          className={`description enrollment-dates ${
+            electiveTag ? "label-padding" : ""
+          }`}
+        >
           {enrollmentText}
         </div>
       </li>

--- a/static/js/components/CourseListItemWithPopover.js
+++ b/static/js/components/CourseListItemWithPopover.js
@@ -95,7 +95,7 @@ export default class CourseListItemWithPopover extends React.Component {
           />
           {popoverLink(url)}
         </Popover>
-        <div className="description enrollment-dates label-padding">
+        <div className={`description enrollment-dates ${electiveTag? 'label-padding': ''}`}>
           {enrollmentText}
         </div>
       </li>

--- a/static/scss/dashboard/course-row.scss
+++ b/static/scss/dashboard/course-row.scss
@@ -28,12 +28,7 @@
 }
 
 .course-row {
-  color: #0070da;
-  font-weight: 500;
-  font-size: 15px;
-  margin: 0 0 6px 0;
   cursor: pointer;
-  line-height: 1.4em;
   display: flex;
 
   .course-info {

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -66,7 +66,7 @@
   }
 
   .program-course h4.course-row {
-    color: #0070da;
+    color: $link-text;
     font-size: 15px;
     line-height: 1.4em;
     margin: 0 0 6px 0;

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -65,6 +65,13 @@
     }
   }
 
+  .program-course h4.course-row {
+    color: #0070da;
+    font-size: 15px;
+    line-height: 1.4em;
+    margin: 0 0 6px 0;
+  }
+
   .mdl-tabs {
     .tab-container {
       background-color: $mm-brand-bg;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
fix  #4459

#### What's this PR do?
Up date styles for course titles, some of the styles overlap with course styles on the dashboard page. 
Also removed the padding for enrollment information if there are no electives.


#### How should this be manually tested?
![Screen Shot 2019-11-15 at 3 33 54 PM](https://user-images.githubusercontent.com/7574259/68974590-1d4db000-07bf-11ea-80e8-c6aae8abd5a7.png)

![Screen Shot 2019-11-15 at 3 37 58 PM](https://user-images.githubusercontent.com/7574259/68974603-2474be00-07bf-11ea-80ce-dedb54493fb6.png)
