### PR TITLE
only update user dashboards on Friday

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -480,7 +480,7 @@ CELERY_TASK_ALWAYS_EAGER = get_bool("CELERY_TASK_ALWAYS_EAGER", False) or get_bo
 CELERY_TASK_EAGER_PROPAGATES = (get_bool("CELERY_TASK_EAGER_PROPAGATES", True) or
                                 get_bool("CELERY_EAGER_PROPAGATES_EXCEPTIONS", True))
 CELERY_BEAT_SCHEDULE = {
-    'batch-update-user-data-every-6-hrs': {
+    'batch-update-user-data-every-friday-every-6-hrs': {
         'task': 'dashboard.tasks.batch_update_user_data',
         'schedule': crontab(minute=0, hour='*/6', day_of_week=5)
     },

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -482,7 +482,7 @@ CELERY_TASK_EAGER_PROPAGATES = (get_bool("CELERY_TASK_EAGER_PROPAGATES", True) o
 CELERY_BEAT_SCHEDULE = {
     'batch-update-user-data-every-6-hrs': {
         'task': 'dashboard.tasks.batch_update_user_data',
-        'schedule': crontab(minute=0, hour='*/6')
+        'schedule': crontab(minute=0, hour='*/6', day_of_week=5)
     },
     'update-currency-exchange-rates-every-24-hrs': {
         'task': 'financialaid.tasks.sync_currency_exchange_rates',


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

part of #5212 

#### What's this PR do?

Stops updating user dashboard data every day. Only updates user dashboard data on Fridays. 

#### How should this be manually tested?

I don't think it can be manually tested

#### Any background context you want to provide?

We need to authorize exams on Tuesday 8/16. We don't want the exam authorization task to be slowed down waiting for these dashboard updates. 

