### PR TITLE
Dashboard: Adding "You passed this course" message with no certificates

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -247,7 +247,8 @@ def get_info_for_course(course, mmtrack):
         "is_elective": ElectiveCourse.objects.filter(course=course).exists(),
         "has_exam": course.has_exam,
         "certificate_url": get_certificate_url(mmtrack, course),
-        "overall_grade": mmtrack.get_overall_final_grade_for_course(course)
+        "overall_grade": mmtrack.get_overall_final_grade_for_course(course),
+        "is_passed": mmtrack.has_passed_course(course)
     }
 
     def _add_run(run, mmtrack_, status):
@@ -303,7 +304,7 @@ def get_info_for_course(course, mmtrack):
         _add_run(run_status.course_run, mmtrack, CourseStatus.CURRENTLY_ENROLLED)
     # check if we need to check the certificate
     elif run_status.status == CourseRunStatus.CHECK_IF_PASSED:
-        if not mmtrack.has_passed_course(run_status.course_run.edx_course_key):
+        if not mmtrack.has_passed_course_run(run_status.course_run.edx_course_key):
             _add_run(run_status.course_run, mmtrack, CourseRunStatus.NOT_PASSED)
         else:
             _add_run(run_status.course_run, mmtrack, CourseStatus.PASSED)
@@ -329,7 +330,7 @@ def get_info_for_course(course, mmtrack):
     # the first one (or two in some cases) has been added with the logic before
     for run_status in run_statuses:
         if run_status.status == CourseRunStatus.CHECK_IF_PASSED:
-            if mmtrack.has_passed_course(run_status.course_run.edx_course_key):
+            if mmtrack.has_passed_course_run(run_status.course_run.edx_course_key):
                 # in this case the user might have passed the course also in the past
                 _add_run(run_status.course_run, mmtrack, CourseStatus.PASSED)
             else:

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -901,6 +901,7 @@ class InfoCourseTest(CourseTests):
         # default behavior for some mmtrack mocked methods
         self.mmtrack.get_course_proctorate_exam_results.return_value = []
         self.mmtrack.get_overall_final_grade_for_course.return_value = ""
+        self.mmtrack.has_passed_course.return_value = False
 
     def assert_course_equal(
             self,
@@ -915,7 +916,7 @@ class InfoCourseTest(CourseTests):
             has_to_pay=False,
             has_exam=False,
             is_elective=False,
-            proct_exams=None
+            proct_exams=None,
     ):
         """Helper to format the course info"""
         proct_exams = proct_exams or []
@@ -939,6 +940,7 @@ class InfoCourseTest(CourseTests):
             "has_exam": has_exam,
             "certificate_url": "",
             "overall_grade": "",
