### PR TITLE
api endpoint for program page config

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -1,3 +1,6 @@
+"""
+Integrate Wagtail's builtin api endpointss
+"""
 from wagtail.api.v2.views import PagesAPIViewSet
 from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.images.api.v2.views import ImagesAPIViewSet

--- a/cms/api.py
+++ b/cms/api.py
@@ -1,0 +1,12 @@
+from wagtail.api.v2.views import PagesAPIViewSet
+from wagtail.api.v2.router import WagtailAPIRouter
+from wagtail.images.api.v2.views import ImagesAPIViewSet
+from wagtail.documents.api.v2.views import DocumentsAPIViewSet
+
+# Create the router. "wagtailapi" is the URL namespace
+api_router = WagtailAPIRouter('wagtailapi')
+
+# Register wagtail built-in api routes
+api_router.register_endpoint('pages', PagesAPIViewSet)
+api_router.register_endpoint('images', ImagesAPIViewSet)
+api_router.register_endpoint('documents', DocumentsAPIViewSet)

--- a/cms/models.py
+++ b/cms/models.py
@@ -453,6 +453,8 @@ class ProgramPage(Page):
 
     api_fields = [
         APIField('title'),
+        APIField('description'),
+        APIField('program_id'),
         APIField('program_letter_footer'),
         APIField('program_letter_footer_text'),
         APIField('program_letter_header_text'),

--- a/cms/models.py
+++ b/cms/models.py
@@ -27,6 +27,7 @@ from micromasters.utils import webpack_dev_server_host
 from roles.models import Instructor, Staff
 from cms.util import get_coupon_code
 from cms.blocks import CourseTeamBlock, ImageWithLinkBlock, ResourceBlock
+from wagtail.api import APIField
 
 common_table_options = {
     'startRows': 3,
@@ -450,6 +451,16 @@ class ProgramPage(Page):
 
         return context
 
+    api_fields = [
+        APIField('title'),
+        APIField('program_letter_footer'),
+        APIField('program_letter_footer_text'),
+        APIField('program_letter_header_text'),
+        APIField('program_letter_logo'),
+        APIField('program_letter_text'),
+        APIField('program_letter_signatories'),
+    ]
+
 
 def get_program_page_context(programpage, request):
     """ Get context for the program page"""
@@ -717,4 +728,11 @@ class ProgramLetterSignatory(Orderable):
                 FieldPanel('signature_image'),
             ]
         )
+    ]
+
+    api_fields = [
+        APIField('name'),
+        APIField('title_line_1'),
+        APIField('title_line_2'),
+        APIField('signature_image'),
     ]

--- a/cms/models.py
+++ b/cms/models.py
@@ -20,6 +20,7 @@ from wagtail.core.models import Orderable, Page
 from wagtail.contrib.table_block.blocks import TableBlock
 from wagtail.images.models import Image
 from wagtail.images.edit_handlers import ImageChooserPanel
+from wagtail.api import APIField
 
 from courses.models import Program
 from micromasters.serializers import serialize_maybe_user
@@ -27,7 +28,7 @@ from micromasters.utils import webpack_dev_server_host
 from roles.models import Instructor, Staff
 from cms.util import get_coupon_code
 from cms.blocks import CourseTeamBlock, ImageWithLinkBlock, ResourceBlock
