### PR TITLE
Update Cache for enrollments and grades for mitxonline

### DIFF
--- a/backends/constants.py
+++ b/backends/constants.py
@@ -1,9 +1,15 @@
 """backend related constants"""
 
 # courseware backend constants
+from micromasters.settings import MITXONLINE_BASE_URL, EDXORG_BASE_URL
+
 BACKEND_EDX_ORG = 'edxorg'
 BACKEND_MITX_ONLINE = 'mitxonline'
 COURSEWARE_BACKENDS = [
     BACKEND_MITX_ONLINE,
     BACKEND_EDX_ORG,
 ]
+COURSEWARE_BACKEND_URL = {
+    BACKEND_MITX_ONLINE: MITXONLINE_BASE_URL,
+    BACKEND_EDX_ORG: EDXORG_BASE_URL,
+}

--- a/backends/pipeline_api_test.py
+++ b/backends/pipeline_api_test.py
@@ -7,7 +7,7 @@ import ddt
 
 from backends import pipeline_api, edxorg
 from courses.factories import ProgramFactory
-from profiles.api import get_edxorg_social_username
+from profiles.api import get_social_username
 from profiles.models import Profile
 from profiles.factories import UserFactory
 from profiles.util import split_name
@@ -101,7 +101,7 @@ class EdxPipelineApiTest(MockedESTestCase):
                 'image_url_small': 'https://edx.org/small.jpg'
             },
             'requires_parental_consent': False,
