### PR TITLE
CMS: add Hubspot form to Benefits page template for organizations link

### DIFF
--- a/app.json
+++ b/app.json
@@ -124,6 +124,14 @@
       "description": "Value provided by Heroku containing the parent app name (eg micromasters-ci for a PR build)",
       "required": true
     },
+    "HUBSPOT_PORTAL_ID": {
+      "description": "Hub spot portal id.",
+      "required": false
+    },
+    "HUBSPOT_ORGANIZATIONS_FORM_GUID": {
+      "description": "Hubspot guid for Organizations contact form on /organizations/ page.",
+      "required": false
+    },
     "MAILGUN_KEY": {
       "description": "The token for authenticating against the Mailgun API"
     },

--- a/cms/models.py
+++ b/cms/models.py
@@ -136,6 +136,10 @@ class BenefitsPage(Page):
         context["js_settings_json"] = json.dumps(js_settings)
         context["title"] = self.title
         context["ga_tracking_id"] = ""
+        context["hubspot_portal_id"] = settings.HUBSPOT_CONFIG.get("HUBSPOT_PORTAL_ID")
+        context["hubspot_ogranizations_form_guid"] = settings.HUBSPOT_CONFIG.get(
+            "HUBSPOT_ORGANIZATIONS_FORM_GUID"
+        )
 
         return context
 

--- a/cms/templates/cms/benefits_page.html
+++ b/cms/templates/cms/benefits_page.html
@@ -49,6 +49,17 @@
         {% endblock %}
         </div>
       </div>
+      {% if '/organizations/' in request.path %}
+        <div class="mdl-cell mdl-cell--4-col">
+          <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/shell.js"></script>
+          <script>
+            hbspt.forms.create({
+              portalId: "{{ hubspot_portal_id | safe }}",
+              formId: "{{ hubspot_ogranizations_form_guid | safe }}"
+            });
+          </script>
+        </div>
+      {% endif %}
     </div>
   </div>
 </main>

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -640,3 +640,13 @@ if DEBUG:
 
 # Travis
 IS_CI_ENV = get_bool('CI', False)
+
+HUBSPOT_CONFIG = {
+    "HUBSPOT_ORGANIZATIONS_FORM_GUID": get_string(
+        name="HUBSPOT_ORGANIZATIONS_FORM_GUID",
+        default="1b63db1a-eb3a-45d6-82f1-c4b8f01835dc",
+    ),
+    "HUBSPOT_PORTAL_ID": get_string(
+        name="HUBSPOT_PORTAL_ID", default="8677455"
+    ),
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #4758 

#### What's this PR do?
CMS: add Hubspot form to Benefits page template for `/orgainzations/` link

#### How should this be manually tested?
Just create the benefits page with organizations slug

#### Screenshots (if appropriate)

**Organizations Page**

<img width="1440" alt="Screenshot 2021-01-25 at 14 49 45" src="https://user-images.githubusercontent.com/4043989/105689527-ad879900-5f1c-11eb-8e52-9fce48ec290a.png">

**Benefits Page**

<img width="1440" alt="Screenshot 2021-01-25 at 14 49 53" src="https://user-images.githubusercontent.com/4043989/105689599-c7c17700-5f1c-11eb-9dd1-1253d0e50627.png">
