### PR TITLE
Pin Dockerfile to 3.7-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7-buster
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #4695

#### What's this PR do?
Pins the debian version of the python docker container. In practice most of we were probably already running this.

#### How should this be manually tested?
`docker-compose build`, then smoke test the app (login, upload a profile picture)