### PR TITLE
Don't refresh learner dashboards for staff (#5061)

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -133,18 +133,20 @@ class CourseRunUserStatus:
         )
 
 
-def get_user_program_info(user):
+def get_user_program_info(user, *, update_cache=True):
     """
     Provides a detailed serialization all of a User's enrolled Programs with enrollment/grade info
 
     Args:
         user (User): A User
+        update_cache (bool): if True, update the cache for the backends
 
     Returns:
         list: Enrolled Program information
     """
-    update_cache_for_backend(user, BACKEND_EDX_ORG)
-    update_cache_for_backend(user, BACKEND_MITX_ONLINE)
+    if update_cache:
+        update_cache_for_backend(user, BACKEND_EDX_ORG)
+        update_cache_for_backend(user, BACKEND_MITX_ONLINE)
     response_data = {
         "programs": [],
         "is_edx_data_fresh": CachedEdxDataApi.are_all_caches_fresh(user)

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1530,6 +1530,7 @@ class InfoCourseTest(CourseTests):
         self.mmtrack.get_course_proctorate_exam_results.assert_called_once_with(self.course_noruns)
 
 
+@ddt.ddt
 class UserProgramInfoIntegrationTest(MockedESTestCase):
     """Integration tests for get_user_program_info"""
     @classmethod
@@ -1550,13 +1551,14 @@ class UserProgramInfoIntegrationTest(MockedESTestCase):
         self.expected_programs = [self.program_non_fin_aid, self.program_fin_aid]
         self.edx_client = MagicMock()
 
+    @ddt.data([[True], [False]])
     @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', return_value=social_extra_data, autospec=True)
     @patch('dashboard.api_edx_cache.CachedEdxDataApi.update_cache_if_expired', new_callable=MagicMock)
-    def test_format(self, mock_cache_refresh, mock_refresh_token):
+    def test_format(self, update_cache, mock_cache_refresh, mock_refresh_token):
         """Test that get_user_program_info fetches edx data and returns a list of Program data"""
         result = api.get_user_program_info(self.user)
-        assert mock_refresh_token.call_count == 1
-        assert mock_cache_refresh.call_count == len(CachedEdxDataApi.EDX_SUPPORTED_CACHES)
+        assert mock_refresh_token.call_count == (1 if update_cache else 0)
+        assert mock_cache_refresh.call_count == (len(CachedEdxDataApi.EDX_SUPPORTED_CACHES) if update_cache else 0)
 
         assert isinstance(result, dict)
         assert 'is_edx_data_fresh' in result

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -51,9 +51,12 @@ class UserDashboard(APIView):
             username=username,
         )
 
+        # if the requesting user is the same as the user whose dashboard we're loading, update the cache
+        update_cache = user == request.user
+
         # get the credentials for the current user for edX
         try:
-            program_dashboard = get_user_program_info(user)
+            program_dashboard = get_user_program_info(user, update_cache=update_cache)
         except utils.InvalidCredentialStored as exc:
             log.exception('Access token for user %s is fresh but invalid; forcing login.', user.username)
             return Response(

--- a/static/js/containers/FinancialAidCalculator_test.js
+++ b/static/js/containers/FinancialAidCalculator_test.js
@@ -54,7 +54,7 @@ import { DASHBOARD_SUCCESS_ACTIONS } from "./test_util"
 import { actions } from "../lib/redux_rest"
 
 describe("FinancialAidCalculator", function() {
-  this.timeout(10000)
+  this.timeout(15000)
 
   let listenForActions, renderComponent, helper
   const financialAidDashboard = _.cloneDeep(DASHBOARD_RESPONSE)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #5061 

#### What's this PR do?
This fixes the following things:
- Updates the appropriate view test to not make API calls to edX
- Updates the view.py and api.py to conditionally update the dashboard only the dashboard user matches the requesting user

#### How should this be manually tested?
For both of the following verify the UI makes a request for the user's dashboard when viewing the profile page and that it does not error. You can shut down openedx or disable your networking if you're using edx staging to ensure that a request isn't being made.
- As any user, view your dashboard, it should load
- As a staff user, view the profile of any learner