### PR TITLE
Fix support link not rendering on error message

### DIFF
--- a/ui/views.py
+++ b/ui/views.py
@@ -86,6 +86,7 @@ class ReactView(View):
             "google_maps_api": False,
             "js_settings_json": json.dumps(js_settings),
             "ga_tracking_id": "",
+            "support_email": settings.EMAIL_SUPPORT,
         }
 
     def get(self, request, *args, **kwargs):  # pylint: disable=unused-argument

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -299,6 +299,7 @@ class DashboardTests(ViewsTests):
             }
             assert resp.context['is_public'] is False
             assert resp.context['has_zendesk_widget'] is True
+            assert resp.context['support_email'] == email_support
             self.assertNotContains(resp, 'Share this page')
 
     def test_roles_setting(self):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds `support_email` to the context so the link renders.

#### How should this be manually tested?
Go to mm.odl.local:8079/complete/edxorg/, you should see the error message in the screenshot

#### Screenshots (if appropriate)
![Screenshot 2021-10-20 at 15-32-44 MITx MicroMasters](https://user-images.githubusercontent.com/28598/138160193-43fb11f3-fc57-4390-982a-88c425515e78.png)


