### PR TITLE
fix: redirect footer logo to the open learning

### DIFF
--- a/ui/templates/footer.html
+++ b/ui/templates/footer.html
@@ -4,7 +4,7 @@
     <div class="row">
       <div class="col-md-8">
         <a href="https://openlearning.mit.edu" target="_blank" rel="noopener noreferrer">
-          <img src="{% static 'images/open_learning_logo.svg' %}" alt="MIT" width="150" height="38">
+          <img src="{% static 'images/open_learning_logo.svg' %}" alt="MIT Open Learning" width="150" height="38">
         </a>
         {% if is_public %}
           <div class="footer-button footer-cta-left">

--- a/ui/templates/footer.html
+++ b/ui/templates/footer.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="row">
       <div class="col-md-8">
-        <a href="https://openlearning.mit.edu/" target="_blank" rel="noopener noreferrer">
+        <a href="https://openlearning.mit.edu" target="_blank" rel="noopener noreferrer">
           <img src="{% static 'images/open_learning_logo.svg' %}" alt="MIT" width="150" height="38">
         </a>
         {% if is_public %}

--- a/ui/templates/footer.html
+++ b/ui/templates/footer.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="row">
       <div class="col-md-8">
-        <a href="http://www.mit.edu" target="_blank" rel="noopener noreferrer">
+        <a href="https://openlearning.mit.edu/" target="_blank" rel="noopener noreferrer">
           <img src="{% static 'images/open_learning_logo.svg' %}" alt="MIT" width="150" height="38">
         </a>
         {% if is_public %}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None, Based on https://github.com/mitodl/micromasters-zendesk-theme-updated/pull/1#issuecomment-2016594288

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates the Link for the Open Learning logo.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Verify that the Open Learning Logo in the footer redirects to https://openlearning.mit.edu
