### PR TITLE
Explicitly set required to false for SENTRY_DSN

### DIFF
--- a/app.json
+++ b/app.json
@@ -240,7 +240,8 @@
       "generator": "secret"
     },
     "SENTRY_DSN": {
-      "description": "The connection settings for Sentry"
+      "description": "The connection settings for Sentry",
+      "required": false
     },
     "SESSION_ENGINE": {
       "description": "Django session engine",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
None
- CI builds were not getting created successfully complaining about this key `SENTRY_DSN` which has not specified the value for `required` key in `app.json`.
- For reference, you can have a look at the review builds [here on heroku](https://dashboard.heroku.com/pipelines/075b4f75-bd1e-4285-bb78-ca3dc829abc4).

#### What's this PR do?
Sets `required` to `false` for `SENTRY_DSN`
