### PR TITLE
Exam message for current exam run

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -520,7 +520,7 @@ def get_exam_register_end_date(course):
     """
     schedulable_exam_run = ExamRun.get_currently_schedulable(course).first()
     if schedulable_exam_run is not None:
-        return schedulable_exam_run.date_last_schedulable.strftime("%B %-d, %I:%M%p %Z")
+        return schedulable_exam_run.date_last_schedulable.strftime("%B %-d, %I:%M %p %Z")
     return ""
 
 

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -16,7 +16,7 @@ from edx_api.client import EdxApi
 
 from backends.exceptions import InvalidCredentialStored
 from backends import utils
-from courses.models import Program, ElectiveCourse, CourseRun
+from courses.models import Program, ElectiveCourse
 from courses.utils import format_season_year_for_course_run
 from dashboard.api_edx_cache import CachedEdxDataApi
 from dashboard.utils import get_mmtrack, ATTEMPTS_PER_PAID_RUN, ATTEMPTS_PER_PAID_RUN_OLD

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1004,7 +1004,7 @@ class InfoCourseTest(CourseTests):
         )
         exam_run = ExamRunFactory.create(course=course)
         exam_register_end_date = '{}'.format(
-            exam_run.date_last_schedulable.strftime("%B %-d, %I:%M%p %Z")
+            exam_run.date_last_schedulable.strftime("%B %-d, %I:%M %p %Z")
         )
         current_exam_dates = '{} and {}'.format(
             exam_run.date_first_eligible.strftime('%b %-d'),

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -897,6 +897,7 @@ class InfoCourseTest(CourseTests):
             exam_register_end_date="",
             exam_url="",
             exams_schedulable_in_future=None,
+            current_exam_dates="",
             has_to_pay=False,
             has_exam=False,
             is_elective=False,
@@ -916,7 +917,7 @@ class InfoCourseTest(CourseTests):
             "exam_register_end_date": exam_register_end_date,
             "exam_url": exam_url,
             "exams_schedulable_in_future": exams_schedulable_in_future,
-            "current_exam_date": '',
+            "current_exam_dates": current_exam_dates,
             "has_to_pay": has_to_pay,
             "proctorate_exams_grades": proct_exams,
             "is_elective": is_elective,
@@ -1002,14 +1003,19 @@ class InfoCourseTest(CourseTests):
             api.get_info_for_course(course, self.mmtrack)
         )
         exam_run = ExamRunFactory.create(course=course)
-        exam_window = '{}'.format(
-            exam_run.date_last_schedulable.strftime("%B %-d")
+        exam_register_end_date = '{}'.format(
+            exam_run.date_last_schedulable.strftime("%B %-d, %I:%M%p %Z")
+        )
+        current_exam_dates = '{} and {}'.format(
+            exam_run.date_first_eligible.strftime('%b %-d'),
+            exam_run.date_last_eligible.strftime('%b %-d, %Y')
         )
         self.assert_course_equal(
             course,
             api.get_info_for_course(course, self.mmtrack),
             has_exam=True,
-            exam_register_end_date=exam_window
+            exam_register_end_date=exam_register_end_date,
+            current_exam_dates=current_exam_dates,
         )
         assert mock_schedulable.call_count == 2
         assert mock_has_to_pay.call_count == 2
@@ -2058,26 +2064,24 @@ class PastExamRunTests(MockedESTestCase):
     """Test for past schedulable exam run"""
 
     @ddt.data(
-        (1, True),
-        (2, True),
-        (3, False),
+        (False, True),
+        (True, True),
+        (False, False),
     )
     @ddt.unpack
-    def test_get_current_exam_run_dates(self, weeks, has_exam):
+    def test_get_current_exam_run_dates(self, eligibility, has_current_exam):
         """test get_past_recent_exam_run"""
-        now = now_in_utc()
-        end_date = now + timedelta(weeks=8)
-        exam_run = ExamRunFactory.create(date_first_schedulable=end_date+timedelta(weeks=weeks))
-        CourseRunFactory.create(
-            course=exam_run.course,
-            start_date=now-timedelta(weeks=5),
-            end_date=end_date
+        exam_run = ExamRunFactory.create(
+            scheduling_past=not has_current_exam,
+            scheduling_future=False,
+            eligibility_past=False,
+            eligibility_future=eligibility
         )
         expected = ''
-        if has_exam:
-            expected = '{} - {}'.format(
-                exam_run.date_first_schedulable.strftime('%b %-d'),
-                exam_run.date_last_schedulable.strftime('%b %-d, %Y')
+        if has_current_exam:
+            expected = '{} and {}'.format(
+                exam_run.date_first_eligible.strftime('%b %-d'),
+                exam_run.date_last_eligible.strftime('%b %-d, %Y')
             )
         self.assertEqual(api.get_current_exam_run_dates(exam_run.course), expected)
 

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -71,7 +71,7 @@ const COURSE: Course = {
   exam_register_end_date:      "",
   exam_url:                    "",
   exams_schedulable_in_future: [],
-  current_exam_date:           "",
+  current_exam_dates:          "",
   has_to_pay:                  false,
   has_exam:                    false,
   proctorate_exams_grades:     [],

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -302,8 +302,10 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
           </a>
           {` You must register by ${
             course.exam_register_end_date
-          } to be eligible to take the exam `}
-          this semester. <br />
+          } to be eligible to take the exam between ${
+            course.current_exam_dates
+          }.`}
+          <br />
           <br />
           If you have already registered for the exam, you can access the exam
           through your <a href={EDX_LINK_BASE}>edX dashboard</a>.
@@ -377,7 +379,7 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     return S.Just(messages)
   } else if (hasMissedDeadlineCourseRun(course)) {
     // the course finished can't pay
-    if (exams && course.current_exam_date) {
+    if (exams) {
       const futureExamMessage = R.isEmpty(course.exams_schedulable_in_future)
         ? " There are no future exams scheduled at this time. Please check back later."
         : ` You can pay now to take the next exam, scheduled for ${formatDate(

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -373,6 +373,7 @@ describe("Course Status Messages", () => {
         course.proctorate_exams_grades[0].passed = true
         course.exam_url = "http://example.com"
         course.exam_register_end_date = "Jan 17"
+        course.current_exam_dates = "Jan 30 - Feb 5"
         const messages = calculateMessages(calculateMessagesProps).value
         assert.equal(messages[0]["message"], "You passed this course.")
         const mountedOne = shallow(messages[1]["message"])
@@ -380,7 +381,9 @@ describe("Course Status Messages", () => {
           mountedOne.text().trim(),
           "You passed the exam. You are authorized to take the virtual proctored exam for this course. " +
             "Please register now and complete the exam onboarding. " +
-            "You must register by Jan 17 to be eligible to take the exam this semester. If " +
+            `You must register by Jan 17 to be eligible to take the exam between ${
+              course.current_exam_dates
+            }.If ` +
             "you have already registered for the exam, you can access the exam through your edX dashboard."
         )
         const mountedTwo = shallow(messages[2]["message"])
@@ -445,6 +448,8 @@ describe("Course Status Messages", () => {
         course.runs = [course.runs[0]]
         course.can_schedule_exam = true
         course.exam_register_end_date = "Jan 17"
+        course.current_exam_dates = "Jan 30 - Feb 5"
+
         let messages = calculateMessages(calculateMessagesProps).value
         assert.equal(
           messages[0]["message"],
@@ -457,7 +462,9 @@ describe("Course Status Messages", () => {
           mounted.text(),
           " You are authorized to take the virtual proctored exam for this " +
             "course. Please register now and complete the exam onboarding. " +
-            "You must register by Jan 17 to be eligible to take the exam this semester. If " +
+            `You must register by Jan 17 to be eligible to take the exam between ${
+              course.current_exam_dates
+            }.If ` +
             "you have already registered for the exam, you can access the exam through your edX dashboard."
         )
       })
@@ -483,6 +490,7 @@ describe("Course Status Messages", () => {
         course.proctorate_exams_grades = [makeProctoredExamResult()]
         course.proctorate_exams_grades[0].passed = true
         course.exam_register_end_date = "Jan 17"
+        course.current_exam_dates = "Jan 30 - Feb 5"
 
         let messages = calculateMessages(calculateMessagesProps).value
         assert.equal(messages[0]["message"], "You passed this course.")
@@ -495,7 +503,9 @@ describe("Course Status Messages", () => {
           mounted.text(),
           "You passed the exam. You are authorized to take the virtual proctored " +
             "exam for this course. Please register now and complete the exam onboarding. " +
-            "You must register by Jan 17 to be eligible to take the exam this semester. If " +
+            `You must register by Jan 17 to be eligible to take the exam between ${
+              course.current_exam_dates
+            }.If ` +
             "you have already registered for the exam, you can access the exam through your edX dashboard."
         )
       })
@@ -515,6 +525,7 @@ describe("Course Status Messages", () => {
         course.proctorate_exams_grades[0].passed = false
         course.can_schedule_exam = true
         course.exam_register_end_date = "Jan 17"
+        course.current_exam_dates = "Jun 30 and July 5"
 
         let messages = calculateMessages(calculateMessagesProps).value
         assert.equal(messages[0]["message"], "You did not pass the exam.")
@@ -526,7 +537,7 @@ describe("Course Status Messages", () => {
           mounted.text(),
           "You did not pass the exam. You are authorized to take the virtual proctored " +
             "exam for this course. Please register now and complete the exam onboarding. " +
-            "You must register by Jan 17 to be eligible to take the exam this semester. If " +
+            "You must register by Jan 17 to be eligible to take the exam between Jun 30 and July 5.If " +
             "you have already registered for the exam, you can access the exam through your edX dashboard."
         )
       })
@@ -705,7 +716,7 @@ describe("Course Status Messages", () => {
       makeRunOverdue(course.runs[0])
 
       course.has_exam = true
-      course.current_exam_date = "Mar 12 - Mar 22, 2018"
+      course.current_exam_dates = "Mar 12 - Mar 22, 2018"
 
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
@@ -730,7 +741,7 @@ describe("Course Status Messages", () => {
       makeRunOverdue(course.runs[0])
 
       course.has_exam = true
-      course.current_exam_date = "Mar 12 - Mar 22, 2018"
+      course.current_exam_dates = "Mar 12 - Mar 22, 2018"
       course.exams_schedulable_in_future = [
         moment()
           .add(2, "day")

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -95,7 +95,7 @@ export const makeCourse = (positionInProgram: number): Course => {
     exam_register_end_date:      "",
     exam_url:                    "",
     exams_schedulable_in_future: [],
-    current_exam_date:           "",
+    current_exam_dates:          "",
     has_to_pay:                  false,
     has_exam:                    false,
     is_elective:                 false,

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -62,7 +62,7 @@ export type Course = {
   exam_register_end_date:       string,
   exam_url:                     string,
   exams_schedulable_in_future:  Array<string>,
-  current_exam_date:               string,
+  current_exam_dates:               string,
   has_to_pay:                   boolean,
   proctorate_exams_grades:      Array<ProctoredExamResult>,
   is_elective:                  boolean,


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Fix #4845

#### What's this PR do?
Updating the exam authorization message, when the exam is currently schedulable

#### How should this be manually tested?
Set up a course that your user has paid for and has passed. You can use the alter_data management command:
`./manage.py alter_data set_past_run_to_passed --username username --program-title Digital --course-title 100`

create and exam run, an exam authorization, exam profile, and exam coupon for the user to use:
```
course = Course.objects.get(title='Digital Learning 100')
exam_run = ExamRunFactory.create(course=course, authorized=True, scheduling_past=False, scheduling_future=False)
au=ExamAuthorizationFactory.create(user=user, course=course, exam_run=exam_run, status= 'success')
exam_profile= ExamProfileFactory.create(status='success', profile=user.profile)
ExamRunCouponFactory.create(is_taken=False, course=course)
```

<img width="797" alt="Screen Shot 2021-04-09 at 11 20 21 AM" src="https://user-images.githubusercontent.com/7574259/114213011-7aa44d00-9930-11eb-9e9d-92bb30475e7c.png">
