### PR TITLE
asadiqbal08/Removed course count block

### DIFF
--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -112,17 +112,6 @@
                               {{ programpage.title }}
                             {% endif %}
                           </h4>
-                          {% with program.course_set.count as course_count %}
-                            {% if course_count %}
-                              <div class="program-num-courses">
-                                {% blocktrans count counter=course_count %}
-                                  {{ counter }} course
-                                {% plural %}
-                                  {{ counter }} courses
-                                {% endblocktrans %}
-                              </div>
-                            {% endif %}
-                          {% endwith %}
                           <div class="program-description">
                             <p class="program-description-text" id="program-{{ program.id }}-description">{{ program.description|default:"No description available for this program." }}</p>
               


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
fixes: #4792 

#### What's this PR do?
As a learner, Count of courses on the home page confusing.
This is because the capstone exam for some programs is a course, and gets counted. The preferred solution is to remove the count.

