### PR TITLE
Update existing FAs with current tier programs

### DIFF
--- a/financialaid/management/commands/migrate_finaid_program_tiers.py
+++ b/financialaid/management/commands/migrate_finaid_program_tiers.py
@@ -28,11 +28,14 @@ class Command(BaseCommand):
 
             except TierProgram.DoesNotExist:
                 raise CommandError(
-                    'Could not find a current tier program with threshold "{}"'.format(threshold)
+                    'Could not find a current tier program with threshold "{}" for financial aid {}'.format(
+                        threshold,
+                        financial_aid.id
+                    )
                 )
             except TierProgram.MultipleObjectsReturned:
                 raise CommandError(
-                    'There are multiple courses with given number "{}"'.format(threshold)
+                    'There are multiple tier programs with threshold "{}"'.format(threshold)
                 )
 
             financial_aid.tier_program = tier_program

--- a/financialaid/management/commands/migrate_finaid_program_tiers.py
+++ b/financialaid/management/commands/migrate_finaid_program_tiers.py
@@ -1,0 +1,42 @@
+"""
+Update FinancialAid objects with current tier program
+"""
+from django.core.management import BaseCommand, CommandError
+
+from financialaid.models import FinancialAid, TierProgram
+
+
+class Command(BaseCommand):
+    """
+    Updates the existing financial aid objects to current tier programs
+    """
+    help = "Updates the existing financial aid objects to current tier programs"
+
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
+
+        fin_aids = FinancialAid.objects.filter(
+            tier_program__current=False,
+        )
+        updated_count = 0
+        for financial_aid in fin_aids:
+            try:
+                threshold = financial_aid.tier_program.income_threshold
+                tier_program = TierProgram.objects.get(
+                    income_threshold=threshold,
+                    current=True,
+                )
+
+            except TierProgram.DoesNotExist:
+                raise CommandError(
+                    'Could not find a current tier program with threshold "{}"'.format(threshold)
+                )
+            except TierProgram.MultipleObjectsReturned:
+                raise CommandError(
+                    'There are multiple courses with given number "{}"'.format(threshold)
+                )
+
+            financial_aid.tier_program = tier_program
+            financial_aid.save_and_log(None)
+            updated_count += 1
+
+        self.stdout.write(self.style.SUCCESS('Updated {} financial aid instances'.format(updated_count)))


### PR DESCRIPTION

#### What are the relevant tickets?
Fix #4823

#### What's this PR do?
Adds a management command for finding all financial aid objects that have outdated program tiers and updating them with new ones.


#### How should this be manually tested?
Try to reproduce the bug as described in the issue. 
Then create new tier_program with the same income_threshold as the one you were testing with. Then run the management command `./manage.py  migrate_finaid_program_tiers`

