### PR TITLE
Print out the number of authorizations that were unused

### DIFF
--- a/exams/management/commands/populate_edx_exam_coupons.py
+++ b/exams/management/commands/populate_edx_exam_coupons.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):  # pylint: disable=unused-argument,too-many-locals
 
         csvfile = kwargs.get('csvfile')
-        reader = csv.DictReader(csvfile.read().splitlines())
+        reader = csv.DictReader(csvfile)
         catalog_query = next(reader)['Catalog Query']
         course_number = re.search(r"\+([A-Za-z0-9.]+)PEx", catalog_query).group(1)
 
@@ -78,7 +78,10 @@ class Command(BaseCommand):
 
         result_messages = [
             'Total coupons: {}'.format(len(validated_urls)),
-            'Authorizations changed: {}'.format(auths_changed)
+            'Authorizations changed: {}'.format(auths_changed),
+            'Let the course team know that the last {} authorizations were unused'.format(
+                len(validated_urls)-auths_changed
+            )
         ]
 
         self.stdout.write(self.style.SUCCESS('\n'.join(result_messages)))


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fix #4684

#### What's this PR do?
Prints out the number of unused coupons so that those could be used for customer service.

#### How should this be manually tested?
Run the managements command `./manage.py populate_edx_exam_coupons`

