### PR TITLE
Youtube embed should be column width - #4581

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -183,4 +183,17 @@
 {% load render_bundle %}
 {% render_bundle "public" %}
 <script defer src="https://code.getmdl.io/1.2.1/material.min.js"></script>
+<script type="text/javascript">
+  let iframes = document.querySelectorAll(".rich-text>div>iframe");
+  iframes.forEach(function(frame) {
+    frame.style.position = "absolute";
+    frame.style.top = 0;
+    frame.style.left = 0;
+    frame.style.width = "100%";
+    frame.style.height = "100%";
+    frame.parentElement.style.position = "relative";
+    frame.parentElement.style['padding-bottom'] = "56.25%";
+    frame.parentElement.style.height = 0;
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
[Ticket](https://trello.com/c/qG78Fr5m/363-css-regression-youtube-videos-should-be-column-width)
#4581 

#### What's this PR do?
Adds javascript code to the program page template to fix styles on video embeds within rich text fields. This cannot be done simply by adding CSS because we're not using Wagtail Streamfield correctly and all the content (text and embeds) are coming from a rich text field. This requires selecting the correct elements from the markup and updating CSS at runtime.

#### How should this be manually tested?
Create a program page and add an embed in the description. Verify that the embed is full-width for the column.

#### Screenshots (if appropriate)
Before
<img width="831" alt="Screenshot 2020-04-01 at 2 40 20 PM" src="https://user-images.githubusercontent.com/6387678/78123261-55c8f000-7427-11ea-90fc-b04f66251965.png">

After
<img width="833" alt="Screenshot 2020-04-01 at 2 39 56 PM" src="https://user-images.githubusercontent.com/6387678/78123168-35009a80-7427-11ea-8b7a-e3318b11444a.png">