### PR TITLE
Add second enroll button for DEDP

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -64,8 +64,17 @@
                   target="blank">LEARN MORE</a>
         {% else %}
             {% if page.program.id == 2 %}
-                <a href="https://learn.mit.edu/programs/program-v1:MITx+DEDP" class="mdl-button hero-button mdl-cell--hide-phone">
-                  Enroll on MIT Learn
+                <a
+                  href="https://learn.mit.edu/programs/program-v1:MITx+DEDP"
+                  class="mdl-button hero-button mdl-cell--hide-phone"
+                >
+                  Enroll in International Development Track
+                </a>
+                <a
+                  href="https://learn.mit.edu/programs/program-v1:MITx+DEDP-Public-Policy"
+                  class="mdl-button hero-button mdl-cell--hide-phone"
+                >
+                  Enroll in Public Policy Track
                 </a>
             {% elif page.program.id == 1 %}
                 <a href="https://learn.mit.edu/programs/program-v1:MITxT+SCM" class="mdl-button hero-button mdl-cell--hide-phone">


### PR DESCRIPTION


### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/11999
### Description (What does it do?)
Add an extra button for DEDP

<img width="1645" height="784" alt="Screenshot 2026-06-25 at 2 04 06 PM" src="https://github.com/user-attachments/assets/3a920b2d-850e-4124-9984-563840410a4d" />


### How can this be tested?
View a program page with id =1. There should be two buttons.

Make sure other program pages stay the same.