### PR TITLE
Fix enrollment API backend (#5041)

### DIFF
--- a/micromasters/factories.py
+++ b/micromasters/factories.py
@@ -56,6 +56,7 @@ class UserSocialAuthFactory(DjangoModelFactory):
 
     class Meta:
         model = UserSocialAuth
+        django_get_or_create = ("provider", "uid")
 
 
 class SocialUserFactory(UserFactory):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #5041 

#### What's this PR do?
This updates the enrollment API to use the courseware base url for the appropriate backend.

#### How should this be manually tested?
A code review is probably adequate here and RC is setup to test this already. The testing setup to reproduce this locally is a bit complicated.
