### PR TITLE
Fixed FAQ background & link underline decoration

### DIFF
--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -684,7 +684,6 @@ a {
 
 .faqs {
   padding: 106px 0;
-  background-color: #ebeced;
 
   .faq-holder {
     max-width: 600px;

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -103,6 +103,7 @@
           line-height: 47px;
           text-transform: uppercase;
           color: rgba(255,255,255,.75);
+          text-decoration: none;
         }
 
         a.tab-link::selection {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#4779 

#### What's this PR do?
- Removes the background from the FAQ content panel
- Removes the tab underlines on Program page

#### How should this be manually tested?
- Add and FAQ page in a Program through CMS
- Open program page in the web app
- Check the background color on FAQs it should be white
- Check the Tabs, their text shouldn't be underlined

#### Any background context you want to provide?
We recently did major design changes in the HomePage for which you can have a context thrugh this PR https://github.com/mitodl/micromasters/pull/4749

#### Screenshots (if appropriate)
<img width="1435" alt="Screenshot 2021-02-11 at 4 00 08 PM" src="https://user-images.githubusercontent.com/34372316/107629929-9ec31500-6c84-11eb-91ac-da867fc48ebf.png">

