### PR TITLE
Splitting exam authorization task into smaller subtasks

### DIFF
--- a/exams/api.py
+++ b/exams/api.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q
 
-from dashboard.models import ProgramEnrollment
 from dashboard.utils import get_mmtrack
 from dashboard.api import has_to_pay_for_exam
 from exams.exceptions import ExamAuthorizationException

--- a/exams/api.py
+++ b/exams/api.py
@@ -158,24 +158,6 @@ def authorize_for_latest_passed_course(mmtrack, exam_run):
             break
 
 
-def bulk_authorize_for_exam_run(exam_run):
-    """
-    Authorize all eligible users for the given exam run
-
-    Args:
-        exam_run(exams.models.ExamRun): the exam run to authorize for
-    """
-    for program_enrollment in ProgramEnrollment.objects.filter(
-            program=exam_run.course.program
-    ).iterator():
-        mmtrack = get_mmtrack(
-            program_enrollment.user,
-            program_enrollment.program
-        )
-
-        authorize_for_latest_passed_course(mmtrack, exam_run)
-
-
 def authorize_user_for_schedulable_exam_runs(user, course_run):
     """
     Authorizes a user for all schedulable ExamRuns for a CourseRun

--- a/exams/tasks.py
+++ b/exams/tasks.py
@@ -8,7 +8,6 @@ from django.db import transaction
 from celery import group
 
 from dashboard.models import ProgramEnrollment
-from dashboard.utils import get_mmtrack
 from exams import api
 from exams.api import authorize_for_latest_passed_course
 from exams.pearson.exceptions import RetryableSFTPException
@@ -247,16 +246,11 @@ def authorize_enrollment_for_exam_run(enrollment_ids, exam_run_id):
     Returns:
         None
     """
-    # pylint: disable=bare-except
     exam_run = ExamRun.objects.get(id=exam_run_id)
     for enrollment in ProgramEnrollment.objects.filter(id__in=enrollment_ids):
         try:
-            mmtrack = get_mmtrack(
-                enrollment.user,
-                enrollment.program
-            )
-            authorize_for_latest_passed_course(mmtrack, exam_run)
-
+            authorize_for_latest_passed_course(enrollment.user, exam_run)
+        # pylint: disable=bare-except
         except:
             log.exception(
                 'Impossible to authorize user "%s" for exam_run %s',

--- a/exams/tasks.py
+++ b/exams/tasks.py
@@ -247,7 +247,7 @@ def authorize_enrollment_for_exam_run(enrollment_ids, exam_run_id):
         None
     """
     exam_run = ExamRun.objects.get(id=exam_run_id)
-    for enrollment in ProgramEnrollment.objects.filter(id__in=enrollment_ids):
+    for enrollment in ProgramEnrollment.objects.filter(id__in=enrollment_ids).prefetch_related('user'):
         try:
             authorize_for_latest_passed_course(enrollment.user, exam_run)
         # pylint: disable=bare-except

--- a/exams/tasks.py
+++ b/exams/tasks.py
@@ -247,6 +247,7 @@ def authorize_enrollment_for_exam_run(enrollment_ids, exam_run_id):
     Returns:
         None
     """
+    # pylint: disable=bare-except
     exam_run = ExamRun.objects.get(id=exam_run_id)
     for enrollment in ProgramEnrollment.objects.filter(id__in=enrollment_ids):
         try:

--- a/exams/tasks_test.py
+++ b/exams/tasks_test.py
@@ -345,7 +345,7 @@ class ExamRunTasksTest(MockedESTestCase):
         """Test authorize_exam_runs()"""
         program, _ = create_program()
         course = program.course_set.first()
-        ProgramEnrollmentFactory.create(program=program)
+        enrollment = ProgramEnrollmentFactory.create(program=program)
         current_run = ExamRunFactory.create(course=course, authorized=authorized)
         past_run = ExamRunFactory.create(course=course, scheduling_future=True, authorized=authorized)
         future_run = ExamRunFactory.create(course=course, scheduling_past=True, authorized=authorized)
@@ -355,6 +355,9 @@ class ExamRunTasksTest(MockedESTestCase):
             assert authorize_for_latest_passed_course_mock.call_count == 0
         else:
             assert authorize_for_latest_passed_course_mock.call_count == 2
+
+            authorize_for_latest_passed_course_mock.assert_any_call(enrollment.user, current_run)
+            authorize_for_latest_passed_course_mock.assert_any_call(enrollment.user, future_run)
 
             for exam_run in (current_run, future_run):
                 exam_run.refresh_from_db()


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fix Sentry issue https://sentry.io/organizations/mit-office-of-digital-learning/issues/1143927971/?project=104497&query=is%3Aunresolved+&statsPeriod=14d

#### What's this PR do?
Splitting exam authorization task into smaller subtasks

#### How should this be manually tested?
Tests should pass
