### PR TITLE
 Program Letter: added css to hide footer on print

### DIFF
--- a/static/scss/letter.scss
+++ b/static/scss/letter.scss
@@ -72,3 +72,10 @@
     }
   }
 }
+
+@media print {
+  #footer {
+    display: none !important;
+    height: 0 !important;
+  }
+}

--- a/static/scss/letter.scss
+++ b/static/scss/letter.scss
@@ -76,6 +76,5 @@
 @media print {
   #footer {
     display: none !important;
-    height: 0 !important;
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Ticket #4988 

#### What's this PR do?
Removes Footer in Program Letter on Printing/Print Preview

#### How should this be manually tested?
- Create a Program Letter if one does not exist.
- Go to the Program Letter url '/letter/program/<program_letter_uuid>' 
- Verify footer is visible.
- Press CTRL+P to open print preview.
- Verify footer is hidden.


#### Screenshots (if appropriate)
Program Letter page with footer visible.
<img width="1408" alt="Screenshot 2021-08-03 at 3 57 49 PM" src="https://user-images.githubusercontent.com/87968618/128010117-3bd0d0a7-7a56-47a8-97ec-85802e89d4be.png">

Print preview with footer hidden.
![image](https://user-images.githubusercontent.com/87968618/128009984-c739edb7-ba71-43e0-9165-f98d7a8b2c8c.png)
