### PR TITLE
Update DEDP and SCM to Login to MIT Learn

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -65,7 +65,11 @@
         {% else %}
             {% if page.program.id == 2 %}
                 <a href="https://learn.mit.edu/programs/program-v1:MITx+DEDP" class="mdl-button hero-button mdl-cell--hide-phone">
-                  ENROLL ON LEARN
+                  Enroll on MIT Learn
+                </a>
+            {% elif page.program.id == 1 %}
+                <a href="https://learn.mit.edu/programs/program-v1:MITxT+SCM" class="mdl-button hero-button mdl-cell--hide-phone">
+                  Enroll on MIT Learn
                 </a>
             {% else %}
               {% if not authenticated %}

--- a/ui/templates/header.html
+++ b/ui/templates/header.html
@@ -4,7 +4,7 @@
           <a class="brand-logo" href="/" rel="noopener noreferrer"></a>
         </div>
         <div class="pull-right" style="padding-top:4px">
-        {% if page.program.id != 2 %}
+        {% if page.program.id != 1 and page.program.id != 2 %}
           {% if authenticated %}
           <a class="header-dashboard-link" href="/dashboard">My Dashboard</a>
           <a class="header-dashboard-link" href="/logout">


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/11606

### Description (What does it do?)
Remove login buttons.
Link to MIT Learn for DEDP and SCM

This is hardcoded to the program ids since those will never change.

### Screenshots (if appropriate):

<img width="1625" height="739" alt="Screenshot 2026-06-03 at 1 48 40 PM" src="https://github.com/user-attachments/assets/8f20b8e1-7d4a-4702-9d00-4ceb6303fdd6" />
<img width="1588" height="730" alt="Screenshot 2026-06-03 at 1 52 34 PM" src="https://github.com/user-attachments/assets/2fb6f333-78ca-408c-a4a3-f7d73c7cd896" />

