### PR TITLE
Link to Learner Dashboard for staff

### DIFF
--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -172,6 +172,7 @@ export default class Navbar extends React.Component {
               {this.programSelector()}
             </div>
             <div className="links">
+              {adminLink(closeDrawer, "/dashboard", "Dashboard", "dashboard")}
               {adminLink(closeDrawer, "/learners", "Learners", "people")}
               {adminLink(closeDrawer, "/cms", "CMS", "description", true, true)}
               {financialAidLink(

--- a/static/js/components/Navbar_test.js
+++ b/static/js/components/Navbar_test.js
@@ -43,6 +43,7 @@ describe("Navbar", () => {
       assert.deepEqual(hrefs, [
         "/learner/jane",
         "/learner/jane",
+        "/dashboard",
         "/learners",
         "/automaticemails",
         "/learner/jane",

--- a/ui/templates/header.html
+++ b/ui/templates/header.html
@@ -9,11 +9,7 @@
           </div>
         <div class="pull-right">
           {% if authenticated %}
-            {% if is_staff %}
-              <a class="header-dashboard-link" href="/learners">My Dashboard</a>
-            {% else %}
-              <a class="header-dashboard-link" href="/dashboard">My Dashboard</a>
-            {% endif %}
+          <a class="header-dashboard-link" href="/dashboard">My Dashboard</a>
           <a class="header-dashboard-link" href="/logout">
             Sign Out
           </a>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
fixes #4888 

#### What's this PR do?
- In the user menu, display a link to "Dashboard" above the link to "Learners"
- on the homepage, change the dashboard link from '/learners' to '/dashboard' 

#### How should this be manually tested?
Just visit the user menu

#### Screenshots
<img width="1440" alt="Screenshot 2021-05-20 at 16 23 40" src="https://user-images.githubusercontent.com/4043989/118970595-da5a3300-b987-11eb-9701-ea48e6cd5380.png">
