### PR TITLE
Mouseover highlight squished fix - #4574

### DIFF
--- a/static/js/components/dashboard/FinalExamCard.js
+++ b/static/js/components/dashboard/FinalExamCard.js
@@ -81,7 +81,7 @@ const accountCreated = (profile, navigateToProfile) => (
 )
 
 const editProfileButton = fn => (
-  <IconButton onClick={fn}>
+  <IconButton className="vertical-center" onClick={fn}>
     <Icon>edit</Icon>
   </IconButton>
 )

--- a/static/scss/final-exam-card.scss
+++ b/static/scss/final-exam-card.scss
@@ -81,6 +81,10 @@
         display: flex;
         justify-content: space-between;
 
+        .vertical-center {
+          align-self: center;
+        }
+
         .address {
           display: flex;
           flex-direction: column;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
[Ticket](https://trello.com/c/S7ayTeW3/356-css-bug-mouseover-highlight-squished)
#4574 

#### What's this PR do?
Updates the css to vertically center and properly size the edit button (plus the hover highlight) on proctored final exam card on the dashboard.

#### How should this be manually tested?
Have a user eligible for a proctored exam, visit the dashboard to view the updated UI.
Instructions in here for proctored exam eligibility setup: https://github.com/mitodl/micromasters/pull/2492

#### Screenshots (if appropriate)
<img width="389" alt="Screenshot 2020-04-07 at 6 47 39 PM" src="https://user-images.githubusercontent.com/6387678/78676909-84036f80-7900-11ea-9ab2-691509b5d0c0.png">
<img width="776" alt="Screenshot 2020-04-07 at 6 07 49 PM" src="https://user-images.githubusercontent.com/6387678/78676929-882f8d00-7900-11ea-8e36-454b5fe42356.png">