### PR TITLE
add (another) link to FAQ on the 404 page

### DIFF
--- a/ui/templates/404.html
+++ b/ui/templates/404.html
@@ -13,6 +13,7 @@ PAGE NOT FOUND
 	<p>Maybe you were looking for one of these pages:</p>
 	<ul>
 		<li><a href="/">Home page</a></li>
+		<li><a target="_blank" href="https://mitx-micromasters.zendesk.com/hc/en-us" rel="noopener noreferrer">Frequently Asked Questions</a></li>
 	</ul>
 	<p>If you think there is a problem, please send an email to
 	<a href="mailto:{{ support_email }}">{{ support_email }}</a></p>


### PR DESCRIPTION
fixes #4915

#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots

#### What are the relevant tickets?

#4915 and #4916

#### What's this PR do?

Adds a link on the 404 page to the FAQ on ZenDesk, for the user you read the error message. 

#### How should this be manually tested?

Does the link work?

