### PR TITLE
Dashboard API: Show any certificate for course

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -645,8 +645,8 @@ def get_certificate_url(mmtrack, course):
         if mmtrack.has_exams:
             certificate = mmtrack.get_course_certificate(course)
             if certificate:
-                url = reverse('certificate', args=[certificate.hash])
-        elif mmtrack.has_passing_certificate(course_key):
+                return reverse('certificate', args=[certificate.hash])
+        if mmtrack.has_passing_certificate(course_key):
             download_url = mmtrack.certificates.get_verified_cert(course_key).download_url
             if download_url:
                 url = urljoin(settings.EDXORG_CALLBACK_URL, download_url)

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -2363,16 +2363,19 @@ class GetCertificateForCourseTests(CourseTests):
         assert api.get_certificate_url(self.mmtrack, self.course) == ''
 
     @ddt.data(
-        ("verified", True, True),
-        ("audit", False, False),
-        ("verified", False, False),
-        ("audit", True, False),
+        ("verified", True, False, True),
+        ("audit", False, False, False),
+        ("verified", False, False, False),
+        ("audit", True, False, False),
+        ("verified", True, True, True),
     )
     @ddt.unpack
-    def test_edx_course_certificate(self, certificate_type, is_passing, has_url):
+    def test_edx_course_certificate(self, certificate_type, is_passing, has_exams, has_url):
         """Test edx certificate url for non FA courses"""
         self.mmtrack.get_best_final_grade_for_course.return_value = self.final_grade
+        self.mmtrack.has_exams = has_exams
         self.mmtrack.has_passing_certificate.return_value = (certificate_type == "verified") and is_passing
+        self.mmtrack.get_course_certificate.return_value = None
 
         cert_json = {
             "username": "staff",

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -2346,6 +2346,7 @@ class GetCertificateForCourseTests(CourseTests):
         self.mmtrack.get_best_final_grade_for_course.return_value = self.final_grade
         MicromastersCourseCertificateFactory.create(course=self.course, user=self.user)
         self.mmtrack.get_course_certificate.return_value = None
+        self.mmtrack.has_passing_certificate.return_value = False
 
         assert api.get_certificate_url(self.mmtrack, self.course) == ''
 
@@ -2358,6 +2359,7 @@ class GetCertificateForCourseTests(CourseTests):
         """Test has passing grade but no certificate"""
         self.mmtrack.get_best_final_grade_for_course.return_value = self.final_grade
         self.mmtrack.get_course_certificate.return_value = None
+        self.mmtrack.has_passing_certificate.return_value = False
         assert api.get_certificate_url(self.mmtrack, self.course) == ''
 
     @ddt.data(
@@ -2370,8 +2372,6 @@ class GetCertificateForCourseTests(CourseTests):
     def test_edx_course_certificate(self, certificate_type, is_passing, has_url):
         """Test edx certificate url for non FA courses"""
         self.mmtrack.get_best_final_grade_for_course.return_value = self.final_grade
-        self.mmtrack.financial_aid_available = False
-        self.mmtrack.has_exams = False
         self.mmtrack.has_passing_certificate.return_value = (certificate_type == "verified") and is_passing
 
         cert_json = {


### PR DESCRIPTION


#### What are the relevant tickets?
Related to https://github.com/mitodl/micromasters/issues/5275

#### What's this PR do?
In the dashboard api, look for a MM course certificate, if not found look for a certificate on edx. Removing the dependence on existence of exams.

#### How should this be manually tested?
Nothing should break