### PR TITLE
Configure sentry's python sdk to not capture SystemExit

### DIFF
--- a/micromasters/sentry.py
+++ b/micromasters/sentry.py
@@ -1,8 +1,12 @@
 """Sentry setup and configuration"""
+from celery.exceptions import WorkerLostError
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
+
+# these errors occur when a shutdown is happening (usually caused by a SIGTERM)
+SHUTDOWN_ERRORS = (WorkerLostError, SystemExit)
 
 
 def init_sentry(*, dsn, environment, version, log_level):
@@ -14,10 +18,28 @@ def init_sentry(*, dsn, environment, version, log_level):
         version (str): the version of the application
         log_level (str): the sentry log level
     """
+
+    def before_send(event, hint):
+        """
+        Filter or transform events before they're sent to Sentry
+        Args:
+            event (dict): event object
+            hint (dict): event hint, see https://docs.sentry.io/platforms/python/#hints
+        Returns:
+            dict or None: returns the modified event or None to filter out the event
+        """
+        if 'exc_info' in hint:
+            _, exc_value, _ = hint['exc_info']
+            if isinstance(exc_value, SHUTDOWN_ERRORS):
+                # we don't want to report shutdown errors to sentry
+                return None
+        return event
+
     sentry_sdk.init(
         dsn=dsn,
         environment=environment,
         release=version,
+        before_send=before_send,
         integrations=[
             DjangoIntegration(),
             CeleryIntegration(),


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#4522, https://trello.com/c/NY9pgeqJ/23-configure-sentrys-python-sdk-to-not-capture-systemexit

#### What's this PR do?
fixes #4522, Configure sentry's python SDK to not capture SystemExit

#### How should this be manually tested?
Just keep running the app, it should keep creating events in Sentry and the app should not keep running

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2020-04-07 at 16 56 42" src="https://user-images.githubusercontent.com/4043989/78666437-d2107700-78f0-11ea-8738-2f78bae9857f.png">
