### PR TITLE
Add link to accomplishment letter in the staff view of the learner profile page

### DIFF
--- a/static/js/components/ProgressWidget.js
+++ b/static/js/components/ProgressWidget.js
@@ -12,7 +12,8 @@ export const circularProgressWidget = (
   radius: number,
   strokeWidth: number,
   totalPassedCourses: number,
-  totalCourses: number
+  totalCourses: number,
+  programLetterUrl: string
 ): React$Element<*> => {
   const radiusForMeasures = radius - strokeWidth / 2
   const width = radius * 2
@@ -60,6 +61,9 @@ export const circularProgressWidget = (
         </text>
       </svg>
       <p className="text-course-complete">Courses complete</p>
+      {SETTINGS.FEATURES.ENABLE_PROGRAM_LETTER &&
+        programLetterUrl &&
+        programLetterLink(programLetterUrl)}
     </div>
   )
 }
@@ -142,15 +146,12 @@ export default class ProgressWidget extends React.Component {
             60,
             6,
             totalPassedCourses,
-            program.number_courses_required
+            program.number_courses_required,
+            program.program_letter_url
           )}
           {SETTINGS.FEATURES.PROGRAM_RECORD_LINK &&
             program.financial_aid_availability &&
             gradeRecordsLink(program.grade_records_url)}
-          {SETTINGS.FEATURES.ENABLE_PROGRAM_LETTER &&
-            !program.financial_aid_availability &&
-            program.program_letter_url &&
-            programLetterLink(program.program_letter_url)}
         </CardContent>
       </Card>
     )

--- a/static/js/components/StaffLearnerInfoCard.js
+++ b/static/js/components/StaffLearnerInfoCard.js
@@ -50,7 +50,8 @@ const StaffLearnerInfoCard = (props: StaffLearnerCardProps) => {
                 63,
                 7,
                 totalPassedCourses,
-                program.number_courses_required
+                program.number_courses_required,
+                program.program_letter_url
               )}
             </div>
             {programInfoBadge(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #4950 

#### What's this PR do?
Add link to accomplishment letter in the staff view of the learner profile page

#### How should this be manually tested?
Just visit the learners page from the staff user and view the user page

#### Screenshots (if appropriate)
**NOW**

<img width="1440" alt="Screenshot 2021-07-19 at 09 00 18" src="https://user-images.githubusercontent.com/4043989/126101028-c139b97a-814b-4b81-8964-e509f20acc84.png">

<img width="1440" alt="Screenshot 2021-07-19 at 09 00 51" src="https://user-images.githubusercontent.com/4043989/126101038-d87ad2c0-07e0-40b2-86d1-7ff103d68fc4.png">

**BEFORE**

<img width="1440" alt="Screenshot 2021-07-16 at 17 23 28" src="https://user-images.githubusercontent.com/4043989/125946867-3e80f498-af10-4686-bd94-0fa3f541d3c6.png">
