### PR TITLE
Removed Pearson integration pkgs

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -31,8 +31,6 @@ open-discussions-client==0.5.0
 phonenumbers==8.10.23
 psycopg2==2.8.6
 pycountry==16.11.27.1
-pysftp==0.2.9
-PyNaCl==1.3.0
 python-dateutil
 sentry-sdk==1.1.0
 redis==3.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,10 @@ amqp==5.0.9
     # via kombu
 anyascii==0.2.0
     # via wagtail
+appnope==0.1.2
+    # via ipython
 backcall==0.1.0
     # via ipython
-bcrypt==3.2.0
-    # via paramiko
 beautifulsoup4==4.8.2
     # via wagtail
 billiard==3.6.4.0
@@ -31,11 +31,6 @@ certifi==2018.1.18
     #   -r requirements.in
     #   requests
     #   sentry-sdk
-cffi==1.14.4
-    # via
-    #   bcrypt
-    #   cryptography
-    #   pynacl
 chardet==3.0.4
     # via requests
 click==8.0.3
@@ -50,8 +45,6 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-cryptography==3.3.2
-    # via paramiko
 decorator==4.3.0
     # via
     #   ipython
@@ -177,8 +170,6 @@ open-discussions-client==0.5.0
     # via -r requirements.in
 openpyxl==3.0.7
     # via tablib
-paramiko==2.7.2
-    # via pysftp
 parso==0.8.1
     # via jedi
 pbr==4.2.0
@@ -206,8 +197,6 @@ ptyprocess==0.6.0
     # via pexpect
 pycountry==16.11.27.1
     # via -r requirements.in
-pycparser==2.19
-    # via cffi
 pygments==2.7.4
     # via ipython
 pyjwt==1.5.2
@@ -216,12 +205,6 @@ pyjwt==1.5.2
     #   social-auth-core
 pymongo==3.7.1
     # via edx-opaque-keys
-pynacl==1.3.0
-    # via
-    #   -r requirements.in
-    #   paramiko
-pysftp==0.2.9
-    # via -r requirements.in
 python-dateutil==2.5.3
     # via
     #   -r requirements.in
@@ -261,9 +244,7 @@ sentry-sdk==1.1.0
 six==1.14.0
     # via
     #   -r requirements.in
-    #   bcrypt
     #   click-repl
-    #   cryptography
     #   django-compat
     #   django-role-permissions
     #   django-server-status
@@ -273,7 +254,6 @@ six==1.14.0
     #   html5lib
     #   l18n
     #   prompt-toolkit
-    #   pynacl
     #   python-dateutil
     #   social-auth-app-django
     #   social-auth-core


### PR DESCRIPTION
#### What's this PR do?
Removes the following two packages:
- PyNaCl
- pysftp

Those were required for the Pearson integration which we no longer have in place.