+            "is_passed": False
         }
         # remove the runs part: assumed checked with the mock assertion
         del course_data_from_call['runs']

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -1142,7 +1142,7 @@ class InfoCourseTest(CourseTests):
             self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay, mock_exam_course_key):
         """test for get_info_for_course for course with run not passed and nothing offered"""
         self.mmtrack.configure_mock(**{
-            'has_passed_course.return_value': False,
+            'has_passed_course_run.return_value': False,
             'is_enrolled_mmtrack.return_value': True
         })
         with patch(
@@ -1169,7 +1169,7 @@ class InfoCourseTest(CourseTests):
             self, mock_schedulable, mock_format, mock_get_cert, mock_future_exams, mock_has_to_pay, mock_exam_course_key):
         """test for get_info_for_course for course with a course current and another not passed"""
         self.mmtrack.configure_mock(**{
-            'has_passed_course.return_value': False,
+            'has_passed_course_run.return_value': False,
             'is_enrolled_mmtrack.return_value': True
         })
         with patch(
@@ -1198,7 +1198,7 @@ class InfoCourseTest(CourseTests):
         test for get_info_for_course in case a check if the course has been passed is required
         """
         self.mmtrack.configure_mock(**{
-            'has_passed_course.return_value': False,
+            'has_passed_course_run.return_value': False,
             'is_enrolled_mmtrack.return_value': True
         })
         with patch(
@@ -1255,7 +1255,7 @@ class InfoCourseTest(CourseTests):
         test for get_info_for_course in case a check if the course has been passed
         is required for the course, the course has not been passed and there is no next run
         """
-        self.mmtrack.configure_mock(**{'has_passed_course.return_value': False})
+        self.mmtrack.configure_mock(**{'has_passed_course_run.return_value': False})
         with patch(
             'dashboard.api.get_status_for_courserun',
             autospec=True,
@@ -1283,7 +1283,7 @@ class InfoCourseTest(CourseTests):
         is required for the course and the course has been passed
         """
         self.mmtrack.configure_mock(**{
-            'has_passed_course.return_value': True,
+            'has_passed_course_run.return_value': True,
             'is_enrolled_mmtrack.return_value': True
         })
         with patch(
@@ -1433,7 +1433,7 @@ class InfoCourseTest(CourseTests):
         test for get_info_for_course in case the less recent course is flagged to be checked if passed
         """
         self.mmtrack.configure_mock(**{
-            'has_passed_course.return_value': True,
+            'has_passed_course_run.return_value': True,
             'is_enrolled_mmtrack.return_value': True
         })
         with patch(

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -358,7 +358,7 @@ class MMTrack:
                 return True
         return False
 
-    def has_passed_course_run_run(self, edx_course_key):
+    def has_passed_course_run(self, edx_course_key):
         """
         Returns whether the user has passed a course run.
 

--- a/dashboard/utils_test.py
+++ b/dashboard/utils_test.py
@@ -259,9 +259,9 @@ class MMTrackTest(MockedESTestCase):
         assert mmtrack.is_enrolled_mmtrack(course_id) is True
 
     @ddt.data(True, False)
-    def test_has_passed_course(self, final_grade_passed):
+    def test_has_passed_course_run(self, final_grade_passed):
         """
-        Test that has_passed_course returns True when a passed FinalGrade exists
+        Test that has_passed_course_run returns True when a passed FinalGrade exists
         """
         final_grade = FinalGradeFactory.create(
             user=self.user,
@@ -273,18 +273,18 @@ class MMTrackTest(MockedESTestCase):
             program=self.program,
             edx_user_data=self.cached_edx_user_data
         )
-        assert mmtrack.has_passed_course(final_grade.course_run.edx_course_key) is final_grade_passed
+        assert mmtrack.has_passed_course_run(final_grade.course_run.edx_course_key) is final_grade_passed
 
-    def test_has_passed_course_no_grade(self):
+    def test_has_passed_course_run_no_grade(self):
         """
-        Test that has_passed_course returns False when no FinalGrade exists
+        Test that has_passed_course_run returns False when no FinalGrade exists
         """
         mmtrack = MMTrack(
             user=self.user,
             program=self.program,
             edx_user_data=self.cached_edx_user_data
         )
-        assert mmtrack.has_passed_course('random-course-id') is False
+        assert mmtrack.has_passed_course_run('random-course-id') is False
 
     def test_get_final_grade_percent(self):
         """

--- a/exams/api.py
+++ b/exams/api.py
@@ -73,7 +73,7 @@ def authorize_for_exam_run(user, course_run, exam_run):
     ExamProfile.objects.get_or_create(profile=mmtrack.user.profile)
 
     # if they didn't pass, they don't get authorized
-    if not mmtrack.has_passed_course(course_run.edx_course_key):
+    if not mmtrack.has_passed_course_run(course_run.edx_course_key):
         errors_message = MESSAGE_NOT_PASSED_OR_EXIST_TEMPLATE.format(
             user=mmtrack.user.username,
             course_id=course_run.edx_course_key

--- a/exams/api_test.py
+++ b/exams/api_test.py
@@ -97,7 +97,7 @@ class ExamAuthorizationApiTests(TestCase):
         create_order(user, self.course_run)
         mmtrack = get_mmtrack(user, self.program)
         self.assertTrue(mmtrack.has_paid(self.course_run.edx_course_key))
-        self.assertTrue(mmtrack.has_passed_course(self.course_run.edx_course_key))
+        self.assertTrue(mmtrack.has_passed_course_run(self.course_run.edx_course_key))
 
         # Neither user has exam profile nor authorization.
         assert ExamProfile.objects.filter(profile=mmtrack.user.profile).exists() is False
@@ -123,7 +123,7 @@ class ExamAuthorizationApiTests(TestCase):
         create_order(self.user, self.course_run)
         mmtrack = get_mmtrack(self.user, self.program)
         self.assertTrue(mmtrack.has_paid(self.course_run.edx_course_key))
-        self.assertTrue(mmtrack.has_passed_course(self.course_run.edx_course_key))
+        self.assertTrue(mmtrack.has_passed_course_run(self.course_run.edx_course_key))
 
         # Neither user has exam profile nor authorization.
         assert ExamProfile.objects.filter(profile=mmtrack.user.profile).exists() is False
@@ -148,7 +148,7 @@ class ExamAuthorizationApiTests(TestCase):
         create_order(self.user, self.course_run)
         mmtrack = get_mmtrack(self.user, self.program)
         self.assertTrue(mmtrack.has_paid(self.course_run.edx_course_key))
-        self.assertTrue(mmtrack.has_passed_course(self.course_run.edx_course_key))
+        self.assertTrue(mmtrack.has_passed_course_run(self.course_run.edx_course_key))
         old_run = ExamRunFactory.create(course=self.course_run.course)
         ExamAuthorizationFactory.create_batch(
             ATTEMPTS_PER_PAID_RUN_OLD,
@@ -273,14 +273,14 @@ class ExamAuthorizationApiTests(TestCase):
         test exam_authorization when user has not passed course but paid.
         """
         create_order(self.user, self.course_run)
-        with patch('dashboard.utils.MMTrack.has_passed_course', autospec=True, return_value=False):
+        with patch('dashboard.utils.MMTrack.has_passed_course_run', autospec=True, return_value=False):
             mmtrack = get_mmtrack(self.user, self.program)
             expected_errors_message = MESSAGE_NOT_PASSED_OR_EXIST_TEMPLATE.format(
                 user=mmtrack.user.username,
                 course_id=self.course_run.edx_course_key
             )
             assert mmtrack.has_paid(self.course_run.edx_course_key) is True
-            assert mmtrack.has_passed_course(self.course_run.edx_course_key) is False
+            assert mmtrack.has_passed_course_run(self.course_run.edx_course_key) is False
 
             # Neither user has exam profile nor authorization.
             assert ExamProfile.objects.filter(profile=mmtrack.user.profile).exists() is False

--- a/seed_data/management/commands/alter_data_test.py
+++ b/seed_data/management/commands/alter_data_test.py
@@ -35,7 +35,7 @@ class AlterDataCommandTests(MockedESTestCase):
         grade = Decimal('0.75')
         set_to_passed(user=self.user, course_run=course_run, grade=grade)
         mmtrack = get_mmtrack(self.user, course_run.course.program)
-        assert mmtrack.has_passed_course(course_run.edx_course_key)
+        assert mmtrack.has_passed_course_run(course_run.edx_course_key)
         assert int(mmtrack.get_final_grade_percent(course_run.edx_course_key)) == (grade * 100)
 
     @ddt.data('fa', 'non_fa')
@@ -45,7 +45,7 @@ class AlterDataCommandTests(MockedESTestCase):
         grade = Decimal('0.55')
         set_to_failed(user=self.user, course_run=course_run, grade=grade)
         mmtrack = get_mmtrack(self.user, course_run.course.program)
-        assert not mmtrack.has_passed_course(course_run.edx_course_key)
+        assert not mmtrack.has_passed_course_run(course_run.edx_course_key)
         assert int(mmtrack.get_final_grade_percent(course_run.edx_course_key)) == (grade * 100)
 
     @ddt.data('fa', 'non_fa')

--- a/static/js/components/CouponNotificationDialog_test.js
+++ b/static/js/components/CouponNotificationDialog_test.js
@@ -78,7 +78,8 @@ const COURSE: Course = {
   proctorate_exams_grades:     [],
   is_elective:                 false,
   certificate_url:             "",
-  overall_grade:               ""
+  overall_grade:               "",
+  is_passed:                   false
 }
 
 const PROGRAM: AvailableProgram = {

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -114,6 +114,9 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
   const exams = course.has_exam
   const paid = firstRun.has_paid
   const passedExam = hasPassingExamGrade(course)
+  const is_firstRun_fall22 = moment(run.course_start_date).isBefore(
+    moment("9/1/2022")
+  )
   const paymentDueDate = moment(
     R.defaultTo("", firstRun.course_upgrade_deadline)
   )
@@ -200,12 +203,10 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
     })
   }
   // course is passed and paid but no certificate yet
-  if (firstRun["status"] === "passed" && paid && !course.certificate_url) {
-    if (!exams || (exams && passedExam)) {
-      messages.push({
-        message: "You passed this course."
-      })
-    }
+  if (!course.certificate_url && course.is_passed) {
+    messages.push({
+      message: "You passed this course."
+    })
   }
   // Course is running, user has already paid,
   if (

--- a/static/js/components/dashboard/courses/StatusMessages.js
+++ b/static/js/components/dashboard/courses/StatusMessages.js
@@ -34,7 +34,7 @@ import {
   hasCanUpgradeCourseRun,
   hasMissedDeadlineCourseRun
 } from "./util"
-import { hasPassingExamGrade, hasPassedCourseRun } from "../../../lib/grades"
+import { hasPassedCourseRun } from "../../../lib/grades"
 import { formatPrettyDateTimeAmPmTz, parseDateString } from "../../../util/date"
 
 type Message = {
@@ -113,10 +113,6 @@ export const calculateMessages = (props: CalculateMessagesProps) => {
 
   const exams = course.has_exam
   const paid = firstRun.has_paid
-  const passedExam = hasPassingExamGrade(course)
-  const is_firstRun_fall22 = moment(run.course_start_date).isBefore(
-    moment("9/1/2022")
-  )
   const paymentDueDate = moment(
     R.defaultTo("", firstRun.course_upgrade_deadline)
   )

--- a/static/js/components/dashboard/courses/StatusMessages_test.js
+++ b/static/js/components/dashboard/courses/StatusMessages_test.js
@@ -307,9 +307,7 @@ describe("Course Status Messages", () => {
 
       it("should prompt when passed the course", () => {
         course.has_exam = true
-        course.can_schedule_exam = true
-        course.proctorate_exams_grades = [makeProctoredExamResult()]
-        course.proctorate_exams_grades[0].passed = true
+        course.is_passed = true
 
         const messages = calculateMessages(calculateMessagesProps).value
         assert.equal(messages[0]["message"], "You passed this course.")
@@ -320,6 +318,7 @@ describe("Course Status Messages", () => {
       makeRunPast(course.runs[0])
       makeRunPassed(course.runs[0])
       makeRunPaid(course.runs[0])
+      course.is_passed = true
       assertIsJust(calculateMessages(calculateMessagesProps), [
         {
           message: "You passed this course."

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -120,7 +120,8 @@ export const makeCourse = (positionInProgram: number): Course => {
     is_elective:                 false,
     proctorate_exams_grades:     [],
     certificate_url:             "",
-    overall_grade:               ""
+    overall_grade:               "",
+    is_passed:                   false
   }
 }
 

--- a/static/js/flow/programTypes.js
+++ b/static/js/flow/programTypes.js
@@ -73,6 +73,7 @@ export type Course = {
   has_exam:                     boolean,
   certificate_url:              string,
   overall_grade:                string,
+  is_passed:                    boolean,
 }
 
 export type ProgramPageCourse = {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
#### What are the relevant tickets?
N/a

#### What's this PR do?
Update course status messages to show the message "You passed the course." for recent DEDP courses that that don't have a certificate.

#### How should this be manually tested?
Create a passing FinalGrade for a course run that has a start date after September 1st, 2022.
In the learner dashboard it should show a message the user passed the course.

<img width="742" alt="Screen Shot 2023-02-22 at 8 13 03 AM" src="https://user-images.githubusercontent.com/7574259/220629946-85165bcc-a41b-4c4a-ac4d-0a320dcd5a4d.png">
