### PR TITLE
Enable newrelic on workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
-worker: bin/start-pgbouncer celery -A micromasters.celery:app worker -Q dashboard,default -B -l $MICROMASTERS_LOG_LEVEL
-extra_worker: bin/start-pgbouncer celery -A micromasters.celery:app worker -Q dashboard,default -l $MICROMASTERS_LOG_LEVEL
+worker: bin/start-pgbouncer newrelic-admin run-program celery -A micromasters.celery:app worker -Q dashboard,default -B -l $MICROMASTERS_LOG_LEVEL
+extra_worker: bin/start-pgbouncer newrelic-admin run-program celery -A micromasters.celery:app worker -Q dashboard,default -l $MICROMASTERS_LOG_LEVEL


### PR DESCRIPTION
#### Pre-Flight checklist
N/A

#### What are the relevant tickets?
N/A

#### What's this PR do?
This wraps the workers with `newrelic-admin run-program`, so that the worker stats get reported to newrelic.

#### How should this be manually tested?
N/A, since it needs to be run on heroku.