### PR TITLE
Admin: Make it possible to search exam auths

### DIFF
--- a/exams/admin.py
+++ b/exams/admin.py
@@ -56,6 +56,8 @@ class ExamAuthorizationAdmin(admin.ModelAdmin):
         'course_number',
         'exam_run_id',
         'exam_coupon_url',
+        'exam_taken',
+        'exam_no_show',
     )
     list_filter = (
         'exam_run__id',

--- a/exams/admin.py
+++ b/exams/admin.py
@@ -67,7 +67,7 @@ class ExamAuthorizationAdmin(admin.ModelAdmin):
     search_fields = (
         'exam_run__id',
         'course__course_number',
-        'user_email',
+        'user__email',
     )
     raw_id_fields = ('user',)
 

--- a/exams/admin.py
+++ b/exams/admin.py
@@ -65,6 +65,7 @@ class ExamAuthorizationAdmin(admin.ModelAdmin):
     search_fields = (
         'exam_run__id',
         'course__course_number',
+        'user_email',
     )
     raw_id_fields = ('user',)
 


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Makes it possible to search for exam authorizations by user email and be able to see is `exam_no_show` and `exam_attempted`. 

#### How should this be manually tested?
go to /admin and try to search for exam authorizations by email.