### PR TITLE
Update has_paid to use edx data

### DIFF
--- a/dashboard/fixtures/user_enrollments.json
+++ b/dashboard/fixtures/user_enrollments.json
@@ -62,9 +62,9 @@
                     "description": null,
                     "expiration_datetime": null,
                     "min_price": 0,
-                    "name": "Audit",
+                    "name": "Verified",
                     "sku": null,
-                    "slug": "audit",
+                    "slug": "Verified",
                     "suggested_prices": ""
                 }
             ],
@@ -75,7 +75,7 @@
         },
         "created": "2016-01-27T18:10:35Z",
         "is_active": true,
-        "mode": "audit",
+        "mode": "Verified",
         "user": "staff"
     }
 ]

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -223,13 +223,15 @@ class MMTrack:
         # If edx course keys lookup is none we should have no payment against it
         if edx_course_key is None:
             return False
-
-        # financial aid programs need to have a paid entry for the course
+        has_paid = False
+        # financial aid programs might have a paid entry for the course
         if self.has_exams:
             # get the course associated with the course key
             course = Course.objects.get(courserun__edx_course_key=edx_course_key)
-            return self.paid_course_fa.get(course.id, False)
+            has_paid = self.paid_course_fa.get(course.id, False)
 
+        if has_paid:
+            return True
         # normal programs need to have paid_on_edx in the final grades or a verified enrollment
         if self.has_final_grade(edx_course_key):
             return self.has_final_grade_paid_on_edx(edx_course_key)


### PR DESCRIPTION
#### Pre-Flight checklist


- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
#### What are the relevant tickets?
Fix https://github.com/mitodl/micromasters/issues/5271


#### What's this PR do?
Since the payments have moved to MITxOnline, we have to switch to rely on edx enrollment data for enrollment status of the course.
`has_paid` is now checking for verified status of the enrollment to mean the user paid.

#### How should this be manually tested?
(Required)

make sure the course you are testing with has exams
`exam_run = ExamRunFactory.create(course=course, authorized=True, scheduling_past=False, scheduling_future=False)`
enroll your user in a course in 'audit' mode:
`./manage.py alter_data set_to_enrolled --username staff --course-title 'Analog Learning 100' --audit`

Then manually upgrade their cached enrollment to verified.
