### PR TITLE
fix phone number issues (came up w/ Vietnamese numbers)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@sentry/browser": "^5.15.4",
     "ajaxchimp": "^1.3.0",
     "autoprefixer": "^7.1.1",
-    "awesome-phonenumber": "^1.1.3",
+    "awesome-phonenumber": "^2.35.0",
     "axios-mock-adapter": "^1.8.1",
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",

--- a/static/js/lib/validation/profile_test.js
+++ b/static/js/lib/validation/profile_test.js
@@ -385,15 +385,32 @@ describe("Profile validation functions", () => {
       assert.deepEqual(personalValidation(profile), {})
     })
 
-    it("should complain if you enter an invalid phone number", () => {
-      const profile = {
-        ...USER_PROFILE_RESPONSE,
-        phone_number: "+1 222"
-      }
-      const errors = {
-        phone_number: "Please enter a valid phone number"
-      }
-      assert.deepEqual(personalValidation(profile), errors)
+    //
+    ;[
+      ["+84-03-6123-4567", true],
+      ["+1-213-223-3321", true],
+      ["+1-911-223-3321", false],
+      ["+1 222", false],
+      ["asdfasdf", false],
+      ["一二三四五六", false]
+    ].forEach(([number, isValid]) => {
+      it(`${
+        isValid ? "shouldn't" : "should"
+      } complain that ${number} is invalid`, () => {
+        const profile = {
+          ...USER_PROFILE_RESPONSE,
+          phone_number: number
+        }
+        assert.d
+        assert.deepEqual(
+          personalValidation(profile),
+          isValid
+            ? {}
+            : {
+              phone_number: "Please enter a valid phone number"
+            }
+        )
+      })
     })
   })
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -20,3 +20,4 @@ semantic-version
 selenium==3.141.0
 testfixtures
 tox
+isort==4.3.21

--- a/yarn.lock
+++ b/yarn.lock
@@ -919,10 +919,10 @@ autoprefixer@^7.1.1:
     postcss "^6.0.17"
     postcss-value-parser "^3.2.3"
 
-awesome-phonenumber@^1.1.3:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/awesome-phonenumber/-/awesome-phonenumber-1.6.0.tgz#fdb89d5d1ac3306cf830ddcb72327e9fdb0b18ec"
-  integrity sha512-/2bqNSeMzZoAelMImkX3cFV44H0CTSCelofYBVN4jJxvtSL3p99/iUysiP1E2nRBbJPoyX0SH0vEwQFF6rXAzw==
+awesome-phonenumber@^2.35.0:
+  version "2.35.0"
+  resolved "https://registry.yarnpkg.com/awesome-phonenumber/-/awesome-phonenumber-2.35.0.tgz#4c8fe5ec74bde86c86f7535fe74b588ce98b9327"
+  integrity sha512-d9PgzixrJqYnk5GHOL+7yKVcgpDAxHCmaiMS4NkuPhCC37I9rDFYbMM9cHftDmCiZ85q24FmXOC1/O6mnD+RbQ==
 
 aws-sign2@~0.7.0:
   version "0.7.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

closes #4620 

#### What's this PR do?

just bumps up the phone number validation lib we're using to the latest version. We were using a fairly old version, and we had some users having issues where valid phone numbers were being marked as invalid (particularly ones from Vietnam).

I also added a regression test that exposed the issue and is fixed by the dependency upgrade.

#### How should this be manually tested?

confirm that you can get past the first screen of the profile flow with a Vietnamese phone number like '+84-03-6123-4567'. Also confirm on master that you cannot do so.