### PR TITLE
Remore coming from fuzzy start date

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -144,7 +144,7 @@ class Course(models.Model):
         if not course_run or not course_run.start_date:
             promised_run = self.get_promised_run()
             if promised_run:
-                return "Coming " + promised_run.fuzzy_start_date
+                return promised_run.fuzzy_start_date
             else:
                 return "Not available"
 

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -333,7 +333,7 @@ class CourseTests(CourseModelTests):  # pylint: disable=too-many-public-methods
             enrollment_start=None,
             enrollment_end=None,
         )
-        assert self.course.enrollment_text == 'Coming Fall 2017'
+        assert self.course.enrollment_text == 'Fall 2017'
 
     def test_url_with_no_run(self):
         """Test course url with no course runs"""


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.mit.edu/micromasters/micromasters-issues/issues/61

### Description (What does it do?)
Remove "Coming" from fuzzy start date

### Screenshots (if appropriate):
Set the Fuzzy start date on a course run. The start date itself should be blank.

Before
<img width="365" alt="Screenshot 2024-11-21 at 12 16 18 PM" src="https://github.com/user-attachments/assets/ea7a4acd-9ab4-45a4-9bb7-d8e7841a83ab">

After:

<img width="366" alt="Screenshot 2024-11-21 at 12 17 00 PM" src="https://github.com/user-attachments/assets/9b10e700-14d5-4fa0-8732-0e9dcdbd1b96">
