### PR TITLE
Mobile Home View: fix header name

### DIFF
--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -68,7 +68,7 @@ body.app-media {
         display: inline-block;
         color: white;
         font-size: 17px;
-        margin: 0 20px 0 0;
+        margin: 0;
         font-weight: 300;
         float: left;
         position: relative;


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fix styling issue for mobile home view

#### How should this be manually tested?
checkout the home page in mobile view
After:
<img width="366" alt="Screen Shot 2020-03-16 at 2 01 32 PM" src="https://user-images.githubusercontent.com/7574259/76787330-2f505700-678f-11ea-987c-3fe8326c20f4.png">
Before:
<img width="411" alt="Screen Shot 2020-03-16 at 2 01 47 PM" src="https://user-images.githubusercontent.com/7574259/76787338-32e3de00-678f-11ea-8d25-01a63ee48a1e.png">