### PR TITLE
make separate celery queue for edx dashboard update tasks

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
-worker: bin/start-pgbouncer celery -A micromasters.celery:app worker -B -l $MICROMASTERS_LOG_LEVEL
-extra_worker: bin/start-pgbouncer celery -A micromasters.celery:app worker -l $MICROMASTERS_LOG_LEVEL
+worker: bin/start-pgbouncer celery -A micromasters.celery:app worker -Q dashboard,default -B -l $MICROMASTERS_LOG_LEVEL
+extra_worker: bin/start-pgbouncer celery -A micromasters.celery:app worker -Q dashboard,default -l $MICROMASTERS_LOG_LEVEL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
     command: >
       /bin/bash -c '
       sleep 3;
-      celery -A micromasters.celery:app worker -B -l ${MICROMASTERS_LOG_LEVEL:-INFO}'
+      celery -A micromasters.celery:app worker -Q dashboard,default -B -l ${MICROMASTERS_LOG_LEVEL:-INFO}'
     links:
       - db
       - elastic

--- a/micromasters/celery.py
+++ b/micromasters/celery.py
@@ -14,4 +14,9 @@ app = Celery('micromasters')
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
 app.config_from_object('django.conf:settings', namespace='CELERY')
+app.conf.task_default_queue = "default"
 app.autodiscover_tasks()
+
+app.conf.task_routes = {
+	"dashboard.tasks.*": {"queue": "dashboard"}
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #4692

#### What's this PR do?
make separate celery queue for edx dashboard update tasks

#### How should this be manually tested?
```
(base)  ✘ /micromasters/  docker-compose exec web python manage.py shell

Python 3.7.6 (default, Feb  2 2020, 09:00:14)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.0.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from dashboard.tasks import batch_update_user_data

In [2]: batch_update_user_data.apply_async(queue='dashboard')
Out[2]: <AsyncResult: ceef2ec5-3327-4366-b30e-393fd5635c01>```
