### PR TITLE
Fix generation of program letters for non FA programs

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -460,6 +460,39 @@ class MMTrack:
             .distinct().count()
         )
 
+    def count_passed_final_grades_for_course_ids(self, course_ids):
+        """
+        Determine the number of passed courses for a non-FA program by
+
+        Args:
+            course_ids (set): a set of course ids
+
+        Returns:
+            int: the number of passed unique courses
+        """
+        return (
+            self.final_grade_qset.filter(
+                course_run__course_id__in=course_ids
+            ).passed().values_list('course_run__course__id', flat=True).distinct().count()
+        )
+
+    def get_number_of_passed_courses(self, course_ids):
+        """
+        Count the number of passed courses for the given set of course ids
+        Args:
+            course_ids (set): a set of course ids
+
+        Returns:
+            int: the number of passed unique courses
+        """
+        if self.program.financial_aid_availability:
+            return MicromastersCourseCertificate.objects.filter(
+                user=self.user,
+                course_id__in=course_ids
+            ).values_list('course__id', flat=True).distinct().count()
+        else:
+            return self.count_passed_final_grades_for_course_ids(course_ids)
+
     def get_exam_card_status(self):  # pylint: disable=too-many-return-statements
         """
         Get the pearson exam status for the user / program combo

--- a/grades/api.py
+++ b/grades/api.py
@@ -18,7 +18,7 @@ from grades.models import (
     FinalGrade,
     FinalGradeStatus,
     MicromastersProgramCertificate,
-    CombinedFinalGrade, MicromastersCourseCertificate,
+    CombinedFinalGrade,
     ProctoredExamGrade, MicromastersProgramCommendation)
 
 CACHE_KEY_FAILED_USERS_BASE_STR = "failed_users_{0}"

--- a/grades/api.py
+++ b/grades/api.py
@@ -231,33 +231,43 @@ def generate_program_certificate(user, program):
     if MicromastersProgramCertificate.objects.filter(user=user, program=program).exists():
         log.warning('User [%s] already has a certificate for program [%s]', user, program)
         return
+    if completed_program(user, program):
+        MicromastersProgramCertificate.objects.create(user=user, program=program)
+        log.info(
+            'Created MM program certificate for [%s] in program [%s]',
+            user.username,
+            program.title
+        )
 
+
+def completed_program(user, program):
+    """
+    Check if the user passed all required courses and satisfied all elective
+    requirements.
+
+    Args:
+        user (User): a Django user.
+        program (programs.models.Program): program where the user is enrolled.
+
+    Returns:
+        bool: if user passed all requirements to complete the program
+    """
+    mmtrack = get_mmtrack(user, program)
     for electives_set in ElectivesSet.objects.filter(program=program):
         elective_courses_id = set(electives_set.electivecourse_set.all().values_list('course__id', flat=True))
-        num_electives_with_cert = MicromastersCourseCertificate.objects.filter(
-            user=user,
-            course_id__in=elective_courses_id
-        ).values_list('course__id', flat=True).distinct().count()
-        if electives_set.required_number > num_electives_with_cert:
-            return
+
+        # each elective set should be fulfilled
+        if electives_set.required_number > mmtrack.get_number_of_passed_courses(elective_courses_id):
+            return False
 
     # filtering out the courses that are not elective
-    courses_in_program_ids = set(program.course_set.filter(electivecourse=None).values_list('id', flat=True))
+    core_courses_ids = set(program.course_set.filter(electivecourse=None).values_list('id', flat=True))
 
-    num_courses_with_cert = MicromastersCourseCertificate.objects.filter(
-        user=user,
-        course_id__in=courses_in_program_ids
-    ).values_list('course__id', flat=True).distinct().count()
+    # checking all core courses are passed
+    if len(core_courses_ids) > mmtrack.get_number_of_passed_courses(core_courses_ids):
+        return False
 
-    if len(courses_in_program_ids) > num_courses_with_cert:
-        return
-
-    MicromastersProgramCertificate.objects.create(user=user, program=program)
-    log.info(
-        'Created MM program certificate for [%s] in program [%s]',
-        user.username,
-        program.title
-    )
+    return True
 
 
 def generate_program_letter(user, program):
@@ -277,22 +287,13 @@ def generate_program_letter(user, program):
             MicromastersProgramCertificate.objects.filter(user=user, program=program).exists()):
         MicromastersProgramCommendation.objects.create(user=user, program=program)
         return
-
-    mmtrack = get_mmtrack(user, program)
-    courses_passed = mmtrack.count_courses_passed()
-    program_course_count = (program.num_required_courses
-                            if program.electives_set.exists()
-                            else program.course_set.count())
-
-    if courses_passed < program_course_count:
-        return
-
-    MicromastersProgramCommendation.objects.create(user=user, program=program)
-    log.info(
-        'Created MM program letter for [%s] in program [%s]',
-        user.username,
-        program.title
-    )
+    if completed_program(user, program):
+        MicromastersProgramCommendation.objects.create(user=user, program=program)
+        log.info(
+            'Created MM program letter for [%s] in program [%s]',
+            user.username,
+            program.title
+        )
 
 
 def update_or_create_combined_final_grade(user, course):

--- a/grades/api_test.py
+++ b/grades/api_test.py
@@ -568,7 +568,7 @@ class GenerateProgramLetterApiTests(MockedESTestCase):
 
         electives_set = ElectivesSet.objects.create(program=self.program, required_number=1)
 
-        for i in range(2):
+        for _ in range(2):
             run_elective = CourseRunFactory.create(
                 freeze_grade_date=now_in_utc() - timedelta(days=1),
                 course__program=self.program,


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #5021

#### What's this PR do?
Fixes a logic for program letter generation for non FA programs.

#### How should this be manually tested?
Enroll your user in a non FA program. 
Create an elective set for the program with 2 elective courses, and 1 course required. 
Make sure to set the num_of_required_courses for the program to an appropriate number.
Create passing grades for all courses besides one core course. You can use the management command:
`./manage.py alter_data set_to_passed --username username --course-title 'Analog Learning 200'`
There is a post save signal to run `generate_program_letter` on FinalGrade creation, so check to see that no letter was generated. 
Then create a final grade for the last missing core course, and check to see that the letter was generated.