### PR TITLE
URL escape usernames for profile urls (#5056)

### DIFF
--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -7,9 +7,10 @@ from dashboard.views import (
     UnEnrollPrograms,
     ToggelProgramEnrollmentShareHash,
 )
+from profiles.constants import USERNAME_RE_PARTIAL
 
 urlpatterns = [
-    url(r'^api/v0/dashboard/(?P<username>[-\w.]+)/$', UserDashboard.as_view(), name='dashboard_api'),
+    url(fr'^api/v0/dashboard/(?P<username>{USERNAME_RE_PARTIAL})/$', UserDashboard.as_view(), name='dashboard_api'),
     url(r'^api/v0/course_enrollments/$', UserCourseEnrollment.as_view(), name='user_course_enrollments'),
     url(r'^api/v0/unenroll_programs/$', UnEnrollPrograms.as_view(), name='unenroll_programs'),
     url(r'^api/v0/enrollment_share_hash/$', ToggelProgramEnrollmentShareHash.as_view(), name='toggle_share_hash'),

--- a/financialaid/urls.py
+++ b/financialaid/urls.py
@@ -13,9 +13,10 @@ from financialaid.views import (
     FinancialAidSkipView,
     ReviewFinancialAidView,
 )
+from profiles.constants import USERNAME_RE_PARTIAL
 
 urlpatterns = [
-    url(r'^api/v0/course_prices/(?P<username>[-\w.]+)/$', CoursePriceListView.as_view(), name='course_price_list'),
+    url(fr'^api/v0/course_prices/(?P<username>{USERNAME_RE_PARTIAL})/$', CoursePriceListView.as_view(), name='course_price_list'),
     url(
         r'^financial_aid/review/(?P<program_id>[\d]+)/?$',
         ReviewFinancialAidView.as_view(),

--- a/micromasters/urls_test.py
+++ b/micromasters/urls_test.py
@@ -12,10 +12,13 @@ class URLTests(TestCase):
         assert reverse('ui-500') == "/500/"
         assert reverse('ui-404') == "/404/"
         assert reverse('ui-users', kwargs={'user': 'x'}) == "/learner/x"
+        assert reverse('ui-users', kwargs={'user': 'x+y'}) == "/learner/x+y"
         assert reverse('terms_of_service') == '/terms_of_service/'
         assert reverse('program-list') == '/api/v0/programs/'
         assert reverse('profile-detail', kwargs={'user': 'xyz'}) == '/api/v0/profiles/xyz/'
+        assert reverse('profile-detail', kwargs={'user': 'abc+xyz'}) == '/api/v0/profiles/abc+xyz/'
         assert reverse('dashboard_api', args=['username']) == '/api/v0/dashboard/username/'
+        assert reverse('dashboard_api', args=['user+name']) == '/api/v0/dashboard/user+name/'
         assert reverse('search_api', kwargs={'elastic_url': 'elastic'}) == '/api/v0/search/elastic'
         assert reverse('checkout') == '/api/v0/checkout/'
         assert reverse('user_program_enrollments') == '/api/v0/enrolledprograms/'
@@ -32,4 +35,5 @@ class URLTests(TestCase):
         assert reverse('financial_aid_skip', kwargs={'program_id': 3}) == '/api/v0/financial_aid_skip/3/'
         assert reverse('financial_aid', kwargs={'financial_aid_id': 123}) == '/api/v0/financial_aid/123/'
         assert reverse('course_price_list', args=['username']) == '/api/v0/course_prices/username/'
+        assert reverse('course_price_list', args=['user+name']) == '/api/v0/course_prices/user+name/'
         assert reverse('order-fulfillment') == '/api/v0/order_fulfillment/'

--- a/profiles/constants.py
+++ b/profiles/constants.py
@@ -1,0 +1,2 @@
+""" Profile constants """
+USERNAME_RE_PARTIAL = r"[\w .@_+-]+"

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -9,6 +9,7 @@ from roles.roles import (
     Instructor,
     Staff,
 )
+from profiles.constants import USERNAME_RE_PARTIAL
 from profiles.models import Profile
 from profiles.serializers import (
     ProfileSerializer,
@@ -28,7 +29,7 @@ class ProfileViewSet(RetrieveModelMixin, UpdateModelMixin, GenericViewSet):
     permission_classes = (CanEditIfOwner, CanSeeIfNotPrivate, )
     lookup_field = 'user__username'
     lookup_url_kwarg = 'user'
-    lookup_value_regex = r'[-\w.]+'
+    lookup_value_regex = USERNAME_RE_PARTIAL
     queryset = Profile.objects.all()
 
     # possible serializers

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -4,6 +4,14 @@ URLs for ui
 from django.conf.urls import url
 from django.contrib.auth import views as auth_views
 
+from certificates.views import (
+    CourseCertificateView,
+    GradeRecordView,
+    ProgramCertificateView,
+    ProgramLetterView,
+    SharedGradeRecordView,
+)
+from profiles.constants import USERNAME_RE_PARTIAL
 from ui.url_utils import (
     DASHBOARD_URLS,
     TERMS_OF_SERVICE_URL,
@@ -19,14 +27,6 @@ from ui.views import (
     need_verified_email,
     oauth_maintenance)
 
-from certificates.views import (
-    CourseCertificateView,
-    GradeRecordView,
-    ProgramCertificateView,
-    ProgramLetterView,
-    SharedGradeRecordView,
-)
-
 dashboard_urlpatterns = [
     url(r'^{}$'.format(dashboard_url.lstrip("/")), DashboardView.as_view(), name='ui-dashboard')
     for dashboard_url in DASHBOARD_URLS
@@ -39,7 +39,7 @@ urlpatterns = [
     url(r'^500/$', page_500, name='ui-500'),
     url(r'^verify-email/$', need_verified_email, name='verify-email'),
     url(r'^oauth_maintenance/(?P<backend>[^/]+)/$', oauth_maintenance, name='oauth_maintenance'),
-    url(r'^learner/(?P<user>[-\w.]+)?/?', UsersView.as_view(), name='ui-users'),
+    url(fr'^learner/(?P<user>{USERNAME_RE_PARTIAL})?/?', UsersView.as_view(), name='ui-users'),
     url(r'^certificate/course/(?P<certificate_hash>[-\w.]+)?/?', CourseCertificateView.as_view(), name='certificate'),
     url(r'^certificate/program/(?P<certificate_hash>[-\w.]+)?/?', ProgramCertificateView.as_view(),
         name='program-certificate'),


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #5056 

#### What's this PR do?

Initially I thought this was because we weren't escaping the username, but those should be fine. Instead it was a url matching issue, so this updates the regex we use in the API urls so that it matches on newer username patterns coming from MITx Online. See the [corresponding regex](https://github.com/mitodl/mitxonline/blob/main/users/serializers.py#L30) in MITx Online.

#### How should this be manually tested?
- On `master`, verify you can reproduce the bug by changing your username to contain a `+` character. You should see 404 responses from the APIs
- Checkout this branch and verify the APIs now return 200 and you can load the dashboard and profile pages.