### PR TITLE
Remove google plus share button from footer

### DIFF
--- a/ui/templates/social_buttons.html
+++ b/ui/templates/social_buttons.html
@@ -24,14 +24,6 @@
         <span class="rrssb-text">twitter</span>
       </a>
     </li>
-    <li class="rrssb-googleplus">
-      <a href="" class="popup" aria-label="Share this page on Google Plus">
-        <span class="rrssb-icon">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-            <path d="M21 8.29h-1.95v2.6h-2.6v1.82h2.6v2.6H21v-2.6h2.6v-1.885H21V8.29zM7.614 10.306v2.925h3.9c-.26 1.69-1.755 2.925-3.9 2.925-2.34 0-4.29-2.016-4.29-4.354s1.885-4.353 4.29-4.353c1.104 0 2.014.326 2.794 1.105l2.08-2.08c-1.3-1.17-2.924-1.883-4.874-1.883C3.65 4.586.4 7.835.4 11.8s3.25 7.212 7.214 7.212c4.224 0 6.953-2.988 6.953-7.082 0-.52-.065-1.104-.13-1.624H7.614z"/></svg>            </span>
-        <span class="rrssb-text">google+</span>
-      </a>
-    </li>
     <li class="rrssb-linkedin">
       <a href="" class="popup" aria-label="Share this page on LinkedIn">
         <span class="rrssb-icon">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/4673

#### What's this PR do?
Removes google plus button from the footer

#### How should this be manually tested?
Just go to any page in MM which shows footer, you will observe that the google-plus button is removed.

#### Screenshots (if appropriate)
Desktop Before:
![image](https://user-images.githubusercontent.com/42243411/98948490-50cd3280-2518-11eb-87d3-8cc884e163c8.png)
Desktop After:
![image](https://user-images.githubusercontent.com/42243411/98948482-4d39ab80-2518-11eb-808a-a0ca77030402.png)

Mobile Before:
![image](https://user-images.githubusercontent.com/42243411/98948659-8c67fc80-2518-11eb-8f41-c8bc5ed911f6.png)
Mobile After:
![image](https://user-images.githubusercontent.com/42243411/98948686-9558ce00-2518-11eb-837b-654f0bb66996.png)



