### PR TITLE
all DEDP courseware will be on mitxonline

### DIFF
--- a/financialaid/constants.py
+++ b/financialaid/constants.py
@@ -75,7 +75,7 @@ FINANCIAL_AID_APPROVAL_MESSAGE = (
     "After reviewing your income documentation, the {program_name} MicroMasters team has determined "
     "that your personalized course price is ${price}.\n\n"
     "You can pay for MicroMasters courses through the MITx MicroMasters portal "
-    "(https://micromasters.mit.edu/dashboard). All coursework will be conducted on edx.org."
+    "(https://micromasters.mit.edu/dashboard). All coursework will be conducted on mitxonline.mit.edu"
 )
 
 FINANCIAL_AID_DOCUMENTS_RESET_MESSAGE = (


### PR DESCRIPTION
In practice, the only program that uses this financial aid system is also the one hosted on mitxonline

#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - ~~Mobile width screenshots~~
- ~~Migrations~~
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- ~~Settings~~

#### What are the relevant tickets?

none, but customer support noted the discrepancy on [slack](https://mitodl.slack.com/archives/CUZSS4FQB/p1632240614018300) 

#### What's this PR do?

replaces a mention of edx.org to mitxonline.mit.edu 

#### How should this be manually tested?

1. Create a user and submit income information that requires review
2. use the financial air review form to approve the income documentation
3. examine the generated email 

