### PR TITLE
Adding course option to CourseCertificateSignatories

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -597,6 +597,7 @@ class CourseCertificateSignatories(Orderable):
     panels = [
         MultiFieldPanel(
             [
+                FieldPanel('course'),
                 FieldPanel('name'),
                 FieldPanel('title_line_1'),
                 FieldPanel('title_line_2'),


### PR DESCRIPTION

#### What are the relevant tickets?
None

#### What's this PR do?
Adds a course panel to CourseCertificateSignatories

Go to cms to edit the program page, and try to add course certificate signatories to the program, you should see an option to select a course.