### PR TITLE
add support for multiple signatories in certificate design

### DIFF
--- a/static/scss/certificate.scss
+++ b/static/scss/certificate.scss
@@ -164,7 +164,9 @@
     font-style: italic;
   }
 
-  .signatory,
+  .signatory {
+    margin-top: 0rem !important;
+  }
   .wrapper-accomplishment-orgs {
     margin-top: 1.5rem !important;
   }
@@ -337,6 +339,11 @@
     max-height: 150px;
   }
 
+  .signatory .signatory-name {
+    margin-top: 0px;
+    margin-bottom: 2px;
+  }
+
   .signatory .signatory-signature {
     max-width: 60%;
     max-height: 60px;
@@ -416,7 +423,7 @@
       text-align: right;
       display: inline-block;
       vertical-align: middle;
-      margin-bottom: 3rem !important;
+      margin-bottom: 0rem !important;
     }
   }
 
@@ -540,6 +547,15 @@
     line-height: 1.5;
   }
 
+  .accomplishment-statement-detail {
+    margin-top: 4rem !important;
+  }
+
+  .accomplishment-statement-detail.institute-detail {
+    margin-top: 1.5rem !important;
+    margin-bottom: 4rem !important;
+  }
+
   .role {
     font-weight: 400;
   }
@@ -548,7 +564,7 @@
 @media print {
   body {
     margin: 0;
-    max-height: 95%;
+    max-height: 98%;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -567,7 +583,6 @@
   .certificate {
     background-color: #e8e8e8 !important;
     max-width: 100%;
-    padding: 5px;
     color-adjust: exact !important;
     // sass-lint:disable no-vendor-prefixes
     -webkit-print-color-adjust: exact !important;
@@ -633,7 +648,8 @@
       max-width: 33.33333%;
       display: inline-block;
       vertical-align: middle;
-      margin-bottom: 30px !important;
+      margin-top: 0px;
+      margin-bottom: 25px !important;
     }
 
     .accomplishment .accomplishment-rendering .wrapper-accomplishment-orgs .organization img {
@@ -685,7 +701,7 @@
     }
 
     .wrapper-accomplishment-stamps {
-      margin-top: 0 !important;
+      margin-top: -40px !important;
     }
 
     .accomplishment-stamps .accomplishment-stamp-platform {
@@ -768,7 +784,11 @@
     .wrapper-organization {
       margin-top: 20px;
       margin-right: 50px;
-      margin-left: 40px;
+      margin-left: 60px;
+    }
+
+    .accomplishment-rendering {
+      margin: 0px !important;
     }
   }
 }

--- a/static/scss/certificate.scss
+++ b/static/scss/certificate.scss
@@ -165,9 +165,12 @@
   }
 
   .signatory {
+    width: 100%;
     margin-top: 0rem !important;
   }
+
   .wrapper-accomplishment-orgs {
+    text-align: center;
     margin-top: 1.5rem !important;
   }
 
@@ -340,6 +343,10 @@
   }
 
   .signatory .signatory-name {
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.6;
+    color: #454545;
     margin-top: 0px;
     margin-bottom: 2px;
   }
@@ -347,13 +354,6 @@
   .signatory .signatory-signature {
     max-width: 60%;
     max-height: 60px;
-  }
-
-  .signatory .signatory-name {
-    font-size: 0.875rem;
-    font-weight: 500;
-    line-height: 1.6;
-    color: #454545;
   }
 
   .signatory .signatory-credentials {
@@ -414,10 +414,6 @@
     }
   }
 
-  .wrapper-accomplishment-orgs {
-    text-align: center;
-  }
-
   @media (min-width: 768px) {
     .wrapper-accomplishment-orgs {
       text-align: right;
@@ -469,10 +465,6 @@
   .list-signatories {
     display: flex;
     flex-flow: row wrap;
-  }
-
-  .signatory {
-    width: 100%;
   }
 
   @media (min-width: 768px) and (max-width: 991.98px) {

--- a/static/scss/certificate.scss
+++ b/static/scss/certificate.scss
@@ -557,9 +557,6 @@
   body {
     margin: 0;
     max-height: 98%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
   }
 
   #footer {
@@ -575,6 +572,7 @@
   .certificate {
     background-color: #e8e8e8 !important;
     max-width: 100%;
+    height: 100%;
     color-adjust: exact !important;
     // sass-lint:disable no-vendor-prefixes
     -webkit-print-color-adjust: exact !important;
@@ -693,7 +691,7 @@
     }
 
     .wrapper-accomplishment-stamps {
-      margin-top: -40px !important;
+      margin-bottom: 0px !important;
     }
 
     .accomplishment-stamps .accomplishment-stamp-platform {
@@ -727,6 +725,8 @@
     }
 
     .wrapper-accomplishment-rendering {
+      height: 100% !important;
+      max-height: 100% !important;
       padding: 0 !important;
     }
 
@@ -774,13 +774,27 @@
     }
 
     .wrapper-organization {
-      margin-top: 20px;
+      margin-top: 5px;
       margin-right: 50px;
       margin-left: 60px;
     }
 
     .accomplishment-rendering {
       margin: 0px !important;
+      height: 100% !important;
+    }
+
+    .accomplishment.accomplishment-main {
+      height: 100% !important;
+    }
+
+    .signatory {
+      margin: 8px !important;
+    }
+
+    #cert_detail {
+      position: absolute;
+      bottom: 30px;
     }
   }
 }

--- a/ui/templates/certificate.html
+++ b/ui/templates/certificate.html
@@ -109,7 +109,7 @@
               </div>
             </div>
         </div>
-        <div class="wrapper-accomplishment-stamps">
+        <div id="cert_detail" class="wrapper-accomplishment-stamps">
           <ul class="accomplishment-stamps copy-list">
             <li class="accomplishment-stamp-platform">
               <a class="img-link" href="http://edx.org">

--- a/ui/templates/certificate.html
+++ b/ui/templates/certificate.html
@@ -75,14 +75,14 @@
                 <span class="accomplishment-course">
                   <span class="accomplishment-course-name">{{ course_title }}</span>
                 </span>
-                <span class="accomplishment-statement-detail">a course of study offered by MITx,
+                <span class="accomplishment-statement-detail institute-detail">a course of study offered by MITx,
                   an online learning initiative of the Massachusetts Institute of Technology.</span>
               {% else %}
                 <span class="accomplishment-summary">successfully completed and received a passing grade in</span>
                 <span class="accomplishment-course">
                   <span class="accomplishment-course-name">{{ program_title }}</span>
                 </span>
-                <span class="accomplishment-statement-detail">a program of study offered by MITx,
+                <span class="accomplishment-statement-detail institute-detail">a program of study offered by MITx,
                   an online learning initiative of the Massachusetts Institute of Technology.</span>
               {% endif %}
             </p>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots

#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/4788

#### What's this PR do?
add support for 4 signatories in certificate design, previously the design started to break at 4.

#### How should this be manually tested?
Create a certificate with 4 signatories and see if the print works well.

#### Screenshots (Printed Version)
![image](https://user-images.githubusercontent.com/42243411/110363654-a350d280-8064-11eb-9f9f-a88214a0925a.png)
