### PR TITLE
Import exam grades: ignore no score rows

### DIFF
--- a/exams/management/commands/import_edx_exam_grades.py
+++ b/exams/management/commands/import_edx_exam_grades.py
@@ -85,7 +85,7 @@ class Command(BaseCommand):
                     'passing_score': exam_run.passing_score,
                     'score': score,
                     'grade': row['grade'],
-                    'percentage_grade': score / 100.0 if row['score'] else 0,
+                    'percentage_grade': score / 100.0 if score else 0,
                     'passed': row['grade'].lower() == EXAM_GRADE_PASS,
                     'row_data': row,
                     'exam_date': now_in_utc()

--- a/exams/management/commands/import_edx_exam_grades.py
+++ b/exams/management/commands/import_edx_exam_grades.py
@@ -70,11 +70,22 @@ class Command(BaseCommand):
                 exam_authorization.exam_no_show = True
                 exam_authorization.save()
             else:
+                try:
+                    score = float(row['score'])
+                except ValueError:
+                    self.stdout.write(
+                        self.style.ERROR('Failed to create grade: empty score for user {} and exam run {}'.format(
+                            user.username,
+                            exam_run.id
+                        ))
+                    )
+                    continue
+
                 defaults = {
                     'passing_score': exam_run.passing_score,
-                    'score': float(row['score']),
+                    'score': score,
                     'grade': row['grade'],
-                    'percentage_grade': float(row['score']) / 100.0 if row['score'] else 0,
+                    'percentage_grade': score / 100.0 if row['score'] else 0,
                     'passed': row['grade'].lower() == EXAM_GRADE_PASS,
                     'row_data': row,
                     'exam_date': now_in_utc()


### PR DESCRIPTION


#### What are the relevant tickets?
Fix #4756

#### What's this PR do?
Update the management command to ignore records that do not have a score.

#### How should this be manually tested?
Run the management command:
```./manage.py import_edx_exam_grades <file>```

