### PR TITLE
fix: enhance the program letter generation for active status

### DIFF
--- a/grades/api.py
+++ b/grades/api.py
@@ -283,19 +283,20 @@ def generate_program_letter(user, program):
         log.info('User [%s] already has a letter for program [%s]', user, program)
         return
 
-    if (program.financial_aid_availability and
-            MicromastersProgramCertificate.objects.filter(user=user, program=program).exists()):
-        MicromastersProgramCommendation.objects.update_or_create(user=user, program=program,
-                                                                 defaults={"is_active": True})
-        return
-    if completed_program(user, program):
-        MicromastersProgramCommendation.objects.update_or_create(user=user, program=program,
-                                                                 defaults={"is_active": True})
+    created = None
+    if (program.financial_aid_availability and MicromastersProgramCertificate.objects.filter(user=user,
+                                                                                             program=program).exists()):
+        _, created = MicromastersProgramCommendation.objects.update_or_create(user=user, program=program,
+                                                                              defaults={"is_active": True})
+
+    elif completed_program(user, program):
+        _, created = MicromastersProgramCommendation.objects.update_or_create(user=user, program=program,
+                                                                              defaults={"is_active": True})
+
+    if created is not None:
         log.info(
-            'Created MM program letter for [%s] in program [%s]',
-            user.username,
-            program.title
-        )
+            f"{'Created' if created else 'Activated'} MM program letter for {user.username} in program {program.title}")
+
 
 
 def update_or_create_combined_final_grade(user, course):

--- a/grades/api.py
+++ b/grades/api.py
@@ -295,8 +295,11 @@ def generate_program_letter(user, program):
 
     if created is not None:
         log.info(
-            f"{'Created' if created else 'Activated'} MM program letter for {user.username} in program {program.title}")
-
+            '[%s] MM program letter for [%s] in program [%s]',
+            'Created' if created else 'Activated',
+            user.username,
+            program.title
+        )
 
 
 def update_or_create_combined_final_grade(user, course):

--- a/grades/api.py
+++ b/grades/api.py
@@ -272,8 +272,11 @@ def completed_program(user, program):
 
 def generate_program_letter(user, program):
     """
-    Create a program letter if the user has a MM course certificate
-    for each course in the program and program is non-fa.
+    Create a program letter based on:
+
+    1. If the program is Financial Assistance based and the user has a certificate for that program.
+    2. If a program is not Financial Assistance based and the user has completed the program e.g. The user has
+       an MM course certificate (Completed course) for required courses in the program.
 
     Args:
         user (User): a Django user.

--- a/grades/api.py
+++ b/grades/api.py
@@ -279,16 +279,18 @@ def generate_program_letter(user, program):
         user (User): a Django user.
         program (programs.models.Program): program where the user is enrolled.
     """
-    if MicromastersProgramCommendation.objects.filter(user=user, program=program).exists():
+    if MicromastersProgramCommendation.objects.filter(user=user, program=program, is_active=True).exists():
         log.info('User [%s] already has a letter for program [%s]', user, program)
         return
 
     if (program.financial_aid_availability and
             MicromastersProgramCertificate.objects.filter(user=user, program=program).exists()):
-        MicromastersProgramCommendation.objects.create(user=user, program=program)
+        MicromastersProgramCommendation.objects.update_or_create(user=user, program=program,
+                                                                 defaults={"is_active": True})
         return
     if completed_program(user, program):
-        MicromastersProgramCommendation.objects.create(user=user, program=program)
+        MicromastersProgramCommendation.objects.update_or_create(user=user, program=program,
+                                                                 defaults={"is_active": True})
         log.info(
             'Created MM program letter for [%s] in program [%s]',
             user.username,

--- a/grades/api_test.py
+++ b/grades/api_test.py
@@ -584,7 +584,7 @@ class GenerateProgramLetterApiTests(MockedESTestCase):
             CourseRunGradingStatus.objects.create(course_run=run_elective, status='complete')
             ElectiveCourse.objects.create(course=run_elective.course, electives_set=electives_set)
 
-        letter_qset = MicromastersProgramCommendation.objects.filter(user=self.user, program=self.program)
+        letter_qset = MicromastersProgramCommendation.objects.filter(user=self.user, program=self.program, is_active=True)
         assert letter_qset.exists() is False
         api.generate_program_letter(self.user, self.program)
         assert letter_qset.exists() is False
@@ -596,6 +596,12 @@ class GenerateProgramLetterApiTests(MockedESTestCase):
                 status='complete',
                 grade=0.8
             )
+        api.generate_program_letter(self.user, self.program)
+        assert letter_qset.exists() is True
+
+        # Test that the inactive letters get activated
+        letter_qset.update(is_active=False)
+        assert letter_qset.exists() is False
         api.generate_program_letter(self.user, self.program)
         assert letter_qset.exists() is True
 
@@ -611,10 +617,16 @@ class GenerateProgramLetterApiTests(MockedESTestCase):
                 program=self.program
             )
 
-        cert_qset = MicromastersProgramCommendation.objects.filter(user=self.user, program=self.program)
-        assert cert_qset.exists() is False
+        letter_qset = MicromastersProgramCommendation.objects.filter(user=self.user, program=self.program, is_active=True)
+        assert letter_qset.exists() is False
         api.generate_program_letter(self.user, self.program)
-        assert cert_qset.exists() is True
+        assert letter_qset.exists() is True
+
+        # Test that the inactive letters get activated
+        letter_qset.update(is_active=False)
+        assert letter_qset.exists() is False
+        api.generate_program_letter(self.user, self.program)
+        assert letter_qset.exists() is True
 
     def test_already_has_program_letter(self):
         """

--- a/grades/models.py
+++ b/grades/models.py
@@ -207,11 +207,7 @@ class MicromastersProgramCommendation(TimestampedModel):
         unique_together = ('user', 'program')
 
     def __str__(self):
-        return 'Program letter for user={user}, program={program}, uuid="{uuid}"'.format(
-            user=self.user,
-            program=self.program,
-            uuid=self.uuid,
-        )
+        return f"Program letter for user={self.user}, program={self.program}, uuid={self.uuid}, is_active={self.is_active}"
 
 
 class CourseRunGradingStatus(TimestampedModel):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#5257 

#### What's this PR do?
- Enhances the logic to generate letters and also activate existing ones

#### How should this be manually tested?
There are a couple of test cases for this:

1. Create an inactive program letter for a **fa** program, Now let's complete the program by passing all the grades and make sure a certificate object is created, also make sure that this existing letter has been activated.
2. Create an inactive Program letter for a **non fa** program, Now let's add final grades for the user and complete the program for the user. The program letter should be activated.
3. Now perform the above two steps without an existing letter, in this case instead of activating, a new letter should be created
4. This is the sum of all above, the logged information should be matched. e.g. the log message should be clear about when a letter is created and when it's activated.
5. Optionally, make sure that the active letter can be seen and in the active letter shows 404 to the user. (There is no specific change in its logic but just a smoke test on this would be good)

#### Where should the reviewer start?
Create program letter

#### Any background context you want to provide?
This is kind of a second part of https://github.com/mitodl/micromasters/pull/5253
