### PR TITLE
Test should not try to refresh token

### DIFF
--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -529,13 +529,16 @@ class UserExamEnrollmentTest(MockedESTestCase, APITestCase):
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
     @patch('backends.utils.refresh_user_token', autospec=True)
-    def test_user_is_not_authorized(self, mock_refresh):
+    @patch('dashboard.views.ExamAuthorization.objects', autospec=True)
+    def test_user_is_not_authorized(self, mock_exam_auth, mock_refresh):
         """
         The user must be authorized for this exam run
+        in order to be enrolled
         """
+        mock_exam_auth.filter.return_value.exists.return_value = False
         resp = self.client.post(self.url, {'exam_course_id': self.exam_course_id}, format='json')
-        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
-        assert mock_refresh.call_count == 1
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert mock_refresh.call_count == 0
 
     @patch('backends.utils.refresh_user_token', autospec=True)
     def test_refresh_token_fails(self, mock_refresh):

--- a/dashboard/views_test.py
+++ b/dashboard/views_test.py
@@ -528,12 +528,14 @@ class UserExamEnrollmentTest(MockedESTestCase, APITestCase):
         resp = self.client.post(self.url, {}, format='json')
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_user_is_not_authorized(self):
+    @patch('backends.utils.refresh_user_token', autospec=True)
+    def test_user_is_not_authorized(self, mock_refresh):
         """
         The user must be authorized for this exam run
         """
         resp = self.client.post(self.url, {'exam_course_id': self.exam_course_id}, format='json')
         assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+        assert mock_refresh.call_count == 1
 
     @patch('backends.utils.refresh_user_token', autospec=True)
     def test_refresh_token_fails(self, mock_refresh):


### PR DESCRIPTION
### What are the relevant tickets?
Related to #3878

### Description (What does it do?)
Updates a test not call edx api and patch the call instead.
The test was not working properly because we didn't patch ExamAuthorization to return no object.
This test is checking to see that a user is authorized before we try enroll them for an exam run.

### How can this be tested?
Tests should pass.