### PR TITLE
Make discussions sync crontab configurable

### DIFF
--- a/micromasters/settings.py
+++ b/micromasters/settings.py
@@ -497,6 +497,7 @@ CELERY_RESULT_BACKEND = get_string(
 CELERY_TASK_ALWAYS_EAGER = get_bool("CELERY_TASK_ALWAYS_EAGER", False) or get_bool("CELERY_ALWAYS_EAGER", False)
 CELERY_TASK_EAGER_PROPAGATES = (get_bool("CELERY_TASK_EAGER_PROPAGATES", True) or
                                 get_bool("CELERY_EAGER_PROPAGATES_EXCEPTIONS", True))
+CRONTAB_DISCUSSIONS_SYNC = get_string("CRONTAB_DISCUSSIONS_SYNC", None)
 CELERY_BEAT_SCHEDULE = {
     'batch-update-user-data-every-friday-every-6-hrs': {
         'task': 'dashboard.tasks.batch_update_user_data',
@@ -516,7 +517,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     'discussions-sync-memberships-every-minute': {
         'task': 'discussions.tasks.sync_channel_memberships',
-        'schedule': crontab(minute='*', hour='*')
+        'schedule': crontab(*CRONTAB_DISCUSSIONS_SYNC.split()) if CRONTAB_DISCUSSIONS_SYNC else crontab(minute='*', hour='*')
     },
     'freeze-final-grades-every-24-hrs-few-times': {
         'task': 'grades.tasks.find_course_runs_and_freeze_grades',


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This makes the discussions sync crontab configurable via an environment variable. The default is left since ideally that's what we'd use.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Set `CRONTAB_DISCUSSIONS_SYNC` to a crontab expression of your choice (e.g. `*/5 * * * *` for every 5 minutes). https://crontab.guru is a good resource to create a more specific one for testing needs.