### PR TITLE
Remove django-storages-redux

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -458,10 +458,6 @@ if (
     )
 if MICROMASTERS_USE_S3:
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
-else:
-    # by default use django.core.files.storage.FileSystemStorage with
-    # overwrite feature
-    DEFAULT_FILE_STORAGE = 'storages.backends.overwrite.OverwriteStorage'
 
 # Celery
 USE_CELERY = True

--- a/profiles/models_test.py
+++ b/profiles/models_test.py
@@ -77,14 +77,9 @@ class ImageTests(MockedESTestCase):
             mocked_now_in_utc.return_value = now_in_utc()
             with mute_signals(post_save):
                 profile = ProfileFactory.create()
-
-            assert profile.image.url.endswith(profile_image_upload_uri(None, "example.jpg").replace("+", ""))
-            assert profile.image_small.url.endswith(
-                profile_image_upload_uri_small(None, "example.jpg").replace("+", "")
-            )
-            assert profile.image_medium.url.endswith(
-                profile_image_upload_uri_medium(None, "example.jpg").replace("+", "")
-            )
+            assert profile_image_upload_uri(None, "example").replace("+", "") in profile.image.url
+            assert profile_image_upload_uri_small(None, "example").replace("+", "") in profile.image_small.url
+            assert profile_image_upload_uri_medium(None, "example").replace("+", "") in profile.image_medium.url
 
 
 class ProfileAddressTests(MockedESTestCase):

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,6 @@ django-ipware==3.0.0
 django-redis==4.7.0
 django-role-permissions==2.2.0
 django-server-status==0.5.0
-django-storages-redux==1.3.2
 django-storages==1.9.1
 django-webpack-loader==0.5.0
 djangorestframework==3.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,8 +92,6 @@ django-server-status==0.5.0
     # via -r requirements.in
 django-storages==1.9.1
     # via -r requirements.in
-django-storages-redux==1.3.2
-    # via -r requirements.in
 django-taggit==1.2.0
     # via wagtail
 django-treebeard==4.3


### PR DESCRIPTION


#### What are the relevant tickets?
Related to #5026

#### What's this PR do?
Remove django-storages-redux
>django-storages-redux was a fork of the original django-storages, because django-storages was unmaintained at the time. django-storages-redux has now become django-storages so now django-storages-redux is deprecated and no longer maintained in favor of django-storages again

#### How should this be manually tested?
nothing should break

