### PR TITLE
Adding overlay over course rows

### DIFF
--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -126,7 +126,10 @@ export default class CourseListCard extends React.Component {
             {showStaffView ? `Courses - ${program.title}` : "Required Courses"}
           </h2>
           {showStaffView ? null : this.renderGradesOutOfDateMessage()}
-          {courseRows}
+          <div className="parent-overlay">
+            <div className="overlay"></div>
+            {courseRows}
+          </div>
         </CardContent>
       </Card>
     )

--- a/static/js/components/dashboard/CourseListCard.js
+++ b/static/js/components/dashboard/CourseListCard.js
@@ -127,7 +127,7 @@ export default class CourseListCard extends React.Component {
           </h2>
           {showStaffView ? null : this.renderGradesOutOfDateMessage()}
           <div className="parent-overlay">
-            <div className="overlay"></div>
+            <div className="overlay" />
             {courseRows}
           </div>
         </CardContent>

--- a/static/scss/dashboard/dashboard.scss
+++ b/static/scss/dashboard/dashboard.scss
@@ -20,7 +20,7 @@
   font-weight: 600;
 }
 
-.parent-overlay{
+.parent-overlay {
   position: relative;
   height: 100%;
   width: 100%;

--- a/static/scss/dashboard/dashboard.scss
+++ b/static/scss/dashboard/dashboard.scss
@@ -20,6 +20,22 @@
   font-weight: 600;
 }
 
+.parent-overlay{
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+
+.overlay {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  display: block;
+  z-index: 999;
+  background-color: black;
+  opacity: 0.2;
+}
+
 .dashboard {
 
   h2 {


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/micromasters/pull/5399
### Description (What does it do?)
Adding overlay over course rows

### Screenshots (if appropriate):
<img width="1248" alt="Screenshot 2024-10-03 at 12 41 40 PM" src="https://github.com/user-attachments/assets/2c21cc0a-6a5f-4207-9a0c-f0e306c22f59">
