### PR TITLE
Upgrade trim-newlines to v3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,5 +152,8 @@
   "devDependencies": {
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.2"
+  },
+  "resolutions": {
+    "node-sass/**/trim-newlines": "^3.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9962,10 +9962,10 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+trim-newlines@^1.0.0, trim-newlines@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/4952

#### What's this PR do?
Upgrade trim-newlines to v3.0.1

#### How should this be manually tested?
Just check everything is working, specifically webpack build compilations

#### Any background context you want to provide?
`node-sass` requires `meow` and `meow` requires `trim-newlines`. To upgrade `trim-newlines` the ideal way is to upgrade node-sass from 5.0.0 to 6.0.0 but that requires the node version from 10 to be upgraded to >12. Even if we upgrade the node version we have to upgrade a lot of other dependencies as well.

That's why we have to use resolution for now.