### PR TITLE
Bump minimist from 1.2.3 to 1.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "keycode": "^2.1.9",
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "^1.1.2",
-    "minimist": "^1.2.3",
+    "minimist": "^1.2.8",
     "mocha": "8.3.0",
     "moment": "^2.18.1",
     "moment-timezone": "^0.5.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8408,7 +8408,7 @@ __metadata:
     keycode: ^2.1.9
     lodash: ^4.17.21
     mini-css-extract-plugin: ^1.1.2
-    minimist: ^1.2.3
+    minimist: ^1.2.8
     mocha: 8.3.0
     moment: ^2.18.1
     moment-timezone: ^0.5.13
@@ -8611,7 +8611,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.3":
+"minimist@npm:^1.2.0":
   version: 1.2.3
   resolution: "minimist@npm:1.2.3"
   checksum: ffa82a3089dffc471afcf1cca93bd687077ed4c7deaace6724fb2e575759fb0c29316526065f58eba420cf58f7f0e2e9ee80423b5cc4fd6af549074e7e0725d3
@@ -8622,6 +8622,13 @@ __metadata:
   version: 1.2.5
   resolution: "minimist@npm:1.2.5"
   checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
+  languageName: node
+  linkType: hard
+
+"minimist@npm:^1.2.8":
+  version: 1.2.8
+  resolution: "minimist@npm:1.2.8"
+  checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


#### What are the relevant tickets?
Fix https://github.com/mitodl/micromasters/pull/5311

#### What's this PR do?
Opening this PR to upgrade minimist instead of this  https://github.com/mitodl/micromasters/pull/5311

#### How should this be manually tested?
nothing should break

