### PR TITLE
Removing sign in buttons from DEDP page

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -64,7 +64,7 @@
                   target="blank">Learn More</a>
         {% else %}
             {% if page.program.id == 2 %}
-                <a href="https://mitxonline.mit.edu/signin/" class="mdl-button hero-button mdl-cell--hide-phone">
+                <a href="https://mitxonline.mit.edu/create-account/" class="mdl-button hero-button mdl-cell--hide-phone">
                   Enroll on MITx Online
                 </a>
             {% else %}

--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -64,7 +64,7 @@
                   target="blank">Learn More</a>
         {% else %}
             {% if page.program.id == 2 %}
-                <a href="https://mitxonline.mit.edu/" class="mdl-button hero-button mdl-cell--hide-phone">
+                <a href="https://mitxonline.mit.edu/signin/" class="mdl-button hero-button mdl-cell--hide-phone">
                   Enroll on MITx Online
                 </a>
             {% else %}

--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -63,17 +63,23 @@
                   href="{{ page.program_subscribe_link }}"
                   target="blank">Learn More</a>
         {% else %}
-          {% if not authenticated %}
-            <a href="{% url 'signin' %}?program={{page.program.id}}" class="mdl-button hero-button mdl-cell--hide-phone">
-              Create Account
-            </a>
-            <div class="log-in mdl-cell--hide-phone">
-              Already a Member?
-              <a href="{% url 'signin' %}?program={{page.program.id}}">
-                Sign In
-              </a>
-            </div>
-          {% endif %}
+            {% if page.program.id == 2 %}
+                <a href="https://mitxonline.mit.edu/" class="mdl-button hero-button mdl-cell--hide-phone">
+                  Enroll on MITx Online
+                </a>
+            {% else %}
+              {% if not authenticated %}
+                <a href="{% url 'signin' %}?program={{page.program.id}}" class="mdl-button hero-button mdl-cell--hide-phone">
+                  Create Account {{page.program.id}}
+                </a>
+                <div class="log-in mdl-cell--hide-phone">
+                  Already a Member?
+                  <a href="{% url 'signin' %}?program={{page.program.id}}">
+                    Sign In
+                  </a>
+                </div>
+              {% endif %}
+            {% endif %}
         {% endif %}
       </div>
     {% endif %}

--- a/ui/templates/header.html
+++ b/ui/templates/header.html
@@ -4,6 +4,7 @@
           <a class="brand-logo" href="{{ request.build_absolute_uri }}" rel="noopener noreferrer"></a>
         </div>
         <div class="pull-right" style="padding-top:4px">
+        {% if page.program.id != 2 %}
           {% if authenticated %}
           <a class="header-dashboard-link" href="/dashboard">My Dashboard</a>
           <a class="header-dashboard-link" href="/logout">
@@ -15,6 +16,7 @@
             Create Account
           </a>
           {% endif %}
+        {% endif %}
         </div>
       </div>
   </nav>


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/3936

### Description (What does it do?)
Removes the sign in buttons from the DEDP program page. 
I used a hardcoded id for the program since it is never going to change. I didn't see much value in introducing a constant. We are moving away from the micromsters site.
### Screenshots (if appropriate):
After:

<img width="1168" alt="Screenshot 2024-05-01 at 5 15 05 PM" src="https://github.com/mitodl/micromasters/assets/7574259/d6dcca85-82f9-4593-a7eb-e82dd1179d57">

Before:

<img width="1400" alt="Screenshot 2024-05-01 at 5 16 57 PM" src="https://github.com/mitodl/micromasters/assets/7574259/8d955316-4f7c-4424-8f28-7c2985da6df9">


### How can this be tested?
Make sure other pages are unaffected.