### PR TITLE
Learner search goes to BI

### DIFF
--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -170,7 +170,7 @@ export default class Navbar extends React.Component {
             </div>
             <div className="links">
               {adminLink(closeDrawer, "/dashboard", "Dashboard", "dashboard")}
-              {adminLink(closeDrawer, "/learners", "Learners", "people")}
+              {adminLink(closeDrawer, "https://bi.ol.mit.edu/superset/dashboard/11/", "Learners", "people", true, true)}
               {adminLink(closeDrawer, "/cms", "CMS", "description", true, true)}
               {financialAidLink(
                 closeDrawer,

--- a/static/js/components/Navbar.js
+++ b/static/js/components/Navbar.js
@@ -170,7 +170,14 @@ export default class Navbar extends React.Component {
             </div>
             <div className="links">
               {adminLink(closeDrawer, "/dashboard", "Dashboard", "dashboard")}
-              {adminLink(closeDrawer, "https://bi.ol.mit.edu/superset/dashboard/11/", "Learners", "people", true, true)}
+              {adminLink(
+                closeDrawer,
+                "https://bi.ol.mit.edu/superset/dashboard/11/",
+                "Learners",
+                "people",
+                true,
+                true
+              )}
               {adminLink(closeDrawer, "/cms", "CMS", "description", true, true)}
               {financialAidLink(
                 closeDrawer,

--- a/static/js/components/Navbar_test.js
+++ b/static/js/components/Navbar_test.js
@@ -43,7 +43,6 @@ describe("Navbar", () => {
         "/learner/jane",
         "/learner/jane",
         "/dashboard",
-        "/learners",
         "/automaticemails",
         "/learner/jane",
         "/settings",


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/5685
### Description (What does it do?)
Direct users accessing learner search to the data platform
### Screenshots (if appropriate):
<img width="417" alt="Screenshot 2024-10-24 at 8 41 54 AM" src="https://github.com/user-attachments/assets/d5862c9e-7f7c-4d3c-a3ba-4ba8c5658060">


### How can this be tested?

The Learners link should open a new tab with  https://bi.ol.mit.edu/superset/dashboard/11/ 