### PR TITLE
fix: A course is not paid for if edx_course_key is None

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -219,6 +219,11 @@ class MMTrack:
         Returns:
             bool: whether the user is paid
         """
+        # edx_course_key for a course run can either be unique or None.
+        # If edx course keys lookup is none we should have no payment against it
+        if edx_course_key is None:
+            return False
+
         # financial aid programs need to have a paid entry for the course
         if self.has_exams:
             # get the course associated with the course key


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
#5237 

#### What's this PR do?
- Adds an additional check on None edx_course_key lookup for has_paid(). We generally have only two possible options for the edx_course_key, (unique or None). So when an `edx_course_key` lookup is `None` it can find multiple courses but for a edx_course_key that is None, we should ideally have no payment for it.

#### How should this be manually tested?
- Enroll in a Program
- Have multiple course runs with `edx_course_key` set to `None` for any course in the program
- Load the dashboard (you should not see any errors and dashboard should load fine)


