### PR TITLE
Peg python-tests ubuntu version to 20.04 (matching heroku stack)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push]
 jobs:
   python-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       # Label used to access the service container


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #5259 

#### What's this PR do?
Changes ubuntu version used for CI testing from "latest" (now 22.x) to 20.04 

#### How should this be manually tested?
CI tests should pass here