### PR TITLE
Have uniform date styling on Program page.

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -104,7 +104,7 @@
           </h3>
           {% for semester_date in  page.semester_dates.all %}
             <div class="semester-date">
-              {{ semester_date.semester_name }}: starts {{ semester_date.start_date }}
+              {{ semester_date.semester_name }}: starts {{ semester_date.start_date|date:'M d, Y' }}
             </div>
           {% endfor %}
         </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested


#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/5254

#### What's this PR do?
Makes sure that all the dates on the program pages are formatted the same way (DD-MMM-YYYY).

#### How should this be manually tested?
1. Have your micromasters up and running with a staff user that you can login with.
2. Seed your database or create courses, course runs (that start in the future), and a program which references your created courses.  It would be best to pick different months for the start dates of each course run.
3. Access CMS (http://mm.odl.local:8079/) and add a child page (Program page) to the main page.
4. Set the program field to the program you created in step 2.
5. Add two or more program courses that you created in step 2.
6. Create a couple future semesters with a random title and a date set in the future.
7. Publish the program page.
8. Within CMS, click the "View Live" button on the program page you published in step 7.
9. Verify that all of the dates shown in the "Courses" and "Future Courses" list sections only show 3 letters for the month.

#### Any background context you want to provide?
Helpful resources:
- https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date.  This resource explains the different characters you can define in your date format specification and what they do.
- https://stackoverflow.com/questions/15378537/django-python-showing-months-in-words-instead-of-numbers.  The answer to this question showed me that I could just add styling to the template and at the specific field I wanted to using `|date`

#### Screenshots (if appropriate)
![Screen Shot 2022-12-06 at 11 46 14](https://user-images.githubusercontent.com/8311573/205971944-4b0a5c23-4de7-4502-902a-ddcb8bc9a25d.png)
