### PR TITLE
Updating the regex for parsing course codes from coupon report

### DIFF
--- a/exams/management/commands/populate_edx_exam_coupons.py
+++ b/exams/management/commands/populate_edx_exam_coupons.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         csvfile = kwargs.get('csvfile')
         reader = csv.DictReader(csvfile.read().splitlines())
         catalog_query = next(reader)['Catalog Query']
-        course_number = re.search(r"key:\(([A-Za-z0-9.]+)", catalog_query).group(1)
+        course_number = re.search(r"\+([A-Za-z0-9.]+)PEx", catalog_query).group(1)
 
         validated_urls = validate_urls(reader)
 


### PR DESCRIPTION
#### What are the relevant tickets?
none

#### What's this PR do?
The coupon report file from edx have a new pattern for exam-course code in the 'Catalog Query` column. 
This PR updates the management command for parsing the coupon codes, with a new regex to parse the course code.

#### How should this be manually tested?
Run the management command with new coupon file.

