### PR TITLE
Fix: stop reporting InvalidCredentialStored to Sentry as an unhandled exception

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -708,7 +708,14 @@ def refresh_user_data(user_id, provider):
 
     try:
         utils.refresh_user_token(user_social)
-    except:
+    except InvalidCredentialStored:
+        # Expected when a student has revoked or expired their OAuth grant with the
+        # courseware provider; logging as an exception floods Sentry with millions
+        # of events for a condition we can't act on beyond marking the refresh as failed.
+        save_cache_update_failure(user_id)
+        log.warning("Unable to refresh token for student %s: invalid credentials", user.username)
+        return
+    except:  # pylint: disable=bare-except
         save_cache_update_failure(user_id)
         log.exception("Unable to refresh token for student %s", user.username)
         return

--- a/dashboard/api_test.py
+++ b/dashboard/api_test.py
@@ -2386,6 +2386,33 @@ def test_refresh_failed_oauth_update(db, mocker):
     assert save_failure_mock.called is True
 
 
+def test_refresh_invalid_credential_stored_not_logged_as_exception(db, mocker, caplog):
+    """
+    If the oauth token refresh fails because the student revoked/expired their
+    credentials, we should log a warning (not a full exception) so this expected,
+    non-actionable condition doesn't flood Sentry, but should still record the failure
+    """
+    user = _make_fake_real_user()
+    user_social = user.social_auth.first()
+    refresh_user_token_mock = mocker.patch(
+        'dashboard.api.utils.refresh_user_token', autospec=True,
+        side_effect=InvalidCredentialStored('error', 400),
+    )
+    edx_api_init = mocker.patch('dashboard.api.EdxApi', autospec=True)
+    update_cache_mock = mocker.patch('dashboard.api.CachedEdxDataApi.update_cache_if_expired')
+    save_failure_mock = mocker.patch('dashboard.api.save_cache_update_failure')
+
+    api.refresh_user_data(user.id, BACKEND_EDX_ORG)
+
+    refresh_user_token_mock.assert_called_once_with(user_social)
+    assert edx_api_init.called is False
+    assert update_cache_mock.called is False
+    assert save_failure_mock.called is True
+    warning_records = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert any("invalid credentials" in record.message for record in warning_records)
+    assert all(record.exc_info is None for record in caplog.records if record.levelname != "WARNING")
+
+
 def test_refresh_failed_edx_client(db, mocker):
     """If we fail to create the edx client, we should skip the edx refresh"""
     user = _make_fake_real_user()


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found via Sentry issues [MICROMASTERS-5C9](https://mit-office-of-digital-learning.sentry.io/issues/MICROMASTERS-5C9) / [MICROMASTERS-9ET](https://mit-office-of-digital-learning.sentry.io/issues/MICROMASTERS-9ET) / [MICROMASTERS-5DT](https://mit-office-of-digital-learning.sentry.io/issues/MICROMASTERS-5DT)

### Description (What does it do?)
This is the single largest unresolved issue in Sentry: `InvalidCredentialStored: Received a 400 status code from the OAUTH server`, with **3.08 million events since 2021**, still actively firing (~40 events per 3 days confirmed in Grafana production logs) from `dashboard.tasks.batch_update_user_data_subtasks`.

Root cause chain:
- `backends/utils.py::_send_refresh_request` raises `InvalidCredentialStored` when the courseware provider's OAuth token endpoint returns 400/401 (i.e. the student revoked access or their refresh token expired).
- `dashboard/api.py::refresh_user_data` (called for every student on every batch run) caught this with a bare `except:` and called `log.exception(...)`, which - because this repo wires up Sentry's `LoggingIntegration` (`micromasters/sentry.py`) - reports a full Sentry event with stack trace on every single occurrence.

This condition is expected and non-actionable per-occurrence: once a student has revoked/expired their grant, there's nothing the server can do besides recording the failure, and it will recur on every batch run until the student re-authorizes. Treating it as a page-worthy unhandled exception, forever, is why this issue alone accounts for millions of Sentry events.

The fix catches `InvalidCredentialStored` specifically before the generic bare `except`, logs it via `log.warning` (no stack trace / no Sentry event) instead of `log.exception`, and still calls `save_cache_update_failure` to preserve the existing failure-count tracking behavior. Truly unexpected errors still fall through to the original bare `except` + `log.exception` path.

### How can this be tested?
Added `test_refresh_invalid_credential_stored_not_logged_as_exception` in `dashboard/api_test.py`, which:
- Mocks `refresh_user_token` to raise `InvalidCredentialStored`
- Asserts `save_cache_update_failure` is still called (failure tracking preserved)
- Asserts a `WARNING`-level log record containing "invalid credentials" is emitted
- Asserts no other captured log record carries `exc_info` (i.e. nothing else triggered a full exception log for this case)

Existing tests `test_update_cache_for_backend_refresh_token_error` / `test_update_cache_for_backend_update_cache_error` (which cover the separate `update_cache_for_backend` code path used by dashboard views, where `InvalidCredentialStored` is deliberately re-raised to the caller) are unaffected — this PR only touches `refresh_user_data`, the batch-task code path.

### Additional Context
`update_cache_for_backend` (used by dashboard views, not by the batch task) already re-raises `InvalidCredentialStored` explicitly and is untouched by this change.