### PR TITLE
Updating usages of fin_aid_availability

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -184,6 +184,7 @@ def get_info_for_program(mmtrack):
         "description": mmtrack.program.description,
         "title": mmtrack.program.title,
         "financial_aid_availability": mmtrack.financial_aid_available,
+        "has_exams": mmtrack.has_exams,
         "courses": [],
         "exam_card_status": mmtrack.get_exam_card_status(),
         "grade_average": mmtrack.calculate_final_grade_average(),
@@ -197,6 +198,7 @@ def get_info_for_program(mmtrack):
     }
     if mmtrack.financial_aid_available:
         data["financial_aid_user_info"] = FinancialAidDashboardSerializer.serialize(mmtrack.user, mmtrack.program)
+    if mmtrack.has_exams:
         data["grade_records_url"] = reverse('grade_records', args=[mmtrack.get_program_enrollment().id])
 
     program_letter_url = mmtrack.get_program_letter_url()
@@ -639,7 +641,7 @@ def get_certificate_url(mmtrack, course):
     best_grade = mmtrack.get_best_final_grade_for_course(course)
     if best_grade:
         course_key = best_grade.course_run.edx_course_key
-        if mmtrack.financial_aid_available:
+        if mmtrack.has_exams:
             certificate = mmtrack.get_course_certificate(course)
             if certificate:
                 url = reverse('certificate', args=[certificate.hash])

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1954,8 +1954,6 @@ class InfoProgramTest(MockedESTestCase):
         res = api.get_info_for_program(self.mmtrack)
         for course in self.courses:
             mock_info_course.assert_any_call(course, self.mmtrack)
-        print(res)
-        print("Response")
         expected_data = {
             "id": self.program.pk,
             "description": self.program.description,
@@ -1971,7 +1969,6 @@ class InfoProgramTest(MockedESTestCase):
             "certificate": "",
             "grade_records_url": reverse('grade_records', args=[self.program_enrollment.id]),
         }
