### PR TITLE
Added possible fix for target container is not a DOM element

### DIFF
--- a/static/js/entry/dashboard.js
+++ b/static/js/entry/dashboard.js
@@ -43,7 +43,6 @@ const renderApp = Component => {
   )
 }
 
-
 if (rootEl) {
   renderApp(DashboardRouter)
 }


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
fixes: #5078 

#### What's this PR do?
The PR contains the possible fix for the exception related to `target container is not a DOM element`.

#### How should this be manually tested?
The issue is not producible either on RC or local instance but the PR added an additional check in order to omit the above exception on the Dashboard page.

