### PR TITLE
Warnings related to wagtail upgrade - #4563

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -432,7 +432,7 @@ class InfoLinks(Orderable):
         help_text='The text for the link to an external homepage.'
     )
 
-    content_panels = [
+    panels = [
         MultiFieldPanel(
             [
                 FieldPanel('url'),
@@ -453,7 +453,7 @@ class SemesterDate(Orderable):
     )
     start_date = models.DateField()
 
-    content_panels = [
+    panels = [
         MultiFieldPanel(
             [
                 FieldPanel('semester_name'),
@@ -476,10 +476,12 @@ class ProgramCourse(Orderable):
     )
     title = models.CharField(max_length=255, default='')
     description = RichTextField(blank=True, null=True)
-    content_panels = Page.content_panels + [
+    panels = [
         MultiFieldPanel(
             [
+                FieldPanel('course'),
                 FieldPanel('title'),
+                FieldPanel('description'),
             ]
         )
     ]
@@ -501,7 +503,7 @@ class ProgramFaculty(Orderable):
         related_name='+',
         help_text='Image for the faculty member. Should be 500px by 385px.'
     )
-    content_panels = Page.content_panels + [
+    panels = [
         MultiFieldPanel(
             [
                 FieldPanel('name'),
@@ -537,7 +539,7 @@ class FrequentlyAskedQuestion(Orderable):
             self.slug = slug
         super(FrequentlyAskedQuestion, self).save(*args, **kwargs)
 
-    content_panels = [
+    panels = [
         MultiFieldPanel(
             [
                 FieldPanel('question'),
@@ -576,7 +578,7 @@ class CourseCertificateSignatories(Orderable):
         on_delete=models.CASCADE,
     )
 
-    content_panels = [
+    panels = [
         MultiFieldPanel(
             [
                 FieldPanel('name'),
@@ -609,7 +611,7 @@ class ProgramCertificateSignatories(Orderable):
         on_delete=models.CASCADE,
     )
 
-    content_panels = [
+    panels = [
         MultiFieldPanel(
             [
                 FieldPanel('name'),
@@ -638,7 +640,7 @@ class ProgramLetterSignatory(Orderable):
         on_delete=models.CASCADE,
     )
 
-    content_panels = [
+    panels = [
         MultiFieldPanel(
             [
                 FieldPanel('name'),


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#4563 

#### What's this PR do?
Modifies inline edited models to use `panels` instead of `content_panels`. This gets rid of warnings from Wagtail.

#### How should this be manually tested?
Go to the CMS and edit different pages. Functionality and UI should remain the same while there should be no more warnings.