### PR TITLE
Redirect cms login and forgot password pages to our site login page

### DIFF
--- a/cms/views.py
+++ b/cms/views.py
@@ -1,0 +1,15 @@
+"""
+cms views
+"""
+from django.contrib.auth.views import redirect_to_login
+from django.urls import reverse
+
+
+def cms_signin_redirect_to_site_signin(request):
+    """Redirect wagtail admin signin to site signin page"""
+    return redirect_to_login(reverse('wagtailadmin_home'), login_url="/")
+
+
+def cms_password_reset_redirect_to_site_signin(request):
+    """Redirect wagtail admin password reset to site signin page"""
+    return redirect_to_login(reverse('wagtailadmin_home'), login_url="/")

--- a/cms/views_test.py
+++ b/cms/views_test.py
@@ -1,0 +1,24 @@
+"""
+Test end to end django views.
+"""
+from django.urls import reverse
+import pytest
+
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_cms_signin_redirect_to_site_signin(client):
+    """
+    Test that the cms/password_reset redirects users to site signin page.
+    """
+    response = client.get(reverse("wagtailadmin_home"), follow=True)
+    assert response.template_name == "cms/home_page.html"
+
+
+def test_cms_password_reset_redirect_to_site_signin(client):
+    """
+    Test that the cms/password_reset redirects users to site signin page.
+    """
+    response = client.get(reverse("wagtailadmin_password_reset"), follow=True)
+    assert response.template_name == "cms/home_page.html"

--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -7,6 +7,10 @@ from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.core import urls as wagtail_urls
 
+from cms.views import (
+    cms_signin_redirect_to_site_signin,
+    cms_password_reset_redirect_to_site_signin
+)
 
 urlpatterns = []
 
@@ -34,6 +38,8 @@ urlpatterns += [
     # Hijack
     url(r'^hijack/', include('hijack.urls', namespace='hijack')),
     # Wagtail
+    url(r'^cms/login/', cms_signin_redirect_to_site_signin, name='wagtailadmin_login'),
+    url(r'^cms/password_reset/', cms_password_reset_redirect_to_site_signin, name='wagtailadmin_password_reset'),
     url(r'^cms/', include(wagtailadmin_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
     url('', include(wagtail_urls)),

--- a/selenium_tests/redirect_test.py
+++ b/selenium_tests/redirect_test.py
@@ -17,7 +17,7 @@ pytestmark = [
 FAKE_RESPONSE = 'Custom response message for selenium test'
 urlpatterns = [
     url(r'login/edxorg/', lambda *args: HttpResponse(content=FAKE_RESPONSE))
-    if urlpattern.app_name == 'social' else urlpattern
+    if hasattr(urlpattern, 'app_name') and urlpattern.app_name == 'social' else urlpattern
     for urlpattern in urlpatterns
 ]
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#684 / https://trello.com/c/QOR6q3J1/307-cms-hide-change-forgotten-password-link-in-wagtail

#### What's this PR do?
fixes #684

#### How should this be manually tested?
Just visit 
- http://mm.odl.local:8079/cms/login
- http://mm.odl.local:8079/cms/password_reset
It will redirect to the site home page.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)