### PR TITLE
use uuid based hashes for certificates

### DIFF
--- a/grades/factories.py
+++ b/grades/factories.py
@@ -80,6 +80,7 @@ class MicromastersProgramCertificateFactory(DjangoModelFactory):
 
     user = SubFactory(UserFactory)
     program = SubFactory(ProgramFactory)
+    hash = uuid.uuid4().hex
 
     class Meta:  # pylint: disable=missing-docstring,no-init,too-few-public-methods
         model = MicromastersProgramCertificate

--- a/grades/factories.py
+++ b/grades/factories.py
@@ -1,5 +1,6 @@
 """Factories for the grades app"""
 import datetime
+import uuid
 
 from factory import (
     SubFactory,
@@ -29,7 +30,7 @@ from grades.models import (
     MicromastersProgramCommendation,
 )
 from micromasters.factories import UserFactory
-from micromasters.utils import now_in_utc, generate_md5
+from micromasters.utils import now_in_utc
 
 
 class FinalGradeFactory(DjangoModelFactory):
@@ -68,7 +69,7 @@ class MicromastersCourseCertificateFactory(DjangoModelFactory):
     """Factory for MicromastersCourseCertificate"""
     user = SubFactory(UserFactory)
     course = SubFactory(CourseFactory)
-    hash = LazyAttribute(lambda cert: generate_md5('{}|{}'.format(cert.user.id, cert.course.id).encode('utf-8')))
+    hash = uuid.uuid4().hex
 
     class Meta:  # pylint: disable=missing-docstring,no-init,too-few-public-methods
         model = MicromastersCourseCertificate

--- a/grades/models.py
+++ b/grades/models.py
@@ -24,7 +24,6 @@ from micromasters.models import (
 from micromasters.utils import (
     now_in_utc,
     serialize_model_object,
-    generate_md5,
 )
 
 
@@ -155,9 +154,7 @@ class MicromastersCourseCertificate(TimestampedModel):
     def save(self, *args, **kwargs):  # pylint: disable=signature-differs
         """Overridden save method"""
         if not self.hash:
-            self.hash = generate_md5(
-                '{}|{}'.format(self.user_id, self.course_id).encode('utf-8')
-            )
+            self.hash = uuid.uuid4().hex
         super().save(*args, **kwargs)
 
     def __str__(self):
@@ -182,9 +179,7 @@ class MicromastersProgramCertificate(TimestampedModel):
     def save(self, *args, **kwargs):  # pylint: disable=signature-differs
         """Overridden save method"""
         if not self.hash:
-            self.hash = generate_md5(
-                '{}|{}'.format(self.user_id, self.program_id).encode('utf-8')
-            )
+            self.hash = uuid.uuid4().hex
         super().save(*args, **kwargs)
 
     def __str__(self):

--- a/grades/models_test.py
+++ b/grades/models_test.py
@@ -21,7 +21,6 @@ from grades.constants import FinalGradeStatus
 from grades.factories import ProctoredExamGradeFactory
 from grades.models import ProctoredExamGrade
 from micromasters.factories import UserFactory
-from micromasters.utils import generate_md5
 from search.base import MockedESTestCase
 
 
@@ -188,7 +187,6 @@ class MicromastersCourseCertificateTests(MockedESTestCase):
         course = CourseFactory.create()
         mm_certificate = MicromastersCourseCertificate.objects.create(user=user, course=course)
         assert len(mm_certificate.hash) == 32
-        assert mm_certificate.hash == generate_md5('{}|{}'.format(user.id, course.id).encode('utf-8'))
 
 
 class MicromastersProgramCertificateTests(MockedESTestCase):
@@ -201,7 +199,6 @@ class MicromastersProgramCertificateTests(MockedESTestCase):
 
         mm_certificate = MicromastersProgramCertificate.objects.create(user=user, program=program)
         assert len(mm_certificate.hash) == 32
-        assert mm_certificate.hash == generate_md5('{}|{}'.format(user.id, program.id).encode('utf-8'))
 
 
 class MicromastersProgramCommendationTests(MockedESTestCase):


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/4964

#### What's this PR do?
It uses UUID based hashes for certificates to make the URLs unpredictable

#### How should this be manually tested?
Create program and course certificates the hash should be working fine, secondly, the old certificates and their hashes should not be disturbed.
