### PR TITLE
enhance validations for romanized fields

### DIFF
--- a/static/js/util/profile_edit.js
+++ b/static/js/util/profile_edit.js
@@ -259,5 +259,12 @@ export function saveProfileStep(
 export function shouldRenderRomanizedFields(profile: Profile): boolean {
   const firstName = _.get(profile, ["first_name"], "")
   const lastName = _.get(profile, ["last_name"], "")
-  return !CP1252_REGEX.test(firstName) || !CP1252_REGEX.test(lastName)
+  const romanizedFirstName = _.get(profile, ["romanized_first_name"], "")
+  const romanizedLastName = _.get(profile, ["romanized_last_name"], "")
+  return (
+    !CP1252_REGEX.test(firstName) ||
+    !CP1252_REGEX.test(lastName) ||
+    !CP1252_REGEX.test(romanizedFirstName) ||
+    !CP1252_REGEX.test(romanizedLastName)
+  )
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/4638

#### What's this PR do?
It restricts users from entering non-Latin names in their profiles.

#### How should this be manually tested?
1) Create a new account
2) Proceed to the first profile page, at /profile/personal
3) Enter non-Latin characters into the first name field. An emoji like 👍 will work.
4) The form expands to display the romanized name fields so the user can enter alternate names
5) Enter non-Latin characters into the Romanized fields.
6) Tab out of the romanized field. You should see a red underline indicating the validation didn't pass
7) Update the first name field to remove the emoji.
8) Submit the form by clicking the Next button 
You will observe that it's not getting submitted until you remove non-Latin character from romanized fields.

#### Screenshots (if appropriate)
Current Scenario: When a user enters a non-Latin word in expended romanized fields and then removes non-Latin characters from Name (above the expended portion). The extended portion gets hidden and validations for romanized fields stop working.
![image](https://user-images.githubusercontent.com/42243411/94687506-c6ed4f80-0345-11eb-80e6-4de2603da60c.png)

After this PR, The extended portion will keep showing even if you have removed non-Latin character from the Name, until you remove that Latin word from romanized fields as well.
![image](https://user-images.githubusercontent.com/42243411/94687525-d076b780-0345-11eb-981b-96329a45c9c0.png)

