### PR TITLE
Downgrade redis to workaround

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -34,7 +34,7 @@ pysftp==0.2.9
 PyNaCl==1.3.0
 python-dateutil
 raven==6.9.0
-redis==3.4.1
+redis==3.3.0
 requests>=2.20.0
 six>=1.11.0
 social-auth-app-django==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ python-dateutil==2.5.3    # via -r requirements.in, edx-api-client, elasticsearc
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.5              # via celery, django, django-modelcluster, wagtail
 raven==6.9.0              # via -r requirements.in
-redis==3.4.1              # via -r requirements.in, django-redis, django-server-status
+redis==3.3.0              # via -r requirements.in, django-redis, django-server-status
 requests-oauthlib==1.0.0  # via social-auth-core
 requests==2.21.0          # via -r requirements.in, edx-api-client, open-discussions-client, requests-oauthlib, social-auth-core, wagtail
 robohash==1.0             # via -r requirements.in


### PR DESCRIPTION
Works around https://github.com/andymccurdy/redis-py/issues/1274#issuecomment-580897258

#### What are the relevant tickets?
https://sentry.io/organizations/mit-office-of-digital-learning/issues/1549202925/?project=159445

#### What's this PR do?
Fixes `wrong number of arguments for AUTH` exception

#### How should this be manually tested?
Merge, then recreate the release candidate. Sentry should stop recording those errors.
