### PR TITLE
asadiqbal08/mm Shard Count while creating index

### DIFF
--- a/app.json
+++ b/app.json
@@ -71,6 +71,9 @@
     "ELASTICSEARCH_HTTP_AUTH": {
       "description": "Basic auth settings for connecting to Elasticsearch"
     },
+    "ELASTICSEARCH_SHARD_COUNT": {
+      "description": "Configurable shard cound for Elasticsearch"
+    },
     "ELASTICSEARCH_INDEX": {
       "description": "Index to use on Elasticsearch"
     },

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -549,6 +549,7 @@ else:
 if not ELASTICSEARCH_INDEX:
     raise ImproperlyConfigured("Missing ELASTICSEARCH_INDEX")
 ELASTICSEARCH_HTTP_AUTH = get_string("ELASTICSEARCH_HTTP_AUTH", None)
+ELASTICSEARCH_SHARD_COUNT = get_int('ELASTICSEARCH_SHARD_COUNT', 5)
 
 # django-role-permissions
 ROLEPERMISSIONS_MODULE = 'roles.roles'

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -537,6 +537,9 @@ def clear_and_create_index(index_name, *, index_type, skip_mapping=False):
     # from https://www.elastic.co/guide/en/elasticsearch/guide/current/asciifolding-token-filter.html
     conn.indices.create(index_name, body={
         'settings': {
+            'index': {
+                'number_of_shards': settings.ELASTICSEARCH_SHARD_COUNT,
+            },
             'analysis': {
                 'analyzer': {
                     'folding': {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
fixes: #4643 

#### What's this PR do?
`search.indexing_api.clear_and_create_index` should specify a configurable shard count when creating a new index, instead of settling for Elasticsearch's default. 