### PR TITLE
Restrict exam authorization if user missed payment deadline

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -289,6 +289,21 @@ class MMTrack:
         """
         return self.has_final_grade(edx_course_key) and self.has_paid(edx_course_key)
 
+    def paid_but_missed_deadline(self, course_run):
+        """
+        Checks if user paid for this run only after the deadline
+        """
+        if self.has_paid(course_run.edx_course_key):
+            orders = Order.objects.filter(
+                status__in=Order.FULFILLED_STATUSES,
+                user=self.user,
+                line__course_key=course_run.edx_course_key,
+                modified_at__gt=course_run.upgrade_deadline,
+            )
+            if orders.exists():
+                return True
+        return False
+
     def has_passed_course(self, edx_course_key):
         """
         Returns whether the user has passed a course run.

--- a/exams/api_test.py
+++ b/exams/api_test.py
@@ -3,8 +3,8 @@ Tests for exams API
 """
 from unittest.mock import patch
 
-import ddt
 import datetime
+import ddt
 from django.db.models.signals import post_save
 from django.test import (
     TestCase,

--- a/exams/utils.py
+++ b/exams/utils.py
@@ -1,5 +1,8 @@
 """Exam related helpers"""
 import re
+import datetime
+
+from courses.models import CourseRun
 
 
 def is_eligible_for_exam(mmtrack, course_run):
@@ -49,3 +52,20 @@ def validate_profile(profile):
         fields.append('postal_code')
 
     return all([_match_field(profile, field) for field in fields])
+
+
+def get_corresponding_course_run(exam_run):
+    """
+    Finds a corresponding course run for this exam.
+    It looks for CourseRun with an end_date field within 4 weeks preceding the exam.
+
+    Args:
+        exam_run (ExamRun): the exam run object
+
+    Returns:
+        (CourseRun): the corresponding course run
+    """
+    four_weeks_earlier = exam_run.date_first_schedulable - datetime.timedelta(weeks=4)
+    return CourseRun.objects.filter(
+        end_date__range=(four_weeks_earlier, exam_run.date_first_schedulable)
+    ).first()


### PR DESCRIPTION
#### Pre-Flight checklist



- [ ] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Depends on #4841 

#### What's this PR do?
Restrict exam authorization if user missed payment deadline

#### How should this be manually tested?
Set a course to enrolled but needs to pay using the alter_date management command:
`./manage.py alter_data set_to_needs_upgrade --username <username> --course-title 'Digital Learning 100' --missed-deadline
`
Then create exam runs, but not exam authorization since user gets authorized only once they paid for the course.
```
exam_run = ExamRunFactory.create(course=course, authorized=True, scheduling_past=False, scheduling_future=False)
```
This will create an exam that that is schedulable now. Which means that once there is a payment the user will get authorized for the exam run.
This restriction applies only user pays for current course run:
find the course run for which your user is auditing(it was printed out when you ran the alter_data command), and set the `end_date` for that course run to 2 weeks ago:
```
from courses.models import *
from micromasters.utils import now_in_utc
edx_course_key=<>
course_run=CourseRun.objects.get(edx_course_key=edx_course_key)
course_run.end_date = now_in_utc - datetime.timedelta(weeks=2)
```
Go ahead and pay for the course:
```
from seed_data.lib import *
set_course_run_to_paid(user, course_run)
```



