### PR TITLE
Adding a dialog for exam enrollment confirmation

### DIFF
--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -894,6 +894,7 @@ class InfoCourseTest(CourseTests):
             course,
             course_data_from_call,
             can_schedule_exam=False,
+            exam_register_end_date="",
             exam_url="",
             exams_schedulable_in_future=None,
             has_to_pay=False,
@@ -912,6 +913,7 @@ class InfoCourseTest(CourseTests):
             "prerequisites": course.prerequisites,
             "has_contact_email": bool(course.contact_email),
             "can_schedule_exam": can_schedule_exam,
+            "exam_register_end_date": exam_register_end_date,
             "exam_url": exam_url,
             "exams_schedulable_in_future": exams_schedulable_in_future,
             "current_exam_date": '',
@@ -999,11 +1001,15 @@ class InfoCourseTest(CourseTests):
             course,
             api.get_info_for_course(course, self.mmtrack)
         )
-        ExamRunFactory.create(course=course)
+        exam_run = ExamRunFactory.create(course=course)
+        exam_window= '{}'.format(
+            exam_run.date_last_schedulable.strftime("%B %d")
+        )
         self.assert_course_equal(
             course,
             api.get_info_for_course(course, self.mmtrack),
-            has_exam=True
+            has_exam=True,
+            exam_register_end_date=exam_window
         )
         assert mock_schedulable.call_count == 2
         assert mock_has_to_pay.call_count == 2
@@ -1942,7 +1948,7 @@ class ExamSchedulableTests(MockedESTestCase):
         (True, False, False, False, True, False),
         (True, True, False, False, True, False),
         (False, False, True, False, True, True),
-        (False, False, True, False, False, False),
+        (False, False, True, False, False, True),
         (False, True, True, False, True, True),
         (True, False, True, False, True, True),
         (True, True, True, False, True, True),

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -139,6 +139,17 @@ export const setConfirmSkipDialogVisibility = createAction(
   SET_CONFIRM_SKIP_DIALOG_VISIBILITY
 )
 
