### PR TITLE
Added course run search in admin based on edx course key

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -47,6 +47,7 @@ class CourseRunAdmin(admin.ModelAdmin):
     list_filter = ('course__program__live', 'course__program', 'course', 'course__course_number', )
     list_editable = ('enrollment_start', 'start_date', 'enrollment_end', 'end_date', 'upgrade_deadline',
                      'freeze_grade_date', )
+    search_fields = ('edx_course_key',)
     ordering = ('course__title', 'course__program__title', 'course__position_in_program', )
 
     def program(self, run):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #4606 

#### What's this PR do?
It adds a search filter by course id on `Django admin's` CourseRun model/page.

#### How should this be manually tested?
- Open admin like `/admin/courses/courserun/?q=course-v1:MITx+15.415.1x+1T2020` and this should resolve to the course run associated with this ID.

#### Where should the reviewer start?
- Micromasters admin.

