### PR TITLE
Only prompt for login for enrollable runs (#5051)

### DIFF
--- a/courses/factories.py
+++ b/courses/factories.py
@@ -112,3 +112,13 @@ class CourseRunFactory(DjangoModelFactory):
 
     class Meta:
         model = CourseRun
+
+    class Params:
+        future_run = factory.Trait(
+            enrollment_start = factory.Faker(
+                'date_time_between',
+                start_date="+1d",
+                end_date="+30d",
+                tzinfo=pytz.utc
+            )
+        )

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -65,6 +65,14 @@ class ProgramTests(MockedESTestCase):
 
         assert course_1.program.has_frozen_grades_for_all_courses() is result
 
+    def test_enrollable_course_runs(self):
+        """ Test that enrollable_course_runs only returns currently enrollable runs """
+        program = ProgramFactory.create()
+        enrollable_run = CourseRunFactory.create(course__program=program)  # enrollable
+        CourseRunFactory.create(course__program=program, future_run=True) # not enrollable
+
+        assert list(program.enrollable_course_runs) == [enrollable_run]
+
 
 def from_weeks(weeks, now=None):
     """Helper function to get a date adjusted by a number of weeks"""
@@ -563,3 +571,10 @@ class CourseRunTests(CourseModelTests):
             date_last_eligible=(now_in_utc() - timedelta(days=1)).date(),
         )
         assert course_run.has_future_exam is False
+
+    def test_enrollable(self):
+        """ Test CourseRun.objects.enrollable() """
+        enrollable_run = CourseRunFactory.create()  # enrollable
+        CourseRunFactory.create(future_run=True) # not enrollable
+
+        assert list(CourseRun.objects.enrollable()) == [enrollable_run]

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -60,7 +60,7 @@ class ProgramSerializer(serializers.ModelSerializer):
             'enrolled',
             'total_courses',
             'topics',
-            'courseware_backends',
+            'enrollable_courseware_backends',
         )
 
 

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -100,7 +100,7 @@ class ProgramSerializerTests(MockedESTestCase):
             'enrolled': False,
             'total_courses': 1,
             'topics': [{'name': topic.name} for topic in self.program.topics.iterator()],
-            "courseware_backends": ["edxorg"],
+            "enrollable_courseware_backends": ["edxorg"],
         }
 
     def test_program_with_programpage(self):
@@ -118,7 +118,7 @@ class ProgramSerializerTests(MockedESTestCase):
             'enrolled': False,
             'total_courses': 1,
             'topics': [{'name': topic.name} for topic in self.program.topics.iterator()],
-            "courseware_backends": ["edxorg"],
+            "enrollable_courseware_backends": ["edxorg"],
         }
         assert len(programpage.url) > 0
 
@@ -135,7 +135,7 @@ class ProgramSerializerTests(MockedESTestCase):
             'enrolled': True,
             'total_courses': 1,
             'topics': [{'name': topic.name} for topic in self.program.topics.iterator()],
-            "courseware_backends": ["edxorg"],
+            "enrollable_courseware_backends": ["edxorg"],
         }
 
     def test_program_courses(self):
@@ -151,7 +151,7 @@ class ProgramSerializerTests(MockedESTestCase):
             'enrolled': False,
             'total_courses': 6,
             'topics': [{'name': topic.name} for topic in self.program.topics.iterator()],
-            "courseware_backends": ["edxorg"],
+            "enrollable_courseware_backends": ["edxorg"],
         }
 
 

--- a/courses/views.py
+++ b/courses/views.py
@@ -39,7 +39,7 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (
         IsAuthenticated,
     )
-    queryset = Program.objects.filter(live=True).prefetch_course_runs()
+    queryset = Program.objects.filter(live=True)
     serializer_class = ProgramSerializer
 
 

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -82,12 +82,12 @@ const COURSE: Course = {
 }
 
 const PROGRAM: AvailableProgram = {
-  id:                  1,
-  title:               "Awesomesauce",
-  enrolled:            true,
-  programpage_url:     null,
-  total_courses:       0,
-  courseware_backends: ["edxorg"]
+  id:                             1,
+  title:                          "Awesomesauce",
+  enrolled:                       true,
+  programpage_url:                null,
+  total_courses:                  0,
+  enrollable_courseware_backends: ["edxorg"]
 }
 
 describe("CouponNotificationDialog", () => {

--- a/static/js/components/SocialAuthDialog.js
+++ b/static/js/components/SocialAuthDialog.js
@@ -21,7 +21,7 @@ const SocialAuthDialog = (props: Props) => {
   const [open, setOpen] = useState(false)
   const missingBackend = R.head(
     R.difference(
-      R.propOr([], "courseware_backends", currentProgramEnrollment),
+      R.propOr([], "enrollable_courseware_backends", currentProgramEnrollment),
       R.propOr([], "social_auth_providers", SETTINGS.user)
     )
   )

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -60,12 +60,12 @@ export const makeAvailableProgram = (
 ) => {
   const programId = newProgramId()
   return {
-    enrolled:            enrolled,
-    id:                  programId,
-    programpage_url:     `/page/${programId}`,
-    title:               `AvailableProgram for ${programId}`,
-    total_courses:       1,
-    courseware_backends: backends
+    enrolled:                       enrolled,
+    id:                             programId,
+    programpage_url:                `/page/${programId}`,
+    title:                          `AvailableProgram for ${programId}`,
+    total_courses:                  1,
+    enrollable_courseware_backends: backends
   }
 }
 
@@ -74,12 +74,12 @@ export const makeAvailablePrograms = (
   enrolled: boolean = true
 ): AvailablePrograms => {
   return dashboard.programs.map(program => ({
-    enrolled:            enrolled,
-    id:                  program.id,
-    programpage_url:     `/page/${program.id}`,
-    title:               `AvailableProgram for ${program.id}`,
-    total_courses:       1,
-    courseware_backends: ["edxorg"]
+    enrolled:                       enrolled,
+    id:                             program.id,
+    programpage_url:                `/page/${program.id}`,
+    title:                          `AvailableProgram for ${program.id}`,
+    total_courses:                  1,
+    enrollable_courseware_backends: ["edxorg"]
   }))
 }
 

--- a/static/js/flow/enrollmentTypes.js
+++ b/static/js/flow/enrollmentTypes.js
@@ -7,7 +7,7 @@ export type AvailableProgram = {
   programpage_url: ?string,
   enrolled: boolean,
   total_courses: ?number,
-  courseware_backends: Array<string>,
+  enrollable_courseware_backends: Array<string>,
 }
 
 export type AvailablePrograms = Array<AvailableProgram>


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #5051

#### What's this PR do?
- Limits the set of `enrollable_courseware_backends` to runs that are currently enrollable.
- Removed `prefetch_course_runs`, since I went to write tests I missed for this previously and discovered it wasn't doing what I thought it was and was probably harming performance if anything.

#### How should this be manually tested?
- Go to a dashboard for a program with past edxorg course runs for a user who doesn't have edxorg auth. You **should not** see the login prompt.
- Go to a dashboard for a program with past edxorg course runs and a future mitx online run for a user who doesn't have mitx online auth. You **should not** see the login prompt.
- Go to a dashboard for a program with past edxorg course runs and a current mitx online run for a user who doesn't have mitx online auth. You **should** see the login prompt.