### PR TITLE
Rewrite the algorithm for exam attempts

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -622,7 +622,6 @@ def has_to_pay_for_exam(mmtrack, course):
     Returns:
         bool: if the user has to pay for another exam attempt
     """
-
     return mmtrack.get_number_of_attempts_left(course) < 1
 
 

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -623,7 +623,7 @@ def has_to_pay_for_exam(mmtrack, course):
         bool: if the user has to pay for another exam attempt
     """
 
-    return mmtrack.get_number_of_attempts_left(course) > 0
+    return mmtrack.get_number_of_attempts_left(course) < 1
 
 
 def get_certificate_url(mmtrack, course):

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -23,7 +23,7 @@ from courses.utils import format_season_year_for_course_run
 from dashboard.api_edx_cache import CachedEdxDataApi
 from dashboard.constants import DEDP_PROGRAM_TITLE
 from dashboard.models import ProgramEnrollment
-from dashboard.utils import get_mmtrack, ATTEMPTS_PER_PAID_RUN, ATTEMPTS_PER_PAID_RUN_OLD
+from dashboard.utils import get_mmtrack
 from financialaid.serializers import FinancialAidDashboardSerializer
 from grades import api
 from grades.models import FinalGrade

--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -622,21 +622,8 @@ def has_to_pay_for_exam(mmtrack, course):
     Returns:
         bool: if the user has to pay for another exam attempt
     """
-    now = now_in_utc()
-    attempt_limit = None
-    num_attempts = ATTEMPTS_PER_PAID_RUN
-    if not mmtrack.program.exam_attempts_first_date:
-        num_attempts = ATTEMPTS_PER_PAID_RUN_OLD
-    elif mmtrack.program.exam_attempts_first_date > now:
-        # still before the date
-        num_attempts = ATTEMPTS_PER_PAID_RUN_OLD
-    elif mmtrack.program.exam_attempts_second_date > now:
-        # in between the dates: check when the user paid for each course run
-        attempt_limit = mmtrack.get_custom_number_of_attempts_for_course(course)
 
-    if attempt_limit is None:
-        attempt_limit = mmtrack.get_payments_count_for_course(course) * num_attempts
-    return ExamAuthorization.objects.filter(user=mmtrack.user, course=course, exam_taken=True).count() >= attempt_limit
+    return mmtrack.get_number_of_attempts_left(course) > 0
 
 
 def get_certificate_url(mmtrack, course):

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -2180,7 +2180,7 @@ class ExamAttemptsTests(CourseTests):
             user=self.user,
             status=Order.FULFILLED
         )
-        line_old = LineFactory.create(
+        LineFactory.create(
             order=order,
             course_key=run.edx_course_key
         )

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -2160,10 +2160,11 @@ class ExamAttemptsTests(CourseTests):
 
     @ddt.data(
         (0, False, False),
-        (1, False, False),
-        (1, True, True),
-        (2, False, False),
-
+        (0, True, False),
+        (1, False, True),
+        (1, True, False),
+        (2, False, True),
+        (2, True, False),
     )
     @ddt.unpack
     def test_has_to_pay_old_payment(self, num_of_taken_exams, new_purchase, result):
@@ -2198,7 +2199,7 @@ class ExamAttemptsTests(CourseTests):
 
             Line.objects.filter(order=order).update(modified_at=first_date+timedelta(weeks=1))
         # before second date
-        for _ in range(num_of_taken_exams+1):
+        for _ in range(num_of_taken_exams):
             exam_auth = ExamAuthorizationFactory.create(user=self.user, course=self.course, exam_taken=True)
             exam_auth.exam_run.date_first_eligible = first_date+timedelta(weeks=1)
             exam_auth.exam_run.save()

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -260,7 +260,6 @@ class MMTrack:
             course_key__in=course.courserun_set.values('edx_course_key')
         ).order_by('created_at')
         used_attempts_qset = ExamAuthorization.objects.filter(user=self.user, course=course, exam_taken=True)
-
         # if for some reason the first date is not set, return the difference between payments and used attempts
         if first_date is None:
             return payments_qset.count() - used_attempts_qset.count()

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -266,10 +266,10 @@ class MMTrack:
         if first_date is None:
             return payments_qset.count() - used_attempts_qset.count()
 
-        # number of payments before the fist date
+        # number of payments before the first date
         old_payments = payments_qset.filter(modified_at__lt=first_date).count()
         # number of payments after the first date
-        new_lines = payments_qset.filter(modified_at__gte=first_date).count()
+        new_payments = payments_qset.filter(modified_at__gte=first_date).count()
 
         # number of used attempts before the second date
         old_attempts = used_attempts_qset.filter(
@@ -281,7 +281,7 @@ class MMTrack:
         ).count()
 
         # calculate any unused attempts from for the period when one payment provided two attempts
-        unused_double_attempts = old_payments * ATTEMPTS_PER_PAID_RUN_OLD - old_attempts
+        unused_double_attempts = (old_payments * ATTEMPTS_PER_PAID_RUN_OLD) - old_attempts
         if unused_double_attempts > 0:
             # the user has unused attempts from before the first date
             # divide unused attempts from before the first date by two since payments are
@@ -291,17 +291,17 @@ class MMTrack:
             #   the number of payments after the first date
             #   minus the number of attempts after the second date
             #   plus the carryover attempts
-            return new_lines - new_attempts + attempts_carryover
+            return new_payments - new_attempts + attempts_carryover
         elif unused_double_attempts == 0:
             # there is no carry over
-            return new_lines - new_attempts
+            return new_payments - new_attempts
 
         else:
             # the user has more used attempts (before the second date) than payments (before the first date)
             # this can happen if the user made at least one payment and attempt both after the first date
             # find the number of attempts without the double attempts and subtract that from new payments
             single_attempts = used_attempts_qset.count() - old_payments * ATTEMPTS_PER_PAID_RUN_OLD
-            return new_lines - single_attempts
+            return new_payments - single_attempts
 
     def has_paid_for_any_in_program(self):
         """

--- a/exams/api_test.py
+++ b/exams/api_test.py
@@ -16,7 +16,7 @@ from dashboard.factories import (
     ProgramEnrollmentFactory,
 )
 from dashboard.utils import get_mmtrack
-from dashboard.api import ATTEMPTS_PER_PAID_RUN_OLD
+from dashboard.utils import ATTEMPTS_PER_PAID_RUN_OLD
 from ecommerce.factories import LineFactory
 from ecommerce.models import Order
 from exams.api import (


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fix #5198

#### What's this PR do?
Update the algorithm for determining the number of attempts still available to the user and whether they have to pay for the course again.

#### How should this be manually tested?
Take a look at the tests, make sure all cases are covered. Tests should pass.
The new algorithm for determining the number of attempts left:
```
Find all payments before the "first date"
Find the number of used attempts before the "second date"
if the number of used attempts is less than the amount of attempts given:
    Compute the carry over amount of attempts, converting them from double attempts to single attempts
if the number of unused attempts (before second date) is 0:
    Then we only compute the number of attempts in the new way, i.e. payment = attempt
else
    # the user has more attempts than payments
    # this means the user made at least one payment and attempt both after the first date
    find the number of attempts without the double attempts and subtract that from new payments

