### PR TITLE
fix: heroku npm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "node": "14.18.2"
   },
   "scripts": {
-    "postinstall": "./webpack_if_prod.sh",
+    "build": "./webpack_if_prod.sh",
     "lint": "node ./node_modules/eslint/bin/eslint.js ./static/js",
     "scss_lint": "node ./node_modules/sass-lint/bin/sass-lint.js --verbose --no-exit",
     "test": "./scripts/test/js_test.sh",


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
After the merge of https://github.com/mitodl/micromasters/commit/b5c818ccb1272ab69b0b783cf193c782aab770bc, our Heroku build has started breaking due to the postinstall script in the package.json file. This PR fixes the build.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