-        print(expected_data)
 
         self.assertEqual(res, expected_data)
 

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1826,6 +1826,7 @@ class InfoProgramTest(MockedESTestCase):
         self.mmtrack.configure_mock(**{
             'program': self.program,
             'financial_aid_available': False,
+            'has_exams': False,
             'get_exam_card_status.return_value': ExamProfile.PROFILE_SUCCESS,
             'calculate_final_grade_average.return_value': 91,
             'get_program_certificate_url.return_value': "",
@@ -1842,6 +1843,7 @@ class InfoProgramTest(MockedESTestCase):
             "title": self.program.title,
             "courses": [{'position_in_program': 1}, {'position_in_program': 1}, {'position_in_program': 1}],
             "financial_aid_availability": False,
+            "has_exams": False,
             "exam_card_status": ExamProfile.PROFILE_SUCCESS,
             'number_courses_required': 3,
             'number_courses_passed': 0,
@@ -1857,6 +1859,7 @@ class InfoProgramTest(MockedESTestCase):
         self.mmtrack.configure_mock(**{
             'program': self.program,
             'financial_aid_available': False,
+            'has_exams': False,
             'get_exam_card_status.return_value': ExamProfile.PROFILE_SUCCESS,
             'calculate_final_grade_average.return_value': 91,
             'get_program_certificate_url.return_value': "",
@@ -1884,6 +1887,7 @@ class InfoProgramTest(MockedESTestCase):
             "courses": [{'position_in_program': 1}, {'position_in_program': 1}, {'position_in_program': 1},
                         {'position_in_program': 1}, {'position_in_program': 1}, {'position_in_program': 1}],
             "financial_aid_availability": False,
+            "has_exams": False,
             "exam_card_status": ExamProfile.PROFILE_SUCCESS,
             'number_courses_required': 5,
             'number_courses_passed': 0,
@@ -1898,6 +1902,7 @@ class InfoProgramTest(MockedESTestCase):
         self.mmtrack.configure_mock(**{
             'program': self.program_no_courses,
             'financial_aid_available': False,
+            'has_exams': False,
             'get_exam_card_status.return_value': ExamProfile.PROFILE_INVALID,
             'calculate_final_grade_average.return_value': 91,
             'get_program_certificate_url.return_value': "",
@@ -1912,6 +1917,7 @@ class InfoProgramTest(MockedESTestCase):
             "title": self.program_no_courses.title,
             "courses": [],
             "financial_aid_availability": False,
+            "has_exams": False,
             "exam_card_status": ExamProfile.PROFILE_INVALID,
             "number_courses_required": 0,
             "number_courses_passed": 0,
@@ -1929,6 +1935,7 @@ class InfoProgramTest(MockedESTestCase):
             'get_exam_card_status.return_value': ExamProfile.PROFILE_IN_PROGRESS,
             'calculate_final_grade_average.return_value': 91,
             'financial_aid_available': True,
+            'has_exams': True,
             'get_program_certificate_url.return_value': "",
             'get_program_enrollment.return_value': self.program_enrollment,
             'get_program_letter_url.return_value': "",
@@ -1947,12 +1954,15 @@ class InfoProgramTest(MockedESTestCase):
         res = api.get_info_for_program(self.mmtrack)
         for course in self.courses:
             mock_info_course.assert_any_call(course, self.mmtrack)
+        print(res)
+        print("Response")
         expected_data = {
             "id": self.program.pk,
             "description": self.program.description,
             "title": self.program.title,
             "courses": [{'position_in_program': 1}, {'position_in_program': 1}, {'position_in_program': 1}],
             "financial_aid_availability": True,
+            "has_exams": True,
             "financial_aid_user_info": serialized_fin_aid,
             "exam_card_status": ExamProfile.PROFILE_IN_PROGRESS,
             "number_courses_required": self.program.course_set.count(),
@@ -1961,6 +1971,8 @@ class InfoProgramTest(MockedESTestCase):
             "certificate": "",
             "grade_records_url": reverse('grade_records', args=[self.program_enrollment.id]),
         }
+        print(expected_data)
+
         self.assertEqual(res, expected_data)
 
     @patch('dashboard.api.get_info_for_course', autospec=True)
@@ -1969,6 +1981,7 @@ class InfoProgramTest(MockedESTestCase):
         self.mmtrack.configure_mock(**{
             'program': self.program,
             'financial_aid_available': False,
+            'has_exams': False,
             'get_exam_card_status.return_value': ExamProfile.PROFILE_SUCCESS,
             'calculate_final_grade_average.return_value': 91,
             'get_program_certificate_url.return_value': "",
@@ -1985,6 +1998,7 @@ class InfoProgramTest(MockedESTestCase):
             "title": self.program.title,
             "courses": [{'position_in_program': 1}, {'position_in_program': 1}, {'position_in_program': 1}],
             "financial_aid_availability": False,
+            "has_exams": False,
             "exam_card_status": ExamProfile.PROFILE_SUCCESS,
             "number_courses_required": self.program.course_set.count(),
             "number_courses_passed": 3,
@@ -2355,6 +2369,7 @@ class GetCertificateForCourseTests(CourseTests):
         """Test edx certificate url for non FA courses"""
         self.mmtrack.get_best_final_grade_for_course.return_value = self.final_grade
         self.mmtrack.financial_aid_available = False
+        self.mmtrack.has_exams = False
         self.mmtrack.has_passing_certificate.return_value = (certificate_type == "verified") and is_passing
 
         cert_json = {

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -84,6 +84,8 @@ class MMTrackTest(MockedESTestCase):
 
         # and the program with financial aid
         finaid_course = CourseFactory.create(program=cls.program_financial_aid)
+        cls.finaid_course_2 = CourseFactory.create(program=cls.program_financial_aid)
+        ExamRunFactory.create(course=cls.finaid_course_2)
         cls.now = now_in_utc()
         cls.end_date = cls.now - timedelta(weeks=45)
         cls.crun_fa = CourseRunFactory.create(
@@ -155,7 +157,7 @@ class MMTrackTest(MockedESTestCase):
         assert mmtrack.certificates == self.cached_edx_user_data.certificates
         assert mmtrack.financial_aid_available == self.program_financial_aid.financial_aid_availability
         assert mmtrack.edx_course_keys == {self.crun_fa.edx_course_key, self.crun_fa2.edx_course_key}
-        assert mmtrack.paid_course_fa == {self.crun_fa.course.id: False}
+        assert mmtrack.paid_course_fa == {self.crun_fa.course.id: False, self.finaid_course_2.id: False}
 
     @ddt.data(Order.FULFILLED, Order.PARTIALLY_REFUNDED)
     def test_fa_paid(self, order_status):
@@ -170,14 +172,14 @@ class MMTrackTest(MockedESTestCase):
             program=self.program_financial_aid,
             edx_user_data=self.cached_edx_user_data
         )
-        assert mmtrack_paid.paid_course_fa == {self.crun_fa.course.id: True}
+        assert mmtrack_paid.paid_course_fa == {self.crun_fa.course.id: True, self.finaid_course_2.id: False}
 
         mmtrack = MMTrack(
             user=UserFactory.create(),
             program=self.program_financial_aid,
             edx_user_data=self.cached_edx_user_data
         )
-        assert mmtrack.paid_course_fa == {self.crun_fa.course.id: False}
+        assert mmtrack.paid_course_fa == {self.crun_fa.course.id: False, self.finaid_course_2.id: False}
 
     def test_is_course_in_program(self):
         """

--- a/grades/api_test.py
+++ b/grades/api_test.py
@@ -511,6 +511,7 @@ class GenerateCertificatesAPITests(MockedESTestCase):
             status='complete',
             grade=0.8
         )
+        ExamRunFactory.create(course=self.run_1.course)
         CourseRunGradingStatus.objects.create(course_run=self.run_1, status='complete')
         cert_qset = MicromastersProgramCertificate.objects.filter(user=self.user, program=self.program)
         assert cert_qset.exists() is False

--- a/selenium_tests/conftest.py
+++ b/selenium_tests/conftest.py
@@ -14,6 +14,7 @@ from selenium.webdriver import (
     Remote,
 )
 
+from exams.factories import ExamRunFactory
 from selenium_tests.util import (
     Browser,
     DEFAULT_PASSWORD,
@@ -181,7 +182,8 @@ def base_test_data():
         financial_aid_availability=True,
         price=1000,
     )
-    CourseRunFactory.create(course__program=program)
+    course_run = CourseRunFactory.create(course__program=program)
+    ExamRunFactory.create(course=course_run.course)
     TierProgramFactory.create_properly_configured_batch(2, program=program)
     # Create users
     staff_user, student_user = (create_user_for_login(is_staff=True), create_user_for_login(is_staff=False))

--- a/static/js/components/ProgressWidget.js
+++ b/static/js/components/ProgressWidget.js
@@ -122,7 +122,7 @@ export default class ProgressWidget extends React.Component {
             View Certificate
           </button>
           {SETTINGS.FEATURES.PROGRAM_RECORD_LINK &&
-            program.financial_aid_availability &&
+            program.has_exams &&
             gradeRecordsLink(program.grade_records_url)}
 
           {SETTINGS.FEATURES.ENABLE_PROGRAM_LETTER &&

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -141,6 +141,7 @@ export const makeProgram = (): Program => {
     courses:                    courses,
     id:                         programId,
     financial_aid_availability: true,
+    has_exams:                  true,
     financial_aid_user_info:    {
       application_status:  FA_STATUS_APPROVED,
       date_documents_sent: "2016-01-01",

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -33,6 +33,7 @@ export type Program = {
   id:                         number,
   title:                      string,
   financial_aid_availability: boolean,
+  has_exams:                  boolean,
   financial_aid_user_info:    FinancialAidUserInfo,
   exam_card_status:        string,
   grade_average:              ?number,


### PR DESCRIPTION

 
#### What are the relevant tickets?
Fix https://github.com/mitodl/micromasters/issues/5227

#### What's this PR do?
Updated all usages of the program field `financial_aid_availability`, that are not related to financial aid so much as much as to the existence of exams, combined final grades, and payments on our MM portal for courses.
In the past all of these were attributes of only one program: DEDP. But now that we are switching the payment system off, and financial aid is no longer available.

#### How should this be manually tested?
Run the app, nothing should break. Go the the dashboard make sure everything works. 
You need to create some exam runs for any courses in your program. 
The "Digital Learning" program by default has 'financial_aid_availability' turned on.

```
from courses.models import *
from exams.factories import *
course = Course.objects.filter(title='Digital Learning 100').first()
exam_run = ExamRunFactory.create(course=course, authorized=True, scheduling_past=False, scheduling_future=False)
```

