### PR TITLE
Fix sentry Errors -- typeError on Checkout & IE 11.0 forEach error

### DIFF
--- a/static/js/containers/OrderSummaryPage.js
+++ b/static/js/containers/OrderSummaryPage.js
@@ -23,6 +23,9 @@ import type { RestState } from "../flow/restTypes"
 import type { CheckoutResponse } from "../flow/checkoutTypes"
 
 export const processCheckout = (result: CheckoutResponse) => {
+  if (!result) {
+    return
+  }
   const { payload, url, method } = result
   if (method === "POST") {
     const form = createForm(url, payload)

--- a/static/js/entry/public.js
+++ b/static/js/entry/public.js
@@ -23,6 +23,11 @@ import {
 import SignupDialog from "../containers/SignupDialog"
 import CopyLinkDialog from "../containers/CopyLinkDialog"
 
+// Adding forEach polyfill for IE
+if (window.NodeList && !NodeList.prototype.forEach) {
+  NodeList.prototype.forEach = Array.prototype.forEach
+}
+
 // Program Page course list
 const courseListEl = document.querySelector("#courses-component")
 let courseList = null


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
- https://github.com/mitodl/micromasters/issues/4834
- https://github.com/mitodl/micromasters/issues/4835
- https://github.com/mitodl/micromasters/issues/4614

#### What's this PR do?
 - Fixes an undefined payload error in case of checkout API failure response
 - Adds a polyfill & Fixes IE 11.0 error on property method forEach on the program page

#### How should this be manually tested?
- To reproduce and test checkout error you can follow the steps defined in https://github.com/mitodl/micromasters/issues/4823, On the order summary page, when you click `Continue` you'll see the error logged in the console in case of 400 API response.

- To reproduce the forEach property error, you'll need to open any program page which has rich text in it. Open the page in IE 11.0 and you'll see the error logged in the console.


**Note:**
I've run the seed commands and added other pages for testing in the [CI deployment](https://micromasters-ci-pr-4830.herokuapp.com/) for this PR, let me know if you'll need anything on that.