### PR TITLE
fix: remove discontinued codecov PyPI package

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,5 @@
 astroid==2.4.2
 bpython
-codecov
 ddt
 django-debug-toolbar
 ipdb


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
None, The CI fails on the build in multiple apps due to `codecov` being removed from PyPI. Similar PRs were created in xPRO, MITxOnline etc.

#### What's this PR do?
- Removes the discontinued `codecov` package

#### How should this be manually tested?
Just check that all the CI checks pass.

