### PR TITLE
Prompt learner to reauthenticate witht the correct social auth if invalid

### DIFF
--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -11,6 +11,7 @@ from celery import group
 from django.conf import settings
 import pytz
 
+from backends.constants import COURSEWARE_BACKENDS
 from dashboard.api import (
     calculate_users_to_refresh_in_bulk,
     refresh_user_data,
@@ -97,4 +98,5 @@ def batch_update_user_data_subtasks(students, expiration_timestamp):
     for user_id in students:
         # if we are past the expiration time we should stop any extra work
         if expiration > now_in_utc():
-            refresh_user_data(user_id)
+            for backend in COURSEWARE_BACKENDS:
+                refresh_user_data(user_id, backend)

--- a/dashboard/tasks_test.py
+++ b/dashboard/tasks_test.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 
 import pytest
 
+from backends.constants import COURSEWARE_BACKENDS
 from dashboard.tasks import (
     batch_update_user_data,
     batch_update_user_data_subtasks,
@@ -60,9 +61,10 @@ def test_batch_update(mocker, db):  # pylint: disable=unused-argument
     assert is_near_now(lock_mock_init.call_args[0][1] - timedelta(hours=5))
     calc_mock.assert_called_once_with()
     lock_mock.acquire.assert_called_once_with()
-    assert refresh_mock.call_count == len(users)
-    for user in users:
-        refresh_mock.assert_any_call(user.id)
+    assert refresh_mock.call_count == len(users) * len(COURSEWARE_BACKENDS)
+    for backend in COURSEWARE_BACKENDS:
+        for user in users:
+            refresh_mock.assert_any_call(user.id, backend)
     release_mock.assert_called_once_with(LOCK_ID, token)
 
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -57,14 +57,8 @@ class UserDashboard(APIView):
         update_cache = user == request.user
 
         # get the credentials for the current user for edX
-        try:
-            program_dashboard = get_user_program_info(user, update_cache=update_cache)
-        except utils.InvalidCredentialStored as exc:
-            log.exception('Access token for user %s is fresh but invalid; forcing login.', user.username)
-            return Response(
-                status=exc.http_status_code,
-                data={'error': str(exc)}
-            )
+        program_dashboard = get_user_program_info(user, update_cache=update_cache)
+
         return Response(
             status=status.HTTP_200_OK,
             data=program_dashboard

--- a/static/js/components/SocialAuthReauthenticateDialog.js
+++ b/static/js/components/SocialAuthReauthenticateDialog.js
@@ -1,0 +1,60 @@
+/* global SETTINGS: false */
+import React, { useState, useEffect } from "react"
+import Button from "@material-ui/core/Button"
+import Dialog from "@material-ui/core/Dialog"
+import DialogActions from "@material-ui/core/DialogActions"
+import DialogContent from "@material-ui/core/DialogContent"
+import DialogTitle from "@material-ui/core/DialogTitle"
+import Grid from "@material-ui/core/Grid"
+import R from "ramda"
+
+import { COURSEWARE_BACKEND_NAMES } from "../constants"
+
+type Props = {
+  invalidBackendCredentials: string[]
+}
+
+const SocialAuthReauthenticateDialog = (props: Props) => {
+  const { invalidBackendCredentials } = props
+  const [open, setOpen] = useState(false)
+  const invalidCredential = R.head(invalidBackendCredentials)
+
+  useEffect(() => {
+    setOpen(!R.isNil(invalidCredential))
+  }, [invalidCredential])
+
+  return (
+    <Dialog
+      classes={{
+        paper: "dialog"
+      }}
+      open={open}
+      onClose={() => setOpen(false)}
+    >
+      <DialogTitle className="dialog-title">Action Required</DialogTitle>
+      <DialogContent>
+        <Grid container style={{ padding: 20 }}>
+          <Grid item xs={12}>
+            <p>
+              Your account is linked to{" "}
+              {COURSEWARE_BACKEND_NAMES[invalidCredential]}, but this link is no
+              longer active. Continue to log in with your account and relink it
+              to your current MicroMasters account.
+            </p>
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          key="cancel"
+          className="primary-button ok-button"
+          href={`/login/${invalidCredential}/`}
+        >
+          Continue to {COURSEWARE_BACKEND_NAMES[invalidCredential]}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default SocialAuthReauthenticateDialog

--- a/static/js/components/SocialAuthReauthenticateDialog_test.js
+++ b/static/js/components/SocialAuthReauthenticateDialog_test.js
@@ -1,0 +1,64 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+import { mount } from "enzyme"
+import { assert } from "chai"
+import Button from "@material-ui/core/Button"
+import Grid from "@material-ui/core/Grid"
+import { MuiThemeProvider, createMuiTheme } from "@material-ui/core/styles"
+
+import SocialAuthReauthenticateDialog from "./SocialAuthReauthenticateDialog"
+import { COURSEWARE_BACKEND_NAMES } from "../constants"
+
+describe("SocialAuthReauthenticateDialog", () => {
+  const renderDialog = (invalidBackendCredentials: string[]) =>
+    mount(
+      <MuiThemeProvider theme={createMuiTheme()}>
+        <SocialAuthReauthenticateDialog
+          invalidBackendCredentials={invalidBackendCredentials}
+        />
+      </MuiThemeProvider>
+    )
+      .find(SocialAuthReauthenticateDialog)
+      .children()
+
+  Object.entries(COURSEWARE_BACKEND_NAMES).forEach(
+    ([invalidAuth, backendLabel]) => {
+      describe(`for invalid credential '${invalidAuth}'`, () => {
+        it("should be closed if the learner has no invalid credentials", () => {
+          const wrapper = renderDialog([])
+          assert.isBoolean(wrapper.prop("open"))
+          assert.notOk(wrapper.prop("open"))
+        })
+
+        it("should be open if the learner has an invalid credential", () => {
+          const wrapper = renderDialog([invalidAuth])
+          assert.isBoolean(wrapper.prop("open"))
+          assert.ok(wrapper.prop("open"))
+        })
+
+        it("should have a continue button linking to the social auth login url", () => {
+          const wrapper = renderDialog([invalidAuth])
+          const btn = wrapper.find(Button)
+          assert.ok(btn.exists())
+          assert.equal(btn.prop("href"), `/login/${invalidAuth}/`)
+          assert.equal(btn.text(), `Continue to ${String(backendLabel)}`)
+        })
+
+        it("should have a description of what the learner needs to do", () => {
+          const wrapper = renderDialog([invalidAuth])
+          const text = wrapper
+            .find(Grid)
+            .at(0)
+            .text()
+          assert.equal(
+            text,
+            `Your account is linked to ${String(
+              backendLabel
+            )}, but this link is no longer active. Continue to log in with your account and relink it to your current MicroMasters account.`
+          )
+        })
+      })
+    }
+  )
+})

--- a/static/js/components/dashboard/FinancialAidCard_test.js
+++ b/static/js/components/dashboard/FinancialAidCard_test.js
@@ -48,8 +48,9 @@ describe("FinancialAidCard", () => {
   const renderCard = (props = {}) => {
     const program = props.program || DASHBOARD_RESPONSE.programs[1]
     const dashboard = {
-      programs:          [program],
-      is_edx_data_fresh: true
+      programs:                    [program],
+      is_edx_data_fresh:           true,
+      invalid_backend_credentials: []
     }
     const couponPrices = calculatePrices(
       dashboard.programs,

--- a/static/js/containers/DashboardPage.js
+++ b/static/js/containers/DashboardPage.js
@@ -94,6 +94,7 @@ import { currencyForCountry } from "../lib/currency"
 import DocsInstructionsDialog from "../components/DocsInstructionsDialog"
 import CouponNotificationDialog from "../components/CouponNotificationDialog"
 import CourseEnrollmentDialog from "../components/CourseEnrollmentDialog"
+import SocialAuthReauthenticateDialog from "../components/SocialAuthReauthenticateDialog"
 import { INCOME_DIALOG } from "./FinancialAidCalculator"
 import { processCheckout } from "./OrderSummaryPage"
 import { getOwnDashboard, getOwnCoursePrices } from "../reducers/util"
@@ -1031,6 +1032,9 @@ class DashboardPage extends React.Component {
             {pageContent}
             {this.renderCourseContactPaymentDialog()}
           </Loader>
+          <SocialAuthReauthenticateDialog
+            invalidBackendCredentials={dashboard.invalidBackendCredentials}
+          />
         </div>
       </DocumentTitle>
     )

--- a/static/js/factories/dashboard.js
+++ b/static/js/factories/dashboard.js
@@ -51,7 +51,11 @@ const newFinancialAidId = makeCounter()
 
 export const makeDashboard = (): Dashboard => {
   const programs = R.range(1, 3).map(makeProgram)
-  return { programs: programs, is_edx_data_fresh: true }
+  return {
+    programs:                    programs,
+    is_edx_data_fresh:           true,
+    invalid_backend_credentials: []
+  }
 }
 
 export const makeAvailableProgram = (

--- a/static/js/flow/dashboardTypes.js
+++ b/static/js/flow/dashboardTypes.js
@@ -6,7 +6,8 @@ import type { APIErrorInfo } from '../flow/generalTypes'
 // likely to change in very near future
 export type Dashboard = {
   programs: Array<Program>,
-  is_edx_data_fresh: boolean
+  is_edx_data_fresh: boolean,
+  invalid_backend_credentials: Array<string>
 }
 
 export type DashboardState = {
@@ -15,6 +16,7 @@ export type DashboardState = {
   fetchStatus?: string,
   noSpinner: boolean,
   errorInfo?: APIErrorInfo,
+  invalidBackendCredentials: Array<string>
 }
 
 export type DashboardsState = {

--- a/static/js/reducers/dashboard.js
+++ b/static/js/reducers/dashboard.js
@@ -15,9 +15,10 @@ import type { Action } from "../flow/reduxTypes"
 import { updateStateByUsername } from "./util"
 
 export const INITIAL_DASHBOARD_STATE: DashboardState = {
-  programs:       [],
-  isEdxDataFresh: true,
-  noSpinner:      false
+  programs:                  [],
+  isEdxDataFresh:            true,
+  noSpinner:                 false,
+  invalidBackendCredentials: []
 }
 
 const INITIAL_DASHBOARDS_STATE: DashboardsState = {}
@@ -50,10 +51,12 @@ export const dashboard = (
     }
   case RECEIVE_DASHBOARD_SUCCESS:
     return updateStateByUsername(state, username, {
-      fetchStatus:    FETCH_SUCCESS,
-      programs:       action.payload.programs,
-      isEdxDataFresh: action.payload.is_edx_data_fresh,
-      noSpinner:      false
+      fetchStatus:               FETCH_SUCCESS,
+      programs:                  action.payload.programs,
+      isEdxDataFresh:            action.payload.is_edx_data_fresh,
+      invalidBackendCredentials:
+          action.payload.invalid_backend_credentials || [],
+      noSpinner: false
     })
   case RECEIVE_DASHBOARD_FAILURE:
     return updateStateByUsername(state, username, {

--- a/static/js/reducers/dashboard_test.js
+++ b/static/js/reducers/dashboard_test.js
@@ -66,9 +66,10 @@ describe("dashboard reducers", () => {
       ]).then(state => {
         const dashboardState = state[SETTINGS.user.username]
         assert.deepEqual(dashboardState, {
-          programs:       [],
-          isEdxDataFresh: true,
-          noSpinner:      false
+          programs:                  [],
+          isEdxDataFresh:            true,
+          invalidBackendCredentials: [],
+          noSpinner:                 false
         })
       })
     })
@@ -108,10 +109,11 @@ describe("dashboard reducers", () => {
     const _username = "_username"
 
     const successExpectation = {
-      programs:       DASHBOARD_RESPONSE.programs,
-      isEdxDataFresh: DASHBOARD_RESPONSE.is_edx_data_fresh,
-      fetchStatus:    FETCH_SUCCESS,
-      noSpinner:      false
+      programs:                  DASHBOARD_RESPONSE.programs,
+      isEdxDataFresh:            DASHBOARD_RESPONSE.is_edx_data_fresh,
+      invalidBackendCredentials: [],
+      fetchStatus:               FETCH_SUCCESS,
+      noSpinner:                 false
     }
 
     beforeEach(() => {
@@ -137,7 +139,12 @@ describe("dashboard reducers", () => {
         state => {
           assert.deepEqual(state, {
             [_username]: successExpectation,
-            [username]:  { programs: [], isEdxDataFresh: true, noSpinner: false }
+            [username]:  {
+              programs:                  [],
+              isEdxDataFresh:            true,
+              noSpinner:                 false,
+              invalidBackendCredentials: []
+            }
           })
         }
       )
@@ -152,11 +159,12 @@ describe("dashboard reducers", () => {
         assert.deepEqual(state, {
           [username]:  successExpectation,
           [_username]: {
-            fetchStatus:    FETCH_FAILURE,
-            errorInfo:      "err",
-            programs:       [],
-            isEdxDataFresh: true,
-            noSpinner:      false
+            fetchStatus:               FETCH_FAILURE,
+            errorInfo:                 "err",
+            programs:                  [],
+            invalidBackendCredentials: [],
+            isEdxDataFresh:            true,
+            noSpinner:                 false
           }
         })
       })
@@ -185,10 +193,11 @@ describe("dashboard reducers", () => {
       ]).then(state => {
         assert.deepEqual(state, {
           username: {
-            noSpinner:      true,
-            isEdxDataFresh: true,
-            programs:       DASHBOARD_RESPONSE.programs,
-            fetchStatus:    FETCH_PROCESSING
+            noSpinner:                 true,
+            isEdxDataFresh:            true,
+            programs:                  DASHBOARD_RESPONSE.programs,
+            invalidBackendCredentials: [],
+            fetchStatus:               FETCH_PROCESSING
           }
         })
       })

--- a/static/js/test_constants.js
+++ b/static/js/test_constants.js
@@ -914,8 +914,9 @@ export const USER_PROGRAM_RESPONSE = deepFreeze({
 })
 
 export const DASHBOARD_RESPONSE: Dashboard = deepFreeze({
-  is_edx_data_fresh: true,
-  programs:          [
+  is_edx_data_fresh:         true,
+  invalidBackendCredentials: [],
+  programs:                  [
     {
       description:             "Not passed program",
       title:                   "Not passed program",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #5327 

#### What's this PR do?
This updates the dashboard logic to not cause a user to get in a circular login/logout loop if their MITx online authentication is no longer valid. It instead prompts them to reauthenticate with the correct provider.

#### How should this be manually tested?

For both MITx Online and EdX
- Authenticate with the social auth for that provider (`/login/mitxonline` and `/login/edxorg`)
- Go to the dashboard and verify you don't see any messages or alerts.

---

- Update the social auth record for that provider, changing the `extra_data` to have incorrect values for the refresh token and access token, this will simulate an expired or otherwise invalid token.
- Go to the dashboard and verify you get the popup dialog prompting you to login.
- You should be able to opt out of this and dismiss the dialog without authenticating and continue to use the dashboard.
- You should also be able to reload the page, which will prompt you again, and then successfully reauthenticate.

---

- In `dashboard/api.py`, put a `raise Exception("error")` on the first line of `update_cache_for_backend`. 
- Verify when you load the dashboard you still get an error message indicating the data is out of date.

#### Where should the reviewer start?
(Optional)

#### Screenshots (if appropriate)

![Screenshot 2023-04-20 at 16-38-23 Learner Dashboard MITx MicroMasters](https://user-images.githubusercontent.com/28598/233482707-016a4af6-ac54-4bc2-8e3b-ead35439a21a.png)
![Screenshot 2023-04-20 at 16-37-17 Learner Dashboard MITx MicroMasters](https://user-images.githubusercontent.com/28598/233482709-5be9f9fc-2d42-4b11-9a8b-5bcf00fe7ff9.png)


If edx or mitxonline are unreachable regardless of social auth validity, you should see this:

![Screenshot 2023-04-20 at 09-51-56 Learner Dashboard MITx MicroMasters](https://user-images.githubusercontent.com/28598/233387850-cde57c26-44d6-405f-a2a1-1cca805f59af.png)