### PR TITLE
Edx coupons: update regex

### DIFF
--- a/exams/management/commands/populate_edx_exam_coupons.py
+++ b/exams/management/commands/populate_edx_exam_coupons.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         first_row = next(reader)
         catalog_query = first_row['Catalog Query']
         course_number = re.search(r"\+([A-Za-z0-9.]+)PEx", catalog_query).group(1)
-        edx_exam_course_key = re.search(r"key:\(([A-Za-z0-9+.]+)", catalog_query).group(1)
+        edx_exam_course_key = re.search(r"key:[(\"]([A-Za-z0-9+.]+)", catalog_query).group(1)
 
         validated_urls = validate_urls(reader)
 


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Edx coupons csv file comes with a variety of formats for the course key field under "catalog query". This PR modifies the regex to match `key:(edx_course_key)` and `key:"edx_course_key"`

#### How should this be manually tested?
Ask me for an sample file
run the management command `./manage.py populate_edx_exam_coupons file.csv`