### PR TITLE
update docker python & nginx images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-buster
+FROM python:3.9-bullseye
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - 9600:9600 # required for Performance Analyzer
 
   nginx:
-    image: nginx:1.9.5
+    image: nginx:1.27
     ports:
       - "8079:8079"
     links:


### PR DESCRIPTION
### What are the relevant tickets?
NA

### Description (What does it do?)
Previously, `docker compose build` would fail since the python docker image being used in this project is no longer supported.  This PR updates the python docker image, as well as the nginx docker image which was throwing an error for being out of date.

### How can this be tested?
`docker compose build` should run without any errors or failure.