### PR TITLE
adding import_course command and course run sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           python-version: "3.9.1"
 
       - id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/test_reqirements.txt') }}
@@ -118,7 +118,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/courses/management/commands/import_course_runs_for_course.py
+++ b/courses/management/commands/import_course_runs_for_course.py
@@ -1,0 +1,66 @@
+"""
+"Imports" a course run from MIT Learn.
+
+You can specify a course by its readable ID, e.g. `MITx+14.100x`.
+
+./manage.py import_course_runs_for_course --course_id MITx+14.100x
+"""
+
+from django.core.management import BaseCommand
+
+from courses.mit_learn_api import sync_mit_learn_courseruns_for_course, \
+    fetch_course_from_mit_learn
+from courses.models import Course
+
+
+class Command(BaseCommand):
+    """
+    Creates/Updates a course with course runs using details from MIT Learn.
+    You can specify a course by its readable ID, e.g. `MITxT+14.100x`.
+    Usage: ./manage.py import_course_runs_for_course --course_id MITxT+14.100x
+    """
+
+    help = "Creates missing course runs and updates existing using details from MIT Learn."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--course_id",
+            type=str,
+            nargs="?",
+            help="This should be the course key, e.g. MITxT+14.100x",
+        )
+
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument  # noqa: C901, PLR0915
+        course_id = kwargs["course_id"]
+        if course_id is None:
+            self.stdout.write(
+                self.style.ERROR("You must provide a course_id to import all the associated course runs.")
+            )
+        self.stdout.write(
+                self.style.SUCCESS(f"Fetching course run data from MIT Learn API for course {course_id}")
+            )
+        raw_course = fetch_course_from_mit_learn(course_id)
+
+        if raw_course is None:
+            self.stdout.write(
+                self.style.ERROR(f"Course {course_id} not found in MIT Learn API.")
+            )
+
+        try:
+            course = Course.objects.get(edx_key=course_id)
+        except Course.DoesNotExist:
+            self.stdout.write(
+                self.style.ERROR(f"Course {course_id} does not exist.")
+            )
+            return None
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Updating course runs for {course_id}: {course.title}"
+            )
+        )
+
+        course_runs_created = sync_mit_learn_courseruns_for_course(course, raw_courseruns=raw_course["runs"])
+        self.stdout.write(self.style.SUCCESS(f"{course_runs_created} course runs created"))
+
+        return None

--- a/courses/mit_learn_api.py
+++ b/courses/mit_learn_api.py
@@ -1,0 +1,86 @@
+from urllib.parse import urlencode
+
+import requests
+import re
+from typing import Any, Dict, List, Optional
+
+from courses.models import Course, CourseRun
+from django.utils.dateparse import parse_datetime
+
+
+class MITLearnAPIError(Exception):
+    """Custom exception for MIT Learn API errors."""
+    pass
+
+LEARN_API_COURSES_LIST_URL = "https://api.learn.mit.edu/api/v1/courses/"
+
+def fetch_course_from_mit_learn(course_id) -> Dict[str, Any]:
+    """
+    Fetch course run data from the MIT Learn API.
+
+    Returns:
+        Dict[str, Any]: course run data dict.
+
+    Raises:
+        MITLearnAPIError: If the API call fails or returns an error.
+    """
+
+    headers = {
+        "Accept": "application/json",
+    }
+    try:
+        params = {"readable_id": course_id}
+        encoded_params = urlencode(params)
+        url = f"{LEARN_API_COURSES_LIST_URL}?{encoded_params}"
+        response = requests.get(url, headers=headers, timeout=20)
+    except requests.exceptions.RequestException as e:
+        raise MITLearnAPIError(f"Network/API error: {e}")
+    try:
+        data = response.json()
+    except ValueError:
+        raise MITLearnAPIError("Invalid JSON response from MIT Learn API.")
+    for course in data["results"]:
+        if course["readable_id"] == course_id:
+            return course
+
+    return {}
+
+
+
+
+
+
+
+
+def sync_mit_learn_courseruns_for_course(course, raw_courseruns: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Process and normalize raw course data from MIT Learn API, but only for courses that already exist in the database.
+
+    Args:
+        raw_courses (List[Dict[str, Any]]): Raw course data from the API.
+
+    Returns:
+        List[Dict[str, Any]]: List of dicts with course and course run info for existing courses only.
+    """
+
+    num_created = 0
+    for raw_courserun in raw_courseruns:
+        print("Syncing course run:", raw_courserun.get("run_id"))
+        run_defaults = {
+            "title": raw_courserun.get("title", ""),
+            "enrollment_start": parse_datetime(raw_courserun.get("enrollment_start")) if raw_courserun.get("enrollment_start") else None,
+            "enrollment_end": parse_datetime(raw_courserun.get("enrollment_end")) if raw_courserun.get("enrollment_end") else None,
+            "start_date": parse_datetime(raw_courserun.get("start_date")) if raw_courserun.get("start_date") else None,
+            "end_date": parse_datetime(raw_courserun.get("end_date"))if raw_courserun.get("end_date") else None,
+            "upgrade_deadline": parse_datetime(raw_courserun.get("upgrade_deadline")) if raw_courserun.get("upgrade_deadline") else None,
+            "courseware_backend": raw_courserun.get("courseware_backend", ""),
+            "enrollment_url": raw_courserun.get("enrollment_url", ""),
+        }
+        course_run, created = CourseRun.objects.update_or_create(
+            course=course, edx_course_key=raw_courserun["run_id"], defaults=run_defaults
+        )
+        if created:
+            num_created += 1
+            print(f"Created course run: {course_run.edx_course_key} for course {course.title}")
+    return num_created
+


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/micromasters/issues/5423

### Description (What does it do?)
Adds a management command to create a new course
Adds a sync process for course runs.


### How can this be tested?
create a program locally
create a course with this edx_key `MITx+CTL.SC0x`
Then run:

`./manage.py import_course_runs_for_course --course_id MITx+CTL.SC0x`

It should create course runs for this course.

Output:
```
Fetching course run data from MIT Learn API for course MITx+CTL.SC0x
Updating course runs for MITx+CTL.SC0x: Supply Chain Analytics (SC0x)
Syncing course run: course-v1:MITx+CTL.SC0x+2T2025
Syncing course run: course-v1:MITx+CTL.SC0x+1T2026
0 course runs created
