### PR TITLE
Update CombinedFinalGrades when exam run gets updated

### DIFF
--- a/grades/api.py
+++ b/grades/api.py
@@ -18,7 +18,8 @@ from grades.models import (
     FinalGrade,
     FinalGradeStatus,
     MicromastersProgramCertificate,
-    CombinedFinalGrade, MicromastersCourseCertificate, MicromastersProgramCommendation)
+    CombinedFinalGrade, MicromastersCourseCertificate,
+    ProctoredExamGrade, MicromastersProgramCommendation)
 
 CACHE_KEY_FAILED_USERS_BASE_STR = "failed_users_{0}"
 
@@ -322,3 +323,19 @@ def update_or_create_combined_final_grade(user, course):
         defaults={'grade': calculated_grade}
     )
     combined_grade.save_and_log(None)
+
+
+def update_existing_combined_final_grade_for_exam_run(exam_run):
+    """
+    Given an exam run, find all users with combined grades and update them
+
+    Args:
+        exam_run (ExamRun): an exam run that was updated
+    """
+    users_with_grade = set(CombinedFinalGrade.objects.filter(course=exam_run.course).values_list('user', flat=True))
+    exam_grades = ProctoredExamGrade.objects.filter(
+        exam_run=exam_run, user_id__in=users_with_grade
+    ).select_related('user')
+
+    for exam_grade in exam_grades:
+        update_or_create_combined_final_grade(exam_grade.user, exam_run.course)

--- a/grades/api.py
+++ b/grades/api.py
@@ -327,7 +327,8 @@ def update_or_create_combined_final_grade(user, course):
 
 def update_existing_combined_final_grade_for_exam_run(exam_run):
     """
-    Given an exam run, find all users with combined grades and update them
+    Given an exam run, find all users with combined grades and
+     exam grades for this exam run and update them
 
     Args:
         exam_run (ExamRun): an exam run that was updated

--- a/grades/signals.py
+++ b/grades/signals.py
@@ -5,7 +5,7 @@ from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from grades.models import MicromastersCourseCertificate, ProctoredExamGrade, FinalGrade, MicromastersProgramCertificate
+from grades.models import MicromastersCourseCertificate, FinalGrade, MicromastersProgramCertificate
 from grades.api import generate_program_certificate, update_or_create_combined_final_grade, generate_program_letter
 
 
@@ -28,14 +28,6 @@ def handle_create_programcertificate(sender, instance, created, **kwargs):  # py
     if created:
         user = instance.user
         transaction.on_commit(lambda: generate_program_letter(user, instance.program))
-
-
-@receiver(post_save, sender=ProctoredExamGrade, dispatch_uid="examgrade_post_save")
-def handle_create_exam_grade(sender, instance, created, **kwargs):  # pylint: disable=unused-argument
-    """
-    When a ProctoredExamGrade model is created or updated
-    """
-    transaction.on_commit(lambda: update_or_create_combined_final_grade(instance.user, instance.course))
 
 
 @receiver(post_save, sender=FinalGrade, dispatch_uid="final_grade_post_save")


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fix #4403

#### What's this PR do?
Add a signal to ExamRun, when it gets updated, find all existing `CombinedFinalGrade`s and update them.

#### How should this be manually tested?
Have a learner with a passing exam grade and a passing final grade. The CombinedFinalGrade should get created with regular task. 
Then later create another exam run for that course, and a passing exam grade. Then set the date for grades available on ExamRun, and the combined grade should get updated.