+export const SET_EXAM_ENROLLMENT_DIALOG_VISIBILITY =
+  "SET_EXAM_ENROLLMENT_DIALOG_VISIBILITY"
+export const setExamEnrollmentDialogVisibility = createAction(
+  SET_EXAM_ENROLLMENT_DIALOG_VISIBILITY
+)
+
+export const SET_SELECTED_EXAM_COUPON_COURSE = "SET_SELECTED_EXAM_COUPON_COURSE"
+export const setSelectedExamCouponCourse = createAction(
+  SET_SELECTED_EXAM_COUPON_COURSE
+)
+
 export const SET_DOCS_INSTRUCTIONS_VISIBILITY =
   "SET_DOCS_INSTRUCTIONS_VISIBILITY"
 export const setDocsInstructionsVisibility = createAction(

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -68,6 +68,7 @@ const COURSE: Course = {
   position_in_program:         1,
   runs:                        [],
   can_schedule_exam:           false,
+  exam_register_end_date:      "",
   exam_url:                    "",
   exams_schedulable_in_future: [],
   current_exam_date:           "",

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -36,6 +36,8 @@ export default class CourseListCard extends React.Component {
     setEnrollSelectedCourseRun?: (r: CourseRun) => void,
     setEnrollCourseDialogVisibility?: (bool: boolean) => void,
     setCalculatePriceDialogVisibility?: (bool: boolean) => void,
+    setExamEnrollmentDialogVisibility?: (bool: boolean) => void,
+    setSelectedExamCouponCourse?: (n: number) => void,
     setShowExpandedCourseStatus?: (n: number) => void,
     setShowGradeDetailDialog: (b: boolean, t: GradeType, title: string) => void,
     ui: UIState,
@@ -161,6 +163,8 @@ export default class CourseListCard extends React.Component {
       setEnrollSelectedCourseRun,
       setEnrollCourseDialogVisibility,
       setCalculatePriceDialogVisibility,
+      setExamEnrollmentDialogVisibility,
+      setSelectedExamCouponCourse,
       setShowExpandedCourseStatus,
       setShowGradeDetailDialog,
       ui,
@@ -189,6 +193,8 @@ export default class CourseListCard extends React.Component {
         setEnrollSelectedCourseRun={setEnrollSelectedCourseRun}
         setEnrollCourseDialogVisibility={setEnrollCourseDialogVisibility}
         setCalculatePriceDialogVisibility={setCalculatePriceDialogVisibility}
+        setExamEnrollmentDialogVisibility={setExamEnrollmentDialogVisibility}
+        setSelectedExamCouponCourse={setSelectedExamCouponCourse}
         ui={ui}
         checkout={checkout}
         setShowExpandedCourseStatus={setShowExpandedCourseStatus}

--- a/static/js/components/dashboard/CourseRow.js
+++ b/static/js/components/dashboard/CourseRow.js
@@ -45,6 +45,8 @@ export default class CourseRow extends React.Component {
     setEnrollSelectedCourseRun: (r: CourseRun) => void,
     setEnrollCourseDialogVisibility: (b: boolean) => void,
     setCalculatePriceDialogVisibility: (b: boolean) => void,
+    setExamEnrollmentDialogVisibility: (b: boolean) => void,
+    setSelectedExamCouponCourse: (n: number) => void,
     ui: UIState,
     checkout: (s: string) => void,
     setShowExpandedCourseStatus: (n: number) => void,
@@ -141,6 +143,8 @@ export default class CourseRow extends React.Component {
       ui,
       setShowExpandedCourseStatus,
       setShowGradeDetailDialog,
+      setExamEnrollmentDialogVisibility,
+      setSelectedExamCouponCourse,
       showStaffView
     } = this.props
 
@@ -169,6 +173,10 @@ export default class CourseRow extends React.Component {
             courseAction={this.courseAction}
             expandedStatuses={ui.expandedCourseStatuses}
             setShowExpandedCourseStatus={setShowExpandedCourseStatus}
+            setExamEnrollmentDialogVisibility={
+              setExamEnrollmentDialogVisibility
+            }
+            setSelectedExamCouponCourse={setSelectedExamCouponCourse}
             coupon={this.getCourseCoupon()}
           />
         )}

--- a/static/js/components/dashboard/ExamEnrollmentDialog.js
+++ b/static/js/components/dashboard/ExamEnrollmentDialog.js
@@ -1,0 +1,69 @@
+// @flow
+import React from "react"
+import PropTypes from "prop-types"
+import Dialog from "@material-ui/core/Dialog"
+import Button from "@material-ui/core/Button"
+
+import { singleBtnDialogActions } from "../inputs/util"
+import DialogTitle from "@material-ui/core/DialogTitle"
+import DialogActions from "@material-ui/core/DialogActions"
+import DialogContent from "@material-ui/core/DialogContent"
+import type { Course } from "../../flow/programTypes"
+
+export default class ExamEnrollmentDialog extends React.Component {
+  static contextTypes = {
+    router: PropTypes.object.isRequired
+  }
+
+  props: {
+    open: boolean,
+    course: ?Course,
+    setVisibility: (v: boolean) => void
+  }
+
+  render() {
+    const { setVisibility, open, course } = this.props
+    if (!course) {
+      return null
+    }
+
+    const examRegisterButton = (
+      <Button
+        key="register-button"
+        onClick={() => {
+          course.exam_url
+            ? (window.location = course.exam_url)
+            : setVisibility(false)
+        }}
+        className="primary-button"
+      >
+        Register Now
+      </Button>
+    )
+    return (
+      <Dialog
+        classes={{
+          paper: "dialog exam-enrollment-dialog",
+          root:  "exam-enrollment-dialog-wrapper"
+        }}
+        open={open}
+        onClose={() => setVisibility(false)}
+      >
+        <DialogTitle className="dialog-title">Are you sure?</DialogTitle>
+        <DialogContent>
+          Are you sure you want to register for the {course.title} exam? You
+          should only click REGISTER NOW if you are certain you are going to
+          take the exam this semester. Registering but not taking the exam will
+          count as a 0 on the proctored exam and will use up one proctored exam
+          attempt.
+        </DialogContent>
+        <DialogActions>
+          {[
+            singleBtnDialogActions(() => setVisibility(false), "cancel"),
+            examRegisterButton
+          ]}
+        </DialogActions>
+      </Dialog>
+    )
+  }
+}

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -311,7 +311,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
       )
     } else if (!R.isEmpty(course.exams_schedulable_in_future)) {
       message =
-        "You can take the exam starting " +
+        `${passedMsg} You can register to take the exam starting ` +
         `on ${formatDate(course.exams_schedulable_in_future[0])}.`
     }
 

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -97,14 +97,16 @@ describe("Course Status Messages", () => {
       financialAid = _.cloneDeep(FINANCIAL_AID_PARTIAL_RESPONSE)
 
       calculateMessagesProps = {
-        courseAction:                sandbox.stub(),
-        financialAid:                financialAid,
-        hasFinancialAid:             false,
-        firstRun:                    course.runs[0],
-        course:                      course,
-        expandedStatuses:            new Set(),
-        setShowExpandedCourseStatus: sandbox.stub(),
-        coupon:                      undefined
+        courseAction:                      sandbox.stub(),
+        financialAid:                      financialAid,
+        hasFinancialAid:                   false,
+        firstRun:                          course.runs[0],
+        course:                            course,
+        expandedStatuses:                  new Set(),
+        setShowExpandedCourseStatus:       sandbox.stub(),
+        setExamEnrollmentDialogVisibility: sandbox.stub(),
+        setSelectedExamCouponCourse:       sandbox.stub(),
+        coupon:                            undefined
       }
       calculateMessagesProps.courseAction.returns("course action was called")
     })
@@ -370,13 +372,16 @@ describe("Course Status Messages", () => {
         course.proctorate_exams_grades = [makeProctoredExamResult()]
         course.proctorate_exams_grades[0].passed = true
         course.exam_url = "http://example.com"
+        course.exam_register_end_date = "Jan 17"
         const messages = calculateMessages(calculateMessagesProps).value
         assert.equal(messages[0]["message"], "You passed this course.")
         const mountedOne = shallow(messages[1]["message"])
         assert.equal(
           mountedOne.text().trim(),
           "You passed the exam. You are authorized to take the virtual proctored exam for this course. " +
-            "Please enroll now and complete the exam onboarding."
+            "Please register now and complete the exam onboarding. " +
+            "You must register by Jan 17 to be eligible to take the exam this semester. If " +
+            "you have already registered for the exam, you can access the exam through your edX dashboard."
         )
         const mountedTwo = shallow(messages[2]["message"])
         assert.equal(
@@ -439,6 +444,7 @@ describe("Course Status Messages", () => {
       it("should prompt the user to take exam if exam coupon available", () => {
         course.runs = [course.runs[0]]
         course.can_schedule_exam = true
+        course.exam_register_end_date = "Jan 17"
         let messages = calculateMessages(calculateMessagesProps).value
         assert.equal(
           messages[0]["message"],
@@ -449,8 +455,10 @@ describe("Course Status Messages", () => {
         const mounted = shallow(messages[0]["message"])
         assert.equal(
           mounted.text(),
-          "You are authorized to take the virtual proctored exam for this " +
-            "course. Please enroll now and complete the exam onboarding."
+          " You are authorized to take the virtual proctored exam for this " +
+            "course. Please register now and complete the exam onboarding. " +
+            "You must register by Jan 17 to be eligible to take the exam this semester. If " +
+            "you have already registered for the exam, you can access the exam through your edX dashboard."
         )
       })
       it("should let the user know when can take exam in the future", () => {
@@ -474,6 +482,7 @@ describe("Course Status Messages", () => {
         course.can_schedule_exam = true
         course.proctorate_exams_grades = [makeProctoredExamResult()]
         course.proctorate_exams_grades[0].passed = true
+        course.exam_register_end_date = "Jan 17"
 
         let messages = calculateMessages(calculateMessagesProps).value
         assert.equal(messages[0]["message"], "You passed this course.")
@@ -485,7 +494,9 @@ describe("Course Status Messages", () => {
         assert.equal(
           mounted.text(),
           "You passed the exam. You are authorized to take the virtual proctored " +
-            "exam for this course. Please enroll now and complete the exam onboarding."
+            "exam for this course. Please register now and complete the exam onboarding. " +
+            "You must register by Jan 17 to be eligible to take the exam this semester. If " +
+            "you have already registered for the exam, you can access the exam through your edX dashboard."
         )
       })
       // Cases with failed exam attempts
@@ -503,6 +514,7 @@ describe("Course Status Messages", () => {
         course.proctorate_exams_grades = [makeProctoredExamResult()]
         course.proctorate_exams_grades[0].passed = false
         course.can_schedule_exam = true
+        course.exam_register_end_date = "Jan 17"
 
         let messages = calculateMessages(calculateMessagesProps).value
         assert.equal(messages[0]["message"], "You did not pass the exam.")
@@ -513,7 +525,9 @@ describe("Course Status Messages", () => {
         assert.equal(
           mounted.text(),
           "You did not pass the exam. You are authorized to take the virtual proctored " +
-            "exam for this course. Please enroll now and complete the exam onboarding."
+            "exam for this course. Please register now and complete the exam onboarding. " +
+            "You must register by Jan 17 to be eligible to take the exam this semester. If " +
+            "you have already registered for the exam, you can access the exam through your edX dashboard."
         )
       })
       it("should prompt about upcoming exam, is failed and has attempt", () => {

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -472,7 +472,7 @@ describe("Course Status Messages", () => {
         assertIsJust(calculateMessages(calculateMessagesProps), [
           {
             message:
-              "You can register to take the exam starting " +
+              " You can register to take the exam starting " +
               `on ${formatDate(course.exams_schedulable_in_future[0])}.`
           }
         ])

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -54,6 +54,8 @@ import {
   setPaymentTeaserDialogVisibility,
   setEnrollCourseDialogVisibility,
   setCalculatePriceDialogVisibility,
+  setExamEnrollmentDialogVisibility,
+  setSelectedExamCouponCourse,
   setEnrollSelectedCourseRun,
   showDialog,
   hideDialog,
@@ -122,6 +124,7 @@ import type { Coupon } from "../flow/couponTypes"
 import type { RestState } from "../flow/restTypes"
 import type { Post } from "../flow/discussionTypes"
 import PersonalCoursePriceDialog from "../components/dashboard/PersonalCoursePriceDialog"
+import ExamEnrollmentDialog from "../components/dashboard/ExamEnrollmentDialog"
 
 const isFinishedProcessing = R.contains(R.__, [FETCH_SUCCESS, FETCH_FAILURE])
 
@@ -505,6 +508,11 @@ class DashboardPage extends React.Component {
     dispatch(setConfirmSkipDialogVisibility(bool))
   }
 
+  setExamEnrollmentDialogVisibility = bool => {
+    const { dispatch } = this.props
+    dispatch(setExamEnrollmentDialogVisibility(bool))
+  }
+
   updateDocumentSentDate = (
     financialAidId: number,
     sentDate: string
@@ -555,6 +563,11 @@ class DashboardPage extends React.Component {
   setEnrollSelectedCourseRun = (run: CourseRun) => {
     const { dispatch } = this.props
     dispatch(setEnrollSelectedCourseRun(run))
+  }
+
+  setSelectedExamCouponCourse = (courseId: number) => {
+    const { dispatch } = this.props
+    dispatch(setSelectedExamCouponCourse(courseId))
   }
 
   setCalculatePriceDialogVisibility = bool => {
@@ -673,6 +686,30 @@ class DashboardPage extends React.Component {
         open={ui.calculatePriceDialogVisibility}
         openFinancialAidCalculator={this.openFinancialAidCalculator}
         setVisibility={this.setCalculatePriceDialogVisibility}
+      />
+    )
+  }
+  renderExamEnrollmentDialog() {
+    const { ui } = this.props
+    const program = this.getCurrentlyEnrolledProgram()
+
+    if (!program) {
+      return null
+    }
+    let course = null
+    if (ui.selectedExamCouponCourse) {
+      course = program.courses.find(
+        course => course.id === ui.selectedExamCouponCourse
+      )
+    }
+    if (!course) {
+      return null
+    }
+    return (
+      <ExamEnrollmentDialog
+        open={ui.examEnrollmentDialogVisibility}
+        setVisibility={this.setExamEnrollmentDialogVisibility}
+        course={course}
       />
     )
   }
@@ -891,6 +928,7 @@ class DashboardPage extends React.Component {
           {this.renderCouponDialog()}
           {this.renderCourseEnrollmentDialog()}
           {this.renderPersonalCoursePriceDialog()}
+          {this.renderExamEnrollmentDialog()}
           <div className="first-column">
             <DashboardUserCard profile={profile} program={program} />
             <FinalExamCard
@@ -910,6 +948,10 @@ class DashboardPage extends React.Component {
               addCourseEnrollment={this.addCourseEnrollment}
               openCourseContactDialog={this.openCourseContactDialog}
               setEnrollSelectedCourseRun={this.setEnrollSelectedCourseRun}
+              setSelectedExamCouponCourse={this.setSelectedExamCouponCourse}
+              setExamEnrollmentDialogVisibility={
+                this.setExamEnrollmentDialogVisibility
+              }
               setEnrollCourseDialogVisibility={
                 this.setEnrollCourseDialogVisibility
               }

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -92,6 +92,7 @@ export const makeCourse = (positionInProgram: number): Course => {
     position_in_program:         positionInProgram,
     title:                       `Title for course ${courseId}`,
     can_schedule_exam:           false,
+    exam_register_end_date:      "",
     exam_url:                    "",
     exams_schedulable_in_future: [],
     current_exam_date:           "",

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -59,6 +59,7 @@ export type Course = {
   id:                           number,
   position_in_program:          number,
   can_schedule_exam:            boolean,
+  exam_register_end_date:       string,
   exam_url:                     string,
   exams_schedulable_in_future:  Array<string>,
   current_exam_date:               string,

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -29,6 +29,7 @@ import {
   SET_ENROLL_SELECTED_PROGRAM,
   SET_ENROLL_SELECTED_COURSE_RUN,
   SET_CONFIRM_SKIP_DIALOG_VISIBILITY,
+  SET_EXAM_ENROLLMENT_DIALOG_VISIBILITY,
   SET_DOCS_INSTRUCTIONS_VISIBILITY,
   SET_COUPON_NOTIFICATION_VISIBILITY,
   SET_NAV_DRAWER_OPEN,
@@ -36,7 +37,8 @@ import {
   SHOW_ENROLL_PAY_LATER_SUCCESS,
   SET_SHOW_EXPANDED_COURSE_STATUS,
   SET_PROGRAMS_TO_UNENROLL,
-  SET_UNENROLL_API_INFLIGHT_STATE
+  SET_UNENROLL_API_INFLIGHT_STATE,
+  SET_SELECTED_EXAM_COUPON_COURSE
 } from "../actions/ui"
 import { EMAIL_COMPOSITION_DIALOG } from "../components/email/constants"
 import { CHANNEL_CREATE_DIALOG } from "../constants"
@@ -89,6 +91,8 @@ export type UIState = {
   documentSentDate: Object,
   selectedProgram: ?AvailableProgram,
   skipDialogVisibility: boolean,
+  examEnrollmentDialogVisibility: boolean,
+  selectedExamCouponCourse: ?number,
   docsInstructionsVisibility: boolean,
   couponNotificationVisibility: boolean,
   navDrawerOpen: boolean,
@@ -130,6 +134,8 @@ export const INITIAL_UI_STATE: UIState = {
   documentSentDate:                   {},
   selectedProgram:                    null,
   skipDialogVisibility:               false,
+  examEnrollmentDialogVisibility:     false,
+  selectedExamCouponCourse:           null,
   docsInstructionsVisibility:         false,
   couponNotificationVisibility:       false,
   navDrawerOpen:                      false,
@@ -312,6 +318,10 @@ export const ui = (
   }
   case SET_CONFIRM_SKIP_DIALOG_VISIBILITY:
     return { ...state, skipDialogVisibility: action.payload }
+  case SET_EXAM_ENROLLMENT_DIALOG_VISIBILITY:
+    return { ...state, examEnrollmentDialogVisibility: action.payload }
+  case SET_SELECTED_EXAM_COUPON_COURSE:
+    return { ...state, selectedExamCouponCourse: action.payload }
   case SET_DOCS_INSTRUCTIONS_VISIBILITY:
     return { ...state, docsInstructionsVisibility: action.payload }
   case SET_COUPON_NOTIFICATION_VISIBILITY:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Fix #4815

#### What's this PR do?
Add a confirmation dialog when the user goes to register for an exam on edx. To register for an exam the user has to follow the link to edx and enroll in the the exam-course on edx. 
The Dialog would warn the user that registering for an exam is going to use their only attempt to take the exam.


#### How should this be manually tested?
Set up a course that your user has paid for and has passed. You can use the alter_data management command:
`./manage.py alter_data set_past_run_to_passed --username username  --program-title Digital --course-title 100`

create and exam run, an exam authorization, exam profile, and exam coupon for  the user to use:
```
course = Course.objects.get(title='Digital Learning 100')
exam_run = ExamRunFactory.create(course=course, authorized=True, scheduling_past=False, scheduling_future=False)
au=ExamAuthorizationFactory.create(user=user, course=course, exam_run=exam_run, status= 'success')
exam_profile= ExamProfileFactory.create(status='success', profile=user.profile)
ExamRunCouponFactory.create(is_taken=False, course=course)
```


<img width="1209" alt="Screen Shot 2021-03-09 at 2 48 37 PM" src="https://user-images.githubusercontent.com/7574259/110529482-53671f80-80e7-11eb-867c-592bd57274de.png">

