### PR TITLE
Run batch user update only on Sunday

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -481,7 +481,7 @@ CELERY_TASK_EAGER_PROPAGATES = (get_bool("CELERY_TASK_EAGER_PROPAGATES", True) o
 CELERY_BEAT_SCHEDULE = {
     'batch-update-user-data-every-6-hrs': {
         'task': 'dashboard.tasks.batch_update_user_data',
-        'schedule': crontab(minute=0, hour='*/6')
+        'schedule': crontab(minute=0, hour='*/6', day_of_week=0)
     },
     'update-currency-exchange-rates-every-24-hrs': {
         'task': 'financialaid.tasks.sync_currency_exchange_rates',


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #5133 

#### What's this PR do?
Change the celery beat schedule to run `batch_update_user_data` only once a week on Sunday.

#### How should this be manually tested?
No new tasks `batch_update_user_data` should get scheduled before Sunday
