### PR TITLE
Remove usages of get_social_username

### DIFF
--- a/backends/pipeline_api_test.py
+++ b/backends/pipeline_api_test.py
@@ -7,7 +7,7 @@ import ddt
 
 from backends import pipeline_api, edxorg
 from courses.factories import ProgramFactory
-from profiles.api import get_social_username
+from profiles.api import get_edxorg_social_username
 from profiles.models import Profile
 from profiles.factories import UserFactory
 from profiles.util import split_name
@@ -101,7 +101,7 @@ class EdxPipelineApiTest(MockedESTestCase):
                 'image_url_small': 'https://edx.org/small.jpg'
             },
             'requires_parental_consent': False,
-            'username': get_social_username(self.user),
+            'username': get_edxorg_social_username(self.user),
             'year_of_birth': 1986,
             "work_history": [
                 {
@@ -243,13 +243,13 @@ class EdxPipelineApiTest(MockedESTestCase):
         result = pipeline_api.check_edx_verified_email(
             backend,
             {'access_token': 'foo_token'},
-            {'username': get_social_username(self.user)}
+            {'username': get_edxorg_social_username(self.user)}
         )
 
         mocked_get_json.assert_called_once_with(
             urljoin(
                 edxorg.EdxOrgOAuth2.EDXORG_BASE_URL,
-                '/api/user/v1/accounts/{0}'.format(get_social_username(self.user))
+                '/api/user/v1/accounts/{0}'.format(get_edxorg_social_username(self.user))
             ),
             headers={'Authorization': 'Bearer foo_token'}
         )

--- a/cms/models.py
+++ b/cms/models.py
@@ -23,7 +23,6 @@ from wagtail.images.models import Image
 from courses.models import Program
 from micromasters.serializers import serialize_maybe_user
 from micromasters.utils import webpack_dev_server_host
-from profiles.api import get_social_username
 from roles.models import Instructor, Staff
 from cms.util import get_coupon_code
 from cms.blocks import CourseTeamBlock, ImageWithLinkBlock
@@ -53,7 +52,6 @@ class HomePage(Page):
             "release_version": settings.VERSION
         }
 
-        username = get_social_username(request.user)
         context = super().get_context(request)
 
         def get_program_page(program):
@@ -70,7 +68,7 @@ class HomePage(Page):
         context["google_maps_api"] = False
         context["authenticated"] = not request.user.is_anonymous
         context["is_staff"] = has_role(request.user, [Staff.ROLE_ID, Instructor.ROLE_ID])
-        context["username"] = username
+        context["username"] = request.user.username
         context["js_settings_json"] = json.dumps(js_settings)
         context["title"] = self.title
         context["ga_tracking_id"] = ""
@@ -124,7 +122,6 @@ class BenefitsPage(Page):
             "release_version": settings.VERSION
         }
 
-        username = get_social_username(request.user)
         context = super().get_context(request)
 
         context["is_public"] = True
@@ -132,7 +129,7 @@ class BenefitsPage(Page):
         context["google_maps_api"] = False
         context["authenticated"] = not request.user.is_anonymous
         context["is_staff"] = has_role(request.user, [Staff.ROLE_ID, Instructor.ROLE_ID])
-        context["username"] = username
+        context["username"] = request.user.username
         context["js_settings_json"] = json.dumps(js_settings)
         context["title"] = self.title
         context["ga_tracking_id"] = ""
@@ -415,7 +412,6 @@ def get_program_page_context(programpage, request):
         "user": serialize_maybe_user(request.user),
         "program": ProgramPageSerializer(programpage).data,
     }
-    username = get_social_username(request.user)
     # pylint: disable=bad-super-call
     context = super(ProgramPage, programpage).get_context(request)
 
@@ -424,7 +420,7 @@ def get_program_page_context(programpage, request):
     context["has_zendesk_widget"] = True
     context["google_maps_api"] = False
     context["authenticated"] = not request.user.is_anonymous
-    context["username"] = username
+    context["username"] = request.user.username
     context["js_settings_json"] = json.dumps(js_settings)
     context["title"] = programpage.title
     context["courses"] = courses_query

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -26,7 +26,7 @@ from grades.models import FinalGrade
 from grades.serializers import ProctoredExamGradeSerializer
 from exams.models import ExamAuthorization, ExamRun, ExamRunCoupon
 from micromasters.utils import now_in_utc
