### PR TITLE
Update the Program record to display grades properly

### DIFF
--- a/certificates/views.py
+++ b/certificates/views.py
@@ -261,17 +261,15 @@ class BaseGradeRecordView(ABC, TemplateView):
             combined_grade = CombinedFinalGrade.objects.filter(user=user, course=course).first()
             letter_grade = convert_to_letter(combined_grade.grade) if combined_grade else ""
             earned = get_certificate_url(mmtrack, course)
-            attempts = mmtrack.get_course_proctorate_exam_results(course).count()
             if best_grade and best_grade.is_already_combined:
                 combined_grade = best_grade
                 letter_grade = convert_to_letter(best_grade.grade_percent)
                 earned = best_grade.passed
-                attempts = ""
 
             context['courses'].append({
                 "title": course.title,
                 "edx_course_key": best_grade.course_run.edx_course_key if best_grade else "",
-                "attempts": attempts,
+                "attempts": mmtrack.get_course_proctorate_exam_results(course).count(),
                 "letter_grade": letter_grade,
                 "status": "Earned" if earned else "Not Earned",
                 "date_earned": combined_grade.created_on if combined_grade else "",

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -259,12 +259,21 @@ class BaseGradeRecordView(ABC, TemplateView):
         for course in courses:
             best_grade = mmtrack.get_best_final_grade_for_course(course)
             combined_grade = CombinedFinalGrade.objects.filter(user=user, course=course).first()
+            letter_grade = convert_to_letter(combined_grade.grade) if combined_grade else ""
+            earned = get_certificate_url(mmtrack, course)
+            attempts = mmtrack.get_course_proctorate_exam_results(course).count()
+            if best_grade and best_grade.is_already_combined:
+                combined_grade = best_grade
+                letter_grade = convert_to_letter(best_grade.grade_percent)
+                earned = best_grade.passed
+                attempts = ""
+
             context['courses'].append({
                 "title": course.title,
                 "edx_course_key": best_grade.course_run.edx_course_key if best_grade else "",
-                "attempts": mmtrack.get_course_proctorate_exam_results(course).count(),
-                "letter_grade": convert_to_letter(combined_grade.grade) if combined_grade else "",
-                "status": "Earned" if get_certificate_url(mmtrack, course) else "Not Earned",
+                "attempts": attempts,
+                "letter_grade": letter_grade,
+                "status": "Earned" if earned else "Not Earned",
                 "date_earned": combined_grade.created_on if combined_grade else "",
                 "overall_grade": mmtrack.get_overall_final_grade_for_course(course),
                 "elective_tag": "elective" if (getattr(course, "electivecourse", None) is not None) else "core"

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -5,9 +5,6 @@ import logging
 from decimal import Decimal
 from math import floor
 
-import datetime
-
-import pytz
 from django.db import transaction
 from django.db.models import Q, Count
 from django.urls import reverse

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -16,7 +16,7 @@ from courses.models import CourseRun, Course
 from dashboard.api_edx_cache import CachedEdxUserData
 from dashboard.models import ProgramEnrollment
 from ecommerce.models import Order, Line
-from grades.constants import FinalGradeStatus
+from grades.constants import FinalGradeStatus, NEW_COMBINED_FINAL_GRADES_DATE
 from grades.models import (
     FinalGrade,
     ProctoredExamGrade,
@@ -389,7 +389,7 @@ class MMTrack:
                 return FinalGrade.objects.filter(
                     user=self.user,
                     course_run__course_id=course.id,
-                    course_run__start_date__gt=datetime.datetime(2022, 9, 1, tzinfo=pytz.UTC),
+                    course_run__start_date__gt=NEW_COMBINED_FINAL_GRADES_DATE,
                 ).passed().exists()
         else:
             return self.final_grade_qset.filter(course_run__course_id=course.id).passed().exists()
@@ -567,7 +567,7 @@ class MMTrack:
             course_ids_passing_grade = FinalGrade.objects.filter(
                 user=self.user,
                 course_run__course_id__in=course_ids,
-                course_run__start_date__gt=datetime.datetime(2022, 9, 1, tzinfo=pytz.UTC),
+                course_run__start_date__gt=NEW_COMBINED_FINAL_GRADES_DATE,
             ).passed().values_list('course_run__course__id', flat=True).distinct()
             num_certs = MicromastersCourseCertificate.objects.filter(
                 user=self.user,

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -453,7 +453,7 @@ class MMTrack:
         best_grade = self.get_best_final_grade_for_course(course)
         if best_grade is None:
             return ""
-        if not course.has_exam:
+        if not course.has_exam or best_grade.is_already_combined:
             return str(round(best_grade.grade_percent))
 
         combined_grade = CombinedFinalGrade.objects.filter(user=self.user, course=course)

--- a/grades/constants.py
+++ b/grades/constants.py
@@ -1,9 +1,13 @@
 """
 Constants for the grades app
 """
+import datetime
+import pytz
 
 COURSE_GRADE_WEIGHT = 0.4
 EXAM_GRADE_WEIGHT = 0.6
+
+NEW_COMBINED_FINAL_GRADES_DATE = datetime.datetime(2022, 9, 1, tzinfo=pytz.UTC)
 
 
 class FinalGradeStatus:

--- a/grades/models.py
+++ b/grades/models.py
@@ -17,7 +17,7 @@ from courses.models import (
 )
 from exams.models import ExamRun
 from exams.constants import EXAM_GRADE_PASS, EXAM_GRADE_FAIL
-from grades.constants import FinalGradeStatus
+from grades.constants import FinalGradeStatus, NEW_COMBINED_FINAL_GRADES_DATE
 from micromasters.models import (
     AuditableModel,
     AuditModel,
@@ -109,7 +109,7 @@ class FinalGrade(TimestampedModel, AuditableModel):
         """
         Returns true if this grade is for a course run that started after Sept 1st, 2022
         """
-        return self.course_run.start_date > datetime.datetime(2022, 9, 1, tzinfo=pytz.UTC)
+        return self.course_run.start_date > NEW_COMBINED_FINAL_GRADES_DATE
 
     @classmethod
     def get_frozen_users(cls, course_run):

--- a/grades/models.py
+++ b/grades/models.py
@@ -2,6 +2,8 @@
 Models for the grades app
 """
 import uuid
+import datetime
+import pytz
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import JSONField
 from django.core.validators import MaxValueValidator, MinValueValidator
@@ -101,6 +103,13 @@ class FinalGrade(TimestampedModel, AuditableModel):
     def grade_percent(self):
         """Returns the grade field value as a number out of 100 (or None if the value is None)"""
         return self.grade * 100 if self.grade is not None else None
+
+    @property
+    def is_already_combined(self):
+        """
+        Returns true if this grade is for a course run that started after Sept 1st, 2022
+        """
+        return self.course_run.start_date > datetime.datetime(2022, 9, 1, tzinfo=pytz.UTC)
 
     @classmethod
     def get_frozen_users(cls, course_run):

--- a/grades/models.py
+++ b/grades/models.py
@@ -2,8 +2,6 @@
 Models for the grades app
 """
 import uuid
-import datetime
-import pytz
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import JSONField
 from django.core.validators import MaxValueValidator, MinValueValidator


### PR DESCRIPTION

#### What are the relevant tickets?
N/A

#### What's this PR do?
Updates the Program Record to display new combined final grades correctly, while not having course certificates and actual combined final grades objects.

#### How should this be manually tested?
As a learner go to your dashboard and view the program record link.
Find a course that you have passed, set the start date of the course run to be After Sept1st, 2022. Also, delete the combined final grade for that course if you had any.

Before:
<img width="1288" alt="Screen Shot 2023-05-15 at 8 54 24 AM" src="https://github.com/mitodl/micromasters/assets/7574259/10d4f6e8-064a-408c-ae98-d9abb003771d">

After:

<img width="1281" alt="Screen Shot 2023-05-15 at 8 53 45 AM" src="https://github.com/mitodl/micromasters/assets/7574259/2e82fe53-7e5f-4459-bb6f-7315e90dae12">



