### PR TITLE
Fix: stale filled_out=false wrongly rejects profile edit PATCH requests

### DIFF
--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -275,10 +275,13 @@ class ProfileFilledOutSerializer(ProfileSerializer):
 
     def validate(self, attrs):
         """
-        Assert that filled_out can't be turned off and that agreed_to_terms_of_service is true
+        filled_out can't be turned off once set. The frontend always PATCHes the
+        full profile object, so a stale `filled_out: false` is often echoed back
+        on unrelated edits (e.g. adding an education entry) - ignore it instead of
+        rejecting the whole request and blocking those edits.
         """
         if 'filled_out' in attrs and not attrs['filled_out']:
-            raise ValidationError("filled_out cannot be set to false")
+            attrs['filled_out'] = True
 
         if 'agreed_to_terms_of_service' in attrs and not attrs['agreed_to_terms_of_service']:
             raise ValidationError("agreed_to_terms_of_service cannot be set to false")

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -275,10 +275,9 @@ class ProfileFilledOutSerializer(ProfileSerializer):
 
     def validate(self, attrs):
         """
-        filled_out can't be turned off once set. The frontend always PATCHes the
-        full profile object, so a stale `filled_out: false` is often echoed back
-        on unrelated edits (e.g. adding an education entry) - ignore it instead of
-        rejecting the whole request and blocking those edits.
+        Ignore stale `filled_out: false` values on full-profile PATCH requests,
+        reject `agreed_to_terms_of_service: false`, and require `postal_code`
+        when `country` is `US` or `CA`.
         """
         if 'filled_out' in attrs and not attrs['filled_out']:
             attrs['filled_out'] = True

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -367,13 +367,15 @@ class ProfileFilledOutTests(ProfileImageCleanupMixin, MockedESTestCase):
 
     def test_filled_out_false(self):
         """
-        filled_out cannot be set to false
+        filled_out cannot be set to false - a stale false value is ignored rather
+        than rejecting the whole request, since the frontend always PATCHes the
+        entire profile and may echo back a stale value on unrelated edits
         """
         self.data['filled_out'] = False
         self.data['image'] = self.profile.image
-        with self.assertRaises(ValidationError) as ex:
-            ProfileFilledOutSerializer(data=self.data).is_valid(raise_exception=True)
-        assert ex.exception.args[0] == {'non_field_errors': ['filled_out cannot be set to false']}
+        serializer = ProfileFilledOutSerializer(data=self.data)
+        serializer.is_valid(raise_exception=True)
+        assert serializer.validated_data['filled_out'] is True
 
     def test_required_fields(self):
         """


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found via Sentry issue [MICROMASTERS-1W2](https://mit-office-of-digital-learning.sentry.io/issues/MICROMASTERS-1W2)

### Description (What does it do?)
`ProfileFilledOutSerializer.validate()` (in `profiles/serializers.py`) rejects any PATCH to `/api/v0/profiles/{user}/` that contains `filled_out: false`, once the profile is already marked `filled_out=True`.

The frontend always PATCHes the *entire* profile object rather than a diff (`patchUserProfile` in `static/js/lib/api.js`). Every post-signup edit — adding an education entry, editing a work history entry, updating personal info — round-trips the full profile object it last fetched, including whatever `filled_out` value was in it. This means the validator's hard rejection blocks legitimate, unrelated edits and is the single highest-volume unresolved error in production: ~150-480 occurrences per 3-day window in Grafana logs, 1,393 events total in Sentry since 2018, most recently 50 minutes before this fix was written.

Since nothing in the frontend ever intends to un-fill a completed profile, this change makes a `false` value a no-op (silently kept `True`) instead of a hard validation error that blocks the whole request.

### How can this be tested?
- Existing test `test_filled_out_false` in `profiles/serializers_test.py` was updated to assert the new no-op behavior (`serializer.validated_data['filled_out'] is True`) instead of expecting a `ValidationError`.
- Manually: mark a profile `filled_out=True`, then PATCH `/api/v0/profiles/{user}/` with the full profile payload including `filled_out: false` plus a genuine field change (e.g. a new education entry) — the request should now succeed and the field change should persist.

### Additional Context
This only affects `ProfileFilledOutSerializer`, which is used once a profile is already complete (`profiles/views.py` `get_serializer_class`). During initial onboarding (`filled_out` still `False` in the DB), the plain `ProfileSerializer` is used instead and this validator doesn't run, so onboarding flow is unaffected.