### PR TITLE
Temporarily remove uwsgi strict mode

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,5 +1,4 @@
 [uwsgi]
-strict = true
 need-app = true
 auto-procname = true
 if-env = DEV_ENV


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?

https://trello.com/c/upfutK0A/44-update-all-uwsgi-configs-with-recommendations-from-bloomberg-article

#### What's this PR do?

Removes uWSGI strict mode directive. We will re-introduce it after renaming some of the environment variables that appear in `uwsgi.ini`.

This is problematic: https://uwsgi-docs.readthedocs.io/en/latest/Configuration.html#environment-variables
... Config variables are automatically assigned for env vars that start with `UWSGI_`. With strict mode on, bogus config setting names raise errors.


#### How should this be manually tested?

We've already tested it in a local environment, removing `strict = true` and observing that an error goes away.