### PR TITLE
Optimization: serve certificate related css separately

### DIFF
--- a/static/js/entry/style_certificate.js
+++ b/static/js/entry/style_certificate.js
@@ -1,0 +1,4 @@
+__webpack_public_path__ = `${SETTINGS.public_path}` // eslint-disable-line no-undef, camelcase
+
+// The file having all the scss regarding certificates
+import "../../scss/certificate.scss"

--- a/static/scss/certificate.scss
+++ b/static/scss/certificate.scss
@@ -1,3 +1,5 @@
+@import "variables";
+
 .certificate {
   max-width: 100%;
 

--- a/static/scss/certificate.scss
+++ b/static/scss/certificate.scss
@@ -1,4 +1,5 @@
 @import "variables";
+@import "breakpoints";
 
 .certificate {
   max-width: 100%;

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -37,7 +37,6 @@
 @import "final-exam-card";
 @import "staff-learner-info-card";
 @import "automatic-emails";
-@import "certificate";
 @import "discussion-card";
 @import "grade_record";
 @import "letter";

--- a/ui/templates/certificate.html
+++ b/ui/templates/certificate.html
@@ -3,6 +3,8 @@
 
 {% block extrahead %}
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600;&display=swap" />
+{% load render_bundle %}
+{% render_bundle "style_certificate" %}
 {% endblock %}
 
 {% block title %}{% trans "MITx MicroMasters" %}{% endblock %}

--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -10,6 +10,7 @@ module.exports = {
       'sentry_client': './static/js/entry/sentry_client.js',
       'style': './static/js/entry/style',
       'style_public': './static/js/entry/style_public',
+      'style_certificate': './static/js/entry/style_certificate',
       'zendesk_widget': './static/js/entry/zendesk_widget.js',
     },
     module: {


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/4788

#### What's this PR do?
It bundles and serves certificate.scss separately only on certificate page.

#### Why is it required?
PRs like https://github.com/mitodl/micromasters/pull/4802 are increasing the size of css bundle considerably, while they only get used on the certificate-page. Serving this separately will reduce bundle size and optimize ranking on google lighthouse as it has negative points for downloading unused css.


#### How should this be manually tested?
Create a certificate and see if the css gets loaded correctly. You can verify it through the Network tab of your browser, it will be showing by the name of `style_certificate`.

#### What GIF best describes this PR or how it makes you feel?
(Optional)
