### PR TITLE
Fix deployments due to conflict with a few library versions.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,6 +24,7 @@ opensearch-dsl==1.0.0
 factory_boy
 faker
 html5lib==0.999999999
+l18n==2021.3
 ipython
 jsonfield==2.0.2
 jsonpatch==1.16
@@ -36,6 +37,7 @@ python-dateutil
 sentry-sdk==1.1.0
 redis==3.5.3
 requests>=2.20.0
+setuptools==67.6.1
 six>=1.11.0
 social-auth-app-django==3.1.0
 robohash

--- a/requirements.txt
+++ b/requirements.txt
@@ -154,8 +154,10 @@ jsonpointer==2.0
     # via jsonpatch
 kombu==5.2.3
     # via celery
-l18n==2018.5
-    # via wagtail
+l18n==2021.3
+    # via
+    #   -r requirements.in
+    #   wagtail
 matplotlib-inline==0.1.3
     # via ipython
 newrelic==6.0.1.155
@@ -222,7 +224,7 @@ python-dateutil==2.5.3
     #   opensearch-dsl
 python3-openid==3.1.0
     # via social-auth-core
-pytz==2018.5
+pytz==2023.3
     # via
     #   celery
     #   django


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
This fixes an issue trying to build the app for heroku deployment. See the trace in the build log:

https://github.com/mitodl/micromasters/actions/runs/4699543907/jobs/8400688419#step:3:29935

The issue here is that heroku appears to have an pre-installed version of `setuptools`. There must've been a recent update that caused this to be upgraded to a version incompatible with how `l18n` invokes it. So I've pinned both `setuptools` (to the version current for Heroku) and `l18n`.

#### How should this be manually tested?
(Required)

#### Where should the reviewer start?
- On `master` branch, add `setuptools==67.6.1` to `requirements.in` and run `pip-compile`. This should error with the same error on the failed build linked above.
- Checkout this branch, rebuild your containers, and smoke test that the app still runs.