-from profiles.api import get_social_auth
+from profiles.api import get_edxorg_social_auth
 
 # key that stores user_key and number of failures in a hash
 CACHE_KEY_FAILURE_NUMS_BY_USER = "update_cache_401_failure_numbers"
@@ -723,7 +723,7 @@ def refresh_user_data(user_id):
 
     # get the credentials for the current user for edX
     try:
-        user_social = get_social_auth(user)
+        user_social = get_edxorg_social_auth(user)
     except:
         log.exception('user "%s" does not have edX credentials', user.username)
         return

--- a/dashboard/api_edx_cache.py
+++ b/dashboard/api_edx_cache.py
@@ -15,7 +15,7 @@ from backends.exceptions import InvalidCredentialStored
 from courses.models import CourseRun
 from dashboard import models
 from micromasters.utils import now_in_utc
-from profiles.api import get_social_username, get_social_auth
+from profiles.api import get_edxorg_social_username, get_edxorg_social_auth
 from search import tasks
 
 log = logging.getLogger(__name__)
@@ -233,7 +233,7 @@ class CachedEdxDataApi:
 
         # Certificates are out of date, so fetch new data from edX.
         certificates = edx_client.certificates.get_student_certificates(
-            get_social_username(user), course_ids)
+            get_edxorg_social_username(user), course_ids)
 
         # This must be done atomically
         with transaction.atomic():
@@ -273,7 +273,7 @@ class CachedEdxDataApi:
 
         # Current Grades are out of date, so fetch new data from edX.
         current_grades = edx_client.current_grades.get_student_current_grades(
-            get_social_username(user), course_ids)
+            get_edxorg_social_username(user), course_ids)
 
         # the update must be done atomically
         with transaction.atomic():
@@ -341,7 +341,7 @@ class CachedEdxDataApi:
             None
         """
         # get the credentials for the current user for edX
-        user_social = get_social_auth(user)
+        user_social = get_edxorg_social_auth(user)
         utils.refresh_user_token(user_social)
         # create an instance of the client to query edX
         edx_client = EdxApi(user_social.extra_data, settings.EDXORG_BASE_URL)

--- a/dashboard/permissions.py
+++ b/dashboard/permissions.py
@@ -6,7 +6,6 @@ from django.http import Http404
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import BasePermission
 
-from backends.edxorg import EdxOrgOAuth2
 from roles.roles import (
     Instructor,
     Staff,
@@ -25,8 +24,7 @@ class CanReadIfStaffOrSelf(BasePermission):
 
         user = get_object_or_404(
             User,
-            social_auth__uid=view.kwargs['username'],
-            social_auth__provider=EdxOrgOAuth2.name
+            username=view.kwargs['username'],
         )
 
         # if the user is looking for their own profile, they're good

--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -62,7 +62,7 @@ class DashboardTest(MockedESTestCase, APITestCase):
             )
 
         # url for the dashboard
-        cls.url = reverse('dashboard_api', args=[cls.user.social_auth.first().uid])
+        cls.url = reverse('dashboard_api', args=[cls.user.username])
 
     def setUp(self):
         super().setUp()
@@ -141,7 +141,7 @@ class DashboardTokensTest(MockedESTestCase, APITestCase):
         cls.enrollments = Enrollments([])
 
         # url for the dashboard
-        cls.url = reverse('dashboard_api', args=[cls.social_auth.uid])
+        cls.url = reverse('dashboard_api', args=[cls.user.username])
 
     def setUp(self):
         super().setUp()

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -359,16 +359,14 @@ class CybersourceTests(MockedESTestCase):
         """
         course_run, user = create_purchasable_course_run()
         order = create_unfulfilled_order(course_run.edx_course_key, user)
-        username = 'username'
         transaction_uuid = 'hex'
         fake_user_ip = "194.100.0.1"
 
         now = now_in_utc()
 
