### PR TITLE
Added elective sets and courses in seed_db command

### DIFF
--- a/seed_data/management/programs.json
+++ b/seed_data/management/programs.json
@@ -5,6 +5,46 @@
         "description": "Learn stuff about digital learning.",
         "financial_aid_availability": true,
         "num_required_courses": 3,
+        "elective_sets": [
+            {
+                "title": "ELECTIVE",
+                "required_number": 1,
+                "courses": [
+                    {
+                        "title": "Digital Learning 400 (ELECTIVE)",
+                        "position_in_program": 4,
+                        "description": "An elective course for Digital Learning",
+                        "course_runs": [
+                            {
+                                "title": "Digital Learning 400 - August 2016",
+                                "upgrade_deadline": "2016-08-22T00:00:00+00:00",
+                                "edx_course_key": "course-v1:MITx+Digital+Learning+400+Aug_2016",
+                                "enrollment_start": "2016-08-15T00:00:00+00:00",
+                                "end_date": "2016-12-15T00:00:00+00:00",
+                                "start_date": "2016-08-15T00:00:00+00:00",
+                                "enrollment_end": "2016-08-29T00:00:00+00:00"
+                            }
+                        ]
+                    },
+                    {
+                        "title": "Digital Learning 500 (ELECTIVE)",
+                        "position_in_program": 5,
+                        "description": "An elective advanced course for Digital Learning",
+                        "course_runs": [
+                            {
+                                "title": "Digital Learning 500 - August 2016",
+                                "upgrade_deadline": "2016-08-22T00:00:00+00:00",
+                                "edx_course_key": "course-v1:MITx+Digital+Learning+500+Aug_2016",
+                                "enrollment_start": "2016-08-15T00:00:00+00:00",
+                                "end_date": "2016-12-15T00:00:00+00:00",
+                                "start_date": "2016-08-15T00:00:00+00:00",
+                                "enrollment_end": "2016-08-29T00:00:00+00:00"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
         "courses": [
             {
                 "title": "Digital Learning 100",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #4438 

#### What's this PR do?
It adds `Elective Sets` and `Elective Courses` in our `seed_db` command.

**Note:** I've just added elective sets and courses for one program(`Digital Learning`) just so we have all relevant data(Programs with electives and without electives) available after seed. 

#### How should this be manually tested?
- Run `docker-compose run web ./manage.py seed_db --staff-user='<username>'`
- See that there are elective sets and courses added (You can verify via Django admin and opening Digital Learning program)



#### Any background context you want to provide?
We had `seed_db` before we implemented the electives feature so, and it didn't have the functionality to add elective sets and courses which is addressed in this PR now.
