### PR TITLE
Add a case when user failed exam but has another attempt

### DIFF
--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -91,7 +91,7 @@ const messageForNotAttemptedEdxExam = (course: Course) => {
     )
   } else if (!R.isEmpty(course.exams_schedulable_in_future)) {
     message =
-      "You can take the exam starting " +
+      "You can register to take the exam starting " +
       `on ${formatDate(course.exams_schedulable_in_future[0])}.`
   }
   return message
@@ -115,7 +115,7 @@ const messageForAttemptedEdxExams = (course: Course, passedExam: boolean) => {
     )
   } else if (!R.isEmpty(course.exams_schedulable_in_future)) {
     return (
-      `${passedMsg} You can take the exam starting ` +
+      `${passedMsg} You can register to take the exam starting ` +
       `on ${formatDate(course.exams_schedulable_in_future[0])}.`
     )
   }

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -113,6 +113,11 @@ const messageForAttemptedEdxExams = (course: Course, passedExam: boolean) => {
         </a>
       </span>
     )
+  } else if (!R.isEmpty(course.exams_schedulable_in_future)) {
+    return (
+      `${passedMsg} You can take the exam starting ` +
+      `on ${formatDate(course.exams_schedulable_in_future[0])}.`
+    )
   }
   return `${passedMsg}`
 }

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -489,6 +489,15 @@ describe("Course Status Messages", () => {
         )
       })
       // Cases with failed exam attempts
+      it("should prompt the user when failed exam", () => {
+        course.runs = [course.runs[0]]
+        course.proctorate_exams_grades = [makeProctoredExamResult()]
+        course.proctorate_exams_grades[0].passed = false
+        course.can_schedule_exam = false
+        assertIsJust(calculateMessages(calculateMessagesProps), [
+          { message: "You did not pass the exam." }
+        ])
+      })
       it("should prompt the user to take another exam if there is exam coupon url", () => {
         course.runs = [course.runs[0]]
         course.proctorate_exams_grades = [makeProctoredExamResult()]
@@ -507,14 +516,23 @@ describe("Course Status Messages", () => {
             "exam for this course. Please enroll now and complete the exam onboarding."
         )
       })
-      it("should prompt the user when failed exam", () => {
+      it("should prompt about upcoming exam, is failed and has attempt", () => {
         course.runs = [course.runs[0]]
         course.proctorate_exams_grades = [makeProctoredExamResult()]
         course.proctorate_exams_grades[0].passed = false
         course.can_schedule_exam = false
-        assertIsJust(calculateMessages(calculateMessagesProps), [
-          { message: "You did not pass the exam." }
-        ])
+        course.exams_schedulable_in_future = [
+          moment()
+            .add(2, "day")
+            .format()
+        ]
+
+        const messages = calculateMessages(calculateMessagesProps).value
+        assert.equal(
+          messages[0]["message"],
+          "You did not pass the exam. You can take the exam starting on " +
+            `${formatDate(course.exams_schedulable_in_future[0])}.`
+        )
       })
     })
 

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -464,7 +464,7 @@ describe("Course Status Messages", () => {
         assertIsJust(calculateMessages(calculateMessagesProps), [
           {
             message:
-              "You can take the exam starting " +
+              "You can register to take the exam starting " +
               `on ${formatDate(course.exams_schedulable_in_future[0])}.`
           }
         ])
@@ -530,7 +530,7 @@ describe("Course Status Messages", () => {
         const messages = calculateMessages(calculateMessagesProps).value
         assert.equal(
           messages[0]["message"],
-          "You did not pass the exam. You can take the exam starting on " +
+          "You did not pass the exam. You can register to take the exam starting on " +
             `${formatDate(course.exams_schedulable_in_future[0])}.`
         )
       })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Zendesk issue https://odl.zendesk.com/agent/tickets/93435

#### What's this PR do?
Add information about upcoming exam if the user failed and has an attempt to take the exam again.

#### How should this be manually tested?
Run this management command:
`alter_data set_past_run_to_passed --username <username> --program-title Digital --course-title 100 `
In django shell:
```course = Course.objects.get(title='Digital Learning 100')
user = User.objects.get(username='username')
exam_profile= ExamProfileFactory.create(status='success', profile=user.profile)
exam_run = ExamRunFactory.create(course=course, authorized=True, scheduling_past=True)
au=ExamAuthorizationFactory.create(user=user, course=course, exam_run=exam_run, status= 'success', exam_taken=True)
exam_grade = ProctoredExamGradeFactory.create(user=user, course=course, exam_run=exam_run, passed=False, percentage_grade=0.4)
exam_run.date_grades_available=now_in_utc()
exam_run.save()
```

Create another exam run in the future:
```
exam_run = ExamRunFactory.create(course=course, authorized=True, scheduling_future=True)
```

Before
<img width="840" alt="Screen Shot 2021-04-06 at 4 19 33 PM" src="https://user-images.githubusercontent.com/7574259/113774303-13e71f80-96f5-11eb-924e-401dcb9c46ed.png">

After:
<img width="781" alt="Screen Shot 2021-04-06 at 4 27 39 PM" src="https://user-images.githubusercontent.com/7574259/113774322-1a759700-96f5-11eb-9411-9ac00fa51cf1.png">