-        with patch('ecommerce.api.get_social_username', autospec=True, return_value=username):
-            with patch('ecommerce.api.now_in_utc', autospec=True, return_value=now) as now_mock:
-                with patch('ecommerce.api.uuid.uuid4', autospec=True, return_value=MagicMock(hex=transaction_uuid)):
-                    payload = generate_cybersource_sa_payload(order, 'dashboard_url', fake_user_ip)
+        with patch('ecommerce.api.now_in_utc', autospec=True, return_value=now) as now_mock:
+            with patch('ecommerce.api.uuid.uuid4', autospec=True, return_value=MagicMock(hex=transaction_uuid)):
+                payload = generate_cybersource_sa_payload(order, 'dashboard_url', fake_user_ip)
         signature = payload.pop('signature')
         assert generate_cybersource_sa_signature(payload) == signature
         signed_field_names = payload['signed_field_names'].split(',')
@@ -378,7 +376,7 @@ class CybersourceTests(MockedESTestCase):
         assert payload == {
             'access_key': CYBERSOURCE_ACCESS_KEY,
             'amount': str(order.total_price_paid),
-            'consumer_id': username,
+            'consumer_id': user.username,
             'currency': 'USD',
             'item_0_code': 'course',
             'item_0_name': '{}'.format(course_run.title),

--- a/ecommerce/permissions.py
+++ b/ecommerce/permissions.py
@@ -6,7 +6,6 @@ import logging
 from rest_framework.permissions import BasePermission
 
 from ecommerce.api import generate_cybersource_sa_signature
-from profiles.api import get_social_username
 
 
 log = logging.getLogger(__name__)
@@ -44,6 +43,6 @@ class IsLoggedInUser(BasePermission):
         Returns true if the username in the request body matches the logged in user.
         """
         try:
-            return request.data['username'] == get_social_username(request.user)
+            return request.data['username'] == request.user.username
         except KeyError:
             return False

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -33,7 +33,6 @@ from ecommerce.models import (
 from ecommerce.serializers import CouponSerializer
 from micromasters.factories import UserFactory, UserSocialAuthFactory
 from micromasters.utils import serialize_model_object
-from profiles.api import get_social_username
 from profiles.factories import ProfileFactory, SocialProfileFactory
 from search.base import MockedESTestCase
 
@@ -515,7 +514,7 @@ class CouponTests(MockedESTestCase):
             # Won't change anything if it already exists
             UserCoupon.objects.all().delete()
         data = {
-            'username': get_social_username(self.user),
+            'username': self.user.username,
         }
         with patch(
             'ecommerce.views.is_coupon_redeemable', autospec=True
@@ -561,7 +560,7 @@ class CouponTests(MockedESTestCase):
         A 404 should be returned if no coupon exists
         """
         resp = self.client.post(reverse('coupon-user-create', kwargs={'code': "missing"}), data={
-            "username": get_social_username(self.user)
+            "username": self.user.username
         }, format='json')
         assert resp.status_code == status.HTTP_404_NOT_FOUND
 
@@ -576,7 +575,7 @@ class CouponTests(MockedESTestCase):
             resp = self.client.post(
                 reverse('coupon-user-create', kwargs={'code': self.coupon.coupon_code}),
                 data={
-                    "username": get_social_username(self.user)
+                    "username": self.user.username
                 },
                 format='json',
             )

--- a/financialaid/views.py
+++ b/financialaid/views.py
@@ -57,7 +57,6 @@ from roles.models import (
     Staff,
 )
 from roles.roles import Permissions
-from backends.edxorg import EdxOrgOAuth2
 
 
 class FinancialAidRequestView(CreateAPIView):
@@ -340,8 +339,7 @@ class CoursePriceListView(APIView):
         """
         user = get_object_or_404(
             User,
-            social_auth__uid=username,
-            social_auth__provider=EdxOrgOAuth2.name
+            username=username,
         )
 
         program_enrollments = (

--- a/financialaid/views_test.py
+++ b/financialaid/views_test.py
@@ -610,9 +610,9 @@ class CoursePriceListViewTests(FinancialAidBaseTestCase, APIClient):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.username = "{}_edx".format(cls.profile.user.username)
-        cls.staff_username = "{}_edx".format(cls.staff_user_profile.user.username)
-        cls.instructor_username = "{}_edx".format(cls.instructor_user_profile.user.username)
+        cls.username = cls.profile.user.username
+        cls.staff_username = cls.staff_user_profile.user.username
+        cls.instructor_username = cls.instructor_user_profile.user.username
         cls.profile.user.social_auth.create(
             provider=EdxOrgOAuth2.name,
             uid=cls.username,

--- a/micromasters/serializers.py
+++ b/micromasters/serializers.py
@@ -5,7 +5,6 @@ import logging
 from rest_framework import serializers
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
-from profiles.api import get_social_username
 
 log = logging.getLogger(__name__)
 
@@ -29,11 +28,9 @@ class UserSerializer(serializers.ModelSerializer):
 
     def get_username(self, obj):
         """
-        Look up the user's username on edX.
-        We do *not* use the `user.username` field, because the Javascript
-        doesn't need to know anything about that.
+        Look up the user's username.
         """
-        return get_social_username(obj)
+        return obj.username
 
     def get_first_name(self, obj):
         """

--- a/micromasters/serializers_test.py
+++ b/micromasters/serializers_test.py
@@ -1,7 +1,6 @@
 """
 Tests for serializing Django User objects
 """
-from unittest import mock
 from django.test import TestCase
 from django.contrib.auth.models import AnonymousUser
 from django.db.models.signals import post_save
@@ -25,7 +24,7 @@ class UserTests(MockedESTestCase):
 
         data = UserSerializer(user).data
         assert data == {
-            "username": None,
+            "username": user.username,
             "email": "fake@example.com",
             "first_name": None,
             "last_name": None,
@@ -41,7 +40,7 @@ class UserTests(MockedESTestCase):
 
         data = serialize_maybe_user(user)
         assert data == {
-            "username": None,
+            "username": user.username,
             "email": "fake@example.com",
             "first_name": None,
             "last_name": None,
@@ -63,32 +62,11 @@ class UserTests(MockedESTestCase):
 
         data = UserSerializer(user).data
         assert data == {
-            "username": None,
+            "username": user.username,
             "email": "fake@example.com",
             "first_name": "Rando",
             "last_name": "Cardrizzian",
             "preferred_name": "Hobo",
-        }
-
-    @mock.patch('micromasters.serializers.get_social_username')
-    def test_social_username(self, mock_get_username):
-        """
-        Make sure serializer gets social username
-        """
-        mock_get_username.return_value = "remote"
-        with mute_signals(post_save):
-            user = UserFactory.create(
-                username="local", email="fake@example.com",
-            )
-
-        data = UserSerializer(user).data
-        mock_get_username.assert_called_with(user)
-        assert data == {
-            "username": "remote",
-            "email": "fake@example.com",
-            "first_name": None,
-            "last_name": None,
-            "preferred_name": None,
         }
 
 

--- a/profiles/api.py
+++ b/profiles/api.py
@@ -10,7 +10,7 @@ from backends.edxorg import EdxOrgOAuth2
 log = logging.getLogger(__name__)
 
 
-def get_social_auth(user):
+def get_edxorg_social_auth(user):
     """
     Returns social auth object for user
 
@@ -20,7 +20,7 @@ def get_social_auth(user):
     return user.social_auth.get(provider=EdxOrgOAuth2.name)
 
 
-def get_social_username(user):
+def get_edxorg_social_username(user):
     """
     Get social auth edX username for a user, or else return None.
 
@@ -32,7 +32,7 @@ def get_social_username(user):
         return None
 
     try:
-        return get_social_auth(user).uid
+        return get_edxorg_social_auth(user).uid
     except ObjectDoesNotExist:
         return None
     except Exception as ex:  # pylint: disable=broad-except

--- a/profiles/api_test.py
+++ b/profiles/api_test.py
@@ -9,7 +9,7 @@ from testfixtures import LogCapture
 
 from backends.edxorg import EdxOrgOAuth2
 
-from profiles.api import get_social_username, get_social_auth
+from profiles.api import get_edxorg_social_username, get_edxorg_social_auth
 from profiles.factories import SocialProfileFactory
 from micromasters.factories import UserSocialAuthFactory
 from search.base import MockedESTestCase
@@ -35,32 +35,32 @@ class SocialTests(MockedESTestCase):
 
     def test_anonymous_user(self):
         """
-        get_social_username should return None for anonymous users
+        get_edxorg_social_username should return None for anonymous users
         """
         user = Mock(is_anonymous=True)
-        assert get_social_username(user) is None
+        assert get_edxorg_social_username(user) is None
 
     def test_zero_social(self):
         """
-        get_social_username should return None if there is no edX account associated yet
+        get_edxorg_social_username should return None if there is no edX account associated yet
         """
         self.user.social_auth.all().delete()
-        assert get_social_username(self.user) is None
+        assert get_edxorg_social_username(self.user) is None
 
     def test_one_social(self):
         """
-        get_social_username should return the social username, not the Django username
+        get_edxorg_social_username should return the social username, not the Django username
         """
-        assert get_social_username(self.user) == self.user.social_auth.first().uid
+        assert get_edxorg_social_username(self.user) == self.user.social_auth.first().uid
 
     def test_two_social(self):
         """
-        get_social_username should return None if there are two social edX accounts for a user
+        get_edxorg_social_username should return None if there are two social edX accounts for a user
         """
         UserSocialAuthFactory.create(user=self.user, uid='other name')
 
         with LogCapture() as log_capture:
-            assert get_social_username(self.user) is None
+            assert get_edxorg_social_username(self.user) is None
             log_capture.check(
                 (
                     'profiles.api',
@@ -70,12 +70,12 @@ class SocialTests(MockedESTestCase):
                 )
             )
 
-    def test_get_social_auth(self):
+    def test_get_edxorg_social_auth(self):
         """
-        Tests that get_social_auth returns a user's edX social auth object, and if multiple edX social auth objects
+        Tests that get_edxorg_social_auth returns a user's edX social auth object, and if multiple edX social auth objects
         exists, it raises an exception
         """
-        assert get_social_auth(self.user) == self.user.social_auth.get(provider=EdxOrgOAuth2.name)
+        assert get_edxorg_social_auth(self.user) == self.user.social_auth.get(provider=EdxOrgOAuth2.name)
         UserSocialAuthFactory.create(user=self.user, uid='other name')
         with self.assertRaises(MultipleObjectsReturned):
-            get_social_auth(self.user)
+            get_edxorg_social_auth(self.user)

--- a/profiles/permissions.py
+++ b/profiles/permissions.py
@@ -42,7 +42,7 @@ class CanSeeIfNotPrivate(BasePermission):
         """
         Implementation of the permission class.
         """
-        profile = get_object_or_404(Profile, user__social_auth__uid=view.kwargs['user'])
+        profile = get_object_or_404(Profile, user__username=view.kwargs['user'])
 
         if request.user == profile.user:
             return True

--- a/profiles/permissions_test.py
+++ b/profiles/permissions_test.py
@@ -10,7 +10,6 @@ import ddt
 from courses.factories import ProgramFactory
 from dashboard.models import ProgramEnrollment
 from micromasters.factories import UserFactory
-from profiles.api import get_social_auth
 from profiles.factories import ProfileFactory, SocialProfileFactory
 from profiles.models import Profile
 from profiles.permissions import (
@@ -77,10 +76,6 @@ class CanSeeIfNotPrivateTests(MockedESTestCase):
         self.user = SocialProfileFactory.create(verified_micromaster_user=False).user
         self.perm = CanSeeIfNotPrivate()
 
-    def get_social_auth_uid(self, user):
-        """Helper method to get social_auth uid for a user"""
-        return get_social_auth(user).uid
-
     def test_cant_view_if_privacy_is_private(self):
         """
         Users are not supposed to view private profiles.
@@ -88,7 +83,7 @@ class CanSeeIfNotPrivateTests(MockedESTestCase):
         new_profile = SocialProfileFactory.create(account_privacy=Profile.PRIVATE)
 
         request = Mock(user=self.user)
-        view = Mock(kwargs={'user': self.get_social_auth_uid(new_profile.user)})
+        view = Mock(kwargs={'user': new_profile.user.username})
 
         with self.assertRaises(Http404):
             self.perm.has_permission(request, view)
@@ -101,7 +96,7 @@ class CanSeeIfNotPrivateTests(MockedESTestCase):
         new_profile = SocialProfileFactory.create(account_privacy=account_privacy_setting)
 
         request = Mock(user=Mock(is_anonymous=True))
-        view = Mock(kwargs={'user': self.get_social_auth_uid(new_profile.user)})
+        view = Mock(kwargs={'user': new_profile.user.username})
 
         with self.assertRaises(Http404):
             self.perm.has_permission(request, view)
@@ -113,7 +108,7 @@ class CanSeeIfNotPrivateTests(MockedESTestCase):
         new_profile = SocialProfileFactory.create(account_privacy=Profile.PUBLIC)
 
         request = Mock(user=Mock(is_anonymous=True))
-        view = Mock(kwargs={'user': self.get_social_auth_uid(new_profile.user)})
+        view = Mock(kwargs={'user': new_profile.user.username})
 
         assert self.perm.has_permission(request, view) is True
 
@@ -124,7 +119,7 @@ class CanSeeIfNotPrivateTests(MockedESTestCase):
         new_profile = SocialProfileFactory.create(account_privacy=Profile.PUBLIC_TO_MM)
 
         request = Mock(user=self.user)
-        view = Mock(kwargs={'user': self.get_social_auth_uid(new_profile.user)})
+        view = Mock(kwargs={'user': new_profile.user.username})
 
         with self.assertRaises(Http404):
             self.perm.has_permission(request, view)
@@ -136,7 +131,7 @@ class CanSeeIfNotPrivateTests(MockedESTestCase):
         new_profile = SocialProfileFactory.create(account_privacy='weird_setting')
 
         request = Mock(user=self.user)
-        view = Mock(kwargs={'user': self.get_social_auth_uid(new_profile.user)})
+        view = Mock(kwargs={'user': new_profile.user.username})
 
         with self.assertRaises(Http404):
             self.perm.has_permission(request, view)
@@ -146,7 +141,7 @@ class CanSeeIfNotPrivateTests(MockedESTestCase):
         Users are allowed to view their own profile.
         """
         request = Mock(user=self.user)
-        view = Mock(kwargs={'user': self.get_social_auth_uid(self.user)})
+        view = Mock(kwargs={'user': self.user.username})
 
         assert self.perm.has_permission(request, view) is True
 
@@ -157,7 +152,7 @@ class CanSeeIfNotPrivateTests(MockedESTestCase):
         new_profile = SocialProfileFactory.create(account_privacy=Profile.PUBLIC)
 
         request = Mock(user=self.user)
-        view = Mock(kwargs={'user': self.get_social_auth_uid(new_profile.user)})
+        view = Mock(kwargs={'user': new_profile.user.username})
         assert self.perm.has_permission(request, view) is True
 
     def test_can_view_if_verified_mm_user(self):
@@ -174,7 +169,7 @@ class CanSeeIfNotPrivateTests(MockedESTestCase):
             )
 
         request = Mock(user=verified_user)
-        view = Mock(kwargs={'user': self.get_social_auth_uid(new_user)})
+        view = Mock(kwargs={'user': new_user.username})
         assert self.perm.has_permission(request, view) is True
 
     def test_view_public_to_mm_when_no_common_programs(self):
@@ -185,7 +180,7 @@ class CanSeeIfNotPrivateTests(MockedESTestCase):
         verified_user = SocialProfileFactory.create(verified_micromaster_user=True).user
 
         request = Mock(user=verified_user)
-        view = Mock(kwargs={'user': self.get_social_auth_uid(new_user)})
+        view = Mock(kwargs={'user': new_user.username})
         with self.assertRaises(Http404):
             self.perm.has_permission(request, view)
 
@@ -212,7 +207,7 @@ class CanSeeIfNotPrivateTests(MockedESTestCase):
             role=role_to_set,
         )
         request = Mock(user=self.user)
-        view = Mock(kwargs={'user': self.get_social_auth_uid(new_user)})
+        view = Mock(kwargs={'user': new_user.username})
 
         assert self.perm.has_permission(request, view) is True
 

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -9,7 +9,6 @@ from rest_framework.serializers import (
     SerializerMethodField,
 )
 
-from profiles.api import get_social_username
 from profiles.models import (
     Education,
     Employment,
@@ -160,7 +159,7 @@ class ProfileBaseSerializer(ModelSerializer):
 
     def get_username(self, obj):
         """Getter for the username field"""
-        return get_social_username(obj.user)
+        return obj.user.username
 
 
 class ProfileSerializer(ProfileBaseSerializer):
@@ -306,7 +305,7 @@ class ProfileImageSerializer(ModelSerializer):
 
     def get_username(self, obj):
         """Getter for the username field"""
-        return get_social_username(obj.user)
+        return obj.user.username
 
     class Meta:
         model = Profile

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -16,7 +16,6 @@ from rest_framework.exceptions import ValidationError
 
 from backends.edxorg import EdxOrgOAuth2
 from micromasters.factories import UserFactory
-from profiles.api import get_social_username
 from profiles.factories import (
     EmploymentFactory,
     EducationFactory,
@@ -61,7 +60,7 @@ class ProfileTests(MockedESTestCase):
         profile = self.create_profile(date_of_birth=birthdate)
         data = ProfileSerializer(profile).data
         assert data == {
-            'username': get_social_username(profile.user),
+            'username': profile.user.username,
             'first_name': profile.first_name,
             'full_name': profile.full_name,
             'filled_out': profile.filled_out,
@@ -104,7 +103,7 @@ class ProfileTests(MockedESTestCase):
         profile = self.create_profile()
         data = ProfileLimitedSerializer(profile).data
         assert data == {
-            'username': get_social_username(profile.user),
+            'username': profile.user.username,
             'first_name': profile.first_name,
             'last_name': profile.last_name,
             'full_name': profile.full_name,

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -26,7 +26,7 @@ class ProfileViewSet(RetrieveModelMixin, UpdateModelMixin, GenericViewSet):
     # pylint: disable=too-many-return-statements
 
     permission_classes = (CanEditIfOwner, CanSeeIfNotPrivate, )
-    lookup_field = 'user__social_auth__uid'
+    lookup_field = 'user__username'
     lookup_url_kwarg = 'user'
     lookup_value_regex = r'[-\w.]+'
     queryset = Profile.objects.all()

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -27,7 +27,7 @@ from rest_framework.test import (
 from backends.edxorg import EdxOrgOAuth2
 from courses.factories import ProgramFactory
 from dashboard.models import ProgramEnrollment
-from micromasters.factories import UserFactory
+from micromasters.factories import SocialUserFactory
 from profiles.factories import (
     EducationFactory,
     EmploymentFactory,
@@ -73,22 +73,11 @@ class ProfileBaseTests(MockedESTestCase):
         Create a user
         """
         with mute_signals(post_save):
-            cls.user1 = UserFactory.create()
-            username = "{}_edx".format(cls.user1.username)
-            cls.user1.social_auth.create(
-                provider=EdxOrgOAuth2.name,
-                uid=username
-            )
-        cls.url1 = reverse('profile-detail', kwargs={'user': username})
-
+            cls.user1 = SocialUserFactory.create()
+        cls.url1 = reverse('profile-detail', kwargs={'user': cls.user1.username})
         with mute_signals(post_save):
-            cls.user2 = UserFactory.create(username="test.dev.example")
-            username = "{}_edx".format(cls.user2.username)
-            cls.user2.social_auth.create(
-                provider=EdxOrgOAuth2.name,
-                uid=username
-            )
-        cls.url2 = reverse('profile-detail', kwargs={'user': username})
+            cls.user2 = SocialUserFactory.create()
+        cls.url2 = reverse('profile-detail', kwargs={'user': cls.user2.username})
 
 
 class ProfileGETTests(ProfileBaseTests):
@@ -458,11 +447,6 @@ class ProfilePATCHTests(ProfileBaseTests):
                 profile.image_medium = None
             profile.save()
         self.client.force_login(self.user1)
-
-        patch_data = ProfileSerializer(profile).data
-        del patch_data['image']
-        del patch_data['image_small']
-        del patch_data['image_medium']
 
         # create a dummy image file in memory for upload
         with make_temp_image_file() as image_file:

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -570,7 +570,7 @@ class SerializerTests(ESTestCase):
                 'image': '/media/{}'.format(profile.image),
                 'image_small': '/media/{}'.format(profile.image_small),
                 'image_medium': '/media/{}'.format(profile.image_medium),
-                'username': None,  # bug in ProfileSerializer, issue #3166
+                'username': profile.user.username,
                 'filled_out': profile.filled_out,
                 'account_privacy': profile.account_privacy,
                 'country': profile.country,

--- a/seed_data/management/commands/seed_db.py
+++ b/seed_data/management/commands/seed_db.py
@@ -16,7 +16,7 @@ from micromasters.utils import (
     load_json_from_file,
     first_matching_item,
 )
-from profiles.api import get_social_username
+from profiles.api import get_edxorg_social_username
 from profiles.models import Employment, Education, Profile
 from roles.models import Role
 from roles.roles import Staff
@@ -109,7 +109,7 @@ def deserialize_dashboard_data(user, user_data, programs):
     fake_course_runs = CourseRun.objects.filter(
         course__program__in=programs
     ).select_related('course__program').all()
-    social_username = get_social_username(user)
+    social_username = get_edxorg_social_username(user)
     enrollment_list = user_data.get('_enrollments', [])
     grade_list = user_data.get('_grades', [])
     deserialize_enrollment_data(user, social_username, fake_course_runs, enrollment_list)

--- a/selenium_tests/management/commands/snapshot_dashboard_states.py
+++ b/selenium_tests/management/commands/snapshot_dashboard_states.py
@@ -36,7 +36,6 @@ from financialaid.factories import FinancialAidFactory
 from financialaid.models import FinancialAidStatus
 from grades.factories import ProctoredExamGradeFactory, MicromastersCourseCertificateFactory, FinalGradeFactory
 from grades.models import FinalGrade, CourseRunGradingStatus, MicromastersCourseCertificate
-from profiles.api import get_social_username
 from roles.models import Role, Staff
 from seed_data.lib import set_course_run_current, CachedEnrollmentHandler, add_paid_order_for_course, \
     set_course_run_past, set_course_run_future
@@ -733,7 +732,7 @@ def test_dashboard_states(browser, override_allowed_hosts, seeded_database_loade
             if not skip_screenshot:
                 browser.get(new_url)
                 browser.store_api_results(
-                    get_social_username(dashboard_states.user),
+                    dashboard_states.user.username,
                     filename=filename
                 )
                 if use_learner_page:

--- a/selenium_tests/util.py
+++ b/selenium_tests/util.py
@@ -158,13 +158,13 @@ class Browser:
             with open(full_filename, 'rb') as f:
                 print("Screenshot as base64: {}".format(b64encode(f.read())))
 
-    def store_api_results(self, edx_username, filename=None):
+    def store_api_results(self, username, filename=None):
         """Helper method to save certain GET REST API responses"""
         sessionid = self.driver.get_cookie('sessionid')['value']
         for endpoint_url, endpoint_name in [
-                ("/api/v0/dashboard/{}/".format(edx_username), 'dashboard'),
+                ("/api/v0/dashboard/{}/".format(username), 'dashboard'),
                 ("/api/v0/coupons/", 'coupons'),
-                ("/api/v0/course_prices/{}/".format(edx_username), 'course_prices'),
+                ("/api/v0/course_prices/{}/".format(username), 'course_prices'),
         ]:
             absolute_url = make_absolute_url(endpoint_url, self.live_server_url)
             api_json = requests.get(absolute_url, cookies={'sessionid': sessionid}).json()

--- a/ui/views.py
+++ b/ui/views.py
@@ -16,7 +16,6 @@ from rolepermissions.checkers import has_role
 
 from micromasters.utils import webpack_dev_server_host
 from micromasters.serializers import serialize_maybe_user
-from profiles.api import get_social_username
 from profiles.permissions import CanSeeIfNotPrivate
 from roles.models import Instructor, Staff
 from ui.decorators import require_mandatory_urls
@@ -120,7 +119,6 @@ def standard_error_page(request, status_code, template_filename):
     """
     name = request.user.profile.preferred_name if not request.user.is_anonymous else ""
     authenticated = not request.user.is_anonymous
-    username = get_social_username(request.user)
     response = render(
         request,
         template_filename,
@@ -135,7 +133,7 @@ def standard_error_page(request, status_code, template_filename):
             }),
             "authenticated": authenticated,
             "name": name,
-            "username": username,
+            "username": request.user.username,
             "is_staff": has_role(request.user, [Staff.ROLE_ID, Instructor.ROLE_ID]),
             "support_email": settings.EMAIL_SUPPORT,
             "sentry_dsn": settings.SENTRY_DSN,


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Part of #4989 

#### What's this PR do?
This PR removes usages of `get_social_username` in favor of simply using `User.username` so that we can support users with social auth other than edx. I also renamed the existing functions in `profiles/api.py` so it's obvious those are edx-specific.

#### How should this be manually tested?
Generally speaking, nothing should break.

You should still be able to:
- View CMS pages
- Create an account
- Login with an existing account
- View your dashboard
- View your profile
- Edit your profile
- Make a payment