### PR TITLE
Missed deadline message for exams

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -237,7 +237,7 @@ def get_info_for_course(course, mmtrack):
         "can_schedule_exam": is_exam_schedulable(mmtrack.user, course),
         "exam_url": get_edx_exam_coupon_url(mmtrack.user, course),
         "exams_schedulable_in_future": get_future_exam_runs(course),
-        "current_exam_date": get_current_exam_run(course),
+        "current_exam_date": get_current_exam_run_dates(course),
         "has_to_pay": has_to_pay_for_exam(mmtrack, course),
         "runs": [],
         "proctorate_exams_grades": ProctoredExamGradeSerializer(
@@ -568,7 +568,7 @@ def get_future_exam_runs(course):
             order_by('date_first_schedulable').values_list('date_first_schedulable', flat=True))
 
 
-def get_current_exam_run(course):
+def get_current_exam_run_dates(course):
     """
     Return scheduling dates for an exam this term, example: 'Mar 7 - Mar 17, 2018'
 

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -2052,16 +2052,28 @@ class PastExamRunTests(MockedESTestCase):
     """Test for past schedulable exam run"""
 
     @ddt.data(
-        (False, False, False),
-        (True, False, True),
-        (False, True, False),
+        (1, True),
+        (2, True),
+        (3, False),
     )
     @ddt.unpack
-    def test_get_past_exam_run(self, is_past, is_future, result):
+    def test_get_current_exam_run_dates(self, weeks, has_exam):
         """test get_past_recent_exam_run"""
-        exam_run = ExamRunFactory.create(scheduling_past=is_past, scheduling_future=is_future)
-
-        self.assertEqual(len(api.get_past_recent_exam_run(exam_run.course)) > 0, result)
+        now = now_in_utc()
+        end_date = now + timedelta(weeks=8)
+        exam_run = ExamRunFactory.create(date_first_schedulable=end_date+timedelta(weeks=weeks))
+        CourseRunFactory.create(
+            course=exam_run.course,
+            start_date=now-timedelta(weeks=5),
+            end_date=end_date
+        )
+        expected = ''
+        if has_exam:
+            expected = '{} - {}'.format(
+                exam_run.date_first_schedulable.strftime('%b %-d'),
+                exam_run.date_last_schedulable.strftime('%b %-d, %Y')
+            )
+        self.assertEqual(api.get_current_exam_run_dates(exam_run.course), expected)
 
 
 @ddt.ddt

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -914,7 +914,7 @@ class InfoCourseTest(CourseTests):
             "can_schedule_exam": can_schedule_exam,
             "exam_url": exam_url,
             "exams_schedulable_in_future": exams_schedulable_in_future,
-            "past_exam_date": '',
+            "current_exam_date": '',
             "has_to_pay": has_to_pay,
             "proctorate_exams_grades": proct_exams,
             "is_elective": is_elective,

--- a/exams/models.py
+++ b/exams/models.py
@@ -1,6 +1,7 @@
 """
 Models for exams
 """
+import datetime
 from django.contrib.auth.models import User
 from django.db import models
 
@@ -85,6 +86,23 @@ class ExamRun(TimestampedModel):
             course=course,
             date_last_schedulable__lt=now
         )
+
+    @classmethod
+    def get_current_term_exam(cls, course, run_end_date):
+        """
+        Get an exam run that is schedulable this current term
+
+        Args:
+            course (courses.models.Course): the course to find exam runs for
+
+        Returns:
+            (exams.models.ExamRun): Exam run that runs this term
+        """
+        two_weeks = datetime.timedelta(weeks=2)
+        return cls.objects.filter(
+            course=course,
+            date_first_schedulable__lt=run_end_date+two_weeks
+        ).order_by('-date_last_schedulable').first()
 
     @property
     def is_schedulable(self):

--- a/exams/models.py
+++ b/exams/models.py
@@ -98,10 +98,10 @@ class ExamRun(TimestampedModel):
         Returns:
             (exams.models.ExamRun): Exam run that runs this term
         """
