### PR TITLE
remove instructors carousel from course team tab page.

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -232,6 +232,13 @@ class CourseTeamTabPage(ProgramChildPage):
         StreamFieldPanel('teaching_assistants'),
     ]
 
+    def get_context(self, request, *args, **kwargs):
+        context = super(CourseTeamTabPage, self).get_context(request)
+
+        # this will help us to disable instructors carousel on course team page
+        context['course_team_tab_title'] = self.title
+        return context
+
 
 class ProgramPage(Page):
     """

--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -157,18 +157,20 @@
     </div>
   </div>
 
-  {% if page.faculty_members.count > 0 %}
-    <section class="faculty-section mdl-grid mdl-grid--no-spacing">
-      <div class="mdl-cell mdl-cell--12-col">
-        <h3 class="title">Instructors</h3>
-        {% if page.faculty_description|length > 0 %}
-          <p class="description">{{ page.faculty_description }}</p>
-        {% endif %}
-      </div>
-      <div id="faculty-carousel" class="mdl-cell--12-col">
-        <!-- React-Slick carousel component injected here -->
-      </div>
-    </section>
+  {% if active_tab != course_team_tab_title %}
+    {% if page.faculty_members.count > 0 %}
+      <section class="faculty-section mdl-grid mdl-grid--no-spacing">
+        <div class="mdl-cell mdl-cell--12-col">
+          <h3 class="title">Instructors</h3>
+          {% if page.faculty_description|length > 0 %}
+            <p class="description">{{ page.faculty_description }}</p>
+          {% endif %}
+        </div>
+        <div id="faculty-carousel" class="mdl-cell--12-col">
+          <!-- React-Slick carousel component injected here -->
+        </div>
+      </section>
+    {% endif %}
   {% endif %}
 
 </main>

--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -157,20 +157,18 @@
     </div>
   </div>
 
-  {% if active_tab != course_team_tab_title %}
-    {% if page.faculty_members.count > 0 %}
-      <section class="faculty-section mdl-grid mdl-grid--no-spacing">
-        <div class="mdl-cell mdl-cell--12-col">
-          <h3 class="title">Instructors</h3>
-          {% if page.faculty_description|length > 0 %}
-            <p class="description">{{ page.faculty_description }}</p>
-          {% endif %}
-        </div>
-        <div id="faculty-carousel" class="mdl-cell--12-col">
-          <!-- React-Slick carousel component injected here -->
-        </div>
-      </section>
-    {% endif %}
+  {% if active_tab != course_team_tab_title and page.faculty_members.count > 0 %}
+    <section class="faculty-section mdl-grid mdl-grid--no-spacing">
+      <div class="mdl-cell mdl-cell--12-col">
+        <h3 class="title">Instructors</h3>
+        {% if page.faculty_description|length > 0 %}
+          <p class="description">{{ page.faculty_description }}</p>
+        {% endif %}
+      </div>
+      <div id="faculty-carousel" class="mdl-cell--12-col">
+        <!-- React-Slick carousel component injected here -->
+      </div>
+    </section>
   {% endif %}
 
 </main>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fixes https://github.com/mitodl/micromasters/issues/4468

#### What's this PR do?
Add a check to remove for instructors carousel from the course team tab page.

#### How should this be manually tested?

- Create a program
- Add faculty members
- Add a child page `course team tab page`
- Render program page, you should see instructors carousel on the program page
- Goto course team tab page, you should not see instructors carousel on the program page
