### PR TITLE
Add course certificate link for staff view

### DIFF
--- a/static/js/components/dashboard/courses/ProgressMessage.js
+++ b/static/js/components/dashboard/courses/ProgressMessage.js
@@ -167,6 +167,7 @@ export default class ProgressMessage extends React.Component {
     const { course } = this.props
     return course.certificate_url && hasAnyStaffRole(SETTINGS.roles) ? (
       <a
+        key={"certificate-link"}
         onClick={() => {
           window.open(course.certificate_url)
         }}

--- a/static/js/components/dashboard/courses/ProgressMessage.js
+++ b/static/js/components/dashboard/courses/ProgressMessage.js
@@ -163,13 +163,26 @@ export default class ProgressMessage extends React.Component {
       </a>
     ) : null
   }
+  renderCourseCertificateLink = (): React$Element<*> | null => {
+    const { course } = this.props
+    return hasAnyStaffRole(SETTINGS.roles) ? (
+      <a
+        onClick={() => {
+          window.open(course.certificate_url)
+        }}
+      >
+        View Certificate
+      </a>
+    ) : null
+  }
 
   renderCourseLinks = (): React$Element<*> | null => {
     const { courseRun } = this.props
 
     const courseLinks = R.reject(R.isNil, [
       this.renderViewCourseEdxLink(courseRun),
-      this.renderCourseContactLink()
+      this.renderCourseContactLink(),
+      this.renderCourseCertificateLink()
     ])
 
     return courseLinks.length > 0 ? (

--- a/static/js/components/dashboard/courses/ProgressMessage.js
+++ b/static/js/components/dashboard/courses/ProgressMessage.js
@@ -165,7 +165,7 @@ export default class ProgressMessage extends React.Component {
   }
   renderCourseCertificateLink = (): React$Element<*> | null => {
     const { course } = this.props
-    return hasAnyStaffRole(SETTINGS.roles) ? (
+    return course.certificate_url && hasAnyStaffRole(SETTINGS.roles) ? (
       <a
         onClick={() => {
           window.open(course.certificate_url)

--- a/static/js/components/dashboard/courses/ProgressMessage_test.js
+++ b/static/js/components/dashboard/courses/ProgressMessage_test.js
@@ -116,6 +116,17 @@ describe("Course ProgressMessage", () => {
     assert.notInclude(wrapper.text(), "Paid")
   })
 
+  it("should show course certificate link to staff", () => {
+    makeRunCurrent(course.runs[0])
+    makeRunEnrolled(course.runs[0])
+    SETTINGS.roles.push({ role: "staff", permissions: [] })
+    let wrapper = renderCourseDescription()
+    assert.lengthOf(wrapper.find("a"), 0)
+    course.certificate_url = "certificate/url"
+    wrapper = renderCourseDescription()
+    assert.include(wrapper.find("a").text(), "View Certificate")
+  })
+
   describe("staffCourseInfo", () => {
     it("should return nothing if the user is not enrolled", () => {
       makeRunCurrent(course.runs[0])


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots

#### What are the relevant tickets?
fix #5099 

#### What's this PR do?

Add course certificate link for staff view
#### How should this be manually tested?
Login as staff and view a learners profile, where the learner passed at course and has a certificate ready for viewing. For a certificate link to be visible the `CourseCertificateSignatories` should be filled out for the program page in the cms.

Make sure that learner's dashboard view is unaffected.

<img width="1059" alt="Screen Shot 2021-11-02 at 1 48 20 PM" src="https://user-images.githubusercontent.com/7574259/139919252-7089de97-55c8-40c9-a4ec-2993a265f054.png">
