### PR TITLE
fix a typo in the program page sidebar

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -100,7 +100,7 @@
         {% if page.semester_dates.exists %}
         <div class="info-box">
           <h3 class="title">
-            Future Courses Dates
+            Future Course Dates
           </h3>
           {% for semester_date in  page.semester_dates.all %}
             <div class="semester-date">


### PR DESCRIPTION
"Future Course Dates " not "Future Courses Dates"

#### What are the relevant tickets?

no ticket

#### What's this PR do?

Fixes a typo on, for example, https://micromasters.mit.edu/scm/

<img width="388" alt="image" src="https://user-images.githubusercontent.com/430126/198899110-63fb37bf-442b-43e4-beb7-40522c74c842.png">

#### How should this be manually tested?

Take a look at a program page

