### PR TITLE
fix degree and employment form fields

### DIFF
--- a/static/js/components/EducationForm.js
+++ b/static/js/components/EducationForm.js
@@ -408,7 +408,7 @@ class EducationForm extends ProfileFormFields {
             true
           )}
         </Grid>
-        <Grid item xs={4}>
+        <Grid item md={4} sm={6} xs={12}>
           <CountrySelectField
             stateKeySet={keySet("school_state_or_territory")}
             countryKeySet={keySet("school_country")}
@@ -418,7 +418,7 @@ class EducationForm extends ProfileFormFields {
             {...this.defaultInputComponentProps()}
           />
         </Grid>
-        <Grid item xs={4}>
+        <Grid item md={4} sm={6} xs={12}>
           <StateSelectField
             stateKeySet={keySet("school_state_or_territory")}
             countryKeySet={keySet("school_country")}
@@ -428,7 +428,7 @@ class EducationForm extends ProfileFormFields {
             {...this.defaultInputComponentProps()}
           />
         </Grid>
-        <Grid item xs={4} key="school_city">
+        <Grid item md={4} sm={6} xs={12} key="school_city">
           {/* eslint-disable-next-line no-invalid-this */}
           {this.boundTextField(keySet("school_city"), "City")}
         </Grid>

--- a/static/js/components/EmploymentForm.js
+++ b/static/js/components/EmploymentForm.js
@@ -135,7 +135,7 @@ class EmploymentForm extends ProfileFormFields {
         <Grid item xs={12}>
           {this.boundTextField(keySet("company_name"), "Name of Employer")}
         </Grid>
-        <Grid item xs={4}>
+        <Grid item md={4} sm={6} xs={12}>
           <CountrySelectField
             stateKeySet={keySet("state_or_territory")}
             countryKeySet={keySet("country")}
@@ -143,7 +143,7 @@ class EmploymentForm extends ProfileFormFields {
             {...this.defaultInputComponentProps()}
           />
         </Grid>
-        <Grid item xs={4}>
+        <Grid item md={4} sm={6} xs={12}>
           <StateSelectField
             stateKeySet={keySet("state_or_territory")}
             countryKeySet={keySet("country")}
@@ -151,7 +151,7 @@ class EmploymentForm extends ProfileFormFields {
             {...this.defaultInputComponentProps()}
           />
         </Grid>
-        <Grid item xs={4}>
+        <Grid item md={4} sm={6} xs={12}>
           {this.boundTextField(keySet("city"), "City")}
         </Grid>
         <Grid item xs={12}>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #5019 

#### What's this PR do?
Can't select some countries in pulldowns on phone in portrait mode

#### How should this be manually tested?
Just see the country field on the profile page by adding degree and employment 

#### Screenshots (if appropriate)

**MOBILE**

<img width="442" alt="Screenshot 2021-09-10 at 14 40 32" src="https://user-images.githubusercontent.com/4043989/132835138-f81099a9-7436-4f1f-ab38-9e27e6b38e82.png">

**TABLET**

<img width="789" alt="Screenshot 2021-09-10 at 14 40 46" src="https://user-images.githubusercontent.com/4043989/132835154-cc73bb36-1c4f-4515-a141-8801af58c4a1.png">

**DESKTOP**

<img width="1040" alt="Screenshot 2021-09-10 at 14 40 55" src="https://user-images.githubusercontent.com/4043989/132835155-61943712-895b-4010-b96e-141f88a0535a.png">
