### PR TITLE
Retire users by email

### DIFF
--- a/profiles/management/commands/retire_users_test.py
+++ b/profiles/management/commands/retire_users_test.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import User
 from django.core.management import CommandError
 from django.test import TestCase
 from social_django.models import UserSocialAuth
+import pytest
 
 from profiles.management.commands import retire_users
 from micromasters.factories import UserFactory, UserSocialAuthFactory
@@ -48,6 +49,38 @@ class AlterDataCommandTests(TestCase):
         assert UserSocialAuth.objects.filter(user=user).count() == 0
         assert ProgramEnrollment.objects.filter(user=user).count() == 0
 
+    def test_single_success_user_with_email(self):
+        """test retire_users command with email success"""
+        user = UserFactory.create(email='foo@example.com', is_active=True)
+        user.profile.email_optin = True
+        user.profile.save()
+        UserSocialAuthFactory.create(user=user, provider='not_edx')
+
+        for _ in range(TOTAL_PROGRAMS):
+            ProgramEnrollmentFactory.create(user=user)
+
+        assert user.is_active is True
+        assert user.profile.email_optin is True
+        assert UserSocialAuth.objects.filter(user=user).count() == 1
+
+        assert ProgramEnrollment.objects.filter(user=user).count() == TOTAL_PROGRAMS
+
+        self.command.handle("retire_users", users=["foo@example.com"])
+
+        user.refresh_from_db()
+        assert user.is_active is False
+        assert user.profile.email_optin is False
+        assert UserSocialAuth.objects.filter(user=user).count() == 0
+        assert ProgramEnrollment.objects.filter(user=user).count() == 0
+
+    def test_error_with_invalid_users(self):
+        """test retire_users command with invalid users """
+        users = ["", "mitodl"]
+        self.command.handle("retire_users", users=users)
+        for user in users:
+            with pytest.raises(User.DoesNotExist):
+                User.objects.get(username=user)
+
     def test_multiple_success(self):
         """test retire_users command success with more than one user"""
         user_names = ["foo", "bar", "baz"]
@@ -69,6 +102,32 @@ class AlterDataCommandTests(TestCase):
 
         for user_name in user_names:
             user = User.objects.get(username=user_name)
+            assert user.is_active is False
+            assert user.profile.email_optin is False
+            assert UserSocialAuth.objects.filter(user=user).count() == 0
+            assert ProgramEnrollment.objects.filter(user=user).count() == 0
+
+    def test_multiple_success_with_user_email(self):
+        """test retire_users command success with more than one user emails"""
+        users = ["foo@example.com", "bar@example.com", "baz@example.com"]
+
+        for current_user in users:
+            user = UserFactory.create(email=current_user, is_active=True)
+            user.profile.email_optin = True
+            user.profile.save()
+            UserSocialAuthFactory.create(user=user, provider='not_edx')
+            for _ in range(TOTAL_PROGRAMS):
+                ProgramEnrollmentFactory.create(user=user)
+
+            assert user.is_active is True
+            assert user.profile.email_optin is True
+            assert UserSocialAuth.objects.filter(user=user).count() == 1
+            assert ProgramEnrollment.objects.filter(user=user).count() == TOTAL_PROGRAMS
+
+        self.command.handle("retire_users", users=users)
+
+        for current_user in users:
+            user = User.objects.get(email=current_user)
             assert user.is_active is False
             assert user.profile.email_optin is False
             assert UserSocialAuth.objects.filter(user=user).count() == 0


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#4525 / https://trello.com/c/H0CezVHG/26-retire-users-by-email-address-in-addition-to-username

#### What's this PR do?
fixes #4525 

#### How should this be manually tested?
Run the retire user management command with the email.
`docker-compose exec web ./manage.py retire_users --user={email}`


#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2020-03-20 at 17 09 44" src="https://user-images.githubusercontent.com/4043989/77163160-511f4600-6acf-11ea-9daa-93289cfc54b4.png">