### PR TITLE
Remove implicit filter on cached models

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -29,18 +29,10 @@ from mail.models import PartnerSchool
 from micromasters.models import TimestampedModel
 
 
-class CachedEdxInfoModelManager(Manager):
-    """Custom model manager"""
-    def get_queryset(self):
-        """Filter out records associated with discontinued runs"""
-        return super().get_queryset().exclude(course_run__is_discontinued=True)
-
 class CachedEdxInfoModel(Model):
     """
     Base class to define other cached models
     """
-    objects = CachedEdxInfoModelManager()
-
     user = ForeignKey(User, on_delete=CASCADE)
     course_run = ForeignKey(CourseRun, on_delete=CASCADE)
     data = JSONField()


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Continuation of #5076 

#### What's this PR do?
Removes another spot we had implicit filtering of `is_discontinued` present

#### How should this be manually tested?
The dashboard should load without issue.
