### PR TITLE
Remove update_exam_run task

### DIFF
--- a/exams/api.py
+++ b/exams/api.py
@@ -6,7 +6,6 @@ import hashlib
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models import Q
 
 from dashboard.utils import get_mmtrack
 from dashboard.api import has_to_pay_for_exam
@@ -18,7 +17,6 @@ from exams.models import (
 )
 from grades.models import FinalGrade
 from grades.constants import FinalGradeStatus
-from micromasters.utils import now_in_utc
 
 MESSAGE_NOT_PASSED_OR_EXIST_TEMPLATE = (
     '[Exam authorization] Unable to authorize user "{user}" for exam, '

--- a/exams/api.py
+++ b/exams/api.py
@@ -179,23 +179,3 @@ def authorize_user_for_schedulable_exam_runs(user, course_run):
                 user.username,
                 course_run.course.id
             )
-
-
-def update_authorizations_for_exam_run(exam_run):
-    """
-    Updates outstanding exam authorizations so we send them to Pearson with new data
-
-    Args:
-        exam_run(exams.models.ExamRun): the ExamRun that updated
-    """
-    if not exam_run.is_schedulable:
-        return
-
-    # Update all existing auths to pending
-    ExamAuthorization.objects.filter(exam_run=exam_run).exclude(
-        Q(status=ExamAuthorization.STATUS_PENDING) | Q(exam_taken=True)
-    ).update(
-        status=ExamAuthorization.STATUS_PENDING,
-        operation=ExamAuthorization.OPERATION_UPDATE,
-        updated_on=now_in_utc()
-    )

--- a/exams/signals.py
+++ b/exams/signals.py
@@ -40,7 +40,6 @@ def update_exam_profile(sender, instance, **kwargs):  # pylint: disable=unused-a
 def update_exam_run(sender, instance, created, **kwargs):  # pylint: disable=unused-argument
     """If we update an ExamRun, update ExamAuthorizations accordingly"""
     if not created:
-        tasks.update_exam_run.delay(instance.id)
         transaction.on_commit(lambda: update_existing_combined_final_grade_for_exam_run(instance))
 
 

--- a/exams/signals.py
+++ b/exams/signals.py
@@ -19,7 +19,6 @@ from exams.models import (
 )
 from exams.utils import is_eligible_for_exam
 
-from exams import tasks
 from grades.api import update_existing_combined_final_grade_for_exam_run
 from grades.models import FinalGrade
 from profiles.models import Profile

--- a/exams/tasks.py
+++ b/exams/tasks.py
@@ -23,22 +23,6 @@ log = logging.getLogger(__name__)
 
 
 @app.task
-def update_exam_run(exam_run_id):
-    """
-    An updated ExamRun means all authorizations should be updated
-
-    Args:
-        exam_run_id(int): id for the ExamRun to update
-    """
-    try:
-        exam_run = ExamRun.objects.get(id=exam_run_id)
-    except ExamRun.DoesNotExist:
-        return
-
-    api.update_authorizations_for_exam_run(exam_run)
-
-
-@app.task
 def authorize_exam_runs():
     """
     Check for outstanding exam runs

--- a/exams/tasks.py
+++ b/exams/tasks.py
@@ -4,7 +4,6 @@ import logging
 from celery import group
 
 from dashboard.models import ProgramEnrollment
-from exams import api
 from exams.api import authorize_for_latest_passed_course
 from exams.models import (
     ExamRun,

--- a/exams/tasks_test.py
+++ b/exams/tasks_test.py
@@ -11,7 +11,6 @@ from exams.factories import (
 )
 from exams.tasks import (
     authorize_exam_runs,
-    update_exam_run,
     authorize_enrollment_for_exam_run)
 from financialaid.api_test import create_program
 from search.base import MockedESTestCase
@@ -20,16 +19,6 @@ from search.base import MockedESTestCase
 @ddt
 class ExamRunTasksTest(MockedESTestCase):
     """Tests for ExamRun tasks"""
-
-    @patch('exams.api.update_authorizations_for_exam_run')
-    def test_update_exam_run(self, update_mock):
-        """Test update_exam_run()"""
-        exam_run = ExamRunFactory.create()
-
-        update_exam_run(exam_run.id)
-        update_exam_run(-exam_run.id)
-
-        update_mock.assert_called_once_with(exam_run)
 
     @data(True, False)
     @patch('exams.tasks.authorize_for_latest_passed_course')


### PR DESCRIPTION

#### What are the relevant tickets?
none 

#### What's this PR do?
This tasks used to run when ExamRun would get updated. It would go through all the exam authorization and set them to PENDING. I think this was done to sync authorizations with pearson. 

#### How should this be manually tested?
nothing should break. Make sure this task wasn't used for anything else other than syncing with pearson.
