### PR TITLE
Fix the size of the SCHEDULE EXAM button

### DIFF
--- a/static/scss/_button.scss
+++ b/static/scss/_button.scss
@@ -263,6 +263,7 @@
   font-weight: 400;
   line-height: 36px;
   border-radius: 2px;
+  height: fit-content;
 
   &[disabled] {
     background-color: adjust-color($button-color, $alpha: -0.5);


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fix https://trello.com/c/a06fND6x/389-css-bug-schedule-an-exam-button-is-too-tall

#### What's this PR do?
Fix the size of the SCHEDULE EXAM button

#### How should this be manually tested?
Set up your dashboard, so that you enrolled in a course or you passed a course. You can use the `alter_data` management command to set that up.  Then create an available exam for scheduling:
```
from courses.models import *
from django.contrib.auth.models import User
from exams.factories import *
from exams.models import *
course = Course.objects.filter(title='Digital Learning 200')[0]

 exam_run = ExamRunFactory.create(course=course, authorized=True)
 user = User.objects.filter(username='student10')[0]

au=ExamAuthorizationFactory.create(user=user, course=course, exam_run=exam_run, status= 'success', exam_taken=True)
exam_profile= ExamProfileFactory.create(status='success', profile=user.profile)
```

<img width="815" alt="Screen Shot 2020-08-12 at 4 20 27 PM" src="https://user-images.githubusercontent.com/7574259/90063714-c9bdb380-dcb7-11ea-93cb-8af2dcf48b65.png">