-        two_weeks = datetime.timedelta(weeks=2)
+        three_weeks = datetime.timedelta(weeks=3)
         return cls.objects.filter(
             course=course,
-            date_first_schedulable__lt=run_end_date+two_weeks
+            date_first_schedulable__lt=run_end_date+three_weeks
         ).order_by('-date_last_schedulable').first()
 
     @property

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -70,7 +70,7 @@ const COURSE: Course = {
   can_schedule_exam:           false,
   exam_url:                    "",
   exams_schedulable_in_future: [],
-  past_exam_date:              "",
+  current_exam_date:              "",
   has_to_pay:                  false,
   has_exam:                    false,
   proctorate_exams_grades:     [],

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -70,7 +70,7 @@ const COURSE: Course = {
   can_schedule_exam:           false,
   exam_url:                    "",
   exams_schedulable_in_future: [],
-  current_exam_date:              "",
+  current_exam_date:           "",
   has_to_pay:                  false,
   has_exam:                    false,
   proctorate_exams_grades:     [],

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -380,7 +380,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     return S.Just(messages)
   } else if (hasMissedDeadlineCourseRun(course)) {
     // the course finished can't pay
-    if (exams && course.past_exam_date) {
+    if (exams && course.current_exam_date) {
       const futureExamMessage = R.isEmpty(course.exams_schedulable_in_future)
         ? " There are no future exams scheduled at this time. Please check back later."
         : ` You can pay now to take the next exam, scheduled for ${formatDate(
@@ -389,8 +389,8 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
 
       messages.push({
         message:
-          "You missed the payment deadline to take the proctored exam scheduled for " +
-          `${course.past_exam_date}.${futureExamMessage}`,
+          "You missed the payment deadline to take the proctored exam this term." +
+          `${futureExamMessage}`,
         action: courseAction(firstRun, COURSE_ACTION_PAY)
       })
     } else {

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -678,11 +678,8 @@ describe("Course Status Messages", () => {
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
           message:
-            "You missed the payment deadline to take the proctored exam " +
-            `scheduled for ${
-              course.current_exam_date
-            }. There are no future exams scheduled at this ` +
-            "time. Please check back later.",
+            "You missed the payment deadline to take the proctored exam this term. There are no future exams " +
+            "scheduled at this time. Please check back later.",
           action: "course action was called"
         }
       ])
@@ -711,9 +708,7 @@ describe("Course Status Messages", () => {
         {
           message:
             "You missed the payment deadline to take the proctored exam " +
-            `scheduled for ${
-              course.current_exam_date
-            }. You can pay now to take the next exam, scheduled for ` +
+            "this term. You can pay now to take the next exam, scheduled for " +
             `${formatDate(course.exams_schedulable_in_future[0])}.`,
           action: "course action was called"
         }

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -673,14 +673,14 @@ describe("Course Status Messages", () => {
       makeRunOverdue(course.runs[0])
 
       course.has_exam = true
-      course.past_exam_date = "Mar 12 - Mar 22, 2018"
+      course.current_exam_date = "Mar 12 - Mar 22, 2018"
 
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
           message:
             "You missed the payment deadline to take the proctored exam " +
             `scheduled for ${
-              course.past_exam_date
+              course.current_exam_date
             }. There are no future exams scheduled at this ` +
             "time. Please check back later.",
           action: "course action was called"
@@ -701,7 +701,7 @@ describe("Course Status Messages", () => {
       makeRunOverdue(course.runs[0])
 
       course.has_exam = true
-      course.past_exam_date = "Mar 12 - Mar 22, 2018"
+      course.current_exam_date = "Mar 12 - Mar 22, 2018"
       course.exams_schedulable_in_future = [
         moment()
           .add(2, "day")
@@ -712,7 +712,7 @@ describe("Course Status Messages", () => {
           message:
             "You missed the payment deadline to take the proctored exam " +
             `scheduled for ${
-              course.past_exam_date
+              course.current_exam_date
             }. You can pay now to take the next exam, scheduled for ` +
             `${formatDate(course.exams_schedulable_in_future[0])}.`,
           action: "course action was called"

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -94,7 +94,7 @@ export const makeCourse = (positionInProgram: number): Course => {
     can_schedule_exam:           false,
     exam_url:                    "",
     exams_schedulable_in_future: [],
-    current_exam_date:              "",
+    current_exam_date:           "",
     has_to_pay:                  false,
     has_exam:                    false,
     is_elective:                 false,

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -94,7 +94,7 @@ export const makeCourse = (positionInProgram: number): Course => {
     can_schedule_exam:           false,
     exam_url:                    "",
     exams_schedulable_in_future: [],
-    past_exam_date:              "",
+    current_exam_date:              "",
     has_to_pay:                  false,
     has_exam:                    false,
     is_elective:                 false,

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -61,7 +61,7 @@ export type Course = {
   can_schedule_exam:            boolean,
   exam_url:                     string,
   exams_schedulable_in_future:  Array<string>,
-  past_exam_date:               string,
+  current_exam_date:               string,
   has_to_pay:                   boolean,
   proctorate_exams_grades:      Array<ProctoredExamResult>,
   is_elective:                  boolean,


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [ ] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fix #4824

#### What's this PR do?
Updates the some logic regarding the exam message when the user missed deadline to pay for the course. 

#### How should this be manually tested?
Set up a course
`./manage.py alter_data set_to_needs_upgrade --username <username> --course-title 'Digital Learning 100' --missed-deadline
`
Then set up an ExamRun that happens the same term as the course run.
You should get a message like this:
<img width="804" alt="Screen Shot 2021-03-21 at 10 00 43 PM" src="https://user-images.githubusercontent.com/7574259/111994877-afba3e00-8aee-11eb-8932-7809dad51aac.png">
And if you create another ExamRun in the future, then:
<img width="861" alt="Screen Shot 2021-03-21 at 10 07 41 PM" src="https://user-images.githubusercontent.com/7574259/111994881-b0eb6b00-8aee-11eb-9b5f-609af02ea00b.png">
