### PR TITLE
Show an error message on checkout request failure

### DIFF
--- a/static/js/components/OrderSummary.js
+++ b/static/js/components/OrderSummary.js
@@ -69,7 +69,7 @@ class OrderSummary extends React.Component {
     ]
   }
 
-  checkAndShowCheckoutError(status: string): React$Element<*> {
+  checkAndShowCheckoutError(status?: string) {
     if (status === FETCH_FAILURE) {
       return (
         <div className="alert-message" style={{ marginTop: 30 }}>

--- a/static/js/components/OrderSummary.js
+++ b/static/js/components/OrderSummary.js
@@ -6,10 +6,11 @@ import Button from "@material-ui/core/Button"
 import Grid from "@material-ui/core/Grid"
 
 import SpinnerButton from "./SpinnerButton"
-import { FETCH_PROCESSING } from "../actions"
+import { FETCH_PROCESSING, FETCH_FAILURE } from "../actions"
 import type { Course, CourseRun } from "../flow/programTypes"
 import type { CoursePrice } from "../flow/dashboardTypes"
 import { formatPrice } from "../util/util"
+import Alert from "react-bootstrap/lib/Alert"
 
 class OrderSummary extends React.Component {
   props: {
@@ -68,6 +69,29 @@ class OrderSummary extends React.Component {
     ]
   }
 
+  checkAndShowCheckoutError(status: string): React$Element<*> {
+    if (status === FETCH_FAILURE) {
+      return (
+        <div className="alert-message" style={{ marginTop: 30 }}>
+          <Alert bsStyle="danger">
+            <p>
+              Something went wrong. Please contact{" "}
+              <a
+                href="https://mitx-micromasters.zendesk.com/hc/en-us/requests/new"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                customer support
+              </a>
+              .
+            </p>
+          </Alert>
+        </div>
+      )
+    }
+    return null
+  }
+
   render() {
     const {
       course,
@@ -120,6 +144,7 @@ class OrderSummary extends React.Component {
         >
           Continue
         </SpinnerButton>
+        {this.checkAndShowCheckoutError(checkoutStatus)}
       </div>
     )
   }

--- a/static/js/components/OrderSummary.js
+++ b/static/js/components/OrderSummary.js
@@ -75,15 +75,14 @@ class OrderSummary extends React.Component {
         <div className="alert-message" style={{ marginTop: 30 }}>
           <Alert bsStyle="danger">
             <p>
-              Something went wrong. Please contact{" "}
+              Something went wrong. Please{" "}
               <a
                 href="https://mitx-micromasters.zendesk.com/hc/en-us/requests/new"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                customer support
+                contact customer support.
               </a>
-              .
             </p>
           </Alert>
         </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#4825 

#### What's this PR do?
- Adds an error message along with support link in case of API failure on the Order Summary page, Previously there was no error shown in case of failure

#### How should this be manually tested?
The steps to reproduce this are explained in detail in https://github.com/mitodl/micromasters/issues/4823.


#### Screenshots (if appropriate)
**Desktop**

<img width="1440" alt="Screenshot 2021-03-16 at 11 17 05 AM" src="https://user-images.githubusercontent.com/34372316/111273193-561cc400-8655-11eb-998f-82b0ac088045.png">


**Mobile**
<img width="502" alt="Screenshot 2021-03-16 at 11 17 12 AM" src="https://user-images.githubusercontent.com/34372316/111273167-4dc48900-8655-11eb-8af1-81e697b6264d.png">
