### PR TITLE
Dashboard program info: filter exam authorizations with coupons

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -508,7 +508,11 @@ def is_exam_schedulable(user, course):
     schedulable_exam_runs = ExamRun.objects.filter(
         course=course, date_last_eligible__gte=now.date()
     )
-    return ExamAuthorization.objects.filter(user=user, exam_run__in=schedulable_exam_runs).exclude(
+    return ExamAuthorization.objects.filter(
+        user=user,
+        exam_run__in=schedulable_exam_runs,
+        exam_coupon_url__isnull=False
+    ).exclude(
         operation=ExamAuthorization.OPERATION_DELETE).exists()
 
 
@@ -523,10 +527,15 @@ def get_edx_exam_coupon_url(user, course):
     Returns:
         str: a url to the exam or empty string
     """
+    now = now_in_utc()
+    schedulable_exam_runs = ExamRun.objects.filter(
+        course=course, date_last_eligible__gte=now.date()
+    )
     exam_auth = ExamAuthorization.objects.filter(
         user=user,
         course=course,
         status=ExamAuthorization.STATUS_SUCCESS,
+        exam_run__in=schedulable_exam_runs,
         exam_coupon_url__isnull=False
     ).first()
     return exam_auth.exam_coupon_url if exam_auth else ""

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -524,7 +524,10 @@ def get_edx_exam_coupon_url(user, course):
         str: a url to the exam or empty string
     """
     exam_auth = ExamAuthorization.objects.filter(
-        user=user, course=course, status=ExamAuthorization.STATUS_SUCCESS
+        user=user,
+        course=course,
+        status=ExamAuthorization.STATUS_SUCCESS,
+        exam_coupon_url__isnull=False
     ).first()
     return exam_auth.exam_coupon_url if exam_auth else ""
 

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1936,18 +1936,19 @@ class InfoProgramTest(MockedESTestCase):
 class ExamSchedulableTests(MockedESTestCase):
     """Tests exam schedulable"""
     @ddt.data(
-        (False, False, False, False, False),
-        (False, True, False, False, False),
-        (True, False, False, False, False),
-        (True, True, False, False, False),
-        (False, False, True, False, True),
-        (False, True, True, False, True),
-        (True, False, True, False, True),
-        (True, True, True, False, True),
-        (True, True, True, True, False),
+        (False, False, False, False, True, False),
+        (False, True, False, False, True, False),
+        (True, False, False, False, True, False),
+        (True, True, False, False, True, False),
+        (False, False, True, False, True, True),
+        (False, False, True, False, False, False),
+        (False, True, True, False, True, True),
+        (True, False, True, False, True, True),
+        (True, True, True, False, True, True),
+        (True, True, True, True, True, False),
     )
     @ddt.unpack
-    def test_is_exam_schedulable(self, is_past, is_future, has_eligibility_future, is_operation_delete,
+    def test_is_exam_schedulable(self, is_past, is_future, has_eligibility_future, is_operation_delete, has_coupon,
                                  can_schedule_exam):
         """Test that is_exam_schedulable is correct"""
         exam_run = ExamRunFactory.create(
@@ -1962,6 +1963,9 @@ class ExamSchedulableTests(MockedESTestCase):
             status=ExamAuthorization.STATUS_SUCCESS,
             operation=ExamAuthorization.OPERATION_DELETE if is_operation_delete else ExamAuthorization.OPERATION_ADD
         )
+        if has_coupon:
+            exam_auth.exam_coupon_url = "http://example.com"
+            exam_auth.save()
 
         assert api.is_exam_schedulable(exam_auth.user, exam_auth.course) is can_schedule_exam
 


### PR DESCRIPTION
#### What are the relevant tickets?
none

#### What's this PR do?
Dashboard program info for a course should return authorizations that have coupons only.

#### How should this be manually tested?
Take a look at
`dashboard/api.py`

Testing in django shell:
```
from courses.models import *
course = Course.objects.get(title='Digital Learning 100')

from exams.factories import *
exam_run_past = ExamRunFactory.create(course=course, authorized=True, scheduling_past=True)
exam_run_current = ExamRunFactory.create(course=course, authorized=True, scheduling_past=False, scheduling_future=False)

from django.contrib.auth.models import User
user = User.objects.get(username='username)
exam_profile= ExamProfileFactory.create(status='success', profile=user.profile)

au_1=ExamAuthorizationFactory.create(user=user, course=course, exam_run=exam_run, status= 'success')

au_2=ExamAuthorizationFactory.create(user=user, course=course, exam_run=exam_run_current, status= 'success', exam_coupon_url="http://example.com")

```