### PR TITLE
Add git ref to Github action 'uses' specifier

### DIFF
--- a/.github/workflows/scanning.yml
+++ b/.github/workflows/scanning.yml
@@ -11,17 +11,17 @@ jobs:
         with:
           ref: refs/heads/master
       - name: OWASP ZAP Baseline Scan of CI
-        uses: zaproxy/action-baseline
+        uses: zaproxy/action-baseline@master
         with:
           target: ${{ secrets.ZAP_CI_TARGET }}
           rules_file_name: '.zap/rules.tsv'
       - name: OWASP ZAP Full Scan of RC
-        uses: zaproxy/action-full-scan
+        uses: zaproxy/action-full-scan@master
         with:
           target: ${{ secrets.ZAP_RC_TARGET }}
           rules_file_name: '.zap/rules.tsv'
       - name: OWASP ZAP Full Scan of Production
-        uses: zaproxy/action-full-scan
+        uses: zaproxy/action-full-scan@master
         with:
           target: ${{ secrets.ZAP_PROD_TARGET }}
           rules_file_name: '.zap/rules.tsv'


### PR DESCRIPTION
In the "scanning.yml" workflow, add '@ref' notation to the 'uses' properties. This is required by Github and we are getting errors without them. I'm adding '@master' to the zaproxy actions in order to get the latest vulnerability definitions without having to update this file whenever they do a new release.

The Github documentation that I read yesterday said they "strongly recommend" the `@ref` syntax, not that it's required, but apparently it is.
