### PR TITLE
Update link on DEDP Program page

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -64,8 +64,8 @@
                   target="blank">LEARN MORE</a>
         {% else %}
             {% if page.program.id == 2 %}
-                <a href="https://mitxonline.mit.edu/create-account/" class="mdl-button hero-button mdl-cell--hide-phone">
-                  ENROLL ON MITx ONLINE
+                <a href="https://learn.mit.edu/programs/program-v1:MITx+DEDP" class="mdl-button hero-button mdl-cell--hide-phone">
+                  ENROLL ON LEARN
                 </a>
             {% else %}
               {% if not authenticated %}


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Update the button "Enroll on MITxOnline" to "Enroll on Learn"

### Screenshots (if appropriate):
<img width="1379" height="719" alt="Screenshot 2026-06-03 at 10 56 00 AM" src="https://github.com/user-attachments/assets/fdc402a7-4283-48c4-807a-af8b02b56b04" />


### How can this be tested?

For testing Your program needs to have id=2. That is the id of DEDP in production and rc.
All other programs show different buttons that link to enroll on EDX.
