### PR TITLE
Removing some pearson text

### DIFF
--- a/static/js/components/dashboard/courses/GradeDetailPopup.js
+++ b/static/js/components/dashboard/courses/GradeDetailPopup.js
@@ -91,7 +91,7 @@ const renderExamRow = (
 ) => (
   <div className="course-run-row" key={idx}>
     <div className="title">
-      {`Pearson test - ${moment(grade.exam_date).format(DASHBOARD_FORMAT)}`}
+      {`Proctored exam - ${moment(grade.exam_date).format(DASHBOARD_FORMAT)}`}
     </div>
     <div className="grade-status">
       <div>{examStatus(grade)}</div>

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -22,7 +22,6 @@ import {
   addCourseEnrollment,
   getCoupons,
   attachCoupon,
-  getPearsonSSO,
   unEnrollProgramEnrollments
 } from "./api"
 import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
@@ -38,7 +37,6 @@ import {
   USER_PROFILE_RESPONSE,
   PROGRAMS
 } from "../test_constants"
-import { makeSSOParameters } from "../factories/pearson"
 
 describe("api", function() {
   this.timeout(5000) // eslint-disable-line no-invalid-this
@@ -619,27 +617,6 @@ describe("api", function() {
               }
             )
           )
-        })
-      })
-    })
-
-    describe("Pearson API functions", () => {
-      describe("getPearsonSSO", () => {
-        it("fetches the pearson sso parameters", () => {
-          const params = makeSSOParameters()
-          fetchJSONStub.returns(Promise.resolve(params))
-
-          return getPearsonSSO().then(() => {
-            assert(fetchJSONStub.calledWith("/api/v0/pearson/sso/"))
-          })
-        })
-
-        it("fails to fetch the pearson sso parameters", () => {
-          fetchJSONStub.returns(Promise.reject())
-
-          return assert.isRejected(getPearsonSSO()).then(() => {
-            assert(fetchJSONStub.calledWith("/api/v0/pearson/sso/"))
-          })
         })
       })
     })


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4795

#### What's this PR do?
Removes text about pearson test on the dashboard, and a test.

#### How should this be manually tested?
This should effect the user dashboard, where the user clicks on the test score to view their attempts.

Where to find the text: In the course row the user has a little box with the exam grade. If the user clicks on that box with the grade, then a little popup opens up with the list of all the exam attempts and grades for that course. 

