### PR TITLE
Remove message about coupon pricing from dashboard

### DIFF
--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -10,13 +10,7 @@ import CourseRow from "./CourseRow"
 import FinancialAidCalculator from "../../containers/FinancialAidCalculator"
 import type { CourseRun } from "../../flow/programTypes"
 import type { UIState } from "../../reducers/ui"
-import {
-  FA_TERMINAL_STATUSES,
-  FA_PENDING_STATUSES,
-  COUPON_CONTENT_TYPE_PROGRAM
-} from "../../constants"
-import { isFreeCoupon } from "../../lib/coupon"
-import { formatPrice, programBackendName } from "../../util/util"
+import { programBackendName } from "../../util/util"
 import type { GradeType } from "../../containers/DashboardPage"
 import CardContent from "@material-ui/core/CardContent"
 
@@ -45,42 +39,10 @@ export default class CourseListCard extends React.Component {
     showStaffView: boolean
   }
 
-  getProgramCouponPrice = (): CouponPrice => {
-    const { couponPrices, program } = this.props
-    if (!couponPrices) {
-      // shouldn't happen, we should not be here unless we already checked this
-      throw new Error("No coupon prices available")
-    }
-    const couponPrice = couponPrices.pricesInclCouponByProgram.get(program.id)
-    if (!couponPrice) {
-      // This shouldn't happen since we should have waited for the API requests to finish before getting here
-      throw new Error(`Unable to find program ${program.id} in list of prices`)
-    }
-    return couponPrice
-  }
-
   handleCalculatePriceClick = (e: Event) => {
     const { openFinancialAidCalculator } = this.props
     if (openFinancialAidCalculator) openFinancialAidCalculator()
     e.preventDefault()
-  }
-
-  renderCalculatePriceLink(): ?React$Element<*> {
-    const calculateLink = (
-      <a
-        href="#"
-        className="calculate-link"
-        onClick={this.handleCalculatePriceClick}
-      >
-        calculate your course price
-      </a>
-    )
-    return (
-      <p className={priceMessageClassName}>
-        *You need to {calculateLink} before you can pay for courses. Or you can
-        audit courses for free by clicking Enroll.
-      </p>
-    )
   }
 
   renderPriceMessage(): ?React$Element<*> {

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -83,66 +83,8 @@ export default class CourseListCard extends React.Component {
     )
   }
 
