### PR TITLE
Run recreate index through a celery task

### DIFF
--- a/search/management/commands/recreate_index.py
+++ b/search/management/commands/recreate_index.py
@@ -16,4 +16,5 @@ class Command(BaseCommand):
         """
         Recreates the index
         """
-        recreate_index_async.delay()
+        recreate_index_task = recreate_index_async.delay()
+        self.stdout.write('Running reindexing task with Id: {}'.format(recreate_index_task.id))

--- a/search/management/commands/recreate_index.py
+++ b/search/management/commands/recreate_index.py
@@ -1,13 +1,8 @@
 """
 Management command to recreate the Elasticsearch index
 """
-import logging
 
 from django.core.management.base import BaseCommand
-
-from search.indexing_api import (
-    __name__ as indexing_api_name,
-)
 from search.tasks import recreate_index_async
 
 
@@ -15,36 +10,10 @@ class Command(BaseCommand):
     """
     Command for recreate_index
     """
-    help = "Clears existing Elasticsearch indices and creates a new index and mapping."
-
-    def add_arguments(self, parser):  # pylint: disable=no-self-use
-        """Configure command args"""
-        parser.add_argument(
-            '--profile',
-            action='store_true',
-            dest='profile',
-            default=False,
-        )
+    help = "Starts a new celery task that clears existing Elasticsearch indices and creates a new index and mapping."
 
     def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
         """
         Recreates the index
         """
-        log = logging.getLogger(indexing_api_name)
-        console = logging.StreamHandler(self.stderr)
-        console.setLevel(logging.DEBUG)
-        log.addHandler(console)
-        log.level = logging.INFO
-
-        if kwargs['profile']:
-            import cProfile
-            import uuid
-            profile = cProfile.Profile()
-            profile.enable()
-            recreate_index_async.delay()
-            profile.disable()
-            filename = 'recreate_index_{}.profile'.format(uuid.uuid4())
-            profile.dump_stats(filename)
-            self.stdout.write('Output profiling data to: {}'.format(filename))
-        else:
-            recreate_index_async.delay()
+        recreate_index_async.delay()

--- a/search/management/commands/recreate_index.py
+++ b/search/management/commands/recreate_index.py
@@ -6,9 +6,9 @@ import logging
 from django.core.management.base import BaseCommand
 
 from search.indexing_api import (
-    recreate_index,
     __name__ as indexing_api_name,
 )
+from search.tasks import recreate_index_async
 
 
 class Command(BaseCommand):
@@ -41,10 +41,10 @@ class Command(BaseCommand):
             import uuid
             profile = cProfile.Profile()
             profile.enable()
-            recreate_index()
+            recreate_index_async.delay()
             profile.disable()
             filename = 'recreate_index_{}.profile'.format(uuid.uuid4())
             profile.dump_stats(filename)
             self.stdout.write('Output profiling data to: {}'.format(filename))
         else:
-            recreate_index()
+            recreate_index_async.delay()

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -144,5 +144,5 @@ def recreate_index_async(self):
     """
     Recreate the index
     """
-    log.info(f"Running reindexing task with Id: {self.request.id.__str__()}")
+    log.info('Running reindexing task with Id: %s', self.request.id.__str__())
     _recreate_index()

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -20,6 +20,7 @@ from search.indexing_api import (
     remove_program_enrolled_user as _remove_program_enrolled_user,
     index_percolate_queries as _index_percolate_queries,
     delete_percolate_query as _delete_percolate_query,
+    recreate_index as _recreate_index,
 )
 from search.models import PercolateQuery
 
@@ -136,3 +137,11 @@ def populate_query_memberships(percolate_query_id):
         percolate_query_id (int): Database id for the PercolateQuery to populate
     """
     api.populate_query_memberships(percolate_query_id)
+
+
+@app.task
+def recreate_index_async():
+    """
+    Recreate the index
+    """
+    _recreate_index()

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -139,9 +139,10 @@ def populate_query_memberships(percolate_query_id):
     api.populate_query_memberships(percolate_query_id)
 
 
-@app.task
-def recreate_index_async():
+@app.task(acks_late=True, bind=True)
+def recreate_index_async(self):
     """
     Recreate the index
     """
+    log.info(f"Running reindexing task with Id: {self.request.id.__str__()}")
     _recreate_index()

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -139,10 +139,9 @@ def populate_query_memberships(percolate_query_id):
     api.populate_query_memberships(percolate_query_id)
 
 
-@app.task(acks_late=True, bind=True)
-def recreate_index_async(self):
+@app.task(acks_late=True)
+def recreate_index_async():
     """
     Recreate the index
     """
-    log.info('Running reindexing task with Id: %s', self.request.id.__str__())
     _recreate_index()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#4959 

#### What's this PR do?
- It moves the execution of `recreate_index` out of the main thread and puts it to a separate celery task


#### How should this be manually tested?
- Running the command e.g.  `./manage.py recreate_index` should now run separately in a celery task.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
Previously we were facing timeouts when running this command with high amount of records.

