### PR TITLE
style: hide delivered on block

### DIFF
--- a/cms/templates/cms/program_page.html
+++ b/cms/templates/cms/program_page.html
@@ -168,20 +168,6 @@
             </div>
           </section>
         {% endif %}
-        <div class="powered-by">
-          <p>
-            Courses delivered on
-          </p>
-            {% if page.program.has_mitxonline_courses %}
-                <img
-                  class="mitx_logo"
-                  src="{% static 'images/mitxonline_logo.png' %}"
-                  alt="MITx"
-                />
-            {% else %}
-                <img src="{% static 'images/edx_logo.svg' %}" alt="edX" />
-            {% endif %}
-        </div>
       </div>
       {% endblock %}
 

--- a/static/scss/program-page.scss
+++ b/static/scss/program-page.scss
@@ -134,11 +134,6 @@
     }
   }
 
-  .info-box, .powered-by {
-    margin: 0 0 23px 15px;
-
-  }
-
   .info-box h3.core {
     color: $mm-brand-bg-dark;
     font-size: 15px;
@@ -175,6 +170,7 @@
   }
 
   .info-box {
+    margin: 0 0 23px 15px;
     padding: 30px;
     background-color: $bg-med-gray;
 
@@ -239,26 +235,6 @@
         font-size: 15px;
         margin: 0 0 12px 0;
       }
-    }
-  }
-
-  .powered-by {
-    padding: 20px;
-
-    p {
-      display: inline-block;
-      font-size: 16px;
-      font-weight: 400;
-      color: $font-gray-form !important;
-    }
-
-    > *:not(:last-child) {
-      margin-right: 7px;
-    }
-
-    img {
-      height: 30px;
-      margin-bottom: 9px;
     }
   }
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12323
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
- Removes the `Courses Delivered on` section from the program pages.
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<img width="1246" height="447" alt="Screenshot 2026-07-21 at 4 37 03 PM" src="https://github.com/user-attachments/assets/76551f1e-38da-465e-a147-a896b1f1d541" />


<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Set up program(s) in MicroMasters
- Set up on this branch
- You should not see any `Delivered on ..` section not MITx Online nor edX
