### PR TITLE
Django Admin: Added course run filter on final grades

### DIFF
--- a/grades/admin.py
+++ b/grades/admin.py
@@ -11,6 +11,7 @@ class FinalGradeAdmin(admin.ModelAdmin):
     """Admin for FinalGrade"""
     model = models.FinalGrade
     list_display = ('id', 'grade', 'user', 'course_run', )
+    list_filter = ('course_run',)
     ordering = ('course_run',)
     raw_id_fields = ('user',)
     search_fields = (


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots

#### What are the relevant tickets?
Fixes #4676 

#### What's this PR do?
It adds a Django admin filter of `course run` for `Final Grade`

#### How should this be manually tested?
go to `admin/grades/finalgrade/` in `Micromasters` and verify if you have course run filter there and it works fine by selecting a run.

#### Where should the reviewer start?
Micromasters django admin.

#### Screenshots (if appropriate)
<img width="1419" alt="Screenshot 2020-11-11 at 4 02 57 PM" src="https://user-images.githubusercontent.com/34372316/98804048-759da900-2437-11eb-8441-413a617cec7f.png">
