### PR TITLE
Upgrading boto to boto3

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -450,7 +450,7 @@ if (
         'AWS_STORAGE_BUCKET_NAME'
     )
 if MICROMASTERS_USE_S3:
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 else:
     # by default use django.core.files.storage.FileSystemStorage with
     # overwrite feature

--- a/micromasters/tests/test_settings.py
+++ b/micromasters/tests/test_settings.py
@@ -49,7 +49,7 @@ class TestSettings(MockedESTestCase):
             settings_vars = self.reload_settings()
             self.assertNotEqual(
                 settings_vars.get('DEFAULT_FILE_STORAGE'),
-                'storages.backends.s3boto.S3BotoStorage'
+                'storages.backends.s3boto3.S3Boto3Storage'
             )
 
         with self.assertRaises(ImproperlyConfigured):
@@ -70,7 +70,7 @@ class TestSettings(MockedESTestCase):
             settings_vars = self.reload_settings()
             self.assertEqual(
                 settings_vars.get('DEFAULT_FILE_STORAGE'),
-                'storages.backends.s3boto.S3BotoStorage'
+                'storages.backends.s3boto3.S3Boto3Storage'
             )
 
     def test_admin_settings(self):

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ django-redis==4.7.0
 django-role-permissions==2.2.0
 django-server-status==0.5.0
 django-storages-redux==1.3.2
-django-storages==1.7.1
+django-storages==1.9.1
 django-webpack-loader==0.5.0
 djangorestframework==3.9.1
 edx-api-client==0.6.1

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 Django==2.2.13
 Pillow==7.1.0
-boto==2.39.0
+boto3==1.9.188
 celery==4.3.0
 certifi==2018.1.18
 dj-database-url==0.3.0
@@ -14,6 +14,7 @@ django-redis==4.7.0
 django-role-permissions==2.2.0
 django-server-status==0.5.0
 django-storages-redux==1.3.2
+django-storages==1.7.1
 django-webpack-loader==0.5.0
 djangorestframework==3.9.1
 edx-api-client==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ django-server-status==0.5.0
     # via -r requirements.in
 django-storages-redux==1.3.2
     # via -r requirements.in
-django-storages==1.7.1
+django-storages==1.9.1
     # via -r requirements.in
 django-taggit==1.2.0
     # via wagtail
@@ -127,8 +127,6 @@ html5lib==0.999999999
     #   wagtail
 idna==2.7
     # via requests
-importlib-metadata==3.4.0
-    # via kombu
 ipython-genutils==0.2.0
     # via traitlets
 ipython==7.0.1
@@ -281,8 +279,6 @@ tornado==5.1.1
     # via robohash
 traitlets==4.3.2
     # via ipython
-typing-extensions==3.7.4.3
-    # via importlib-metadata
 unidecode==0.4.21
     # via wagtail
 urllib3==1.24.2
@@ -308,8 +304,6 @@ willow==1.3
     # via wagtail
 xlsxwriter==1.3.7
     # via wagtail
-zipp==3.4.0
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,12 @@ beautifulsoup4==4.8.2
     # via wagtail
 billiard==3.6.2.0
     # via celery
-boto==2.39.0
+boto3==1.9.188
     # via -r requirements.in
+botocore==1.12.253
+    # via
+    #   boto3
+    #   s3transfer
 celery==4.3.0
     # via
     #   -r requirements.in
@@ -73,6 +77,8 @@ django-server-status==0.5.0
     # via -r requirements.in
 django-storages-redux==1.3.2
     # via -r requirements.in
+django-storages==1.7.1
+    # via -r requirements.in
 django-taggit==1.2.0
     # via wagtail
 django-treebeard==4.3
@@ -83,6 +89,7 @@ django==2.2.13
     # via
     #   -r requirements.in
     #   django-role-permissions
+    #   django-storages
     #   django-taggit
     #   django-treebeard
     #   jsonfield
@@ -91,6 +98,8 @@ djangorestframework==3.9.1
     # via
     #   -r requirements.in
     #   wagtail
+docutils==0.15.2
+    # via botocore
 draftjs-exporter==2.1.7
     # via wagtail
 edx-api-client==0.6.1
@@ -126,6 +135,10 @@ ipython==7.0.1
     # via -r requirements.in
 jedi==0.13.0
     # via ipython
+jmespath==0.10.0
+    # via
+    #   boto3
+    #   botocore
 jsonfield==2.0.2
     # via -r requirements.in
 jsonpatch==1.16
@@ -192,6 +205,7 @@ pysftp==0.2.9
 python-dateutil==2.5.3
     # via
     #   -r requirements.in
+    #   botocore
     #   edx-api-client
     #   elasticsearch-dsl
     #   faker
@@ -220,6 +234,8 @@ requests==2.21.0
     #   wagtail
 robohash==1.0
     # via -r requirements.in
+s3transfer==0.2.1
+    # via boto3
 sentry-sdk==0.14.3
     # via -r requirements.in
 simplegeneric==0.8.1
@@ -272,6 +288,7 @@ unidecode==0.4.21
 urllib3==1.24.2
     # via
     #   -r requirements.in
+    #   botocore
     #   elasticsearch
     #   requests
     #   sentry-sdk


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
#4753 

#### What's this PR do?
Upgrades deprecating `boto` to `boto3`

#### How should this be manually tested?
To test it manually we might need to do A/B testing and see nothing broke after this change. More critical parts on the testing would be the ones actually using boto, In our case it could be wagtail.

#### Any background context you want to provide?
(Copied from the main issue) 
>`boto` is unmaintained and hasn't been updated in over 2 years. It's also now caused the warning

