### PR TITLE
Adds commands to list users who need upgrade

### DIFF
--- a/exams/management/commands/list_authorized_exam_learners.py
+++ b/exams/management/commands/list_authorized_exam_learners.py
@@ -1,0 +1,60 @@
+"""
+List all users authorized for current exam run
+"""
+import datetime
+from django.conf import settings
+from django.core.management import BaseCommand, CommandError
+from django.db import models
+
+
+from courses.models import CourseRun
+from dashboard.models import CachedEnrollment
+from exams.models import ExamRun, ExamAuthorization
+from micromasters.utils import now_in_utc
+
+
+class Command(BaseCommand):
+    """
+    List all users authorized for current exam run and did not use it, also
+    make sure they are not enrolled in future runs
+    """
+    help = "List all users authorized for current exam run"
+
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
+
+        two_months = datetime.timedelta(weeks=8)
+        # get most recent exam runs
+        exam_runs = list(ExamRun.objects.filter(
+            date_first_schedulable__gte=now_in_utc()-two_months,
+        ).values_list('id', flat=True))
+        if exam_runs is None:
+            raise CommandError('There are no exam runs that were schedulable within the last two months')
+
+        course_runs = CourseRun.objects.filter(
+            models.Q(edx_course_key__contains='3T2022') | models.Q(edx_course_key__contains='1T2023')
+        )
+        final_list = []
+        for course_run in course_runs:
+            enrolled_user_ids = set(CachedEnrollment.get_cached_users(course_run))
+            exam_auths = ExamAuthorization.objects.filter(
+                exam_run__in=exam_runs,
+                course=course_run.course,
+                exam_taken=False
+            ).exclude(user__in=enrolled_user_ids).values_list('user__email', flat=True)
+            if exam_auths:
+                [final_list.append((auth_email, course_run.course_id)) for auth_email in exam_auths]
+        file_name = 'authorized_users.csv'
+        path = '{}/{}'.format(settings.BASE_DIR, file_name)
+        with open(path, 'w') as f:
+            for email, course_id in final_list:
+                f.write(f'{email},{course_id}\n')
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'Successfully created {file_name}'
+            )
+        )
+
+
+
+

--- a/exams/management/commands/list_authorized_exam_learners.py
+++ b/exams/management/commands/list_authorized_exam_learners.py
@@ -27,11 +27,11 @@ class Command(BaseCommand):
         exam_runs = list(ExamRun.objects.filter(
             date_first_schedulable__gte=now_in_utc()-two_months,
         ).values_list('id', flat=True))
-        if exam_runs is None:
+        if not exam_runs:
             raise CommandError('There are no exam runs that were schedulable within the last two months')
 
         course_runs = CourseRun.objects.filter(
-            models.Q(edx_course_key__contains='3T2022') | models.Q(edx_course_key__contains='1T2023')
+            models.Q(edx_course_key__icontains='3T2022') | models.Q(edx_course_key__icontains='1T2023')
         )
         final_list = []
         for course_run in course_runs:

--- a/exams/management/commands/list_currently_enrolled_paid.py
+++ b/exams/management/commands/list_currently_enrolled_paid.py
@@ -1,0 +1,62 @@
+"""
+List all users that enrolled in current or future run and paid for course and have an exam attempt
+"""
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.management import BaseCommand, CommandError
+from django.db import models
+
+
+from courses.models import CourseRun
+from dashboard.api import has_to_pay_for_exam
+from dashboard.models import CachedEnrollment
+from dashboard.utils import get_mmtrack
+from ecommerce.models import Order, Line
+
+
+class Command(BaseCommand):
+    """
+    List all users that
+        1) enrolled in a current course in current or future run
+        2) paid
+        3) have an exam attempt
+    """
+    help = "List all users that enrolled in current or future run and paid for course"
+
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
+
+        future_runs = CourseRun.objects.filter(
+            models.Q(edx_course_key__contains='3T2022') | models.Q(edx_course_key__contains='1T2023')
+        )
+        if not future_runs:
+            raise CommandError('There are no current or future course runs')
+
+        user_for_upgrade = []
+        for course_run in future_runs:
+            course = course_run.course
+            program = course_run.course.program
+            enrolled_user_ids = set(CachedEnrollment.get_cached_users(course_run))
+            paid_enrolled_users_ids = list(Line.objects.filter(
+                order__status__in=Order.FULFILLED_STATUSES,
+                order__user__in=enrolled_user_ids,
+                course_key__in=course.courserun_set.values('edx_course_key'),
+            ).values_list('order__user', flat=True))
+            paid_enrolled_users = User.objects.filter(id__in=paid_enrolled_users_ids)
+            for user in paid_enrolled_users:
+                mmtrack = get_mmtrack(user, program)
+                has_paid = mmtrack.has_paid(course_run.edx_course_key)
+                has_to_pay_exam = has_to_pay_for_exam(mmtrack, course)
+                if not has_to_pay_exam and has_paid:
+                    user_for_upgrade.append((user.email, course_run.edx_course_key))
+
+        file_name = 'users_eligible_for_upgrade.csv'
+        path = '{}/{}'.format(settings.BASE_DIR, file_name)
+        with open(path, 'w') as f:
+            for email, run_key in user_for_upgrade:
+                f.write(f'{email},{run_key}\n')
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'Successfully created {file_name}'
+            )
+        )

--- a/exams/management/commands/list_currently_enrolled_paid.py
+++ b/exams/management/commands/list_currently_enrolled_paid.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
 
         future_runs = CourseRun.objects.filter(
-            models.Q(edx_course_key__contains='3T2022') | models.Q(edx_course_key__contains='1T2023')
+            models.Q(edx_course_key__icontains='3T2022') | models.Q(edx_course_key__icontains='1T2023')
         )
         if not future_runs:
             raise CommandError('There are no current or future course runs')


### PR DESCRIPTION
#### What are the relevant tickets?
Fix https://github.com/mitodl/mitxonline/issues/960

#### What's this PR do?
Adds commands to list users who need upgrade.


#### How should this be manually tested?
 1) Run `./manage.py seed_db` to set up the programs and course runs 
2) create your test learner user by creating an account and filling out the profile
3) Run `./manage.py alter_data set_past_run_to_passed --username <username> --program-title Digital --course-title 100`   to enroll your test user in a course run, and create a passing grade and payment record, ( you will see the edx_course_key printed by the command, save it so that you can use it later)
4) Create an exam run and authorize the user for the exam:
```
from courses.models import *
from exams.factories import *
course = Course.objects.get(title='Digital Learning 100')
exam_run = ExamRunFactory.create(course=course, authorized=True, scheduling_past=False, scheduling_future=False)
from django.contrib.auth.models import User
user = User.objects.get(username=<username>)
ExamAuthorization.objects.create(user=user, course=course, status=ExamAuthorization.STATUS_SUCCESS, exam_run=exam_run)

```

5) Then run 
`./manage.py list_authorized_exam_learners`
This should create a csv file with users that can be upgraded in mitxonline.


Now for testing the second management command:
1) Run `./manage.py alter_data set_to_enrolled --username <username> --course-title 'Digital Learning 100' --audit`
this should create an audit enrollment for a current course run
2) Run `./manage.py list_currently_enrolled_paid `
The user should get writted into the file `users_eligible_for_upgrade.csv`