### PR TITLE
Adding user to raw fields in FinancialAidAdmin

### DIFF
--- a/financialaid/admin.py
+++ b/financialaid/admin.py
@@ -24,6 +24,7 @@ class CountryIncomeThresholdAdmin(admin.ModelAdmin):
 class FinancialAidAdmin(admin.ModelAdmin):
     """Admin for FinancialAid"""
     model = FinancialAid
+    raw_id_fields = ('user',)
 
     def has_delete_permission(self, *args, **kwargs):  # pylint: disable=unused-argument, signature-differs
         return False


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#4826 

#### What's this PR do?
Adds the user field to the `raw_id_fields` in FinancialAidAdmin.

#### How should this be manually tested?
Visit FinancialAidAdmin in Django, and check that don't see a dropdown for the user, instead, we should see a search icon which then opens a new window and loads the UserAdmin page to select user.


#### Screenshots (if appropriate)
<img width="806" alt="Screenshot 2021-03-16 at 1 07 59 PM" src="https://user-images.githubusercontent.com/34372316/111277443-46ec4500-865a-11eb-981d-2263e89e307c.png">


<img width="795" alt="Screenshot 2021-03-16 at 1 08 25 PM" src="https://user-images.githubusercontent.com/34372316/111277478-4fdd1680-865a-11eb-96a1-c3cac40c5c48.png">
