### PR TITLE
switch to depending on our forked iso-3166-2 package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@fancyapps/fancybox": "^3.5.7",
     "@material-ui/core": "^4.2.1",
+    "@mitodl/iso-3166-2": "^1.0.1",
     "@sentry/browser": "^6.4.1",
     "ajaxchimp": "^1.3.0",
     "autoprefixer": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -336,6 +336,11 @@
     prop-types "^15.7.2"
     react-is "^16.8.0"
 
+"@mitodl/iso-3166-2@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@mitodl/iso-3166-2/-/iso-3166-2-1.0.1.tgz#18dfe97d1d82e6746cd9b5918fca7daa64394381"
+  integrity sha512-VEMq2LpcoyXUY1OS5SNs0AYFQa3tC55qoH3yKBfoDkyt/e9tiLkYOjI29OXRNGBew5ouRsIFDChiKE7oYixDZg==
+
 "@sentry/browser@^6.4.1":
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.7.1.tgz#e01144a08984a486ecc91d7922cc457e9c9bd6b7"


### PR DESCRIPTION

#### What are the relevant tickets?

none

#### What's this PR do?

I set up our forked repo (https://github.com/mitodl/iso-3166-2.js) to be published as an npm package (https://github.com/mitodl/iso-3166-2.js/pull/4) so we don't have to include the package from github directly. Doing this will let us upgrade to the newest version of yarn, and do some of the build / CI setup simplifications we've done on other projects.

#### How should this be manually tested?

The features that use this project should work as normal, and tests should pass.