### PR TITLE
Remove implicit filtering of course runs (#5074)

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -20,20 +20,6 @@ class CourseRunInline(admin.StackedInline):
     extra = 1
     show_change_link = True
 
-    def get_queryset(self, request):
-        """
-        Return a QuerySet of all model instances that can be edited by the
-        admin site. This is used by changelist_view.
-        """
-        # NOTE: this is a copy/paste of the django source code with the following change:
-        #       self.model._default_manager -> self.model.all_objects
-        #       this is to support showing all records regardless of the is_discontinued value
-        qs = self.model.all_objects.get_queryset()
-        ordering = self.get_ordering(request)
-        if ordering:
-            qs = qs.order_by(*ordering)
-        return qs
-
 
 class ProgramAdmin(admin.ModelAdmin):
     """ModelAdmin for Programs"""
@@ -63,20 +49,6 @@ class CourseRunAdmin(admin.ModelAdmin):
                      'freeze_grade_date', )
     search_fields = ('edx_course_key',)
     ordering = ('course__title', 'course__program__title', 'course__position_in_program', )
-
-    def get_queryset(self, request):
-        """
-        Return a QuerySet of all model instances that can be edited by the
-        admin site. This is used by changelist_view.
-        """
-        # NOTE: this is a copy/paste of the django source code with the following change:
-        #       self.model._default_manager -> self.model.all_objects
-        #       this is to support showing all records regardless of the is_discontinued value
-        qs = self.model.all_objects.get_queryset()
-        ordering = self.get_ordering(request)
-        if ordering:
-            qs = qs.order_by(*ordering)
-        return qs
 
     def program(self, run):
         """method to show program for list display."""

--- a/courses/catalog_serializers.py
+++ b/courses/catalog_serializers.py
@@ -97,7 +97,7 @@ class CatalogProgramSerializer(serializers.ModelSerializer):
         if not course:
             return None
         first_unexpired = first_matching_item(
-            course.courserun_set.all().order_by("start_date"), lambda run: run.is_unexpired
+            course.courserun_set.not_discontinued().order_by("start_date"), lambda run: run.is_unexpired
         )
         return first_unexpired.start_date if first_unexpired else None
 
@@ -107,7 +107,7 @@ class CatalogProgramSerializer(serializers.ModelSerializer):
         if not course:
             return None
         last_unexpired = first_matching_item(
-            course.courserun_set.all().order_by("-start_date"), lambda run: run.is_unexpired
+            course.courserun_set.not_discontinued().order_by("-start_date"), lambda run: run.is_unexpired
         )
         return last_unexpired.end_date if last_unexpired else None
 
@@ -117,7 +117,7 @@ class CatalogProgramSerializer(serializers.ModelSerializer):
         if not course:
             return None
         first_unexpired = first_matching_item(
-            course.courserun_set.all().order_by("start_date"), lambda run: run.is_unexpired
+            course.courserun_set.not_discontinued().order_by("start_date"), lambda run: run.is_unexpired
         )
         return first_unexpired.enrollment_start if first_unexpired else None
 

--- a/courses/views.py
+++ b/courses/views.py
@@ -1,5 +1,6 @@
 """Views for courses"""
 from django.db import transaction
+from django.db.models import Prefetch
 from rest_framework import (
     viewsets,
     mixins,
@@ -125,12 +126,16 @@ class ProgramEnrollmentListView(CreateAPIView):
 class CourseRunViewSet(viewsets.ReadOnlyModelViewSet):
     """API for the CourseRun model"""
     serializer_class = CourseRunSerializer
-    queryset = CourseRun.objects.all()
+    queryset = CourseRun.objects.not_discontinued()
 
 
 class CatalogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     """API for program/course catalog list"""
     serializer_class = CatalogProgramSerializer
     queryset = Program.objects.filter(live=True).prefetch_related(
-        "course_set__courserun_set", "programpage__thumbnail_image"
+        Prefetch(
+            "course_set__courserun_set",
+            queryset=CourseRun.objects.not_discontinued(),
+        ),
+        "programpage__thumbnail_image"
     )

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -70,7 +70,7 @@ class MMTrack:
         with transaction.atomic():
             # Maps a CourseRun's edx_course_key to its parent Course id
             self.edx_key_course_map = dict(
-                CourseRun.objects.filter(course__program=program).exclude(
+                CourseRun.objects.not_discontinued().filter(course__program=program).exclude(
                     Q(edx_course_key__isnull=True) | Q(edx_course_key__exact='')
                 ).values_list("edx_course_key", "course__id")
             )
@@ -78,7 +78,7 @@ class MMTrack:
 
             if self.financial_aid_available:
                 # edx course keys for courses with no exam
-                self.edx_course_keys_no_exam = set(CourseRun.objects.filter(
+                self.edx_course_keys_no_exam = set(CourseRun.objects.not_discontinued().filter(
                     course__program=program, course__exam_runs__isnull=True
                 ).values_list("edx_course_key", flat=True))
 
@@ -397,7 +397,7 @@ class MMTrack:
             if course_id in final_grades or self.enrollments.is_enrolled_in(course_id):
                 enrolled_course_ids.append(course_id)
 
-        return list(CourseRun.objects.filter(edx_course_key__in=enrolled_course_ids).select_related('course'))
+        return list(CourseRun.objects.not_discontinued().filter(edx_course_key__in=enrolled_course_ids).select_related('course'))
 
     def calculate_final_grade_average(self):
         """

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -398,7 +398,7 @@ def is_coupon_redeemable(coupon, user):
         )
 
         # For this coupon type the user must have already purchased a course run on edX
-        return any((mmtrack.has_verified_enrollment(run.edx_course_key) for run in course.courserun_set.all()))
+        return any((mmtrack.has_verified_enrollment(run.edx_course_key) for run in course.courserun_set.not_discontinued()))
 
     return True
 

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -244,9 +244,9 @@ class Coupon(TimestampedModel, AuditableModel):
         """Get the course keys which the coupon can be redeemed with"""
         obj = self.content_object
         if isinstance(obj, Program):
-            return CourseRun.objects.filter(course__program=obj).values_list('edx_course_key', flat=True)
+            return CourseRun.objects.not_discontinued().filter(course__program=obj).values_list('edx_course_key', flat=True)
         elif isinstance(obj, Course):
-            return CourseRun.objects.filter(course=obj).values_list('edx_course_key', flat=True)
+            return CourseRun.objects.not_discontinued().filter(course=obj).values_list('edx_course_key', flat=True)
         else:
             # Should probably not get here, clean() should take care of validating this
             raise ImproperlyConfigured("content_object expected to be one of Program, Course, CourseRun")


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #5074 

#### What's this PR do?
This removes the implicit `filter(is_discontinued=False)` from the `CourseRun` queryset. Django was pulling this criteria in when querying tables that had FK's into `CourseRun`, which in turn caused psotgres to lock the corresponding `CourseRun` row when doing certain operations that triggered a `select_for_update()` (e.g. `update_or_create()`). The implicit query filter via a custom manager has been replaced with explicit `not_discontinued()` filter calls. These calls were placed in very targeted areas, as the main goal here is to not include those course runs in the dashboard.

#### How should this be manually tested?
- Verify that runs that are discontinued still don't show up in the dashboard and nothing errors.