-  renderFinancialAidPriceMessage(): ?React$Element<*> {
-    const { program } = this.props
-    const finAidStatus = program.financial_aid_user_info.application_status
-
-    if (FA_TERMINAL_STATUSES.includes(finAidStatus)) {
-      const { coupon, price } = this.getProgramCouponPrice()
-
-      if (coupon) {
-        // financial aid + coupon
-        return (
-          <p className={priceMessageClassName}>
-            Your price is <strong>{formatPrice(price)} USD per course,</strong>{" "}
-            including both financial aid and your coupon. If you want to audit
-            courses for FREE and upgrade later, click Enroll then choose the
-            audit option.
-          </p>
-        )
-      } else {
-        return (
-          <p className={priceMessageClassName}>
-            Your Personal Course Price is{" "}
-            <strong>{formatPrice(price)} USD per course.</strong> If you want to
-            audit courses for FREE and upgrade later, click Enroll then choose
-            the audit option.
-          </p>
-        )
-      }
-    } else if (FA_PENDING_STATUSES.includes(finAidStatus)) {
-      return (
-        <p className={priceMessageClassName}>
-          *Your personal course price is pending, and needs to be approved
-          before you can pay for courses. Or you can audit courses for free by
-          clicking Enroll.
-        </p>
-      )
-    } else {
-      return this.renderCalculatePriceLink()
-    }
-  }
-
   renderPriceMessage(): ?React$Element<*> {
     const { program } = this.props
-    const { coupon } = this.getProgramCouponPrice()
-
-    // Special case: 100% off coupon
-    if (
-      coupon &&
-      isFreeCoupon(coupon) &&
-      coupon.content_type === COUPON_CONTENT_TYPE_PROGRAM
-    ) {
-      return (
-        <p className={priceMessageClassName}>
-          Courses in this program are free, because of your coupon.
-        </p>
-      )
-    }
-
-    if (program.financial_aid_availability) {
-      return this.renderFinancialAidPriceMessage()
-    }
 
     return (
       <p className={priceMessageClassName}>

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -5,7 +5,7 @@ import R from "ramda"
 import Card from "@material-ui/core/Card"
 
 import type { Program, Course } from "../../flow/programTypes"
-import type { CouponPrice, CouponPrices } from "../../flow/couponTypes"
+import type { CouponPrices } from "../../flow/couponTypes"
 import CourseRow from "./CourseRow"
 import FinancialAidCalculator from "../../containers/FinancialAidCalculator"
 import type { CourseRun } from "../../flow/programTypes"

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -121,139 +121,22 @@ describe("CourseListCard", () => {
   }
 
   describe("pricing message", () => {
-    it("is displayed", () => {
-      const wrapper = renderCourseListCard()
-      const messageEl = wrapper.find(".price-message")
-      assert.lengthOf(messageEl, 1)
-      assert.include(
-        messageEl.text(),
-        `you must pay for a verified certificate from ${programBackendName(
-          program
-        )}.`
-      )
-    })
 
     describe("with financial aid", () => {
-      it("requires applying for financial aid", () => {
+      it(" does not require applying for financial aid", () => {
         changeToFinancialAid(FA_STATUS_CREATED, false)
         const wrapper = renderCourseListCard()
         const messageEl = wrapper.find(".price-message")
-        assert.lengthOf(messageEl, 1)
-        assert.include(
-          messageEl.text(),
-          "You need to calculate your course price before you can pay for courses."
-        )
-
-        const linkEl = messageEl.find("a.calculate-link")
-        assert.include(linkEl.text(), "calculate your course price")
-        linkEl.simulate("click")
-        sinon.assert.calledOnce(openFinancialAidCalculatorStub)
+        assert.lengthOf(messageEl, 0)
       })
 
-      it("notifies about pending financial aid", () => {
-        changeToFinancialAid(FA_STATUS_PENDING_DOCS, true)
-        const wrapper = renderCourseListCard()
-        const messageEl = wrapper.find(".price-message")
-        assert.lengthOf(messageEl, 1)
-        assert.include(
-          messageEl.text(),
-          "Your personal course price is pending, and needs to be approved before you can " +
-            "pay for courses. Or you can audit courses for free by clicking Enroll."
-        )
-      })
-
-      it("displays price after financial aid", () => {
-        changeToFinancialAid(FA_STATUS_APPROVED, true)
-        const wrapper = renderCourseListCard()
-        const messageEl = wrapper.find(".price-message")
-        assert.lengthOf(messageEl, 1)
-        assert.include(
-          messageEl.text(),
-          "Your Personal Course Price is $4000 USD per course."
-        )
-      })
-
-      it("displays price with fixed discount coupon", () => {
+      it("does not display price with both coupon and financial aid", () => {
         changeToFinancialAid(FA_STATUS_APPROVED, true)
         const coupon = makeCoupon(program)
         const couponPrices = calculatePrices([program], [coursePrice], [coupon])
         const wrapper = renderCourseListCard({ couponPrices })
         const messageEl = wrapper.find(".price-message")
-        assert.lengthOf(messageEl, 1)
-        assert.include(
-          messageEl.text(),
-          "Your price is $3950 USD per course, including both financial aid and your coupon."
-        )
-      })
-
-      it("should show regular course price on coupon message", () => {
-        changeToFinancialAid(FA_STATUS_APPROVED, true)
-        const coupon = makeCourseCoupon(program.courses[0], program)
-        const couponPrices = calculatePrices([program], [coursePrice], [coupon])
-        const wrapper = renderCourseListCard({ couponPrices })
-        const messageEl = wrapper.find(".price-message")
-        assert.lengthOf(messageEl, 1)
-        assert.include(
-          messageEl.text(),
-          "Your Personal Course Price is $4000 USD per course."
-        )
-      })
-
-      it("displays regular price on course coupon message for financial aid program", () => {
-        changeToFinancialAid(FA_STATUS_APPROVED, true)
-        const coupon = makeCourseCoupon(program.courses[0], program)
-        const couponPrices = calculatePrices([program], [coursePrice], [coupon])
-        const wrapper = renderCourseListCard({ couponPrices })
-        const messageEl = wrapper.find(".price-message")
-        assert.lengthOf(messageEl, 1)
-        assert.include(
-          messageEl.text(),
-          "Your Personal Course Price is $4000 USD per course."
-        )
-      })
-
-      it("displays price with percentage discount coupon", () => {
-        changeToFinancialAid(FA_STATUS_APPROVED, true)
-        const coupon = makeCoupon(program)
-        coupon.amount_type = COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT
-        coupon.amount = new Decimal("0.30")
-        const couponPrices = calculatePrices([program], [coursePrice], [coupon])
-        const wrapper = renderCourseListCard({ couponPrices })
-        const messageEl = wrapper.find(".price-message")
-        assert.lengthOf(messageEl, 1)
-        assert.include(
-          messageEl.text(),
-          "Your price is $2800 USD per course, including both financial aid and your coupon."
-        )
-      })
-
-      it("displays price with both coupon and financial aid", () => {
-        changeToFinancialAid(FA_STATUS_APPROVED, true)
-        const coupon = makeCoupon(program)
-        const couponPrices = calculatePrices([program], [coursePrice], [coupon])
-        const wrapper = renderCourseListCard({ couponPrices })
-        const messageEl = wrapper.find(".price-message")
-        assert.lengthOf(messageEl, 1)
-        // This is $4000 - a $50 discount from the coupon
-        assert.include(
-          messageEl.text(),
-          "Your price is $3950 USD per course, including both financial aid and your coupon."
-        )
-      })
-
-      it("handles 100% coupon (special case)", () => {
-        changeToFinancialAid(FA_STATUS_APPROVED, true)
-        const coupon = makeCoupon(program)
-        coupon.amount_type = COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT
-        coupon.amount = new Decimal("1")
-        const couponPrices = calculatePrices([program], [coursePrice], [coupon])
-        const wrapper = renderCourseListCard({ couponPrices })
-        const messageEl = wrapper.find(".price-message")
-        assert.lengthOf(messageEl, 1)
-        assert.include(
-          messageEl.text(),
-          "Courses in this program are free, because of your coupon."
-        )
+        assert.lengthOf(messageEl, 0)
       })
     })
   })

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -129,7 +129,7 @@ describe("CourseListCard", () => {
         assert.lengthOf(messageEl, 1)
         assert.include(
           messageEl.text(),
-          "You need to calculate your course price before you can pay for courses."
+          "To get credit for the courses in this program, you must pay for a verified certificate from"
         )
       })
 
@@ -144,7 +144,7 @@ describe("CourseListCard", () => {
         assert.lengthOf(messageEl, 1)
         assert.include(
           messageEl.text(),
-          "Courses in this program are free, because of your coupon."
+          "To get credit for the courses in this program, you must pay for a verified certificate from"
         )
       })
     })

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -121,7 +121,6 @@ describe("CourseListCard", () => {
   }
 
   describe("pricing message", () => {
-
     describe("with financial aid", () => {
       it(" does not require applying for financial aid", () => {
         changeToFinancialAid(FA_STATUS_CREATED, false)

--- a/static/js/components/dashboard/CourseListCard_test.js
+++ b/static/js/components/dashboard/CourseListCard_test.js
@@ -126,16 +126,26 @@ describe("CourseListCard", () => {
         changeToFinancialAid(FA_STATUS_CREATED, false)
         const wrapper = renderCourseListCard()
         const messageEl = wrapper.find(".price-message")
-        assert.lengthOf(messageEl, 0)
+        assert.lengthOf(messageEl, 1)
+        assert.include(
+          messageEl.text(),
+          "You need to calculate your course price before you can pay for courses."
+        )
       })
 
       it("does not display price with both coupon and financial aid", () => {
         changeToFinancialAid(FA_STATUS_APPROVED, true)
         const coupon = makeCoupon(program)
+        coupon.amount_type = COUPON_AMOUNT_TYPE_PERCENT_DISCOUNT
+        coupon.amount = new Decimal("1")
         const couponPrices = calculatePrices([program], [coursePrice], [coupon])
         const wrapper = renderCourseListCard({ couponPrices })
         const messageEl = wrapper.find(".price-message")
-        assert.lengthOf(messageEl, 0)
+        assert.lengthOf(messageEl, 1)
+        assert.include(
+          messageEl.text(),
+          "Courses in this program are free, because of your coupon."
+        )
       })
     })
   })


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #5293
#### What's this PR do?
Removes pricing messages from course list card
Removes financial aid messages from course list card.

#### How should this be manually tested?
Create coupons for course, and go to the dashboard, there should be not messages about coupons.
You would need to create a Coupon and UserCoupon.

Before:
<img width="836" alt="Screen Shot 2023-01-31 at 4 00 27 PM" src="https://user-images.githubusercontent.com/7574259/215888434-67e1422a-a0c5-439d-8c29-f950abc7b9cd.png">


After:
<img width="811" alt="Screen Shot 2023-01-31 at 3 56 17 PM" src="https://user-images.githubusercontent.com/7574259/215888674-c5367cb0-da26-4446-b387-284ea45ff48b.png">

