### PR TITLE
Fix: profile photo Save button enabled before crop finishes, causing FormData TypeError

### DIFF
--- a/static/js/components/CropperWrapper.js
+++ b/static/js/components/CropperWrapper.js
@@ -28,7 +28,13 @@ export default class CropperWrapper extends React.Component {
           height: 512
         })
       }
-      canvas.toBlob(blob => updatePhotoEdit(blob), "image/jpeg")
+      canvas.toBlob(blob => {
+        // toBlob can invoke the callback with null if the canvas has no
+        // pixel data (e.g. a broken/zero-size source image)
+        if (blob) {
+          updatePhotoEdit(blob)
+        }
+      }, "image/jpeg")
     }
   }
 

--- a/static/js/components/ProfileImageUploader.js
+++ b/static/js/components/ProfileImageUploader.js
@@ -81,12 +81,15 @@ const ProfileImageUploader = ({
   startPhotoEdit,
   clearPhotoEdit,
   updatePhotoEdit,
-  imageUpload: { photo, error, patchStatus },
+  imageUpload: { photo, edit, error, patchStatus },
   updateUserPhoto,
   setPhotoError
 }: ImageUploadProps) => {
   const inFlight = patchStatus === FETCH_PROCESSING
-  const disabled = patchStatus === FETCH_PROCESSING || !photo
+  // `edit` is only populated once the cropper has produced a cropped blob
+  // (see CropperWrapper's cropend/ready handlers). Without this check, clicking
+  // Save before that finishes sends an undefined image to the server.
+  const disabled = patchStatus === FETCH_PROCESSING || !photo || !edit
 
   return (
     <Dialog

--- a/static/js/containers/ProfileImage_test.js
+++ b/static/js/containers/ProfileImage_test.js
@@ -11,7 +11,11 @@ import ProfileImage, { PROFILE_IMAGE_DIALOG } from "./ProfileImage"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { showDialog } from "../actions/ui"
 import * as api from "../lib/api"
-import { startPhotoEdit, requestPatchUserPhoto } from "../actions/image_upload"
+import {
+  startPhotoEdit,
+  updatePhotoEdit,
+  requestPatchUserPhoto
+} from "../actions/image_upload"
 
 describe("ProfileImage", () => {
   let helper, sandbox, updateProfileImageStub, div
@@ -122,11 +126,12 @@ describe("ProfileImage", () => {
     })
 
     describe("save button", () => {
-      it("should show the save button when there's an image", () => {
+      it("should show the save button once the image has been cropped", () => {
         renderProfileImage({
           editable: true
         })
         helper.store.dispatch(startPhotoEdit({ name: "a name" }))
+        helper.store.dispatch(updatePhotoEdit(new Blob()))
         helper.store.dispatch(showDialog(PROFILE_IMAGE_DIALOG))
         const dialog = document.querySelector(".photo-upload-dialog")
         const saveButton = dialog.querySelector(".save-button")
@@ -148,6 +153,21 @@ describe("ProfileImage", () => {
         ReactTestUtils.Simulate.click(saveButton)
         assert.isFalse(updateProfileImageStub.called)
         assert.isNull(dialog.querySelector(".MuiCircularProgress-root"))
+      })
+
+      it("should disable the save button if an image is picked but not yet cropped", () => {
+        // regression test: clicking Save before the cropper produces a blob
+        // used to send an undefined image and throw a FormData TypeError
+        renderProfileImage({
+          editable: true
+        })
+        helper.store.dispatch(startPhotoEdit({ name: "a name" }))
+        helper.store.dispatch(showDialog(PROFILE_IMAGE_DIALOG))
+        const dialog = document.querySelector(".photo-upload-dialog")
+        const saveButton = dialog.querySelector(".save-button")
+        assert.isTrue(saveButton.disabled)
+        ReactTestUtils.Simulate.click(saveButton)
+        assert.isFalse(updateProfileImageStub.called)
       })
 
       it("should show a spinner while uploading the image", () => {


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found via Sentry issues [MICROMASTERS-2XA](https://mit-office-of-digital-learning.sentry.io/issues/MICROMASTERS-2XA) / [MICROMASTERS-63J](https://mit-office-of-digital-learning.sentry.io/issues/MICROMASTERS-63J)

### Description (What does it do?)
`TypeError: Failed to execute 'append' on 'FormData': parameter 2 is not of type 'Blob'` has recurred in `updateProfileImage` (`static/js/lib/api.js`) since 2019, most recently within the hour before this fix.

Root cause is a race condition in the profile photo upload dialog:
- `ProfileImageUploader.js` only disabled the Save button while `!photo` (no file picked yet): `const disabled = patchStatus === FETCH_PROCESSING || !photo`.
- The actual cropped image blob (`imageUpload.edit` in Redux) is populated asynchronously — `CropperWrapper.js`'s `cropend`/`ready` handlers call `canvas.toBlob(blob => updatePhotoEdit(blob), "image/jpeg")`, and `canvas.toBlob` doesn't resolve synchronously.
- If a user picks a photo and clicks Save before that callback fires, `imageUpload.edit` is still its initial value (`null`/`undefined`), and that gets passed straight through `updateUserPhoto` → `updateProfileImage` → `formData.append("image", undefined, name)`, which throws the TypeError.

Fix:
1. `ProfileImageUploader.js`: disable Save until `imageUpload.edit` is also populated (`!photo || !edit`), not just until a photo is picked.
2. `CropperWrapper.js`: defensively guard the `canvas.toBlob` callback against a `null` blob (per MDN, `toBlob` invokes its callback with `null` if the canvas has no pixel data, e.g. a broken/zero-size source image) so a bad crop can't populate `edit` with a non-Blob value either.

### Screenshots (if appropriate):
No visual change — the Save button's disabled window is now slightly longer (until the crop preview finishes rendering), which is imperceptible in normal use.

### How can this be tested?
- Updated `static/js/containers/ProfileImage_test.js`:
  - `"should show the save button once the image has been cropped"` now dispatches `updatePhotoEdit(new Blob())` in addition to `startPhotoEdit`, matching the real flow, before asserting Save is enabled.
  - New test `"should disable the save button if an image is picked but not yet cropped"` dispatches only `startPhotoEdit` (no `updatePhotoEdit`) and asserts Save stays disabled and clicking it doesn't call `updateProfileImage` — this is the direct regression test for the race condition.
- Manually: open the profile photo upload dialog, select an image, and try clicking Save the instant the cropper preview appears (before it visibly finishes rendering) — it should be disabled until the crop completes, and should never throw.

### Additional Context
`node_modules` wasn't installed in this environment so the JS test suite (`mocha` via `scripts/test/js_test.sh`) could not be run locally — please confirm CI passes on this PR.