### PR TITLE
Add site-wide MIT Learn transition banner

### DIFF
--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -1,6 +1,7 @@
 @import "grid-settings";
 @import "variables";
 @import "breakpoints";
+@import "mitlearn-banner";
 @import "page-layout";
 @import "navbar";
 @import "dashboard/dashboard";

--- a/static/scss/mitlearn-banner.scss
+++ b/static/scss/mitlearn-banner.scss
@@ -14,6 +14,12 @@
     color: white;
     text-decoration: underline;
     font-weight: 600;
+
+    &:hover,
+    &:focus {
+      color: darken(white, 15%);
+      text-decoration: none;
+    }
   }
 
   @include breakpoint(phone) {

--- a/static/scss/mitlearn-banner.scss
+++ b/static/scss/mitlearn-banner.scss
@@ -1,0 +1,26 @@
+.mitlearn-transition-banner {
+  background-color: $mm-brand-bg;
+  padding: 10px 20px;
+  text-align: center;
+
+  p {
+    margin: 0;
+    color: white;
+    font-size: 15px;
+    line-height: 1.4em;
+  }
+
+  a {
+    color: white;
+    text-decoration: underline;
+    font-weight: 600;
+  }
+
+  @include breakpoint(phone) {
+    padding: 10px 12px;
+
+    p {
+      font-size: 13px;
+    }
+  }
+}

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -49,6 +49,12 @@
     {% endspaceless %}
   </head>
   <body class="{% block bodyclass %}{% endblock %}">
+    <div class="mitlearn-transition-banner" role="banner">
+      <p>
+        All MITx MicroMasters programs are now offered exclusively on
+        <a href="https://learn.mit.edu" target="_blank" rel="noopener noreferrer">MIT Learn</a>.
+      </p>
+    </div>
     {% if APIKEYS.GOOGLE_TAG_MANAGER %}
       <!-- Google Tag Manager (noscript) -->
       <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ APIKEYS.GOOGLE_TAG_MANAGER }}"

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -49,18 +49,18 @@
     {% endspaceless %}
   </head>
   <body class="{% block bodyclass %}{% endblock %}">
-    <div class="mitlearn-transition-banner" role="banner">
-      <p>
-        All MITx MicroMasters programs are now offered exclusively on
-        <a href="https://learn.mit.edu" target="_blank" rel="noopener noreferrer">MIT Learn</a>.
-      </p>
-    </div>
     {% if APIKEYS.GOOGLE_TAG_MANAGER %}
       <!-- Google Tag Manager (noscript) -->
       <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ APIKEYS.GOOGLE_TAG_MANAGER }}"
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <!-- End Google Tag Manager (noscript) -->
     {% endif %}
+    <div class="mitlearn-transition-banner" role="region" aria-label="Announcement">
+      <p>
+        All MITx MicroMasters programs are now offered exclusively on
+        <a href="https://learn.mit.edu" target="_blank" rel="noopener noreferrer">MIT Learn<span class="sr-only"> (opens in a new window)</span></a>.
+      </p>
+    </div>
     {% block content %}
     {% endblock %}
     <script type="text/javascript">


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12237

### Description (What does it do?)
Adds a persistent, site-wide banner informing MicroMasters learners that MITx MicroMasters programs are now offered exclusively on MIT Learn, with a link to https://learn.mit.edu.

The banner is added once, directly to the Django base template (`ui/templates/base.html`), right after the opening `<body>` tag and before `{% block content %}`. Every page in the portal — the React dashboard SPA shell, sign-in, certificates, grade records, program letters, error pages, and Wagtail CMS pages — extends this base template (directly or via `base_error.html`), so a single change covers the entire site rather than needing separate updates to the React `App.js` root and each Django/CMS template.

Styling lives in a new `static/scss/mitlearn-banner.scss` partial (MIT-brand-red background, centered white text, underlined link) imported into the existing `static/scss/layout.scss` bundle, with a phone-width breakpoint (reusing the existing `breakpoint()` mixin) that reduces padding/font-size for mobile.

### Screenshots (if appropriate):
- [x] Desktop screenshots
- [x] Mobile width screenshots

**Homepage**

| Desktop | Tablet | Mobile |
|---|---|---|
| ![desktop homepage](https://raw.githubusercontent.com/mitodl/micromasters/47557e283da09c9ff835cbd82a43482e55f432e9/screenshots/mitlearn-transition-banner/desktop/homepage.png) | ![tablet homepage](https://raw.githubusercontent.com/mitodl/micromasters/47557e283da09c9ff835cbd82a43482e55f432e9/screenshots/mitlearn-transition-banner/tablet/homepage.png) | ![mobile homepage](https://raw.githubusercontent.com/mitodl/micromasters/47557e283da09c9ff835cbd82a43482e55f432e9/screenshots/mitlearn-transition-banner/mobile/homepage.png) |

**Sign-in page**

| Desktop | Tablet | Mobile |
|---|---|---|
| ![desktop signin](https://raw.githubusercontent.com/mitodl/micromasters/47557e283da09c9ff835cbd82a43482e55f432e9/screenshots/mitlearn-transition-banner/desktop/signin.png) | ![tablet signin](https://raw.githubusercontent.com/mitodl/micromasters/47557e283da09c9ff835cbd82a43482e55f432e9/screenshots/mitlearn-transition-banner/tablet/signin.png) | ![mobile signin](https://raw.githubusercontent.com/mitodl/micromasters/47557e283da09c9ff835cbd82a43482e55f432e9/screenshots/mitlearn-transition-banner/mobile/signin.png) |

_Images hosted on the `screenshots/mitlearn-transition-banner` branch (not merged into this PR's diff), safe to delete once this PR is closed._

### How can this be tested?
1. Run the app locally (`docker compose up`) and visit any page (home, dashboard, sign-in, a program page, etc.) — the banner appears at the very top of every page, above the existing nav/header, with the text "All MITx MicroMasters programs are now offered exclusively on MIT Learn." and a link to https://learn.mit.edu opening in a new tab.
2. Resize the viewport down to phone width (≤580px) to confirm the banner remains legible and doesn't overflow.

### Additional Context
Verified locally end-to-end before opening this PR:
- Booted the full `docker compose` stack (db, redis, opensearch, sftp, web, and the webpack `watch` dev-server) and hit the running app. Confirmed via `curl` that the banner markup renders on both a pure Django page (`/signin/`) and the homepage, and confirmed the compiled `style.js` webpack bundle contains the `.mitlearn-transition-banner` CSS rule.
- Captured the screenshots above with `shot-scraper` against the same running stack.
- `static/scss/mitlearn-banner.scss` compiles cleanly with the project's `sass` and `sass-lint` tooling.
- Ran the Python test suite against the live containers: `ui/views_test.py` (35/35 passed) and the full `ui/` + `cms/` suite via pytest (64/64 passed) — no regressions.

Per the issue's acceptance criteria, this needs to be live by July 22 when all MicroMasters programs move to MIT Learn. No date-gating logic was added — the banner is unconditional starting from merge/deploy, which satisfies "the feature is up from July 22" as a deadline rather than a conditional display date. Happy to add a date guard if the team would rather it appear only starting a specific date.

One minor design note: the banner uses the same MIT-brand-red as the nav bar directly beneath it on the homepage, so they visually merge into one continuous red block (see homepage screenshots above). Still fully legible; happy to add a border/different shade for clearer separation if desired.