### PR TITLE
Updated Link text in course PopUp

### DIFF
--- a/static/js/components/CourseListItemWithPopover.js
+++ b/static/js/components/CourseListItemWithPopover.js
@@ -8,7 +8,7 @@ import type { ProgramPageCourse } from "../flow/programTypes"
 const popoverLink = url =>
   url ? (
     <a className="edx-link" href={url}>
-      View on {url.includes("edx.org") ? "edX" : "MITx Online"}
+      Learn More
     </a>
   ) : null
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #5070 

#### What's this PR do?
This PR accomplishes the following
-  Updates text to `Learn More`
-  Removed conditional

#### How should this be manually tested?
This PR can be tested the following way
- Create a course run for a course
- Open Program page of a Program with that course.
- Click one of the courses in the sidebar
- Verify the link text is `Learn More`. 


#### Screenshots (if appropriate)
<img width="511" alt="Screenshot 2021-10-04 at 4 34 01 PM" src="https://user-images.githubusercontent.com/87968618/135844547-930cad0a-c7e7-4bfc-9ae0-a60bbd8be106.png">

