### PR TITLE
Let the exam coupon command run many times

### DIFF
--- a/exams/api.py
+++ b/exams/api.py
@@ -120,6 +120,7 @@ def authorize_for_exam_run(user, course_run, exam_run):
         user=mmtrack.user,
         course=course_run.course,
         exam_run=exam_run,
+        status=ExamAuthorization.STATUS_SUCCESS,
     )
     log.info(
         '[Exam authorization] user "%s" is authorized for the exam for course id "%s"',

--- a/exams/management/commands/populate_edx_exam_coupons.py
+++ b/exams/management/commands/populate_edx_exam_coupons.py
@@ -61,15 +61,7 @@ class Command(BaseCommand):
             status=ExamAuthorization.STATUS_SUCCESS,
             exam_coupon_url__isnull=True
         )
-        if exam_auths.count() > len(validated_urls):
-            raise CommandError(
-                'Not enough coupon codes for course_number "{}", '
-                'number of coupons:{}, authorizations: {}'.format(
-                    course_number,
-                    len(validated_urls),
-                    exam_auths.count()
-                )
-            )
+
         auths_changed = 0
         for exam_auth, url in zip(exam_auths, validated_urls):
             exam_auth.exam_coupon_url = url
@@ -78,6 +70,7 @@ class Command(BaseCommand):
 
         result_messages = [
             'Total coupons: {}'.format(len(validated_urls)),
+            'Total exam authorizations that need coupon: {}'.format(exam_auths.count()),
             'Authorizations changed: {}'.format(auths_changed)
         ]
 


### PR DESCRIPTION
#### What are the relevant tickets?
none

#### What's this PR do?
This modifies the management command to run with any size coupon files.
Also it changes the the creation of the `ExamAuthorization`(s) to set the status for `SUCCESS` since we don't consult with Pearson anymore.

#### How should this be manually tested?
Run `./manage.py populate_edx_exam_coupons <coupons-report.csv>` 
Check the dashboard to see the link to edx to register for exam in that course.

