### PR TITLE
Add OWASP ZAP scanning with Github action

### DIFF
--- a/.github/workflows/scanning.yml
+++ b/.github/workflows/scanning.yml
@@ -11,17 +11,17 @@ jobs:
         with:
           ref: refs/heads/master
       - name: OWASP ZAP Baseline Scan of CI
-        uses: zaproxy/action-baseline@v0.4.0
+        uses: zaproxy/action-baseline
         with:
           target: ${{ secrets.ZAP_CI_TARGET }}
           rules_file_name: '.zap/rules.tsv'
       - name: OWASP ZAP Full Scan of RC
-        uses: zaproxy/action-full-scan@v0.2.0
+        uses: zaproxy/action-full-scan
         with:
           target: ${{ secrets.ZAP_RC_TARGET }}
           rules_file_name: '.zap/rules.tsv'
       - name: OWASP ZAP Full Scan of Production
-        uses: zaproxy/action-full-scan@v0.2.0
+        uses: zaproxy/action-full-scan
         with:
           target: ${{ secrets.ZAP_PROD_TARGET }}
           rules_file_name: '.zap/rules.tsv'

--- a/.github/workflows/scanning.yml
+++ b/.github/workflows/scanning.yml
@@ -1,0 +1,27 @@
+name: Scanning
+on:
+  schedule:
+    - cron: '0 5 * * *'
+jobs:
+  zap_scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: refs/heads/master
+      - name: OWASP ZAP Baseline Scan of CI
+        uses: zaproxy/action-baseline@v0.4.0
+        with:
+          target: ${{ secrets.ZAP_CI_TARGET }}
+          rules_file_name: '.zap/rules.tsv'
+      - name: OWASP ZAP Full Scan of RC
+        uses: zaproxy/action-full-scan@v0.2.0
+        with:
+          target: ${{ secrets.ZAP_RC_TARGET }}
+          rules_file_name: '.zap/rules.tsv'
+      - name: OWASP ZAP Full Scan of Production
+        uses: zaproxy/action-full-scan@v0.2.0
+        with:
+          target: ${{ secrets.ZAP_PROD_TARGET }}
+          rules_file_name: '.zap/rules.tsv'

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,2 @@
+10027	IGNORE	(Suspicious comments)
+10096	IGNORE	(Timestamp disclosure)


### PR DESCRIPTION
Add [OWASP ZAP](https://www.zaproxy.org/getting-started/) ["baseline"](https://github.com/marketplace/actions/owasp-zap-baseline-scan) and ["full"](https://github.com/marketplace/actions/owasp-zap-full-scan) scans on a schedule, with Github actions.

These are run on a schedule, not in response to code commits, in order to catch vulnerabilities that are announced in between code updates. A couple of tests are ignored which we have found generate false positives too often.
