### PR TITLE
fix: display instructors on mobile as well

### DIFF
--- a/static/js/components/FacultyCarousel.js
+++ b/static/js/components/FacultyCarousel.js
@@ -26,7 +26,7 @@ export default class FacultyCarousel extends React.Component {
         {
           breakpoint: 840,
           settings:   {
-            slidesToShow: 1
+            slidesToShow: 2
           }
         },
         {

--- a/static/js/components/FacultyCarousel.js
+++ b/static/js/components/FacultyCarousel.js
@@ -19,11 +19,15 @@ export default class FacultyCarousel extends React.Component {
       responsive:     [
         {
           breakpoint: 600,
-          settings:   "unslick"
+          settings:   {
+            slidesToShow: 1
+          }
         },
         {
-          breakpoint: 800,
-          settings:   "unslick"
+          breakpoint: 840,
+          settings:   {
+            slidesToShow: 1
+          }
         },
         {
           breakpoint: 1000,

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -508,10 +508,19 @@
 
     .slick-prev {
       left: -50px;
+
+      @media (max-width: 840px) {
+        margin-left: 25px;
+        z-index: 1;
+      }
     }
 
     .slick-next {
       right: -50px;
+
+      @media (max-width: 840px) {
+        margin-right: 25px;
+      }
     }
 
     .slick-dots li button:before {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#4961 

#### What's this PR do?
- Displays the instructors on mobile and tablets as well
- Updates the styling to fix left arrows spacing on mobile/tablet
- Fixes left arrow overlap display issue on mobile

#### How should this be manually tested?
- Add a program page through CMS
- Add instructors within the page
- Load the page and check the instructor's list is showing up fine on mobile/tablets as well as on desktop versions

#### Where should the reviewer start?
Program Page

#### Screenshots
**Desktop Screenshot**
<img width="1439" alt="Screenshot 2021-06-23 at 3 52 35 PM" src="https://user-images.githubusercontent.com/34372316/123087286-cea5d480-d43d-11eb-9fc7-482ad02bb5c3.png">


**Mobile Screenshot**
<img width="497" alt="Screenshot 2021-06-23 at 3 52 48 PM" src="https://user-images.githubusercontent.com/34372316/123087303-d5344c00-d43d-11eb-94af-42c0a9060cd9.png">


**Mobile Second Item Screenshot**
<img width="493" alt="Screenshot 2021-06-23 at 3 53 01 PM" src="https://user-images.githubusercontent.com/34372316/123087307-d6657900-d43d-11eb-9364-ceb95d37eeb2.png">


**Tablet Screenshot**
<img width="750" alt="Screenshot 2021-06-23 at 4 10 46 PM" src="https://user-images.githubusercontent.com/34372316/123087313-d8c7d300-d43d-11eb-81f1-af81bd8da552.png">

