### PR TITLE
Populate exam coupons:look for more specific course number

### DIFF
--- a/exams/management/commands/populate_edx_exam_coupons.py
+++ b/exams/management/commands/populate_edx_exam_coupons.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
         validated_urls = validate_urls(reader)
 
         try:
-            course = Course.objects.get(course_number__startswith=course_number)
+            course = Course.objects.get(course_number__startswith=f'{course_number}x')
         except Course.DoesNotExist:
             raise CommandError(
                 'Could not find a course with number "{}"'.format(course_number)


### PR DESCRIPTION

#### What are the relevant tickets?
Ran into an error while populating edx exam coupons, there are 2 courses with number 14.310

#### What's this PR do?
Updates the command to check for a x after the course number.

#### How should this be manually tested?
Run the command:
./manage.py populate_edx_exam_coupons <file>
ask me for an example file