-from wagtail.api import APIField
+
 
 common_table_options = {
     'startRows': 3,

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -2,10 +2,6 @@
 
 from django.conf.urls import include, url
 from rest_framework import routers
-
-from cms.views import (
-    ProgramPageViewSet,
-)
 from cms.api import api_router
 
 urlpatterns = [

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -1,7 +1,6 @@
 """URLs for courses and programs"""
 
-from django.conf.urls import include, url
-from rest_framework import routers
+from django.conf.urls import url
 from cms.api import api_router
 
 urlpatterns = [

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -1,0 +1,13 @@
+"""URLs for courses and programs"""
+
+from django.conf.urls import include, url
+from rest_framework import routers
+
+from cms.views import (
+    ProgramPageViewSet,
+)
+from cms.api import api_router
+
+urlpatterns = [
+    url('api/v0/wagtail/', api_router.urls),
+]

--- a/cms/wagtail_api_test.py
+++ b/cms/wagtail_api_test.py
@@ -1,24 +1,38 @@
+"""
+Tests for wagtail built-in endpoints
+"""
 from django.urls import reverse
 from cms.factories import ProgramPageFactory, ProgramLetterSignatoryFactory
-from django.urls import reverse
 from search.base import MockedESTestCase
 
 
 class WagtailAPITestCase(MockedESTestCase):
+    """
+    Tests for Wagtail api
+    """
     def test_program_page_api_detail(self):
+        """
+        Basic test to ensure the page detail endpoint returns data
+        """
         page = ProgramPageFactory(title="test program page title")
-        response = self.client.get(reverse("wagtailapi:pages:detail", args=[page.id]))
+        response = self.client.get(
+            reverse("wagtailapi:pages:detail", args=[page.id]))
         json = response.json()
         self.assertTrue(json["title"] == page.title)
 
     def test_program_page_api_serializes_signatories(self):
+        """
+        Test that program letter signatories
+        are included along with image data
+        """
         page = ProgramPageFactory(
             description="test program page description", title="test program page title"
         )
         ProgramLetterSignatoryFactory.create_batch(3, program_page=page)
-        response = self.client.get(reverse("wagtailapi:pages:detail", args=[page.id]))
+        response = self.client.get(
+            reverse("wagtailapi:pages:detail", args=[page.id]))
         json = response.json()
-        signatories = response.json()["program_letter_signatories"]
+        signatories = json["program_letter_signatories"]
         self.assertTrue(len(signatories) == 3)
         self.assertTrue("signature_image" in signatories[0].keys())
         self.assertTrue(
@@ -40,14 +54,20 @@ class WagtailAPITestCase(MockedESTestCase):
         )
         json = response.json()
         response_keys = list(json["items"][0].keys())
-        self.assertTrue(all([key in response_keys for key in[
-                "title",
-                "program_id",
-                "program_letter_footer",
-                "program_letter_footer_text",
-                "program_letter_header_text",
-                "program_letter_logo",
-                "program_letter_text",
-                "program_letter_signatories",
-            ]]))
-        
+        self.assertTrue(
+            all(
+                [
+                    key in response_keys
+                    for key in [
+                        "title",
+                        "program_id",
+                        "program_letter_footer",
+                        "program_letter_footer_text",
+                        "program_letter_header_text",
+                        "program_letter_logo",
+                        "program_letter_text",
+                        "program_letter_signatories",
+                    ]
+                ]
+            )
+        )

--- a/cms/wagtail_api_test.py
+++ b/cms/wagtail_api_test.py
@@ -1,7 +1,3 @@
-"""
-cms views
-"""
-from django.contrib.auth.views import redirect_to_login
 from django.urls import reverse
 from cms.factories import ProgramPageFactory, ProgramLetterSignatoryFactory
 from django.urls import reverse

--- a/cms/wagtail_api_test.py
+++ b/cms/wagtail_api_test.py
@@ -1,0 +1,57 @@
+"""
+cms views
+"""
+from django.contrib.auth.views import redirect_to_login
+from django.urls import reverse
+from cms.factories import ProgramPageFactory, ProgramLetterSignatoryFactory
+from django.urls import reverse
+from search.base import MockedESTestCase
+
+
+class WagtailAPITestCase(MockedESTestCase):
+    def test_program_page_api_detail(self):
+        page = ProgramPageFactory(title="test program page title")
+        response = self.client.get(reverse("wagtailapi:pages:detail", args=[page.id]))
+        json = response.json()
+        self.assertTrue(json["title"] == page.title)
+
+    def test_program_page_api_serializes_signatories(self):
+        page = ProgramPageFactory(
+            description="test program page description", title="test program page title"
+        )
+        ProgramLetterSignatoryFactory.create_batch(3, program_page=page)
+        response = self.client.get(reverse("wagtailapi:pages:detail", args=[page.id]))
+        json = response.json()
+        signatories = response.json()["program_letter_signatories"]
+        self.assertTrue(len(signatories) == 3)
+        self.assertTrue("signature_image" in signatories[0].keys())
+        self.assertTrue(
+            "download_url" in signatories[0]["signature_image"]["meta"].keys()
+        )
+
+    def test_program_page_api_list_view_details(self):
+        """
+        Tests that we can get all the program letter
+        related detail from the list view directly
+        """
+        page = ProgramPageFactory(
+            description="test program page description", title="test program page title"
+        )
+        ProgramLetterSignatoryFactory.create_batch(3, program_page=page)
+        response = self.client.get(
+            reverse("wagtailapi:pages:listing"),
+            {"id": page.id, "type": "cms.ProgramPage", "fields": "*"},
+        )
+        json = response.json()
+        response_keys = list(json["items"][0].keys())
+        self.assertTrue(all([key in response_keys for key in[
+                "title",
+                "program_id",
+                "program_letter_footer",
+                "program_letter_footer_text",
+                "program_letter_header_text",
+                "program_letter_logo",
+                "program_letter_text",
+                "program_letter_signatories",
+            ]]))
+        

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -88,8 +88,10 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'rest_framework',
     'rest_framework.authtoken',
+    'django_filters',
     'server_status',
     'social_django',
+    'wagtail.api.v2',
 
     # WAGTAIL
     'wagtail.contrib.forms',

--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -91,9 +91,9 @@ INSTALLED_APPS = (
     'django_filters',
     'server_status',
     'social_django',
-    'wagtail.api.v2',
 
     # WAGTAIL
+    'wagtail.api.v2',
     'wagtail.contrib.forms',
     'wagtail.contrib.redirects',
     'wagtail.contrib.table_block',

--- a/micromasters/urls.py
+++ b/micromasters/urls.py
@@ -25,6 +25,7 @@ urlpatterns += [
     url(r'', include('backends.urls')),
     url(r'^admin/', admin.site.urls),
     url('', include('courses.urls')),
+    url("", include("cms.urls")),
     url('', include('dashboard.urls')),
     url('', include('ecommerce.urls')),
     url('', include('financialaid.urls')),


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes [#3711](https://github.com/mitodl/hq/issues/3711)
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR has changes that integrate wagtail built-in api endpoints so we can retrieve content used in program letters from mit-open.

### How can this be tested?
1. Checkout this branch.
2. If you dont already have some mock data, create a ProgramPage via /cms - make sure it is not sitting in the 'root' (should be a child of the "Micromasters Home" page. Fill out the required fields in addition to the fields starting with "program_letter_*"
3. Save and publish the page
4. navigate to the wagtail endpoint and specify the pagetype and wildcard for the fields http://localhost:8079/api/v0/wagtail/pages/?type=cms.ProgramPage&fields=*
5. See that all the program letter fields are shown (inckuding the list of signatories) in addition to links for the signature images