-            'username': get_edxorg_social_username(self.user),
+            'username': get_social_username(self.user),
             'year_of_birth': 1986,
             "work_history": [
                 {
@@ -243,13 +243,13 @@ class EdxPipelineApiTest(MockedESTestCase):
         result = pipeline_api.check_edx_verified_email(
             backend,
             {'access_token': 'foo_token'},
-            {'username': get_edxorg_social_username(self.user)}
+            {'username': get_social_username(self.user)}
         )
 
         mocked_get_json.assert_called_once_with(
             urljoin(
                 edxorg.EdxOrgOAuth2.EDX_BASE_URL,
-                '/api/user/v1/accounts/{0}'.format(get_edxorg_social_username(self.user))
+                '/api/user/v1/accounts/{0}'.format(get_social_username(self.user))
             ),
             headers={'Authorization': 'Bearer foo_token'}
         )

--- a/grades/api.py
+++ b/grades/api.py
@@ -169,7 +169,7 @@ def freeze_user_final_grade(user, course_run, raise_on_exception=False):
             )
     # update one last time the user's certificates and current grades
     try:
-        CachedEdxDataApi.update_all_cached_grade_data(user)
+        CachedEdxDataApi.update_all_cached_grade_data(user, course_run.courseware_backend)
     except Exception as ex:  # pylint: disable=broad-except
         con = get_redis_connection("redis")
         con.lpush(CACHE_KEY_FAILED_USERS_BASE_STR.format(course_run.edx_course_key), user.id)

--- a/grades/api_test.py
+++ b/grades/api_test.py
@@ -357,7 +357,7 @@ class GradeAPITests(MockedESTestCase):
             with self.assertRaises(FreezeGradeFailedException):
                 api.freeze_user_final_grade(self.user, self.run_fa, raise_on_exception=raise_on_exception)
         assert mock_get_fg.called is False
-        mock_refr.assert_called_once_with(self.user)
+        mock_refr.assert_called_once_with(self.user, self.run_fa.courseware_backend)
         assert FinalGrade.objects.filter(user=self.user, course_run=self.run_fa).exists() is False
 
         con = get_redis_connection("redis")
@@ -380,7 +380,7 @@ class GradeAPITests(MockedESTestCase):
         else:
             with self.assertRaises(FreezeGradeFailedException):
                 api.freeze_user_final_grade(self.user, self.run_fa, raise_on_exception=raise_on_exception)
-        mock_refr.assert_called_once_with(self.user)
+        mock_refr.assert_called_once_with(self.user, self.run_fa.courseware_backend)
         mock_get_fg.assert_called_once_with(self.user, self.run_fa)
         assert FinalGrade.objects.filter(user=self.user, course_run=self.run_fa).exists() is False
 
@@ -397,7 +397,7 @@ class GradeAPITests(MockedESTestCase):
         """
         final_grade = api.freeze_user_final_grade(self.user, self.run_fa)
         assert final_grade is not None
-        mock_refr.assert_called_once_with(self.user)
+        mock_refr.assert_called_once_with(self.user, self.run_fa.courseware_backend)
         fg_qset = FinalGrade.objects.filter(user=self.user, course_run=self.run_fa)
         assert fg_qset.exists() is True
         fg_status = fg_qset.first()
@@ -418,7 +418,7 @@ class GradeAPITests(MockedESTestCase):
         # first call
         final_grade = api.freeze_user_final_grade(self.user, self.run_fa)
         assert final_grade is not None
-        mock_refr.assert_called_once_with(self.user)
+        mock_refr.assert_called_once_with(self.user, self.run_fa.courseware_backend)
         assert fg_qset.count() == 1
 
         # second call

--- a/profiles/api.py
+++ b/profiles/api.py
@@ -5,26 +5,28 @@ import logging
 
 from django.core.exceptions import ObjectDoesNotExist
 
-from backends.edxorg import EdxOrgOAuth2
+from backends.constants import BACKEND_EDX_ORG
 
 log = logging.getLogger(__name__)
 
 
-def get_edxorg_social_auth(user):
+def get_social_auth(user, provider=BACKEND_EDX_ORG):
     """
     Returns social auth object for user
 
     Args:
          user (django.contrib.auth.models.User):  A Django user
+         provider (str): 'mitxonline' or 'edxorg'
     """
-    return user.social_auth.get(provider=EdxOrgOAuth2.name)
+    return user.social_auth.get(provider=provider)
 
 
-def get_edxorg_social_username(user):
+def get_social_username(user, provider=BACKEND_EDX_ORG):
     """
     Get social auth edX username for a user, or else return None.
 
     Args:
+        provider:
         user (django.contrib.auth.models.User):
             A Django user
     """
@@ -32,7 +34,7 @@ def get_edxorg_social_username(user):
         return None
 
     try:
-        return get_edxorg_social_auth(user).uid
+        return get_social_auth(user, provider).uid
     except ObjectDoesNotExist:
         return None
     except Exception as ex:  # pylint: disable=broad-except

--- a/profiles/api_test.py
+++ b/profiles/api_test.py
@@ -9,7 +9,7 @@ from testfixtures import LogCapture
 
 from backends.edxorg import EdxOrgOAuth2
 
-from profiles.api import get_edxorg_social_username, get_edxorg_social_auth
+from profiles.api import get_social_username, get_social_auth
 from profiles.factories import SocialProfileFactory
 from micromasters.factories import UserSocialAuthFactory
 from search.base import MockedESTestCase
@@ -35,32 +35,32 @@ class SocialTests(MockedESTestCase):
 
     def test_anonymous_user(self):
         """
-        get_edxorg_social_username should return None for anonymous users
+        get_social_username should return None for anonymous users
         """
         user = Mock(is_anonymous=True)
-        assert get_edxorg_social_username(user) is None
+        assert get_social_username(user) is None
 
     def test_zero_social(self):
         """
-        get_edxorg_social_username should return None if there is no edX account associated yet
+        get_social_username should return None if there is no edX account associated yet
         """
         self.user.social_auth.all().delete()
-        assert get_edxorg_social_username(self.user) is None
+        assert get_social_username(self.user) is None
 
     def test_one_social(self):
         """
-        get_edxorg_social_username should return the social username, not the Django username
+        get_social_username should return the social username, not the Django username
         """
-        assert get_edxorg_social_username(self.user) == self.user.social_auth.first().uid
+        assert get_social_username(self.user) == self.user.social_auth.first().uid
 
     def test_two_social(self):
         """
-        get_edxorg_social_username should return None if there are two social edX accounts for a user
+        get_social_username should return None if there are two social edX accounts for a user
         """
         UserSocialAuthFactory.create(user=self.user, uid='other name')
 
         with LogCapture() as log_capture:
-            assert get_edxorg_social_username(self.user) is None
+            assert get_social_username(self.user) is None
             log_capture.check(
                 (
                     'profiles.api',
@@ -70,12 +70,12 @@ class SocialTests(MockedESTestCase):
                 )
             )
 
-    def test_get_edxorg_social_auth(self):
+    def test_get_social_auth(self):
         """
-        Tests that get_edxorg_social_auth returns a user's edX social auth object, and if multiple edX social auth objects
+        Tests that get_social_auth returns a user's edX social auth object, and if multiple edX social auth objects
         exists, it raises an exception
         """
-        assert get_edxorg_social_auth(self.user) == self.user.social_auth.get(provider=EdxOrgOAuth2.name)
+        assert get_social_auth(self.user) == self.user.social_auth.get(provider=EdxOrgOAuth2.name)
         UserSocialAuthFactory.create(user=self.user, uid='other name')
         with self.assertRaises(MultipleObjectsReturned):
-            get_edxorg_social_auth(self.user)
+            get_social_auth(self.user)

--- a/seed_data/management/commands/seed_db.py
+++ b/seed_data/management/commands/seed_db.py
@@ -16,7 +16,7 @@ from micromasters.utils import (
     load_json_from_file,
     first_matching_item,
 )
-from profiles.api import get_edxorg_social_username
+from profiles.api import get_social_username
 from profiles.models import Employment, Education, Profile
 from roles.models import Role
 from roles.roles import Staff
@@ -109,7 +109,7 @@ def deserialize_dashboard_data(user, user_data, programs):
     fake_course_runs = CourseRun.objects.filter(
         course__program__in=programs
     ).select_related('course__program').all()
-    social_username = get_edxorg_social_username(user)
+    social_username = get_social_username(user)
     enrollment_list = user_data.get('_enrollments', [])
     grade_list = user_data.get('_grades', [])
     deserialize_enrollment_data(user, social_username, fake_course_runs, enrollment_list)


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #4992 

#### What's this PR do?
Add support of cached enrollements and grades with another courseware backend mitxonline.

#### How should this be manually tested?
Register with edx org and enroll in courses there.
Register and enroll in courses with mitxonline as the courseware backend.
Test that:
Learner with only edxorg course runs can update their dashboard
Learner with only mitxonline course runs can update their dashboard