### PR TITLE
Count passing final grades since Fall 22

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 from math import floor
 
 import datetime
+
+import pytz
 from django.db import transaction
 from django.db.models import Q, Count
 from django.urls import reverse
@@ -541,7 +543,7 @@ class MMTrack:
             course_ids_passing_grade = FinalGrade.objects.filter(
                 user=self.user,
                 course_run__course_id__in=course_ids,
-                course_run__start_date__gt=datetime.datetime(2022, 9, 1, 18, 00),
+                course_run__start_date__gt=datetime.datetime(2022, 9, 1, tzinfo=pytz.UTC),
             ).passed().values_list('course__id', flat=True).distinct()
             num_certs = MicromastersCourseCertificate.objects.filter(
                 user=self.user,

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -544,7 +544,7 @@ class MMTrack:
                 user=self.user,
                 course_run__course_id__in=course_ids,
                 course_run__start_date__gt=datetime.datetime(2022, 9, 1, tzinfo=pytz.UTC),
-            ).passed().values_list('course__id', flat=True).distinct()
+            ).passed().values_list('course_run__course__id', flat=True).distinct()
             num_certs = MicromastersCourseCertificate.objects.filter(
                 user=self.user,
                 course_id__in=list(set(course_ids) - set(course_ids_passing_grade))

--- a/grades/api_test.py
+++ b/grades/api_test.py
@@ -418,6 +418,7 @@ class GradeAPITests(MockedESTestCase):
         assert fg_qset.count() == 1
 
 
+@ddt.ddt
 class GenerateCertificatesAPITests(MockedESTestCase):
     """
     Tests for final grades api

--- a/grades/api_test.py
+++ b/grades/api_test.py
@@ -1,10 +1,12 @@
 """
 Tests for grades API
 """
+import datetime
 from datetime import timedelta
 from unittest.mock import patch, MagicMock
 
 import ddt
+import pytz
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.signals import post_save
 from django_redis import get_redis_connection
@@ -488,10 +490,17 @@ class GenerateCertificatesAPITests(MockedESTestCase):
         api.generate_program_certificate(self.user, self.program)
         assert cert_qset.exists() is False
 
-    def test_final_grade_with_no_certificate(self):
+    @ddt.data(
+        (2021, False),
+        (2022, True),
+    )
+    @ddt.unpack
+    def test_final_grade_with_no_certificate(self, year, cert_generated):
         """
-        Test has a final grade but no certificate
+        Test has a final grade but no certificate, before and after Sept 1st, 22
         """
+        self.run_1.start_date = datetime.datetime(year, 10, 1, tzinfo=pytz.UTC)
+        self.run_1.save()
         FinalGradeFactory.create(
             user=self.user,
             course_run=self.run_1,
@@ -504,7 +513,7 @@ class GenerateCertificatesAPITests(MockedESTestCase):
         cert_qset = MicromastersProgramCertificate.objects.filter(user=self.user, program=self.program)
         assert cert_qset.exists() is False
         api.generate_program_certificate(self.user, self.program)
-        assert cert_qset.exists() is False
+        assert cert_qset.exists() is cert_generated
 
     def test_already_has_program_certificate(self):
         """


### PR DESCRIPTION

#### What are the relevant tickets?
Fix https://github.com/mitodl/micromasters/issues/5299

#### What's this PR do?
 if the user has a passing FinalGrade for a course run that finished after September 2022.


#### How should this be manually tested?
The tests should pass.

Create a passing final grade for your user for a course run with start date after September 1st 2022. Make sure CourseRunFreezeStatus is 'complete'.

This course should be counted in the towards completion of the program in the ProgressWidget on the right of your dashboard.


