### PR TITLE
fix: instruction dialog frame design enhancement and closing operation

### DIFF
--- a/static/js/components/DocsInstructionsDialog.js
+++ b/static/js/components/DocsInstructionsDialog.js
@@ -26,14 +26,17 @@ const DocsInstructionsDialog = ({
   open,
   setDialogVisibility
 }: DocsInstructions) => (
+  // onRequestClose is not used below because an extra click or touch event causes material-ui
+  // to close the dialog right after opening it. See https://github.com/JedWatson/react-select/issues/532
   <Dialog
+    classes={{ paper: "docs-instructions-dialog-paper" }}
     title={dialogTitle(setDialogVisibility)}
     titleClassName="dialog-title"
     contentClassName="dialog docs-instructions-dialog"
     className="docs-instructions-dialog-wrapper"
     open={open}
-    onRequestClose={() => setDialogVisibility(false)}
     autoScrollBodyContent={true}
+    onClose={() => setDialogVisibility(false)}
   >
     <div className="heading">Whose income should I report?</div>
     <p>

--- a/static/scss/docs-instructions.scss
+++ b/static/scss/docs-instructions.scss
@@ -27,6 +27,7 @@
     }
   }
 }
+
 .docs-instructions-dialog-paper {
   padding: 31px 32px 25px;
 }

--- a/static/scss/docs-instructions.scss
+++ b/static/scss/docs-instructions.scss
@@ -27,3 +27,6 @@
     }
   }
 }
+.docs-instructions-dialog-paper {
+  padding: 31px 32px 25px;
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#4972 

#### What's this PR do?
- Fixes the frame design as per the dialog that is shown when clicked on the course link on the program page.
- Fixes the close event for the dialog

#### How should this be manually tested?
- Setup person price on the dashboard
- Check the dialog spacing
- Check that dialog closes upon closing outside the dialog boundary

#### Where should the reviewer start?
- Setting up the personal price in the dashboard. More instructions can be seen on the associated ticket

#### Screenshots (if appropriate)
**Desktop**
<img width="1214" alt="Screenshot 2021-07-06 at 4 02 50 PM" src="https://user-images.githubusercontent.com/34372316/124589748-c6a15800-de73-11eb-97e8-3bf3345022f1.png">

**Mobile**
<img width="340" alt="Screenshot 2021-07-06 at 4 03 48 PM" src="https://user-images.githubusercontent.com/34372316/124589770-cb660c00-de73-11eb-804a-1e272d8eb00b.png">


**Reference dialog -- With which the design is matched now**
<img width="572" alt="Screenshot 2021-07-06 at 4 08 26 PM" src="https://user-images.githubusercontent.com/34372316/124590380-81315a80-de74-11eb-8a72-1113d150d014.png">
