### PR TITLE
Adding common FAQ section for Zendesk 

### DIFF
--- a/cms/templates/cms/benefits_page.html
+++ b/cms/templates/cms/benefits_page.html
@@ -68,6 +68,7 @@
 {% if not DO_NOT_TRACK %}
   {% include "adwords.html" %}
 {% endif %}
+{% include "faqs.html" %}
 {% include "footer.html" %}
 
 <div id="signup-dialog">

--- a/cms/templates/cms/home_page.html
+++ b/cms/templates/cms/home_page.html
@@ -217,19 +217,7 @@
           </div>
         </div>
       </section>
-
-      <section class="faqs">
-        <div class="faq-holder">
-          <img src="{% static 'images/faq.png' %}" alt="FAQs">
-          <div class="info">
-            <span class="title">frequently asked questions</span>
-            <span class="description">
-              <a target="_blank" href="https://mitx-micromasters.zendesk.com/hc/en-us" rel="noopener noreferrer">Find Answers</a> to Your Questions
-            </span>
-          </div>
-        </div>
-      </section>
-
+      {% include "faqs.html" %}
       <section class="quote-section">
         <div class="row quote">
           <img class="person" src="{% static 'images/reif1.png' %}" alt="">

--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -175,6 +175,7 @@
 {% if not DO_NOT_TRACK %}
   {% include "adwords.html" %}
 {% endif %}
+{% include "faqs.html" %}
 {% include "footer.html" %}
 
 <div id="signup-dialog">

--- a/financialaid/templates/review_financial_aid.html
+++ b/financialaid/templates/review_financial_aid.html
@@ -277,6 +277,7 @@
       </div>
     </div>
   </div>
+  {% include "faqs.html" %}
   {% include "footer.html" %}
   <script>
     window.CSRF_TOKEN = "{{ csrf_token }}";

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -6,6 +6,7 @@
 
 {% block content %}
 <div id="dashboard"></div>
+{% include "faqs.html" %}
 {% include "footer.html" %}
 
 {% load render_bundle %}

--- a/ui/templates/faqs.html
+++ b/ui/templates/faqs.html
@@ -1,0 +1,12 @@
+{% load static %}
+<section class="faqs">
+  <div class="faq-holder">
+    <img src="{% static 'images/faq.png' %}" alt="FAQs">
+    <div class="info">
+      <span class="title">frequently asked questions</span>
+      <span class="description">
+        <a target="_blank" href="https://mitx-micromasters.zendesk.com/hc/en-us" rel="noopener noreferrer">Find Answers</a> to Your Questions
+      </span>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#4887 

#### What's this PR do?
Adds link to Zendesk's HelpCenter(FAQ)
Pages that this PR adds the FAQ section to:
- Benefits Page (Main/HomeScreen). (this is usually accessed at `/benefits`)
- Program Page(s)/Tab(s) (This includes all the tabs that show under a program)
- Dashboard Page (`/dashboard`)
- Order Summary (`/order_summary/?<course_key>`)
- Learners Page (`/learners`)
- Settings Page (`/settings`)
- Profile Page (`/learner/<username>`)
- Financial Aid Admin/submissions Page (`/financial_aid`)

#### How should this be manually tested?
Check that the FAQ show just above footer on all the aforementioned pages just above And the FAQ link is functional.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)

**Program Page**
<img width="1436" alt="mm_program_page" src="https://user-images.githubusercontent.com/34372316/118685074-3607ad80-b81c-11eb-89b6-efe76df4c480.png">

**Program Page without Instructors**
<img width="1440" alt="program_page_without_instructors" src="https://user-images.githubusercontent.com/34372316/118685083-37d17100-b81c-11eb-903a-f6b61ad2bfe4.png">

**Program FAQ's Tab/Page**
<img width="1438" alt="program_faq_page" src="https://user-images.githubusercontent.com/34372316/118686610-95b28880-b81d-11eb-832f-9ce7d4d4ffc4.png">

**Benefits Page**
<img width="1439" alt="mm_benefits_page" src="https://user-images.githubusercontent.com/34372316/118685063-343dea00-b81c-11eb-8904-4cfefcaecc8a.png">

**Dashboard**
<img width="1438" alt="mm_dashboard" src="https://user-images.githubusercontent.com/34372316/118782869-f71f3980-b8a7-11eb-922b-33177c279831.png">

**Order Summary Page**
<img width="1440" alt="mm_order_summary" src="https://user-images.githubusercontent.com/34372316/118782885-fb4b5700-b8a7-11eb-9383-71b6f6495600.png">


**Learners Page**
<img width="1440" alt="learners_page" src="https://user-images.githubusercontent.com/34372316/118685061-33a55380-b81c-11eb-8213-8d3a74178413.png">

**Home Page**
<img width="1435" alt="mm_home_page" src="https://user-images.githubusercontent.com/34372316/118685064-34d68080-b81c-11eb-823a-f5007dd47fb6.png">

**Email Campaigns Page**
<img width="1439" alt="email_campaigns_page" src="https://user-images.githubusercontent.com/34372316/118685045-2f793600-b81c-11eb-983d-a8a3416d099f.png">

**Profile Edit Page**
<img width="1435" alt="mm_profile_page" src="https://user-images.githubusercontent.com/34372316/118685072-356f1700-b81c-11eb-874a-084adb6dcff2.png">

**Settings Page**
<img width="1440" alt="mm_settings_page" src="https://user-images.githubusercontent.com/34372316/118685076-36a04400-b81c-11eb-94f8-e55f3fcb2d89.png">

**Personal Price Admin page**
<img width="1440" alt="personal_price_admin_page" src="https://user-images.githubusercontent.com/34372316/118685078-3738da80-b81c-11eb-8774-341662483718.png">
