### PR TITLE
don't fail CI if codecov upload fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
-          fail_ci_if_error: true
   
   javascript-tests:
     runs-on: ubuntu-latest
@@ -152,7 +151,6 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: coverage/lcov.info
-          fail_ci_if_error: true
 
   selenium-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Updates github action ci.yml to allow codecov to fail softly.

#### How should this be manually tested?
Github actions should succeed, especially if the codecov upload fails.