### PR TITLE
Fixed the FAQ background regression

### DIFF
--- a/static/scss/homepage.scss
+++ b/static/scss/homepage.scss
@@ -684,6 +684,7 @@ a {
 
 .faqs {
   padding: 106px 0;
+  background-color: #ebeced;
 
   .faq-holder {
     max-width: 600px;

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -372,6 +372,7 @@
 
   .faqs {
     margin-top: 20px;
+    background-color: transparent;
 
     @include breakpoint(phone) {
       margin: 18px auto;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#4801 

[`Invision link`](https://projects.invisionapp.com/share/YFZ4N7KMWT3#/screens/435513872_Homepage_V2) for HomePage

#### What's this PR do?
Fixes the FAQ background color discrepancy in the program and homepage.

#### How should this be manually tested?
- Check that the FAQ section on the HomePage has a background (`#EBECED`)
- Check the FAQs tab on the program page doesn't have a grey background.

#### Any background context you want to provide?
In PR #4781 we removed the background color on the Program FAQ page, a regression that had been introduced by the home page update PR #4749.
While fixing that we somehow missed the color on the homepage since the SCSS for both had the same class names for FAQs and its background removal got overridden on the homepage too.

#### Screenshots (if appropriate)
**Home Page(Desktop)**
<img width="1436" alt="Screenshot 2021-02-25 at 1 31 20 PM" src="https://user-images.githubusercontent.com/34372316/109128425-4f471380-7771-11eb-903d-794b791c833c.png">

**Home Page(Mobile)**
<img width="501" alt="Screenshot 2021-02-25 at 1 31 35 PM" src="https://user-images.githubusercontent.com/34372316/109128444-53733100-7771-11eb-9062-a110b3b5f8f5.png">

**Program Page(Desktop)**
<img width="1440" alt="Screenshot 2021-02-25 at 1 51 00 PM" src="https://user-images.githubusercontent.com/34372316/109128447-540bc780-7771-11eb-8af6-6f55570dd4d5.png">

**Program Page(Mobile)**
<img width="463" alt="Screenshot 2021-02-25 at 1 51 15 PM" src="https://user-images.githubusercontent.com/34372316/109128452-54a45e00-7771-11eb-87e0-d7038417f749.png">


#### What GIF best describes this PR or how it makes you feel?
I wish I could find a very relevant one for this 😥 