### PR TITLE
Update computation of final grades for courses with exams

### DIFF
--- a/grades/api.py
+++ b/grades/api.py
@@ -39,14 +39,8 @@ def _compute_grade_for_fa(user_edx_run_data):
         UserFinalGrade: a namedtuple of (float, bool,) representing the final grade
             of the user in the course run and whether she passed it
     """
-    if user_edx_run_data.certificate is not None:
-        run_passed = user_edx_run_data.certificate.status == 'downloadable'
-        # the following line should be updated when
-        # we add support for honor enrollments and certificates in the edx-api-client
-        payed_on_edx = user_edx_run_data.certificate.certificate_type in ['honor', 'verified']
-    else:
-        run_passed = user_edx_run_data.current_grade.passed
-        payed_on_edx = False
+    run_passed = user_edx_run_data.current_grade.passed
+    payed_on_edx = user_edx_run_data.enrollment.mode in ['verified', 'honor']
     # making sure the grade is a float
     try:
         grade = float(user_edx_run_data.current_grade.percent)
@@ -96,7 +90,7 @@ def _get_compute_func(course_run):
     Returns:
         function: a function to be called to compute the final grade
     """
-    return _compute_grade_for_fa if course_run.course.program.financial_aid_availability else _compute_grade_for_non_fa
+    return _compute_grade_for_fa if course_run.course.has_exam else _compute_grade_for_non_fa
 
 
 def get_final_grade(user, course_run):


### PR DESCRIPTION


#### What are the relevant tickets?
Fix https://github.com/mitodl/micromasters/issues/5301

#### What's this PR do?
Update the computation of the final grade for courses that have exams during the freeze process of final grades.

#### How should this be manually tested?
Take a look at the code and the tests, that they make sense.

The main change is that we don't want to rely on certificate data when we are freezing grades for MITxonline courses.
Few assumptions made:

- [ ] If the enrollment status is ['verified', 'honor'], then paid_on_edx is true 
- [ ] If the current grade passed=True then we the learner has a passing final grade, and also have passed the course.

#### Where should the reviewer start?
nothing should brake.


