### PR TITLE
Just log info when user has no social auth

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -730,8 +730,8 @@ def refresh_user_data(user_id, provider):
     # get the credentials for the current user for edX
     try:
         user_social = get_social_auth(user, provider)
-    except:
-        log.exception('user "%s" does not have edX credentials', user.username)
+    except ObjectDoesNotExist:
+        log.info('No social auth for %s for user %s', provider, user.username)
         return
 
     try:


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/6165
### Description (What does it do?)
Instead of throwing an exception just log. We don't expect all users to have social auth both both backends.

### How can this be tested?
Just look at the code.
Nothing should break.
