### PR TITLE
Check if user paid for course having free coupon

### DIFF
--- a/static/js/components/dashboard/CourseAction.js
+++ b/static/js/components/dashboard/CourseAction.js
@@ -78,13 +78,14 @@ export default class CourseAction extends React.Component {
   handleEnrollButtonClick(run: CourseRun): void {
     const {
       coupon,
+      courseRun,
       setEnrollSelectedCourseRun,
       setEnrollCourseDialogVisibility
     } = this.props
 
     setEnrollSelectedCourseRun(run)
 
-    if (coupon && isFreeCoupon(coupon)) {
+    if (coupon && isFreeCoupon(coupon) && !courseRun.has_paid) {
       this.redirectToOrderSummary(run)
     } else {
       setEnrollCourseDialogVisibility(true)

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -18,7 +18,9 @@ import {
   COURSE_ACTION_CALCULATE_PRICE,
   COURSE_ACTION_ENROLL,
   COURSE_ACTION_REENROLL,
-  FA_STATUS_PENDING_DOCS, FA_STATUS_APPROVED, COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT
+  FA_STATUS_PENDING_DOCS,
+  FA_STATUS_APPROVED,
+  COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT
 } from "../../constants"
 import {
   findCourse,
@@ -260,7 +262,7 @@ describe("CourseAction", () => {
 
     it("enroll button redirects to order summary if full coupon and order fulfilled", () => {
       const firstRun = alterFirstRun(course, {
-        enrollment_start_date: now.toISOString(),
+        enrollment_start_date: now.toISOString()
       })
       const wrapper = renderCourseAction({
         coupon: {
@@ -273,7 +275,7 @@ describe("CourseAction", () => {
           has_user_applied:   true,
           application_status: FA_STATUS_APPROVED
         },
-        actionType:      COURSE_ACTION_ENROLL
+        actionType: COURSE_ACTION_ENROLL
       })
       const enrollButton = wrapper.find(".enroll-button")
       assert.equal(wrapper.find(SpinnerButton).props().children, "Enroll")

--- a/static/js/components/dashboard/CourseAction_test.js
+++ b/static/js/components/dashboard/CourseAction_test.js
@@ -1,6 +1,7 @@
 /* global SETTINGS: false */
 /* eslint-disable no-unused-vars */
 import React from "react"
+import Decimal from "decimal.js-light"
 import { shallow } from "enzyme"
 import moment from "moment-timezone"
 import { assert } from "chai"
@@ -17,7 +18,7 @@ import {
   COURSE_ACTION_CALCULATE_PRICE,
   COURSE_ACTION_ENROLL,
   COURSE_ACTION_REENROLL,
-  FA_STATUS_PENDING_DOCS
+  FA_STATUS_PENDING_DOCS, FA_STATUS_APPROVED, COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT
 } from "../../constants"
 import {
   findCourse,
@@ -255,6 +256,30 @@ describe("CourseAction", () => {
       const payButton = wrapper.find(".pay-button")
       payButton.simulate("click")
       assert.equal(checkoutStub.calledWith(firstRun.course_id), true)
+    })
+
+    it("enroll button redirects to order summary if full coupon and order fulfilled", () => {
+      const firstRun = alterFirstRun(course, {
+        enrollment_start_date: now.toISOString(),
+      })
+      const wrapper = renderCourseAction({
+        coupon: {
+          amount_type: COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT,
+          amount:      new Decimal("1")
+        },
+        courseRun:       firstRun,
+        hasFinancialAid: true,
+        financialAid:    {
+          has_user_applied:   true,
+          application_status: FA_STATUS_APPROVED
+        },
+        actionType:      COURSE_ACTION_ENROLL
+      })
+      const enrollButton = wrapper.find(".enroll-button")
+      assert.equal(wrapper.find(SpinnerButton).props().children, "Enroll")
+      enrollButton.simulate("click")
+      assert.equal(checkoutStub.calledWith(firstRun.course_id), false)
+      assert.equal(routerPushStub.called, true)
     })
   })
 })


### PR DESCRIPTION

#### What are the relevant tickets?
Fix #5087

#### What's this PR do?
When checking for a free coupon also check if the user has already paid (has fulfilled order) for the course run, and allow them to enroll in the course.

#### How should this be manually tested?
Create a UserCoupon for a user
Attempt to enroll in a course run when edx/devstack is unreachable in order to have enrollment not be created (Order will still be created)
Attempt to subsequently enroll in the run


