### PR TITLE
Product Page: show correct "delievered on" logo

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -149,7 +149,15 @@
           <p>
             Courses delivered on
           </p>
-          <img src="{% static 'images/edx_logo.svg' %}" alt="edX" />
+            {% if page.program.has_mitxonline_courses %}
+                <img
+                  class="mitx_logo"
+                  src="{% static 'images/logo-mitxonline.png' %}"
+                  alt="MITx"
+                />
+            {% else %}
+                <img src="{% static 'images/edx_logo.svg' %}" alt="edX" />
+            {% endif %}
         </div>
       </div>
       {% endblock %}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots

#### What are the relevant tickets?
Fix https://github.com/mitodl/micromasters/issues/5245

#### What's this PR do?
Show mitxonline logo for programs that run on mitxonline.

#### How should this be manually tested?
Make sure you have the program page setup through wagtail: http://mm.odl.local:8079/cms.
One of the course runs in the Program should have the "courseware backend" set to mitxonline. You can set it through django admin.

Go to view the program page.
Before:
<img width="426" alt="Screen Shot 2023-02-28 at 8 05 06 AM" src="https://user-images.githubusercontent.com/7574259/221864915-c0a51736-ac30-46f8-b181-819d92814a52.png">

After:
<img width="434" alt="Screen Shot 2023-02-28 at 8 04 27 AM" src="https://user-images.githubusercontent.com/7574259/221864950-edccd43a-8bd4-4ab1-b67c-54169bfa876b.png">
