### PR TITLE
Dashboard: fix elective tags

### DIFF
--- a/certificates/views.py
+++ b/certificates/views.py
@@ -228,7 +228,7 @@ class GradeRecordView(TemplateView):
                 "status": "Earned" if get_certificate_url(mmtrack, course) else "Not Earned",
                 "date_earned": combined_grade.created_on if combined_grade else "",
                 "overall_grade": mmtrack.get_overall_final_grade_for_course(course),
-                "elective_tag": "Elective" if (getattr(course, "electivecourse", None) is not None) else "Core"
+                "elective_tag": "elective" if (getattr(course, "electivecourse", None) is not None) else "core"
             })
 
         return context

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -78,7 +78,7 @@ class CourseSerializer(serializers.ModelSerializer):
         """If the course is an elective"""
         if not course.program.electives_set.exists():
             return ""
-        return 'Elective' if ElectiveCourse.objects.filter(course=course).exists() else 'Core'
+        return 'elective' if ElectiveCourse.objects.filter(course=course).exists() else 'core'
 
     class Meta:
         model = Course

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -60,7 +60,7 @@ class CourseSerializerTests(MockedESTestCase):
         elective_set = ElectivesSet.objects.create(program=course.program, required_number=1)
         ElectiveCourse.objects.create(course=course, electives_set=elective_set)
         data = CourseSerializer(course).data
-        assert data['elective_tag'] == 'Elective'
+        assert data['elective_tag'] == 'elective'
 
 
 class CourseRunSerializerTests(MockedESTestCase):

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -206,7 +206,7 @@ export default class CourseRow extends React.Component {
   }
   getCourseTag = (): React$Element<*> => {
     const { course } = this.props
-    const tag = course.is_elective ? "Elective" : "Core"
+    const tag = course.is_elective ? "elective" : "core"
     return <div className={`elective-tag ${tag}`}>{tag}</div>
   }
 

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -206,11 +206,8 @@ export default class CourseRow extends React.Component {
   }
   getCourseTag = (): React$Element<*> => {
     const { course } = this.props
-    return (
-      <div className="elective-tag">
-        {course.is_elective ? "Elective" : "Core"}
-      </div>
-    )
+    const tag = course.is_elective ? "Elective" : "Core"
+    return <div className={`elective-tag ${tag}`}>{tag}</div>
   }
 
   renderCourseInfo = (run: CourseRun) => {

--- a/static/js/components/dashboard/CourseRow_test.js
+++ b/static/js/components/dashboard/CourseRow_test.js
@@ -95,7 +95,7 @@ describe("CourseRow", () => {
       },
       true
     )
-    assert.deepEqual(wrapper.find(".elective-tag").text(), "Elective")
+    assert.deepEqual(wrapper.find(".elective-tag").text(), "elective")
   })
 
   it("displays a CourseAction if the showStaffView prop is not set", () => {

--- a/static/scss/dashboard/course-row.scss
+++ b/static/scss/dashboard/course-row.scss
@@ -33,6 +33,7 @@
 
   .course-info {
     margin: 29px 22px 35px 28px;
+    width: 100%;
 
     .course-title {
       font-weight: 500;

--- a/static/scss/dashboard/course-row.scss
+++ b/static/scss/dashboard/course-row.scss
@@ -12,19 +12,26 @@
   display: inline-flex;
   color: $lightgray;
   padding: 1px 4px;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 300;
   float: right;
   border-radius: 4px;
   margin: 1px 5px;
+  text-transform: uppercase;
 }
 
-.elective-tag.Core {
+.elective-tag.core {
   background: $mm-brand-bg-dark;
 }
 
-.elective-tag.Elective {
+.elective-tag.elective {
   background: $elective-bg-color;
+}
+
+.course-row.course-container {
+  .course-info {
+    width: 100%;
+  }
 }
 
 .course-row {
@@ -33,7 +40,6 @@
 
   .course-info {
     margin: 29px 22px 35px 28px;
-    width: 100%;
 
     .course-title {
       font-weight: 500;

--- a/ui/templates/grade_record.html
+++ b/ui/templates/grade_record.html
@@ -71,7 +71,7 @@
           {% for record in courses %}
             <tr>
               <td>{{ record.title }}
-                {% if has_electives %}<div class="elective-tag">{{ record.elective_tag }}</div>{% endif %}</td>
+                {% if has_electives %}<div class="elective-tag {{ record.elective_tag | lower}}}">{{ record.elective_tag }}</div>{% endif %}</td>
               <td>{{ record.edx_course_key }}</td>
               <td>{% if record.overall_grade %}{{ record.overall_grade}}%{% endif %}</td>
               <td>{{ record.letter_grade }}</td>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fix #4484

#### What's this PR do?
Add the missing styles to the elective tags.

#### How should this be manually tested?
Test with a program that has elective courses
In the dashboard, the list of courses should be labeled accordingly:
<img width="461" alt="Screen Shot 2019-12-18 at 1 24 58 PM" src="https://user-images.githubusercontent.com/7574259/71112694-0c1b0900-219a-11ea-93be-9aa53d7a8b38.png">


