### PR TITLE
CourseRun.objects.enrollable() support null dates (#5059)

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -197,7 +197,14 @@ class CourseRunQuerySet(models.QuerySet):
     def enrollable(self):
         """Returns a new query that returns currently enrollable runs"""
         now = now_in_utc()
-        return self.filter(enrollment_start__lte=now, enrollment_end__gt=now)
+        return self.filter(
+            # null start dates are excluded by default
+            models.Q(enrollment_start__lte=now) & (
+                # null end dates are considered +Infinity
+                models.Q(enrollment_end__isnull=True) |
+                models.Q(enrollment_end__gt=now)
+            )
+        )
 
 
 class CourseRun(models.Model):

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -68,10 +68,18 @@ class ProgramTests(MockedESTestCase):
     def test_enrollable_course_runs(self):
         """ Test that enrollable_course_runs only returns currently enrollable runs """
         program = ProgramFactory.create()
-        enrollable_run = CourseRunFactory.create(course__program=program)  # enrollable
-        CourseRunFactory.create(course__program=program, future_run=True) # not enrollable
+        enrollable_runs = [
+            # a current run with enrollment_start and enrollment_end
+            CourseRunFactory.create(course__program=program),
+            # a current run with enrollment_start and a NULL enrollment_end
+            CourseRunFactory.create(course__program=program, enrollment_end=None),
+        ]
+        # future runs aren't enrollable
+        CourseRunFactory.create(course__program=program, future_run=True)
+        # runs with both enrollment datetimes set as NULL aren't enrollable
+        CourseRunFactory.create(course__program=program, enrollment_start=None, enrollment_end=None)
 
-        assert list(program.enrollable_course_runs) == [enrollable_run]
+        assert list(program.enrollable_course_runs.order_by("id")) == enrollable_runs
 
 
 def from_weeks(weeks, now=None):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #5059

#### What's this PR do?
(Required)

#### How should this be manually tested?
- Go to `/api/v0/programs/`
- For one program, ensure there is exactly 1 course run configured for mitxonline
- Reloading the API response between changes, verify that in the `enrollable_courseware_backends` array, `"mitxonlin"` is present/absent with the following states for that run:

| `enrollment_start` | `enrollment_end` | `"mitxonline"` appears in `enrollable_courseware_backends` |
| --- | --- | --- |
| `None` | `None` | `False` |
| DATE IN THE PAST | `None` | `True` |
| DATE IN THE PAST | DATE IN THE FUTURE | `True` |